### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The preview examples below demonstrate how to provide the **Project ID** and **C
 ### BigQuery
 
 - [google-cloud-bigquery README](google-cloud-bigquery/README.md)
-- [google-cloud-bigquery API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery)
+- [google-cloud-bigquery API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery/master/google/cloud/bigquery)
 - [google-cloud-bigquery on RubyGems](https://rubygems.org/gems/google-cloud-bigquery)
 - [Google Cloud BigQuery documentation](https://cloud.google.com/bigquery/docs)
 
@@ -88,7 +88,7 @@ end
 ### Datastore
 
 - [google-cloud-datastore README](google-cloud-datastore/README.md)
-- [google-cloud-datastore API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-datastore)
+- [google-cloud-datastore API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-datastore/master/google/cloud/datastore)
 - [google-cloud-datastore on RubyGems](https://rubygems.org/gems/google-cloud-datastore)
 - [Google Cloud Datastore documentation](https://cloud.google.com/datastore/docs)
 
@@ -129,7 +129,7 @@ tasks = datastore.run query
 ### DNS
 
 - [google-cloud-dns README](google-cloud-dns/README.md)
-- [google-cloud-dns API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-dns)
+- [google-cloud-dns API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-dns/master/google/cloud/dns)
 - [google-cloud-dns on RubyGems](https://rubygems.org/gems/google-cloud-dns)
 - [Google Cloud DNS documentation](https://cloud.google.com/dns/docs)
 
@@ -166,7 +166,7 @@ end
 ### Logging
 
 - [google-cloud-logging README](google-cloud-logging/README.md)
-- [google-cloud-logging API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging)
+- [google-cloud-logging API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/master/google/cloud/logging)
 - [google-cloud-logging on RubyGems](https://rubygems.org/gems/google-cloud-logging)
 - [Stackdriver Logging documentation](https://cloud.google.com/logging/docs/)
 
@@ -206,7 +206,7 @@ logging.write_entries entry
 ### Natural Language
 
 - [google-cloud-language README](google-cloud-language/README.md)
-- [google-cloud-language API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-language)
+- [google-cloud-language API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-language/master/google/cloud/language)
 - [google-cloud-language on RubyGems](https://rubygems.org/gems/[google-cloud-language)
 - [Google Cloud Natural Language API documentation](https://cloud.google.com/language/docs)
 
@@ -238,7 +238,7 @@ annotation.tokens.count #=> 10
 ### Pub/Sub
 
 - [google-cloud-pubsub README](google-cloud-pubsub/README.md)
-- [google-cloud-pubsub API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-pubsub)
+- [google-cloud-pubsub API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-pubsub/master/google/cloud/pubsub)
 - [google-cloud-pubsub on RubyGems](https://rubygems.org/gems/[google-cloud-pubsub)
 - [Google Cloud Pub/Sub documentation](https://cloud.google.com/pubsub/docs)
 
@@ -273,7 +273,7 @@ msgs = sub.pull
 ### Resource Manager
 
 - [google-cloud-resource_manager README](google-cloud-resource_manager/README.md)
-- [google-cloud-resource_manager API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-resource_manager)
+- [google-cloud-resource_manager API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-resource_manager/master/google/cloud/resourcemanager)
 - [google-cloud-resource_manager on RubyGems](https://rubygems.org/gems/google-cloud-resource_manager)
 - [Google Cloud Resource Manager documentation](https://cloud.google.com/resource-manager/)
 
@@ -309,7 +309,7 @@ projects = resource_manager.projects filter: "labels.env:production"
 ### Storage
 
 - [google-cloud-storage README](google-cloud-storage/README.md)
-- [google-cloud-storage API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage)
+- [google-cloud-storage API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage/master/google/cloud/storage)
 - [google-cloud-storage on RubyGems](https://rubygems.org/gems/google-cloud-storage)
 - [Google Cloud Storage documentation](https://cloud.google.com/storage/docs)
 
@@ -343,7 +343,7 @@ file.copy backup, file.name
 ### Translate
 
 - [google-cloud-translate README](google-cloud-translate/README.md)
-- [google-cloud-translate API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate)
+- [google-cloud-translate API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/master/google/cloud/translate)
 - [google-cloud-translate on RubyGems](https://rubygems.org/gems/google-cloud-translate)
 - [Google Translate documentation](https://cloud.google.com/translate/docs)
 
@@ -374,7 +374,7 @@ translation.text #=> "Salve mundi!"
 ### Vision
 
 - [google-cloud-vision README](google-cloud-vision/README.md)
-- [google-cloud-ruby-vision API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-vision)
+- [google-cloud-ruby-vision API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-vision/master/google/cloud/vision)
 - [google-cloud-vision on RubyGems](https://rubygems.org/gems/google-cloud-vision)
 - [Google Cloud Vision documentation](https://cloud.google.com/vision/docs)
 

--- a/docs/json/home.html
+++ b/docs/json/home.html
@@ -1,8 +1,8 @@
 <section class="hero-banner">
   <div class="container clearfix">
     <div class="quote-box">
-      <h1>gcloud</h1>
-      <p>Google Cloud Client Library for Ruby
+      <h1>google-cloud</h1>
+      <p>The Google Cloud client library for Ruby
       - an idiomatic, intuitive, and natural way for Ruby developers to
       integrate with Google Cloud Platform services, like Cloud Datastore
       and Cloud Storage.</p>
@@ -61,7 +61,7 @@
     <div class="quote-box">
       <h3 class="block-title">What is it?</h3>
 
-      <p><code>gcloud</code> is a client library for accessing Google
+      <p>The google-cloud library is a client for accessing Google
       Cloud Platform services that significantly reduces the boilerplate
       code you have to write. The library provides high-level API
       abstractions so they're easier to understand. It embraces
@@ -70,7 +70,7 @@
       All this means you spend more time creating code that matters
       to you.</p>
 
-      <p><code>gcloud</code> is configured to access Google Cloud Platform
+      <p>The google-cloud library is configured to access Google Cloud Platform
       services and authenticate (OAuth 2.0) automatically on your behalf.
       With a one-line install and a private key, you are up and ready
       to go. Better yet, if you are running on a Google Compute Engine
@@ -81,10 +81,11 @@
     <div class="quote-box--supplementary">
       <h4>Retrieve an entity from Cloud Datastore</h4>
       <div hljs hljs-language="ruby">
-require "gcloud/datastore"
+require "google/cloud"
 
-datastore = Gcloud.datastore "my-project",
-                             "key.json"
+gcloud = Google::Cloud.new "my-todo-project-id",
+                           "/path/to/keyfile.json"
+datastore = gcloud.datastore
 
 product = datastore.find "Product", 123</div>
 
@@ -96,12 +97,12 @@ product = datastore.find "Product", 123</div>
     <div class="container clearfix">
     <h3 class="block-title">FAQ</h3>
 
-      <h4>What is the relationship between the gcloud package and the gcloud command-line tool?</h4>
+      <h4>What is the relationship between the google-cloud library and the gcloud command-line tool?</h4>
 
-      <p>Both the gcloud command-line tool and gcloud package are a part of the Google Cloud SDK: a collection of tools and libraries that enable you to easily create and manage resources on the Google Cloud Platform. The gcloud command-line tool can be used to manage both your development workflow and your Google Cloud Platform resources while the gcloud package is the Google Cloud Client Library for Ruby.</p>
+      <p>Both the gcloud command-line tool and google-cloud library are a part of the Google Cloud SDK: a collection of tools and libraries that enable you to easily create and manage resources on the Google Cloud Platform. The gcloud command-line tool can be used to manage both your development workflow and your Google Cloud Platform resources while the google-cloud library is the Google Cloud Client Library for Ruby.</p>
 
-      <h4>What is the relationship between gcloud and the Google APIs Ruby Client?</h4>
+      <h4>What is the relationship between the google-cloud library and the Google APIs Ruby Client?</h4>
 
-      <p>The <a href="https://github.com/google/google-api-ruby-client">Google APIs Ruby Client</a> is a client library for using the broad set of Google APIs. gcloud is built specifically for the Google Cloud Platform and is the recommended way to integrate Google Cloud APIs into your Ruby applications. If your application requires both Google Cloud Platform and other Google APIs, the 2 libraries may be used by your application.</p>
+      <p>The <a href="https://github.com/google/google-api-ruby-client">Google APIs Ruby Client</a> is a client library for using the broad set of Google APIs. The google-cloud library is built specifically for the Google Cloud Platform and is the recommended way to integrate Google Cloud APIs into your Ruby applications. If your application requires both Google Cloud Platform and other Google APIs, the 2 libraries may be used by your application.</p>
     </div>
 </section> <!-- end of FAQ -->

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -4,7 +4,7 @@
 
 The current `gcloud` gem exists only to facilitate the timely transition of legacy code from the deprecated `Gcloud` namespace to the new `Google::Cloud` namespace. Please see the top-level project [README](../README.md) for current information about using the `google-cloud` umbrella gem and the individual service gems.
 
-- [gcloud API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/gcloud)
+- [gcloud API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/master/gcloud)
 - [gcloud on RubyGems](https://rubygems.org/gems/gcloud)
 
 ## Quick Start

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -2,7 +2,7 @@
 
 [Google Cloud BigQuery](https://cloud.google.com/bigquery/) ([docs](https://cloud.google.com/bigquery/docs)) enables super-fast, SQL-like queries against append-only tables, using the processing power of Google's infrastructure. Simply move your data into BigQuery and let it handle the hard work. You can control access to both the project and your data based on your business needs, such as giving others the ability to view or query your data.
 
-- [google-cloud-bigquery API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery/google/cloud/bigquery)
+- [google-cloud-bigquery API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery/master/google/cloud/bigquery)
 - [google-cloud-bigquery on RubyGems](https://rubygems.org/gems/google-cloud-bigquery)
 - [Google Cloud BigQuery documentation](https://cloud.google.com/bigquery/docs)
 

--- a/google-cloud-core/README.md
+++ b/google-cloud-core/README.md
@@ -2,7 +2,7 @@
 
 This library contains shared types, such as error classes, for the google-cloud project. Please see the top-level project [README](../README.md) for general information.
 
-- [google-cloud-core API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-core/google/cloud/errors)
+- [google-cloud-core API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-core/master/google/cloud/errors)
 
 ## Supported Ruby Versions
 

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -4,7 +4,7 @@
 
 Follow the [activation instructions](https://cloud.google.com/datastore/docs/activate) to use the Google Cloud Datastore API with your project.
 
-- [google-cloud-datastore API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-datastore/google/cloud/datastore)
+- [google-cloud-datastore API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-datastore/master/google/cloud/datastore)
 - [google-cloud-datastore on RubyGems](https://rubygems.org/gems/google-cloud-datastore)
 - [Google Cloud Datastore documentation](https://cloud.google.com/datastore/docs)
 

--- a/google-cloud-dns/README.md
+++ b/google-cloud-dns/README.md
@@ -2,7 +2,7 @@
 
 [Google Cloud DNS](https://cloud.google.com/dns/) ([docs](https://cloud.google.com/dns/docs)) is a high-performance, resilient, global DNS service that provides a cost-effective way to make your applications and services available to your users. This programmable, authoritative DNS service can be used to easily publish and manage DNS records using the same infrastructure relied upon by Google. To learn more, read [What is Google Cloud DNS?](https://cloud.google.com/dns/what-is-cloud-dns).
 
-- [google-cloud-dns API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-dns/google/cloud/dns)
+- [google-cloud-dns API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-dns/master/google/cloud/dns)
 - [google-cloud-dns on RubyGems](https://rubygems.org/gems/google-cloud-dns)
 - [Google Cloud DNS documentation](https://cloud.google.com/dns/docs)
 

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -4,7 +4,7 @@
 
 The Google Cloud Natural Language API is currently a beta release, and might be changed in backward-incompatible ways. It is not subject to any SLA or deprecation policy and is not intended for real-time usage in critical applications.
 
-- [google-cloud-language API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-language/google/cloud/language)
+- [google-cloud-language API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-language/master/google/cloud/language)
 - [google-cloud-language on RubyGems](https://rubygems.org/gems/google-cloud-language)
 - [Google Cloud Natural Language API documentation](https://cloud.google.com/language/docs)
 

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -2,7 +2,7 @@
 
 [Stackdriver Logging](https://cloud.google.com/logging/) ([docs](https://cloud.google.com/logging/docs/)) allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud Platform and Amazon Web Services (AWS). It supports ingestion of any custom log data from any source. Stackdriver Logging is a fully-managed service that performs at scale and can ingest application and system log data from thousands of VMs. Even better, you can analyze all that log data in real-time.
 
-- [google-cloud-logging API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/google/cloud/logging)
+- [google-cloud-logging API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/master/google/cloud/logging)
 - [google-cloud-logging on RubyGems](https://rubygems.org/gems/google-cloud-logging)
 - [Stackdriver Logging documentation](https://cloud.google.com/logging/docs/)
 

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -2,7 +2,7 @@
 
 [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) ([docs](https://cloud.google.com/pubsub/reference/rest/)) is designed to provide reliable, many-to-many, asynchronous messaging between applications. Publisher applications can send messages to a “topic” and other applications can subscribe to that topic to receive the messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications.
 
-- [google-cloud-pubsub API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-pubsub/google/cloud/pubsub)
+- [google-cloud-pubsub API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-pubsub/master/google/cloud/pubsub)
 - [google-cloud-pubsub on RubyGems](https://rubygems.org/gems/[google-cloud-pubsub)
 - [Google Cloud Pub/Sub documentation](https://cloud.google.com/pubsub/docs)
 

--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -11,7 +11,7 @@ programmatically manage  container resources such as Organizations and Projects,
 
 The Resource Manager API is a Beta release and is not covered by any SLA or deprecation policy and may be subject to backward-incompatible changes.
 
-- [google-cloud-resource_manager API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-resource_manager/google/cloud/resourcemanager)
+- [google-cloud-resource_manager API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-resource_manager/master/google/cloud/resourcemanager)
 - [google-cloud-resource_manager on RubyGems](https://rubygems.org/gems/google-cloud-resource_manager)
 - [Google Cloud Resource Manager documentation](https://cloud.google.com/resource-manager/)
 

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -2,7 +2,7 @@
 
 [Google Cloud Storage](https://cloud.google.com/storage/) ([docs](https://cloud.google.com/storage/docs/json_api/)) allows you to store data on Google infrastructure with very high reliability, performance and availability, and can be used to distribute large data objects to users via direct download.
 
-- [google-cloud-storage API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage/google/cloud/storage)
+- [google-cloud-storage API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-storage/master/google/cloud/storage)
 - [google-cloud-storage on RubyGems](https://rubygems.org/gems/google-cloud-storage)
 - [Google Cloud Storage documentation](https://cloud.google.com/storage/docs)
 

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -4,7 +4,7 @@
 
 Translate API supports more than ninety different languages, from Afrikaans to Zulu. Used in combination, this enables translation between thousands of language pairs. Also, you can send in HTML and receive HTML with translated text back. You don't need to extract your source text or reassemble the translated content.
 
-- [google-cloud-translate API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/google/cloud/translate)
+- [google-cloud-translate API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/master/google/cloud/translate)
 - [google-cloud-translate on RubyGems](https://rubygems.org/gems/google-cloud-translate)
 - [Google Translate documentation](https://cloud.google.com/translate/docs)
 

--- a/google-cloud-vision/README.md
+++ b/google-cloud-vision/README.md
@@ -2,7 +2,7 @@
 
 [Google Cloud Vision](https://cloud.google.com/vision/) ([docs](https://cloud.google.com/vision/docs)) allows developers to easily integrate vision detection features within applications, including image labeling, face and landmark detection, optical character recognition (OCR), and tagging of explicit content.
 
-- [google-cloud-vision API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-vision/google/cloud/vision)
+- [google-cloud-vision API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-vision/master/google/cloud/vision)
 - [google-cloud-vision on RubyGems](https://rubygems.org/gems/google-cloud-vision)
 - [Google Cloud Vision documentation](https://cloud.google.com/vision/docs)
 


### PR DESCRIPTION
This PR updates `gcloud` usages in `home.html`, and also contains a temporary fix:
Specify master in link paths to avoid infinite redirect (possible bug in site). Restore to version-less path after fix.