### PR TITLE
Improve Language use of "syntax"

### DIFF
--- a/google-cloud-language/acceptance/language/html_test.rb
+++ b/google-cloud-language/acceptance/language/html_test.rb
@@ -196,6 +196,50 @@ describe "Language (HTML)", :language do
     end
   end
 
+  describe "syntax" do
+    it "works without creating a document" do
+      annotation = language.syntax content, format: :html
+
+      annotation.language.must_equal "en"
+
+      annotation.sentiment.must_be :nil?
+
+      annotation.entities.must_be :empty?
+
+      annotation.sentences.map(&:text).must_equal [hello, sayhi, ruby]
+      annotation.tokens.count.must_equal 24
+      token = annotation.tokens.first
+      token.text.must_equal "Hello"
+      token.part_of_speech.must_equal :X
+      token.head_token_index.must_equal 0
+      token.label.must_equal :ROOT
+      token.lemma.must_equal "Hello"
+    end
+
+    it "works with creating a document" do
+      doc = language.document content, format: :html
+      doc.must_be :html?
+      doc.wont_be :text?
+
+      annotation = doc.syntax
+
+      annotation.language.must_equal "en"
+
+      annotation.sentiment.must_be :nil?
+
+      annotation.entities.must_be :empty?
+
+      annotation.sentences.map(&:text).must_equal [hello, sayhi, ruby]
+      annotation.tokens.count.must_equal 24
+      token = annotation.tokens.first
+      token.text.must_equal "Hello"
+      token.part_of_speech.must_equal :X
+      token.head_token_index.must_equal 0
+      token.label.must_equal :ROOT
+      token.lemma.must_equal "Hello"
+    end
+  end
+
   describe "entities" do
     it "works without creating a document" do
       entities = language.entities content, format: :html

--- a/google-cloud-language/acceptance/language/html_test.rb
+++ b/google-cloud-language/acceptance/language/html_test.rb
@@ -123,13 +123,13 @@ describe "Language (HTML)", :language do
       token.lemma.must_equal "Hello"
     end
 
-    it "runs only the text feature" do
+    it "runs only the syntax feature" do
       doc = language.document content
       doc.html!
       doc.must_be :html?
       doc.wont_be :text?
 
-      annotation = doc.annotate text: true
+      annotation = doc.annotate syntax: true
 
       annotation.language.must_equal "en"
 

--- a/google-cloud-language/acceptance/language/storage/html_file_test.rb
+++ b/google-cloud-language/acceptance/language/storage/html_file_test.rb
@@ -164,13 +164,13 @@ describe "Language (HTML/Storage File)", :language do
       token.lemma.must_equal "Hello"
     end
 
-    it "runs only the text feature" do
+    it "runs only the syntax feature" do
       doc = language.document file, format: :text
       doc.html!
       doc.must_be :html?
       doc.wont_be :text?
 
-      annotation = doc.annotate text: true
+      annotation = doc.annotate syntax: true
 
       annotation.language.must_equal "en"
 

--- a/google-cloud-language/acceptance/language/storage/html_url_test.rb
+++ b/google-cloud-language/acceptance/language/storage/html_url_test.rb
@@ -164,13 +164,13 @@ describe "Language (HTML/Storage URL)", :language do
       token.lemma.must_equal "Hello"
     end
 
-    it "runs only the text feature" do
+    it "runs only the syntax feature" do
       doc = language.document url, format: :text
       doc.html!
       doc.must_be :html?
       doc.wont_be :text?
 
-      annotation = doc.annotate text: true
+      annotation = doc.annotate syntax: true
 
       annotation.language.must_equal "en"
 

--- a/google-cloud-language/acceptance/language/storage/text_file_test.rb
+++ b/google-cloud-language/acceptance/language/storage/text_file_test.rb
@@ -162,13 +162,13 @@ describe "Language (TEXT/Storage File)", :language do
       token.lemma.must_equal "Hello"
     end
 
-    it "runs only the text feature" do
+    it "runs only the syntax feature" do
       doc = language.document file, format: :text
       doc.text!
       doc.must_be :text?
       doc.wont_be :html?
 
-      annotation = doc.annotate text: true
+      annotation = doc.annotate syntax: true
 
       annotation.language.must_equal "en"
 

--- a/google-cloud-language/acceptance/language/storage/text_url_test.rb
+++ b/google-cloud-language/acceptance/language/storage/text_url_test.rb
@@ -163,13 +163,13 @@ describe "Language (TEXT/Storage URL)", :language do
       token.lemma.must_equal "Hello"
     end
 
