### PR TITLE
Add GAX call_options to methods making API calls

### DIFF
--- a/google-cloud-language/lib/google/cloud/language/document.rb
+++ b/google-cloud-language/lib/google/cloud/language/document.rb
@@ -143,6 +143,8 @@ module Google
         #   Optional.
         # @param [String] encoding The encoding type used by the API to
         #   calculate offsets. Optional.
+        # @param [Hash] call_options A hash of values to override the default
+        #   behavior of the API call. See Google::Gax::CallOptions. Optional.
         #
         # @return [Annotation>] The results for the content analysis.
         #
@@ -158,11 +160,12 @@ module Google
         #   annotation.thing #=> Some Result
         #
         def annotate text: false, entities: false, sentiment: false,
-                     encoding: nil
+                     encoding: nil, call_options: nil
           ensure_service!
           grpc = service.annotate to_grpc, text: text, entities: entities,
                                            sentiment: sentiment,
-                                           encoding: encoding
+                                           encoding: encoding,
+                                           call_options: call_options
           Annotation.from_grpc grpc
         end
         alias_method :mark, :annotate
@@ -173,6 +176,8 @@ module Google
         #
         # @param [String] encoding The encoding type used by the API to
         #   calculate offsets. Optional.
+        # @param [Hash] call_options A hash of values to override the default
+        #   behavior of the API call. See Google::Gax::CallOptions. Optional.
         #
         # @return [Annotation::Entities>] The results for the entities analysis.
         #
@@ -187,14 +192,18 @@ module Google
         #   entities = doc.entities
         #   entities.count #=> 2
         #
-        def entities encoding: nil
+        def entities encoding: nil, call_options: nil
           ensure_service!
-          grpc = service.entities to_grpc, encoding: encoding
+          grpc = service.entities to_grpc, encoding: encoding,
+                                           call_options: call_options
           Annotation::Entities.from_grpc grpc
         end
 
         ##
         # TODO: Details
+        #
+        # @param [Hash] call_options A hash of values to override the default
+        #   behavior of the API call. See Google::Gax::CallOptions. Optional.
         #
         # @return [Annotation::Sentiment>] The results for the sentiment
         #   analysis.
@@ -211,9 +220,9 @@ module Google
         #   sentiment.polarity #=> 1.0
         #   sentiment.magnitude #=> 0.8999999761581421
         #
-        def sentiment
+        def sentiment call_options: nil
           ensure_service!
-          grpc = service.sentiment to_grpc
+          grpc = service.sentiment to_grpc, call_options: call_options
           Annotation::Sentiment.from_grpc grpc
         end
 

--- a/google-cloud-language/lib/google/cloud/language/project.rb
+++ b/google-cloud-language/lib/google/cloud/language/project.rb
@@ -155,6 +155,8 @@ module Google
         #   BCP-47 language codes are accepted. Optional.
         # @param [String] encoding The encoding type used by the API to
         #   calculate offsets. Optional.
+        # @param [Hash] call_options A hash of values to override the default
+        #   behavior of the API call. See Google::Gax::CallOptions. Optional.
         #
         # @return [Annotation>] The results for the content analysis.
         #
@@ -170,12 +172,14 @@ module Google
         #   annotation.thing #=> Some Result
         #
         def annotate content, text: false, entities: false, sentiment: false,
-                     format: nil, language: nil, encoding: nil
+                     format: nil, language: nil, encoding: nil,
+                     call_options: nil
           ensure_service!
           doc = document content, language: language, format: format
           grpc = service.annotate doc.to_grpc, text: text, entities: entities,
                                                sentiment: sentiment,
-                                               encoding: encoding
+                                               encoding: encoding,
+                                               call_options: call_options
           Annotation.from_grpc grpc
         end
         alias_method :mark, :annotate
@@ -194,6 +198,8 @@ module Google
         #   BCP-47 language codes are accepted. Optional.
         # @param [String] encoding The encoding type used by the API to
         #   calculate offsets. Optional.
+        # @param [Hash] call_options A hash of values to override the default
+        #   behavior of the API call. See Google::Gax::CallOptions. Optional.
         #
         # @return [Annotation::Entities>] The results for the entities analysis.
         #
