### PR TITLE
Updates for Windows tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,12 +1,8 @@
 environment:
   matrix:
-    - RUBY_VERSION: 23
     - RUBY_VERSION: 23-x64
-    - RUBY_VERSION: 22
     - RUBY_VERSION: 22-x64
-    - RUBY_VERSION: 21
     - RUBY_VERSION: 21-x64
-    - RUBY_VERSION: 200
     - RUBY_VERSION: 200-x64
 
 install:

--- a/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
@@ -211,7 +211,7 @@ describe Google::Cloud::Datastore::Properties do
   end
 
   it "encodes IO as blob" do
-    raw = File.open "acceptance/data/CloudPlatform_128px_Retina.png"
+    raw = File.open "acceptance/data/CloudPlatform_128px_Retina.png", "rb"
     value = Google::Cloud::Core::GRPCUtils.to_value raw
     value.value_type.must_equal :blob_value
     value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
@@ -226,6 +226,7 @@ describe Google::Cloud::Datastore::Properties do
 
   it "encodes Temfile as blob" do
     raw = Tempfile.new "raw"
+    raw.binmode
     raw.write(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     raw.rewind
     value = Google::Cloud::Core::GRPCUtils.to_value raw


### PR DESCRIPTION
Make a relatively small change for tests running on Windows. Also update the AppVeyor config to only run on 64bit rubies.