### PR TITLE
Add GAX client_config to service factory

### DIFF
--- a/google-cloud-language/acceptance/language_helper.rb
+++ b/google-cloud-language/acceptance/language_helper.rb
@@ -19,7 +19,7 @@ require "minitest/rg"
 require "google/cloud/language"
 
 # Create shared language object so we don't create new for each test
-$language = Google::Cloud.language retries: 10
+$language = Google::Cloud.language
 
 require "google/cloud/storage"
 

--- a/google-cloud-language/lib/google-cloud-language.rb
+++ b/google-cloud-language/lib/google-cloud-language.rb
@@ -38,8 +38,9 @@ module Google
     #   The default scope is:
     #
     #   * `"https://www.googleapis.com/auth/cloud-platform"`
-    # @param [Integer] retries This option is not currently supported.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
+    # @param [Hash] client_config A hash of values to override the default
+    #   behavior of the API client. See Google::Gax::CallSettings. Optional.
     #
     # @return [Google::Cloud::Language::Project]
     #
@@ -60,10 +61,10 @@ module Google
     #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
     #   language = gcloud.language scope: platform_scope
     #
-    def language scope: nil, retries: nil, timeout: nil
-      Google::Cloud.language @project, @keyfile, scope: scope,
-                                                 retries: (retries || @retries),
-                                                 timeout: (timeout || @timeout)
+    def language scope: nil, timeout: nil, client_config: nil
+      Google::Cloud.language @project, @keyfile,
+                             scope: scope, timeout: (timeout || @timeout),
+                             client_config: client_config
     end
 
     ##
@@ -85,8 +86,9 @@ module Google
     #   The default scope is:
     #
     #   * `"https://www.googleapis.com/auth/cloud-platform"`
-    # @param [Integer] retries  This option is not currently supported.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
+    # @param [Hash] client_config A hash of values to override the default
+    #   behavior of the API client. See Google::Gax::CallSettings. Optional.
     #
     # @return [Google::Cloud::Language::Project]
     #
@@ -99,8 +101,8 @@ module Google
     #   document = language.document content
     #   annotation = document.annotate
     #
-    def self.language project = nil, keyfile = nil, scope: nil, retries: nil,
-                      timeout: nil
+    def self.language project = nil, keyfile = nil, scope: nil, timeout: nil,
+                      client_config: nil
       require "google/cloud/language"
       project ||= Google::Cloud::Language::Project.default_project
       if keyfile.nil?
@@ -111,7 +113,7 @@ module Google
       end
       Google::Cloud::Language::Project.new(
         Google::Cloud::Language::Service.new(
-          project, credentials, retries: retries, timeout: timeout))
+          project, credentials, timeout: timeout, client_config: client_config))
     end
   end
 end

--- a/google-cloud-language/lib/google/cloud/language/service.rb
+++ b/google-cloud-language/lib/google/cloud/language/service.rb
@@ -26,16 +26,16 @@ module Google
       # @private Represents the gRPC Language service, including all the API
       # methods.
       class Service
-        attr_accessor :project, :credentials, :host, :retries, :timeout
+        attr_accessor :project, :credentials, :host, :client_config, :timeout
 
         ##
         # Creates a new Service instance.
-        def initialize project, credentials, host: nil, retries: nil,
+        def initialize project, credentials, host: nil, client_config: nil,
                        timeout: nil
           @project = project
           @credentials = credentials
           @host = host || V1beta1::LanguageServiceApi::SERVICE_ADDRESS
-          @retries = retries
+          @client_config = client_config || {}
           @timeout = timeout
         end
 
@@ -51,13 +51,13 @@ module Google
 
         def service
           return mocked_service if mocked_service
-          @service ||= \
-            V1beta1::LanguageServiceApi.new(
-              service_path: host,
-              channel: channel,
-              timeout: timeout,
-              app_name: "google-cloud-language",
-              app_version: Google::Cloud::Language::VERSION)
+          @service ||= V1beta1::LanguageServiceApi.new(
+            service_path: host,
+            channel: channel,
+            timeout: timeout,
+            client_config: client_config,
+            app_name: "google-cloud-language",
+            app_version: Google::Cloud::Language::VERSION)
         end
         attr_accessor :mocked_service
 

