### PR TITLE
Fix for using GCS URLs in Vision

### DIFF
--- a/google-cloud-language/acceptance/language/storage/html_file_test.rb
+++ b/google-cloud-language/acceptance/language/storage/html_file_test.rb
@@ -21,7 +21,6 @@ describe "Language (HTML/Storage File)", :language do
   let(:content) { "<html><head><title>#{hello}</title></head>" + \
                   "<body><h1>#{sayhi}</h1><p>#{ruby}</p></body></html>" }
 
-  let(:storage) { Google::Cloud.storage }
   let(:bucket)  { storage.bucket($lang_prefix) || storage.create_bucket($lang_prefix) }
   let(:file_io) { t = Tempfile.new(["language", ".html"]); t.write content.encode("UTF-8"); t.rewind; t }
   let(:file)    { bucket.file("language.html") || bucket.create_file(file_io, "language.html") }

--- a/google-cloud-language/acceptance/language/storage/html_url_test.rb
+++ b/google-cloud-language/acceptance/language/storage/html_url_test.rb
@@ -21,7 +21,6 @@ describe "Language (HTML/Storage URL)", :language do
   let(:content) { "<html><head><title>#{hello}</title></head>" + \
                   "<body><h1>#{sayhi}</h1><p>#{ruby}</p></body></html>" }
 
-  let(:storage) { Google::Cloud.storage }
   let(:bucket)  { storage.bucket($lang_prefix) || storage.create_bucket($lang_prefix) }
   let(:file_io) { t = Tempfile.new(["language", ".html"]); t.write content.encode("UTF-8"); t.rewind; t }
   let(:file)    { bucket.file("language.html") || bucket.create_file(file_io, "language.html") }

--- a/google-cloud-language/acceptance/language/storage/text_file_test.rb
+++ b/google-cloud-language/acceptance/language/storage/text_file_test.rb
@@ -20,7 +20,6 @@ describe "Language (TEXT/Storage File)", :language do
   let(:ruby)    { "We love ruby and writing code." }
   let(:content) { "#{hello} #{sayhi} #{ruby}" }
 
-  let(:storage) { Google::Cloud.storage }
   let(:bucket)  { storage.bucket($lang_prefix) || storage.create_bucket($lang_prefix) }
   let(:file_io) { t = Tempfile.new(["language", ".txt"]); t.write content.encode("UTF-8"); t.rewind; t }
   let(:file)    { bucket.file("language.txt") || bucket.create_file(file_io, "language.txt") }

--- a/google-cloud-language/acceptance/language/storage/text_url_test.rb
+++ b/google-cloud-language/acceptance/language/storage/text_url_test.rb
@@ -20,7 +20,6 @@ describe "Language (TEXT/Storage URL)", :language do
   let(:ruby)    { "We love ruby and writing code." }
   let(:content) { "#{hello} #{sayhi} #{ruby}" }
 
-  let(:storage) { Google::Cloud.storage }
   let(:bucket)  { storage.bucket($lang_prefix) || storage.create_bucket($lang_prefix) }
   let(:file_io) { t = Tempfile.new(["language", ".txt"]); t.write content.encode("UTF-8"); t.rewind; t }
   let(:file)    { bucket.file("language.txt") || bucket.create_file(file_io, "language.txt") }

--- a/google-cloud-language/acceptance/language_helper.rb
+++ b/google-cloud-language/acceptance/language_helper.rb
@@ -40,7 +40,7 @@ module Acceptance
   #     end
   #   end
   class LanguageTest < Minitest::Test
-    attr_accessor :language
+    attr_accessor :language, :storage
 
     ##
     # Setup project based on available ENV variables

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem "rake"
 gem "google-cloud-core", path: "../google-cloud-core"
+gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"

--- a/google-cloud-vision/acceptance/vision/vision_test.rb
+++ b/google-cloud-vision/acceptance/vision/vision_test.rb
@@ -23,9 +23,38 @@ describe "Vision", :vision do
   let(:landmark_image) { "acceptance/data/landmark.jpg" }
   let(:text_image)     { "acceptance/data/text.png" }
 