-    it "runs only the text feature" do
+    it "runs only the syntax feature" do
       doc = language.document url, format: :text
       doc.text!
       doc.must_be :text?
       doc.wont_be :html?
 
-      annotation = doc.annotate text: true
+      annotation = doc.annotate syntax: true
 
       annotation.language.must_equal "en"
 

--- a/google-cloud-language/acceptance/language/text_test.rb
+++ b/google-cloud-language/acceptance/language/text_test.rb
@@ -230,6 +230,50 @@ describe "Language (TEXT)", :language do
     end
   end
 
+  describe "syntax" do
+    it "works without creating a document" do
+      annotation = language.syntax content, format: :text
+
+      annotation.language.must_equal "en"
+
+      annotation.sentiment.must_be :nil?
+
+      annotation.entities.must_be :empty?
+
+      annotation.sentences.map(&:text).must_equal [hello, sayhi, ruby]
+      annotation.tokens.count.must_equal 24
+      token = annotation.tokens.first
+      token.text.must_equal "Hello"
+      token.part_of_speech.must_equal :X
+      token.head_token_index.must_equal 0
+      token.label.must_equal :ROOT
+      token.lemma.must_equal "Hello"
+    end
+
+    it "works with creating a document" do
+      doc = language.document content
+      doc.must_be :text?
+      doc.wont_be :html?
+
+      annotation = doc.syntax
+
+      annotation.language.must_equal "en"
+
+      annotation.sentiment.must_be :nil?
+
+      annotation.entities.must_be :empty?
+
+      annotation.sentences.map(&:text).must_equal [hello, sayhi, ruby]
+      annotation.tokens.count.must_equal 24
+      token = annotation.tokens.first
+      token.text.must_equal "Hello"
+      token.part_of_speech.must_equal :X
+      token.head_token_index.must_equal 0
+      token.label.must_equal :ROOT
+      token.lemma.must_equal "Hello"
+    end
+  end
+
   describe "entities" do
     it "works without creating a document" do
       entities = language.entities content, format: :text

--- a/google-cloud-language/acceptance/language/text_test.rb
+++ b/google-cloud-language/acceptance/language/text_test.rb
@@ -157,13 +157,13 @@ describe "Language (TEXT)", :language do
       token.lemma.must_equal "Hello"
     end
 
-    it "runs only the text feature" do
+    it "runs only the syntax feature" do
       doc = language.document content, format: :text
       doc.text!
       doc.must_be :text?
       doc.wont_be :html?
 
-      annotation = doc.annotate text: true
+      annotation = doc.annotate syntax: true
 
       annotation.language.must_equal "en"
 

--- a/google-cloud-language/lib/google/cloud/language/document.rb
+++ b/google-cloud-language/lib/google/cloud/language/document.rb
@@ -174,6 +174,29 @@ module Google
         # @param [String] encoding The encoding type used by the API to
         #   calculate offsets. Optional.
         #
+        # @return [Annotation>] The results for the content analysis.
+        #
+        # @example
+        #   require "google/cloud"
+        #
+        #   gcloud = Google::Cloud.new
+        #   language = gcloud.language
+        #
+        #   doc = language.document "Hello world!"
+        #
+        #   annotation = doc.syntax
+        #   annotation.thing #=> Some Result
+        #
+        def syntax encoding: nil
+          annotate syntax: true, encoding: nil
+        end
+
+        ##
+        # TODO: Details
+        #
+        # @param [String] encoding The encoding type used by the API to
+        #   calculate offsets. Optional.
+        #
         # @return [Annotation::Entities>] The results for the entities analysis.
         #
         # @example

--- a/google-cloud-language/lib/google/cloud/language/document.rb
+++ b/google-cloud-language/lib/google/cloud/language/document.rb
@@ -242,7 +242,9 @@ module Google
 
         # @private
         def inspect
-          "#<#{self.class.name} (#{(content? ? "\"#{source[0,16]}...\"" : source)}, format: #{format.inspect}, language: #{language.inspect})>"
+          "#<#{self.class.name} (" \
+            "#{(content? ? "\"#{source[0,16]}...\"" : source)}, " \
+            "format: #{format.inspect}, language: #{language.inspect})>"
         end
 
         ##

--- a/google-cloud-language/lib/google/cloud/language/document.rb
+++ b/google-cloud-language/lib/google/cloud/language/document.rb
@@ -135,7 +135,7 @@ module Google
         ##
         # TODO: Details
         #