@@ -208,10 +214,12 @@ module Google
         #   entities = language.entities doc
         #   entities.count #=> 2
         #
-        def entities content, format: :text, language: nil, encoding: nil
+        def entities content, format: :text, language: nil, encoding: nil,
+                     call_options: nil
           ensure_service!
           doc = document content, language: language, format: format
-          grpc = service.entities doc.to_grpc, encoding: encoding
+          grpc = service.entities doc.to_grpc, encoding: encoding,
+                                               call_options: call_options
           Annotation::Entities.from_grpc grpc
         end
 
@@ -226,6 +234,8 @@ module Google
         # @param [String] language The language of the document (if not
         #   specified, the language is automatically detected). Both ISO and
         #   BCP-47 language codes are accepted. Optional.
+        # @param [Hash] call_options A hash of values to override the default
+        #   behavior of the API call. See Google::Gax::CallOptions. Optional.
         #
         # @return [Annotation::Sentiment>] The results for the sentiment
         #   analysis.
@@ -242,10 +252,10 @@ module Google
         #   sentiment.polarity #=> 1.0
         #   sentiment.magnitude #=> 0.8999999761581421
         #
-        def sentiment content, format: :text, language: nil
+        def sentiment content, format: :text, language: nil, call_options: nil
           ensure_service!
           doc = document content, language: language, format: format
-          grpc = service.sentiment doc.to_grpc
+          grpc = service.sentiment doc.to_grpc, call_options: call_options
           Annotation::Sentiment.from_grpc grpc
         end
 

--- a/google-cloud-language/lib/google/cloud/language/service.rb
+++ b/google-cloud-language/lib/google/cloud/language/service.rb
@@ -67,7 +67,7 @@ module Google
         ##
         # Returns API::BatchAnnotateImagesResponse
         def annotate doc_grpc, text: false, entities: false, sentiment: false,
-                     encoding: nil
+                     encoding: nil, call_options: nil
           if text == false && entities == false && sentiment == false
             text = true
             entities = true
@@ -77,16 +77,21 @@ module Google
             extract_syntax: text, extract_entities: entities,
             extract_document_sentiment: sentiment)
           encoding = verify_encoding! encoding
-          execute { service.annotate_text doc_grpc, features, encoding }
+          execute do
+            service.annotate_text doc_grpc, features, encoding,
+                                  options: call_options
+          end
         end
 
-        def entities doc_grpc, encoding: nil
+        def entities doc_grpc, encoding: nil, call_options: nil
           encoding = verify_encoding! encoding
-          execute { service.analyze_entities doc_grpc, encoding }
+          execute do
+            service.analyze_entities doc_grpc, encoding, options: call_options
+          end
         end
 
-        def sentiment doc_grpc
-          execute { service.analyze_sentiment doc_grpc }
+        def sentiment doc_grpc, call_options: nil
+          execute { service.analyze_sentiment doc_grpc, options: call_options }
         end
 
         def inspect

--- a/google-cloud-language/test/google/cloud/language/document/full_html_annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/document/full_html_annotation_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Language::Document, :full_html_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
     doc.service.mocked_service = mock
     annotation = doc.annotate
@@ -42,7 +42,7 @@ describe Google::Cloud::Language::Document, :full_html_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
     doc.service.mocked_service = mock
     doc.language = "en"

--- a/google-cloud-language/test/google/cloud/language/document/full_text_annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/document/full_text_annotation_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Language::Document, :full_text_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
     doc.service.mocked_service = mock
     annotation = doc.annotate
@@ -42,7 +42,7 @@ describe Google::Cloud::Language::Document, :full_text_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
     doc.service.mocked_service = mock
     doc.text!
@@ -60,7 +60,7 @@ describe Google::Cloud::Language::Document, :full_text_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
     doc.service.mocked_service = mock
     doc.text!
@@ -79,7 +79,7 @@ describe Google::Cloud::Language::Document, :full_text_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
     doc.service.mocked_service = mock
     doc.language = :en

