### PR TITLE
Fix issues around embedded entities

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
@@ -363,9 +363,9 @@ module Google
         # object.
         def to_grpc
           grpc = Google::Datastore::V1::Entity.new(
-            key: @key.to_grpc,
             properties: @properties.to_grpc
           )
+          grpc.key = @key.to_grpc unless @key.nil?
           update_properties_indexed! grpc.properties
           grpc
         end

--- a/google-cloud-datastore/lib/google/cloud/datastore/grpc_utils.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/grpc_utils.rb
@@ -102,6 +102,7 @@ module Google
           elsif Google::Cloud::Datastore::Key === value
             v.key_value = value.to_grpc
           elsif Google::Cloud::Datastore::Entity === value
+            value.key = nil # Embedded entities can't have keys
             v.entity_value = value.to_grpc
           elsif String === value
             v.string_value = value

--- a/google-cloud-datastore/lib/google/cloud/datastore/key.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/key.rb
@@ -265,6 +265,7 @@ module Google
         # @private Create a new Key from a Google::Datastore::V1::Key
         # object.
         def self.from_grpc grpc
+          return nil if grpc.nil?
           key_grpc = grpc.dup
           key = Key.new
           path_grpc = key_grpc.path.pop

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
@@ -46,6 +46,20 @@ describe Google::Cloud::Datastore::Entity do
     grpc.properties["email"].string_value.must_equal entity["email"]
   end
 
+  it "returns a correct GRPC object when key is nil" do
+    # This is important because embedded entities don't have a key
+    entity.key = nil
+    grpc = entity.to_grpc
+
+    # Key values
+    grpc.key.must_be :nil?
+
+    # Property values
+    grpc.properties.count.must_equal 2
+    grpc.properties["name"].string_value.must_equal entity["name"]
+    grpc.properties["email"].string_value.must_equal entity["email"]
+  end
+
   it "can be created with a GRPC object" do
     grpc = Google::Datastore::V1::Entity.new
     grpc.key = Google::Datastore::V1::Key.new

--- a/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
@@ -200,6 +200,14 @@ describe Google::Cloud::Datastore::Key do
     key.must_be :frozen?
   end
 
+  it "returns nil when the GRPC object is nil" do
+    # This is important because embedded entities don't have a key
+    grpc = nil
+    key = Google::Cloud::Datastore::Key.from_grpc grpc
+
+    key.must_be :nil?
+  end
+
   it "knows its serialized side" do
     # Don't care about the exact value, just want a number and no error
     key = Google::Cloud::Datastore::Key.new "ThisThing", 1234

--- a/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
@@ -139,7 +139,8 @@ describe Google::Cloud::Datastore::Properties do
     entity["name"] = "Thing 1"
     value = Google::Cloud::Core::GRPCUtils.to_value entity
     value.value_type.must_equal :entity_value
-    value.entity_value.must_equal entity.to_grpc
+    value.entity_value.properties.must_equal entity.to_grpc.properties
+    value.entity_value.key.must_be :nil? # embedded entities can't have keys
   end
 
   it "decodes Entity" do


### PR DESCRIPTION
Entities in another entity's properties will not have a key.
Ensure such entities can be decoded properly.
Also ensure such entities can be encoded properly.

[fixes #857]