-        # @param [Boolean] text Whether to perform the textual analysis.
+        # @param [Boolean] syntax Whether to perform the textual analysis.
         #   Optional.
         # @param [Boolean] entities Whether to perform the entitiy analysis.
         #   Optional.
@@ -157,10 +157,10 @@ module Google
         #   annotation = doc.annotate
         #   annotation.thing #=> Some Result
         #
-        def annotate text: false, entities: false, sentiment: false,
+        def annotate syntax: false, entities: false, sentiment: false,
                      encoding: nil
           ensure_service!
-          grpc = service.annotate to_grpc, text: text, entities: entities,
+          grpc = service.annotate to_grpc, syntax: syntax, entities: entities,
                                            sentiment: sentiment,
                                            encoding: encoding
           Annotation.from_grpc grpc

--- a/google-cloud-language/lib/google/cloud/language/project.rb
+++ b/google-cloud-language/lib/google/cloud/language/project.rb
@@ -185,6 +185,39 @@ module Google
         ##
         # TODO: Details
         #
+        # @param [String, Document, Google::Cloud::Storage::File] content The
+        #   content to annotate. This can be an {Document} instance, or any
+        #   other type that converts to an {Document}. See {#document} for
+        #   details.
+        # @param [String] format The format of the document (TEXT/HTML).
+        #   Optional.
+        # @param [String] language The language of the document (if not
+        #   specified, the language is automatically detected). Both ISO and
+        #   BCP-47 language codes are accepted. Optional.
+        # @param [String] encoding The encoding type used by the API to
+        #   calculate offsets. Optional.
+        #
+        # @return [Annotation>] The results for the content syntax analysis.
+        #
+        # @example
+        #   require "google/cloud"
+        #
+        #   gcloud = Google::Cloud.new
+        #   language = gcloud.language
+        #
+        #   doc = language.document "Hello world!"
+        #
+        #   annotation = language.syntax doc
+        #   annotation.thing #=> Some Result
+        #
+        def syntax content, format: nil, language: nil, encoding: nil
+          annotate content, syntax: true, format: format, language: language,
+                            encoding: encoding
+        end
+
+        ##
+        # TODO: Details
+        #
         # @param [String, Document] content The content to annotate. This
         #   can be an {Document} instance, or any other type that converts to an
         #   {Document}. See {#document} for details.

--- a/google-cloud-language/lib/google/cloud/language/project.rb
+++ b/google-cloud-language/lib/google/cloud/language/project.rb
@@ -142,7 +142,7 @@ module Google
         #   content to annotate. This can be an {Document} instance, or any
         #   other type that converts to an {Document}. See {#document} for
         #   details.
-        # @param [Boolean] text Whether to perform the textual analysis.
+        # @param [Boolean] syntax Whether to perform the textual analysis.
         #   Optional.
         # @param [Boolean] entities Whether to perform the entitiy analysis.
         #   Optional.
@@ -169,11 +169,12 @@ module Google
         #   annotation = language.annotate doc
         #   annotation.thing #=> Some Result
         #
-        def annotate content, text: false, entities: false, sentiment: false,
+        def annotate content, syntax: false, entities: false, sentiment: false,
                      format: nil, language: nil, encoding: nil
           ensure_service!
           doc = document content, language: language, format: format
-          grpc = service.annotate doc.to_grpc, text: text, entities: entities,
+          grpc = service.annotate doc.to_grpc, syntax: syntax,
+                                               entities: entities,
                                                sentiment: sentiment,
                                                encoding: encoding
           Annotation.from_grpc grpc

--- a/google-cloud-language/lib/google/cloud/language/service.rb
+++ b/google-cloud-language/lib/google/cloud/language/service.rb
@@ -66,15 +66,15 @@ module Google
 
         ##
         # Returns API::BatchAnnotateImagesResponse
-        def annotate doc_grpc, text: false, entities: false, sentiment: false,
+        def annotate doc_grpc, syntax: false, entities: false, sentiment: false,
                      encoding: nil
-          if text == false && entities == false && sentiment == false
-            text = true
+          if syntax == false && entities == false && sentiment == false
+            syntax = true
             entities = true
             sentiment = true
           end
           features = V1beta1::AnnotateTextRequest::Features.new(
-            extract_syntax: text, extract_entities: entities,
+            extract_syntax: syntax, extract_entities: entities,
             extract_document_sentiment: sentiment)
           encoding = verify_encoding! encoding
           execute { service.annotate_text doc_grpc, features, encoding }


### PR DESCRIPTION
Rename the `text` optional argument to `syntax`, and add `syntax` methods to Project and Document to run just the syntax analysis.