--- a/google-cloud-language/test/google/cloud/language/project/full_html_annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/project/full_html_annotation_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate html_content, format: :html
@@ -41,7 +41,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate html_content, format: :html, language: :en
@@ -60,7 +60,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document html_content, format: :html
@@ -78,7 +78,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document html_content, format: :html, language: :en
@@ -97,7 +97,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         doc = language.html html_content
@@ -115,7 +115,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         doc = language.html html_content, language: :en
@@ -136,7 +136,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", format: :html
@@ -153,7 +153,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", format: :html, language: :en
@@ -170,7 +170,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.html"
@@ -189,7 +189,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", format: :html
@@ -207,7 +207,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", format: :html, language: :en
@@ -225,7 +225,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.html"
@@ -244,7 +244,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         doc = language.html "gs://bucket/path.ext"
@@ -262,7 +262,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         doc = language.html "gs://bucket/path.ext", language: :en
@@ -283,7 +283,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -301,7 +301,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -319,7 +319,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.html"
@@ -339,7 +339,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -358,7 +358,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -377,7 +377,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.html"
@@ -397,7 +397,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -416,7 +416,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"

--- a/google-cloud-language/test/google/cloud/language/project/full_text_annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/project/full_text_annotation_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate text_content
@@ -41,7 +41,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate text_content, format: :text
@@ -58,7 +58,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate text_content, format: :text, language: :en
@@ -75,7 +75,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate text_content, language: :en
@@ -94,7 +94,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document text_content
@@ -112,7 +112,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document text_content, format: :text
@@ -130,7 +130,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document text_content, format: :text, language: :en
@@ -148,7 +148,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document text_content, language: :en
@@ -167,7 +167,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         doc = language.text text_content
@@ -185,7 +185,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         doc = language.text text_content, language: :en
@@ -206,7 +206,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext"
@@ -223,7 +223,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", format: :text
@@ -240,7 +240,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", format: :text, language: :en
@@ -257,7 +257,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", language: :en
@@ -276,7 +276,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext"
@@ -294,7 +294,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", format: :text
@@ -312,7 +312,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", format: :text, language: :en
@@ -330,7 +330,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", language: :en
@@ -349,7 +349,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         doc = language.text "gs://bucket/path.ext"
@@ -367,7 +367,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         doc = language.text "gs://bucket/path.ext", language: :en
@@ -388,7 +388,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -406,7 +406,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -424,7 +424,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -442,7 +442,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -462,7 +462,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -481,7 +481,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -500,7 +500,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -519,7 +519,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -539,7 +539,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -558,7 +558,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: nil]
 
         language.service.mocked_service = mock
         gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"


### PR DESCRIPTION
This is an attempt to allow users more control over the behavior of the client making API calls. GAX implements retries and incremental backoff, but the GAX configuration is a bit different than what is used by other services. This is an option to allow users to override the GAX configuration on the API call while continuing to use Google Cloud. #848 allows users to configure the client settings, but this PR is for configuring the API call settings. Either approach is independent of the other.

This change is additive, but it does leak the GAX implementation to the Google Cloud Language public API. This means that if GAX ever changes its implementation Google Cloud Language may need to also make a breaking change to support the new GAX API. So far we have resisted leaking these types of details, but there is no better way to allow the GAX client to be fully configurable other than leaking these details.

What do you think of this type of change? Is this a direction you want to see the other GRPC/GAX services move towards?

The call_config hash can contain any part of the [GAX CallOptions](http://www.rubydoc.info/gems/google-gax/0.4.4/Google/Gax/CallOptions) object structure. Here is what this may look like:

``` ruby
my_options = {"retry_options"=>
               {"backoff_settings"=>
                 {"initial_retry_delay_millis"=>100,
                  "retry_delay_multiplier"=>1.3,
                  "max_retry_delay_millis"=>60000,
                  "initial_rpc_timeout_millis"=>60000,
                  "rpc_timeout_multiplier"=>1.0,
                  "max_rpc_timeout_millis"=>60000,
                  "total_timeout_millis"=>600000},
                "retry_codes"=>["DEADLINE_EXCEEDED", "UNAVAILABLE"]}

require "google/cloud"

gcloud = Google::Cloud.new
results = gcloud.language.annotate "Hello world!", call_options: my_options
```
