### PR TITLE
Make Job#wait_until_done! flexible

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -239,8 +239,8 @@ module Google
         #                               format: "json"
         #   extract_job.wait_until_done!
         #   extract_job.done? #=> true
-        def wait_until_done!
-          backoff = ->(retries) { sleep 2 * retries + 5 }
+        def wait_until_done!(base: 2, offset: 5)
+          backoff = ->(retries) { sleep base * retries + offset }
           retries = 0
           until done?
             backoff.call retries

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -239,7 +239,7 @@ module Google
         #                               format: "json"
         #   extract_job.wait_until_done!
         #   extract_job.done? #=> true
-        def wait_until_done!(base: 2, offset: 5)
+        def wait_until_done! base: 2, offset: 5
           backoff = ->(retries) { sleep base * retries + offset }
           retries = 0
           until done?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -227,6 +227,11 @@ module Google
         # Refreshes the job until the job is `DONE`.
         # The delay between refreshes will incrementally increase.
         #
+        # @param [Integer] min The minimum time in seconds for waiting.
+        # @param [Integer] max The maximum time in seconds for waiting.
+        #   The method call will time out and return within the time.
+        #   The default value is infinity, so will not time out.
+        #
         # @example
         #   require "google/cloud"
         #
@@ -239,12 +244,16 @@ module Google
         #                               format: "json"
         #   extract_job.wait_until_done!
         #   extract_job.done? #=> true
-        def wait_until_done! base: 2, offset: 5
-          backoff = ->(retries) { sleep base * retries + offset }
+        def wait_until_done! min: 5, max: Float::INFINITY
+          backoff = ->(retries) { 2 * retries + min }
           retries = 0
+          total = 0
           until done?
-            backoff.call retries
+            interval = backoff.call retries
+            return unless total + interval < max
+            sleep interval
             retries += 1
+            total += interval
             reload!
           end
         end


### PR DESCRIPTION
The default interval of Job#wait_until_done! is 5 seconds at least. I think it is a little long in some cases. So I just move the degrees to the arguments.
