### PR TITLE
Override #inspect on Document and Annotation

### DIFF
--- a/google-cloud-language/lib/google/cloud/language/annotation.rb
+++ b/google-cloud-language/lib/google/cloud/language/annotation.rb
@@ -70,6 +70,19 @@ module Google
           @grpc.language
         end
 
+        # @private
+        def to_s
+          tmplt = "(sentences: %i, tokens: %i, entities: %i," \
+                  " sentiment: %s, language: %s)"
+          format tmplt, sentences.count, tokens.count, entities.count,
+                 !sentiment.nil?, language.inspect
+        end
+
+        # @private
+        def inspect
+          "#<#{self.class.name} #{self}>"
+        end
+
         ##
         # @private New Annotation from a V1beta1::AnnotateTextResponse object.
         def self.from_grpc grpc

--- a/google-cloud-language/lib/google/cloud/language/document.rb
+++ b/google-cloud-language/lib/google/cloud/language/document.rb
@@ -217,6 +217,11 @@ module Google
           Annotation::Sentiment.from_grpc grpc
         end
 
+        # @private
+        def inspect
+          "#<#{self.class.name} (#{(content? ? "\"#{source[0,16]}...\"" : source)}, format: #{format.inspect}, language: #{language.inspect})>"
+        end
+
         ##
         # @private New gRPC object.
         def to_grpc

--- a/google-cloud-language/test/google/cloud/language/annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/annotation_test.rb
@@ -108,4 +108,9 @@ describe Google::Cloud::Language::Annotation, :mock_language do
     token.label.must_equal :ROOT
     token.lemma.must_equal "Hello"
   end
+
+  it "has a pretty #inspect" do
+    annotation = Google::Cloud::Language::Annotation.from_grpc html_annotation_grpc
+    annotation.inspect.must_equal %{#<Google::Cloud::Language::Annotation (sentences: 3, tokens: 24, entities: 2, sentiment: true, language: "en")>}
+  end
 end

--- a/google-cloud-language/test/google/cloud/language/document_test.rb
+++ b/google-cloud-language/test/google/cloud/language/document_test.rb
@@ -112,4 +112,12 @@ describe Google::Cloud::Language::Document, :mock_language do
     doc.language = nil
     doc.language.must_equal ""
   end
+
+  it "has a pretty #inspect" do
+    doc1 = language.document "Four score and seven years ago our fathers brought forth on this continent a new nation, conceived in liberty, and dedicated to the proposition that all men are created equal."
+    doc1.inspect.must_equal %{#<Google::Cloud::Language::Document ("Four score and s...", format: :text, language: "")>}
+
+    doc2 = language.document "gs://bucket-name/path/to/document.ext"
+    doc2.inspect.must_equal %{#<Google::Cloud::Language::Document (gs://bucket-name/path/to/document.ext, format: :text, language: "")>}
+  end
 end


### PR DESCRIPTION
This makes working with these objects in an interactive console much better.

Here is what IRB looks like with this code:

```
$ rake console
irb(main):001:0> doc = gcloud.language.document "Darth Vader is the best villain in Star Wars"
=> #<Google::Cloud::Language::Document ("Darth Vader is t...", format: :text, language: "")>
irb(main):002:0> annotation = doc.annotate
=> #<Google::Cloud::Language::Annotation (sentences: 1, tokens: 9, entities: 1, sentiment: true, language: "en")>
irb(main):003:0> annotation.sentences
=> [#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f828428 @text="Darth Vader is the best villain in 
Star Wars", @offset=0>]
irb(main):004:0> annotation.tokens
=> [#<Google::Cloud::Language::Annotation::Token:0x007fd62f828388 
@text_span=#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f8283b0 @text="Darth", @offset=0>, 
@part_of_speech=:NOUN, @head_token_index=1, @label=:NN, @lemma="Darth">, 
#<Google::Cloud::Language::Annotation::Token:0x007fd62f828338 
@text_span=#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f828360 @text="Vader", @offset=6>, 
@part_of_speech=:NOUN, @head_token_index=2, @label=:NSUBJ, @lemma="Vader">, 
#<Google::Cloud::Language::Annotation::Token:0x007fd62f8282e8 
@text_span=#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f828310 @text="is", @offset=12>, 
@part_of_speech=:VERB, @head_token_index=2, @label=:ROOT, @lemma="be">, 
#<Google::Cloud::Language::Annotation::Token:0x007fd62f828298 
@text_span=#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f8282c0 @text="the", @offset=15>, 
@part_of_speech=:DET, @head_token_index=5, @label=:DET, @lemma="the">, 
#<Google::Cloud::Language::Annotation::Token:0x007fd62f828248 
@text_span=#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f828270 @text="best", @offset=19>, 
@part_of_speech=:ADJ, @head_token_index=5, @label=:AMOD, @lemma="good">, 
#<Google::Cloud::Language::Annotation::Token:0x007fd62f8281f8 
@text_span=#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f828220 @text="villain", @offset=24>, 
@part_of_speech=:NOUN, @head_token_index=2, @label=:ATTR, @lemma="villain">, 
#<Google::Cloud::Language::Annotation::Token:0x007fd62f828158 
@text_span=#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f8281d0 @text="in", @offset=32>, 
@part_of_speech=:ADP, @head_token_index=5, @label=:PREP, @lemma="in">, 
#<Google::Cloud::Language::Annotation::Token:0x007fd62f828108 
@text_span=#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f828130 @text="Star", @offset=35>, 
@part_of_speech=:NOUN, @head_token_index=8, @label=:TITLE, @lemma="Star">, 
#<Google::Cloud::Language::Annotation::Token:0x007fd62f828090 
@text_span=#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f8280b8 @text="Wars", @offset=40>, 
@part_of_speech=:NOUN, @head_token_index=6, @label=:POBJ, @lemma="Wars">]
irb(main):005:0> annotation.entities
=> [#<Google::Cloud::Language::Annotation::Entity:0x007fd62f81be30 @name="Darth Vader", @type=:PERSON, 
@metadata={"wikipedia_url"=>"http://en.wikipedia.org/wiki/Darth_Vader"}, @salience=0.8048039674758911, 
@mentions=[#<Google::Cloud::Language::Annotation::TextSpan:0x007fd62f81be58 @text="Darth Vader", @offset=0>]>]
irb(main):006:0> annotation.sentiment
=> #<Google::Cloud::Language::Annotation::Sentiment:0x007fd62f81bdb8 @polarity=1.0, 
@magnitude=0.8999999761581421, @language="en">
```