### PR TITLE
Add travis:release task for individual gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ script:
 - bundle exec rake jsondoc
 - bundle exec rake test:coveralls
 - bundle exec rake travis:acceptance
+after_success:
+- bundle exec rake travis:post
 matrix:
   include:
   - rvm: 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rubocop", "<= 0.35.1"
 gem "simplecov", "~> 0.9"
 gem "coveralls", "~> 0.7"
 gem "yard", "~> 0.9"
+gem "gems", "~> 0.8"
 
 gem "google-cloud-core", path: "google-cloud-core"
 gem "google-cloud-bigquery", path: "google-cloud-bigquery"


### PR DESCRIPTION
Create a `travis:post` task to be run on a successful build. Create a `travis:release` task that accepts a package name (`"google-cloud-datastore"`) and a version (`"0.20.1"`) and builds and pushes the gem to RubyGems. The push to RubyGems will use the `RUBYGEMS_API_TOKEN` environment variable when available.