### PR TITLE
Fix timeout configuration

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -47,7 +47,8 @@ module Google
           @service.client_options.application_version = \
             Google::Cloud::Bigquery::VERSION
           @service.request_options.retries = retries || 3
-          @service.request_options.timeout_sec = timeout if timeout
+          @service.request_options.timeout_sec      = timeout
+          @service.request_options.open_timeout_sec = timeout
           @service.authorization = @credentials.client
         end
 

--- a/google-cloud-dns/lib/google/cloud/dns/service.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/service.rb
@@ -41,7 +41,8 @@ module Google
           @service.client_options.application_version = \
             Google::Cloud::Dns::VERSION
           @service.request_options.retries = retries || 3
-          @service.request_options.timeout_sec = timeout if timeout
+          @service.request_options.timeout_sec      = timeout
+          @service.request_options.open_timeout_sec = timeout
           @service.authorization = @credentials.client
         end
 

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
@@ -41,7 +41,8 @@ module Google
           @service.client_options.application_version = \
             Google::Cloud::ResourceManager::VERSION
           @service.request_options.retries = retries || 3
-          @service.request_options.timeout_sec = timeout if timeout
+          @service.request_options.timeout_sec      = timeout
+          @service.request_options.open_timeout_sec = timeout
           @service.authorization = @credentials.client
         end
 

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -48,7 +48,8 @@ module Google
           @service.client_options.application_version = \
             Google::Cloud::Storage::VERSION
           @service.request_options.retries = retries || 3
-          @service.request_options.timeout_sec = timeout if timeout
+          @service.request_options.timeout_sec      = timeout
+          @service.request_options.open_timeout_sec = timeout
           @service.authorization = @credentials.client
         end
 

--- a/google-cloud-translate/lib/google/cloud/translate/service.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/service.rb
@@ -38,7 +38,8 @@ module Google
           @service.client_options.application_version = \
             Google::Cloud::Translate::VERSION
           @service.request_options.retries = retries || 3
-          @service.request_options.timeout_sec = timeout if timeout
+          @service.request_options.timeout_sec      = timeout
+          @service.request_options.open_timeout_sec = timeout
           @service.authorization = nil
           @service.key = key
         end

--- a/google-cloud-vision/lib/google/cloud/vision/service.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/service.rb
@@ -41,7 +41,8 @@ module Google
           @service.client_options.application_version = \
             Google::Cloud::Vision::VERSION
           @service.request_options.retries = retries || 3
-          @service.request_options.timeout_sec = timeout if timeout
+          @service.request_options.timeout_sec      = timeout
+          @service.request_options.open_timeout_sec = timeout
           @service.authorization = @credentials.client
         end
 


### PR DESCRIPTION
Configure `open_timeout_sec` as well as `timeout_sec` to fix an issue with uploads timing out. Uploads appear to use `open_timeout_sec` instead of `timeout_sec` because the upload data is part of the request.

[fixes #876]