### PR TITLE
Autoload all Google Cloud services

### DIFF
--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -68,3 +68,8 @@ module Google
     end
   end
 end
+
+# Auto-load all Google Cloud service gems.
+Gem.find_files("google-cloud-*.rb").each do |google_cloud_service|
+  require google_cloud_service
+end


### PR DESCRIPTION
When calling `require "google/cloud"` all service gems should also be loaded.
This happens automatically if Bundler's autorequire feature is on.
But if users aren't using Bundler then load all gems with this code.