### PR TITLE
Use post-install message

### DIFF
--- a/gcloud/gcloud.gemspec
+++ b/gcloud/gcloud.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+
+  gem.post_install_message = "gcloud is now google-cloud, please change the gem name in your dependencies"
 end


### PR DESCRIPTION
The `post_install_message` will will be shown when the gem is first installed. We can use this message to direct users to migrate to google-cloud. What do you think?