### PR TITLE
Add BigQuery standard SQL support

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -578,10 +578,12 @@ module Google
         # @!group Data
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
-                      create: nil, write: nil, large_results: nil, flatten: nil
+                      create: nil, write: nil, large_results: nil, flatten: nil,
+                      use_legacy_sql: true
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
-                      large_results: large_results, flatten: flatten }
+                      large_results: large_results, flatten: flatten,
+                      use_legacy_sql: use_legacy_sql }
           options[:dataset] ||= self
           ensure_service!
           gapi = service.query_job query, options
@@ -635,8 +637,10 @@ module Google
         #
         # @!group Data
         #
-        def query query, max: nil, timeout: 10000, dryrun: nil, cache: true
-          options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache }
+        def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
+                  use_legacy_sql: true
+          options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
+                      use_legacy_sql: use_legacy_sql }
           options[:dataset] ||= dataset_id
           options[:project] ||= project_id
           ensure_service!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -155,12 +155,12 @@ module Google
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                       create: nil, write: nil, large_results: nil, flatten: nil,
-                      dataset: nil
+                      dataset: nil, use_legacy_sql: true
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
-                      dataset: dataset }
+                      dataset: dataset, use_legacy_sql: use_legacy_sql }
           gapi = service.query_job query, options
           Job.from_gapi gapi, service
         end
@@ -225,10 +225,11 @@ module Google
         #   end
         #
         def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  dataset: nil, project: nil
+                  dataset: nil, project: nil, use_legacy_sql: true
           ensure_service!
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
-                      dataset: dataset, project: project }
+                      dataset: dataset, project: project,
+                      use_legacy_sql: use_legacy_sql }
           gapi = service.query query, options
           QueryData.from_gapi gapi, service
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -99,6 +99,14 @@ module Google
         end
 
         ##
+        # Checks if the query job is using legacy sql.
+        def use_legacy_sql?
+          val = @gapi.configuration.query.use_legacy_sql
+          return false if val.nil?
+          val
+        end
+
+        ##
         # Retrieves the query results for the job.
         #
         # @param [String] token Page token, returned by a previous call,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -397,7 +397,8 @@ module Google
                 write_disposition: write_disposition(options[:write]),
                 allow_large_results: options[:large_results],
                 flatten_results: options[:flatten],
-                default_dataset: default_dataset
+                default_dataset: default_dataset,
+                use_legacy_sql: options[:use_legacy_sql]
               )
             )
           )
@@ -412,7 +413,8 @@ module Google
             default_dataset: dataset_config,
             timeout_ms: options[:timeout],
             dry_run: options[:dryrun],
-            use_query_cache: options[:cache]
+            use_query_cache: options[:cache],
+            use_legacy_sql: options[:use_legacy_sql]
           )
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -367,10 +367,12 @@ module Google
         #
         # @!group Data
         #
-        def data max: nil, timeout: 10000, cache: true, dryrun: nil
+        def data max: nil, timeout: 10000, cache: true, dryrun: nil,
+                 use_legacy_sql: true
           sql = "SELECT * FROM #{query_id}"
           ensure_service!
-          options = { max: max, timeout: timeout, cache: cache, dryrun: dryrun }
+          options = { max: max, timeout: timeout, cache: cache, dryrun: dryrun,
+                      use_legacy_sql: use_legacy_sql }
           gapi = service.query sql, options
           QueryData.from_gapi gapi, service
         end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
@@ -200,7 +200,8 @@ describe Google::Cloud::Bigquery::QueryJob, :query_results, :mock_bigquery do
       "priority" => "BATCH",
       "allowLargeResults" => true,
       "useQueryCache" => true,
-      "flattenResults" => true
+      "flattenResults" => true,
+      "useLegacySql" => true,
     }
     hash
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -45,6 +45,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     job.must_be :large_results?
     job.must_be :cache?
     job.must_be :flatten?
+    job.must_be :use_legacy_sql?
   end
 
   it "knows its statistics data" do
@@ -82,7 +83,8 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
       "priority" => "BATCH",
       "allowLargeResults" => true,
       "useQueryCache" => true,
-      "flattenResults" => true
+      "flattenResults" => true,
+      "useLegacySql" => true
     }
     hash["statistics"]["query"] = {
       "cacheHit" => false,

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -328,7 +328,8 @@ class MockBigquery < Minitest::Spec
           "priority" => "INTERACTIVE",
           "allowLargeResults" => nil,
           "useQueryCache" => true,
-          "flattenResults" => nil
+          "flattenResults" => nil,
+          "useLegacySql" => true
         }
       }
     }.to_json
@@ -343,7 +344,8 @@ class MockBigquery < Minitest::Spec
       max_results: nil,
       query: "SELECT name, age, score, active FROM [some_project:some_dataset.users]",
       timeout_ms: 10000,
-      use_query_cache: true
+      use_query_cache: true,
+      use_legacy_sql: true,
     )
   end
 


### PR DESCRIPTION
Add argument of use_legacy_sql for #query and #query_job .
Can use BigQuery's [standard SQL](https://cloud.google.com/bigquery/sql-reference/) if use_legacy_sql is false(default true).