+  let(:bucket)   { storage.bucket($vision_prefix) || storage.create_bucket($vision_prefix) }
+  let(:gcs_file) { bucket.file(face_image) || bucket.create_file(face_image) }
+  let(:gcs_url)  { gcs_file.to_gs_url }
+
   describe "default" do
     it "runs all annotations if none are specified" do
       annotation = vision.annotate face_image
+
+      annotation.must_be :face?
+      annotation.wont_be :landmark?
+      annotation.wont_be :logo?
+      annotation.must_be :label?
+      annotation.wont_be :text?
+      annotation.must_be :safe_search?
+      annotation.must_be :properties?
+    end
+
+    it "runs all annotations on a Storage File" do
+      annotation = vision.annotate gcs_file
+
+      annotation.must_be :face?
+      annotation.wont_be :landmark?
+      annotation.wont_be :logo?
+      annotation.must_be :label?
+      annotation.wont_be :text?
+      annotation.must_be :safe_search?
+      annotation.must_be :properties?
+    end
+
+    it "runs all annotations on a GCS URL" do
+      image = vision.image gcs_url
+      annotation = vision.annotate image
 
       annotation.must_be :face?
       annotation.wont_be :landmark?

--- a/google-cloud-vision/lib/google/cloud/vision/image.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/image.rb
@@ -334,7 +334,7 @@ module Google
               @io.rewind
               "(#{@io.read(16)}...)"
             else
-              "(#{url})"
+              "(#{@url})"
             end
           end
         end

--- a/google-cloud-vision/lib/google/cloud/vision/image.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/image.rb
@@ -351,7 +351,7 @@ module Google
             @io.rewind
             Google::Apis::VisionV1::Image.new content: @io.read
           elsif url?
-            Google::Apis::VisionV1::Image.new source: { gcsImageUri: @url }
+            Google::Apis::VisionV1::Image.new source: { gcs_image_uri: @url }
           else
             fail ArgumentError, "Unable to use Image with Vision service."
           end

--- a/google-cloud-vision/test/google/cloud/vision/image_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image_test.rb
@@ -24,6 +24,9 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.must_be_kind_of Google::Cloud::Vision::Image
     image.must_be :io?
     image.wont_be :url?
+
+    image.inspect.must_be_kind_of String
+    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
   end
 
   it "can create from a Pathname object" do
@@ -32,6 +35,9 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.must_be_kind_of Google::Cloud::Vision::Image
     image.must_be :io?
     image.wont_be :url?
+
+    image.inspect.must_be_kind_of String
+    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
   end
 
   it "can create from a File object" do
@@ -40,6 +46,9 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.must_be_kind_of Google::Cloud::Vision::Image
     image.must_be :io?
     image.wont_be :url?
+
+    image.inspect.must_be_kind_of String
+    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
   end
 
   it "can create from a StringIO object" do
@@ -48,6 +57,9 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.must_be_kind_of Google::Cloud::Vision::Image
     image.must_be :io?
     image.wont_be :url?
+
+    image.inspect.must_be_kind_of String
+    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
   end
 
   it "can create from a Tempfile object" do
@@ -57,11 +69,14 @@ describe Google::Cloud::Vision::Image, :mock_vision do
       tmpfile.write File.read(filepath, mode: "rb")
 
       image = vision.image tmpfile
-    end
 
-    image.must_be_kind_of Google::Cloud::Vision::Image
-    image.must_be :io?
-    image.wont_be :url?
+      image.must_be_kind_of Google::Cloud::Vision::Image
+      image.must_be :io?
+      image.wont_be :url?
+
+      image.inspect.must_be_kind_of String
+      image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
+    end
   end
 
   it "can create from a Google Storage URL" do
@@ -70,6 +85,9 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.must_be_kind_of Google::Cloud::Vision::Image
     image.wont_be :io?
     image.must_be :url?
+
+    image.inspect.must_be_kind_of String
+    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
   end
 
   it "can create from a Storage::File object" do
@@ -79,6 +97,9 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.must_be_kind_of Google::Cloud::Vision::Image
     image.wont_be :io?
     image.must_be :url?
+
+    image.inspect.must_be_kind_of String
+    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
   end
 
   it "raises when giving an object that is not IO or a Google Storage URL" do


### PR DESCRIPTION
The Vision Image object was not properly formatting the GCS URL. This change corrects this.

[fixes #880]