--- a/google-cloud-language/test/google/cloud/language_test.rb
+++ b/google-cloud-language/test/google/cloud/language_test.rb
@@ -18,12 +18,12 @@ describe Google::Cloud do
   describe "#language" do
     it "calls out to Google::Cloud.language" do
       gcloud = Google::Cloud.new
-      stubbed_language = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_language = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal nil
         keyfile.must_equal nil
         scope.must_be :nil?
-        retries.must_be :nil?
         timeout.must_be :nil?
+        client_config.must_be :nil?
         "language-project-object-empty"
       }
       Google::Cloud.stub :language, stubbed_language do
@@ -34,12 +34,12 @@ describe Google::Cloud do
 
     it "passes project and keyfile to Google::Cloud.language" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_language = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_language = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_be :nil?
-        retries.must_be :nil?
         timeout.must_be :nil?
+        client_config.must_be :nil?
         "language-project-object"
       }
       Google::Cloud.stub :language, stubbed_language do
@@ -50,16 +50,16 @@ describe Google::Cloud do
 
     it "passes project and keyfile and options to Google::Cloud.language" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_language = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_language = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_equal "http://example.com/scope"
-        retries.must_equal 5
         timeout.must_equal 60
+        client_config.must_equal({ "gax" => "options" })
         "language-project-object-scoped"
       }
       Google::Cloud.stub :language, stubbed_language do
-        project = gcloud.language scope: "http://example.com/scope", retries: 5, timeout: 60
+        project = gcloud.language scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
         project.must_equal "language-project-object-scoped"
       end
     end
@@ -90,11 +90,11 @@ describe Google::Cloud do
         scope.must_equal nil
         "language-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "language-credentials"
-        retries.must_equal nil
         timeout.must_equal nil
+        client_config.must_equal nil
         OpenStruct.new project: project
       }
 


### PR DESCRIPTION
Language is the first service using GAX. GAX implements retries and incremental backoff, and our original plan was to make it conform to the `retries` value used by other services. However, GAX is different enough that it probably isn't feasible to share the same configuration approach as Google API Client. Therefore, here is an option for allowing users to configure the GAX client while continuing to use Google Cloud. See also #849 for overriding the GAX configuration on API calls. Either approach is independent of the other.

This change replaces `retries` with `client_config`; it effectively leaks the GAX implementation to the Google Cloud Language public API. This means that if GAX ever changes its implementation Google Cloud Language may need to also make a breaking change to support the new GAX API. So far we have resisted leaking these types of details, but there is no better way to allow the GAX client to be fully configurable other than leaking these details.

What do you think of this type of change? Is this a direction you want to see the other GRPC/GAX services move towards?

The `client_config` hash can contain any part of the [config JSON](https://github.com/GoogleCloudPlatform/gcloud-ruby/blob/master/google-cloud-language/lib/google/cloud/language/v1beta1/language_service_client_config.json) that is intended to be overridden. Here is what this may look like:

```ruby
my_config = {"interfaces"=>
              {"google.cloud.language.v1beta1.LanguageService"=>
                {"retry_codes"=>
                  {"retry_codes_def"=>
                    {"idempotent"=>["DEADLINE_EXCEEDED", "UNAVAILABLE"],
                     "non_idempotent"=>[]}},
                 "retry_params"=>
                  {"default"=>
                    {"initial_retry_delay_millis"=>100,
                     "retry_delay_multiplier"=>1.3,
                     "max_retry_delay_millis"=>60000,
                     "initial_rpc_timeout_millis"=>60000,
                     "rpc_timeout_multiplier"=>1.0,
                     "max_rpc_timeout_millis"=>60000,
                     "total_timeout_millis"=>600000}}}}}

require "google/cloud"

gcloud = Google::Cloud.new
lang = gcloud.language client_config: my_config
```