### PR TITLE
Added chunk_size option to the bigquery::table::load method

### DIFF
--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -748,7 +748,8 @@ module Gcloud
       def load file, format: nil, create: nil, write: nil,
                projection_fields: nil, jagged_rows: nil, quoted_newlines: nil,
                encoding: nil, delimiter: nil, ignore_unknown: nil,
-               max_bad_records: nil, quote: nil, skip_leading: nil, dryrun: nil
+               max_bad_records: nil, quote: nil, skip_leading: nil,
+               dryrun: nil, chunk_size: nil
         ensure_connection!
         options = { format: format, create: create, write: write,
                     projection_fields: projection_fields,
@@ -756,7 +757,8 @@ module Gcloud
                     encoding: encoding, delimiter: delimiter,
                     ignore_unknown: ignore_unknown,
                     max_bad_records: max_bad_records, quote: quote,
-                    skip_leading: skip_leading, dryrun: dryrun }
+                    skip_leading: skip_leading, dryrun: dryrun,
+                    chunk_size: chunk_size }
         return load_storage(file, options) if storage_url? file
         return load_local(file, options) if local_file? file
         fail Gcloud::Bigquery::Error, "Don't know how to load #{file}"


### PR DESCRIPTION
I was using version 0.10 where the chunk_size option was introduced for the bigquery::table::load method. But there we have an error in the method bigquery:table:load_resumable ( line 920).

The calculation for the file size should be File.size(file) instead of file.length.

I was checking the version 0.11 and I realised that the chunk_size option was removed again. So I added it again and added a test in order to ensure that if is removed accidentally in the future a test will fail.
