### PR TITLE
Delay loading GRPC until its used

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -14,7 +14,7 @@
 
 
 require "google/cloud/datastore/credentials"
-require "google/datastore/v1/datastore_services_pb"
+require "google/datastore/v1/datastore_pb"
 require "google/cloud/core/grpc_backoff"
 
 module Google
@@ -45,8 +45,12 @@ module Google
 
         def datastore
           return mocked_datastore if mocked_datastore
-          @datastore ||= Google::Datastore::V1::Datastore::Stub.new(
-            host, creds, timeout: timeout)
+          @datastore ||= begin
+            require "google/datastore/v1/datastore_services_pb"
+
+            Google::Datastore::V1::Datastore::Stub.new(
+              host, creds, timeout: timeout)
+          end
         end
         attr_accessor :mocked_datastore
 

--- a/google-cloud-language/lib/google/cloud/language/service.rb
+++ b/google-cloud-language/lib/google/cloud/language/service.rb
@@ -16,7 +16,7 @@
 require "google/cloud/errors"
 require "google/cloud/language/credentials"
 require "google/cloud/language/version"
-require "google/cloud/language/v1beta1/language_service_api"
+require "google/cloud/language/v1beta1/language_service_pb"
 
 module Google
   module Cloud
@@ -50,13 +50,17 @@ module Google
 
         def service
           return mocked_service if mocked_service
-          @service ||= V1beta1::LanguageServiceApi.new(
-            service_path: host,
-            channel: channel,
-            timeout: timeout,
-            app_name: "google-cloud-language",
-            app_version: Google::Cloud::Language::VERSION)
-          # TODO: Get retries configured
+          @service ||= begin
+            require "google/cloud/language/v1beta1/language_service_api"
+
+            V1beta1::LanguageServiceApi.new(
+              service_path: host,
+              channel: channel,
+              timeout: timeout,
+              app_name: "google-cloud-language",
+              app_version: Google::Cloud::Language::VERSION)
+            # TODO: Get retries configured
+          end
         end
         attr_accessor :mocked_service
 

--- a/google-cloud-logging/lib/google/cloud/logging/service.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/service.rb
@@ -15,9 +15,9 @@
 
 require "google/cloud/errors"
 require "google/cloud/core/grpc_backoff"
-require "google/logging/v2/logging_services_pb"
-require "google/logging/v2/logging_config_services_pb"
-require "google/logging/v2/logging_metrics_services_pb"
+require "google/logging/v2/logging_pb"
+require "google/logging/v2/logging_config_pb"
+require "google/logging/v2/logging_metrics_pb"
 
 module Google
   module Cloud
@@ -46,22 +46,34 @@ module Google
 
         def logging
           return mocked_logging if mocked_logging
-          @logging ||= Google::Logging::V2::LoggingServiceV2::Stub.new(
-            host, creds, timeout: timeout)
+          @logging ||= begin
+            require "google/logging/v2/logging_services_pb"
+
+            Google::Logging::V2::LoggingServiceV2::Stub.new(
+              host, creds, timeout: timeout)
+          end
         end
         attr_accessor :mocked_logging
 
         def sinks
           return mocked_sinks if mocked_sinks
-          @sinks ||= Google::Logging::V2::ConfigServiceV2::Stub.new(
-            host, creds, timeout: timeout)
+          @sinks ||= begin
+            require "google/logging/v2/logging_config_services_pb"
+
+            Google::Logging::V2::ConfigServiceV2::Stub.new(
+              host, creds, timeout: timeout)
+          end
         end
         attr_accessor :mocked_sinks
 
         def metrics
           return mocked_metrics if mocked_metrics
-          @metrics ||= Google::Logging::V2::MetricsServiceV2::Stub.new(
-            host, creds, timeout: timeout)
+          @metrics ||= begin
+            require "google/logging/v2/logging_metrics_services_pb"
+
+            Google::Logging::V2::MetricsServiceV2::Stub.new(
+              host, creds, timeout: timeout)
+          end
         end
         attr_accessor :mocked_metrics
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -15,8 +15,8 @@
 
 require "google/cloud/errors"
 require "google/cloud/core/grpc_backoff"
-require "google/pubsub/v1/pubsub_services_pb"
-require "google/iam/v1/iam_policy_services"
+require "google/pubsub/v1/pubsub_pb"
+require "google/iam/v1/iam_policy"
 require "google/cloud/core/grpc_utils"
 require "json"
 
@@ -48,22 +48,34 @@ module Google
 
         def subscriber
           return mocked_subscriber if mocked_subscriber
-          @subscriber ||= Google::Pubsub::V1::Subscriber::Stub.new(
-            host, creds, timeout: timeout)
+          @subscriber ||= begin
+            require "google/pubsub/v1/pubsub_services_pb"
+
+            Google::Pubsub::V1::Subscriber::Stub.new(
+              host, creds, timeout: timeout)
+          end
         end
         attr_accessor :mocked_subscriber
 
         def publisher
           return mocked_publisher if mocked_publisher
-          @publisher ||= Google::Pubsub::V1::Publisher::Stub.new(
-            host, creds, timeout: timeout)
+          @publisher ||= begin
+            require "google/pubsub/v1/pubsub_services_pb"
+
+            Google::Pubsub::V1::Publisher::Stub.new(
+              host, creds, timeout: timeout)
+          end
         end
         attr_accessor :mocked_publisher
 
         def iam
           return mocked_iam if mocked_iam
-          @iam ||= Google::Iam::V1::IAMPolicy::Stub.new(
-            host, creds, timeout: timeout)
+          @iam ||= begin
+            require "google/iam/v1/iam_policy_services"
+
+            Google::Iam::V1::IAMPolicy::Stub.new(
+              host, creds, timeout: timeout)
+          end
         end
         attr_accessor :mocked_iam
 


### PR DESCRIPTION
This change is an attempt to solve issues using the GRPC client in
environments like Rails that fork subprocesses to handle requests.
The GRPC client is initialized when require grpc is called, so we are
attempting to control when that is called.
With this change it is called only when an API call is going to be made.
The protobuf files can still be created, however.