### PR TITLE
Stackdriver product rename

### DIFF
--- a/google-cloud-logging/.yardopts
+++ b/google-cloud-logging/.yardopts
@@ -1,5 +1,5 @@
 --no-private
---title=Google Cloud Logging
+--title=Stackdriver Logging
 --exclude lib/google/logging
 --exclude lib/google/cloud/logging/v2
 --exclude lib/google/cloud/logging/v2.rb

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -39,7 +39,7 @@ module Google
       # applications. For example, the log `compute.googleapis.com/activity_log`
       # is produced by Google Compute Engine. Logs are simply referenced by name
       # in google-cloud. There is no `Log` type in google-cloud or `Log`
-      # resource in the Cloud Logging API.
+      # resource in the Stackdriver Logging API.
       #
       # @see https://cloud.google.com/logging/docs/view/logs_index List of Log
       #   Types

--- a/google-cloud-logging/test/google/cloud/logging/backoff_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/backoff_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe "Google Cloud Logging Backoff", :mock_logging do
+describe "Stackdriver Logging Backoff", :mock_logging do
   it "retries when the session times out" do
     metric_name = "session-timed-out-metric"
 


### PR DESCRIPTION
Renaming some APIs to Stackdriver brand