### PR TITLE
Add example testing to Translate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rubocop", "<= 0.35.1"
 gem "simplecov", "~> 0.9"
 gem "coveralls", "~> 0.7"
 gem "yard", "~> 0.9"
+gem "yard-doctest", "~> 0.1.6"
 gem "gems", "~> 0.8"
 
 gem "google-cloud-core", path: "google-cloud-core"

--- a/Rakefile
+++ b/Rakefile
@@ -165,6 +165,21 @@ task :rubocop, :bundleupdate do |t, args|
   end
 end
 
+desc "Runs yard-doctest example tests for all gems individually."
+task :doctest, :bundleupdate do |t, args|
+  bundleupdate = args[:bundleupdate]
+  Rake::Task["bundleupdate"].invoke if bundleupdate
+  header "Running yard-doctest example code tests"
+  gems.each do |gem|
+    Dir.chdir gem do
+      Bundler.with_clean_env do
+        header "DOCTEST FOR #{gem}"
+        sh "bundle exec rake doctest"
+      end
+    end
+  end
+end
+
 desc "Runs jsondoc report for all gems individually."
 task :jsondoc, :bundleupdate do |t, args|
   bundleupdate = args[:bundleupdate]

--- a/gcloud/Rakefile
+++ b/gcloud/Rakefile
@@ -33,6 +33,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/gcloud/gcloud.gemspec
+++ b/gcloud/gcloud.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 
   gem.post_install_message = "gcloud is now google-cloud, please change the gem name in your dependencies"
 end

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -81,6 +81,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-core/Rakefile
+++ b/google-cloud-core/Rakefile
@@ -33,6 +33,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-core/google-cloud-core.gemspec
+++ b/google-cloud-core/google-cloud-core.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -61,6 +61,10 @@ namespace :acceptance do
   # TODO: Add a setup task to create indexes for the datastore
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -80,6 +80,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -61,6 +61,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -79,6 +79,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -75,6 +75,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-resource_manager/Rakefile
+++ b/google-cloud-resource_manager/Rakefile
@@ -33,6 +33,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
+++ b/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -46,6 +46,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -74,6 +74,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-translate/.rubocop.yml
+++ b/google-cloud-translate/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - "acceptance/**/*"
     - "google-cloud-translate.gemspec"
     - "Rakefile"
+    - "support/**/*"
     - "test/**/*"
 
 Documentation:

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -56,6 +56,11 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+  sh "bundle exec yard doctest"
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-translate/lib/google/cloud/translate/api.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/api.rb
@@ -43,7 +43,7 @@ module Google
       #
       #   translation = translate.translate "Hello world!", to: "la"
       #
-      #   puts translation #=> Salve mundi!
+      #   translation.to_s #=> "Salve mundi!"
       #
       #   translation.from #=> "en"
       #   translation.origin #=> "Hello world!"
@@ -96,7 +96,7 @@ module Google
         #
         #   translation = translate.translate "Hello world!", to: "la"
         #
-        #   puts translation #=> Salve mundi!
+        #   translation.to_s #=> "Salve mundi!"
         #
         #   translation.detected? #=> true
         #   translation.from #=> "en"
@@ -171,8 +171,8 @@ module Google
         #   translate = gcloud.translate
         #
         #   detection = translate.detect "Hello world!"
-        #   puts detection.language #=> en
-        #   puts detection.confidence #=> 0.7100697
+        #   detection.language #=> "en"
+        #   detection.confidence #=> 0.7100697
         #
         # @example Detecting multiple texts.
         #   require "google/cloud"
@@ -182,11 +182,11 @@ module Google
         #
         #   detections = translate.detect "Hello world!",
         #                                 "Bonjour le monde!"
-        #   puts detections.count #=> 2
-        #   puts detection.first.language #=> en
-        #   puts detection.first.confidence #=> 0.7100697
-        #   puts detection.last.language #=> fr
-        #   puts detection.last.confidence #=> 0.40440267
+        #   detections.count #=> 2
+        #   detections.first.language #=> "en"
+        #   detections.first.confidence #=> 0.7100697
+        #   detections.last.language #=> "fr"
+        #   detections.last.confidence #=> 0.40440267
         #
         def detect *text
           return nil if text.empty?

--- a/google-cloud-translate/lib/google/cloud/translate/translation.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/translation.rb
@@ -33,7 +33,7 @@ module Google
       #
       #   translation = translate.translate "Hello world!", to: "la"
       #
-      #   puts translation #=> Salve mundi!
+      #   translation.to_s #=> "Salve mundi!"
       #
       #   translation.from #=> "en"
       #   translation.origin #=> "Hello world!"

--- a/google-cloud-translate/support/doctest_helper.rb
+++ b/google-cloud-translate/support/doctest_helper.rb
@@ -1,0 +1,176 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/translate"
+
+# TODO: Pull up for reuse across services
+module Google
+  module Cloud
+    def self.stub_service name
+      original_method = "__google_cloud_yard_doctest__#{name}"
+      raise "Method '#{name}' not found." unless respond_to?(name) && methods.map(&:to_s).include?(name.to_s)
+      alias_method original_method, name
+      define_method name do |*args|
+        yield *args
+      end
+    end
+
+    def self.unstub_service name
+      original_method = "__google_cloud_yard_doctest__#{name}"
+      if respond_to?(original_method) && methods.map(&:to_s).include?(original_method.to_s)
+        puts "undef_method #{name}"
+        undef_method name
+        alias_method name, original_method
+        undef_method original_method
+      end
+    end
+  end
+end
+
+# TODO: Pull up for reuse across services
+def mock_service name
+  #if name == :translate # TODO: case for each service
+  Google::Cloud.stub_service name do |*args|
+    key = "test-api-key"
+    translate = Google::Cloud::Translate::Api.new(Google::Cloud::Translate::Service.new(key))
+
+    translate.service.mocked_service = Minitest::Mock.new
+    yield translate.service.mocked_service
+    translate
+  end
+end
+
+# Mocks: setup and teardown for all tests
+
+YARD::Doctest.configure do |doctest|
+  doctest.skip "Google::Cloud.translate" # Do not unit test service factory class methods
+  doctest.before("Google::Cloud#translate") do
+    mock_service :translate do |mock|
+      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+  doctest.before("Google::Cloud#translate@Using API Key from the environment variable.") do
+    mock_service :translate do |mock|
+      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Api") do
+    mock_service :translate do |mock|
+      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Api#translate") do
+    mock_service :translate do |mock|
+      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Api#translate@Setting the `from` language.") do
+    mock_service :translate do |mock|
+      res_attrs = { detected_source_language: nil, translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>"en"}]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Api#translate@Retrieving multiple translations.") do
+    mock_service :translate do |mock|
+      res_attrs_1 = { detected_source_language: nil, translated_text: "Salve amice." }
+      res_attrs_2 = { detected_source_language: nil, translated_text: "Vide te mox." }
+      mock.expect :list_translations, list_translations_response([res_attrs_1, res_attrs_2]), [["Hello my friend.", "See you soon."], "la", {:cid=>nil, :format=>nil, :source=>"en"}]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Api#translate@Preserving HTML tags.") do
+    mock_service :translate do |mock|
+      res_attrs = { detected_source_language: nil, translated_text: "<strong>Salve</strong> mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["<strong>Hello</strong> world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Api#detect") do
+    mock_service :translate do |mock|
+      res_attrs = { confidence: 0.7100697, language: "en", is_reliable: false }
+      mock.expect :list_detections, list_detections_response([res_attrs]), [["Hello world!"]]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Api#detect@Detecting multiple texts.") do
+    mock_service :translate do |mock|
+      res_attrs = { confidence: 0.7100697, language: "en", is_reliable: false }
+      res_attrs_2 = { confidence: 0.40440267, language: "fr", is_reliable: false }
+      mock.expect :list_detections, list_detections_response([res_attrs, res_attrs_2]), [["Hello world!", "Bonjour le monde!"]]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Api#languages") do
+    mock_service :translate do |mock|
+      res_attrs = { language: "en", name: nil }
+      mock.expect :list_languages, list_languages_response(res_attrs), [{:target=>nil}]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Api#languages@Get all languages with their names in French.") do
+    mock_service :translate do |mock|
+      res_attrs = { language: "en", name: "Anglais" }
+      mock.expect :list_languages, list_languages_response(res_attrs), [{:target=>"fr"}]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Detection") do
+    mock_service :translate do |mock|
+      res_attrs = { confidence: 0.7109375, language: "fr", is_reliable: false }
+      res_attrs_2 = { confidence: 0.59922177, language: "en", is_reliable: false }
+      mock.expect :list_detections, list_detections_response([res_attrs, res_attrs_2]), [["chien", "chat"]]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Language") do
+    mock_service :translate do |mock|
+      res_attrs = { language: "af", name: "Afrikaans" }
+      mock.expect :list_languages, list_languages_response(res_attrs), [{:target=>"en"}]
+    end
+  end
+  doctest.before("Google::Cloud::Translate::Translation") do
+    mock_service :translate do |mock|
+      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+
+  doctest.after do
+    #Google::Cloud.unstub_service :translate  # TODO: Investigate why this has no effect, fix, and restore
+  end
+end
+
+# Fixture helpers
+
+def list_translations_response attrs_arr
+  translations = attrs_arr.map do |attrs|
+    Google::Cloud::Translate::Service::API::TranslationsResource.new attrs
+  end
+  Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: translations
+end
+
+def list_detections_response attrs_arr
+  detections = attrs_arr.map do |attrs|
+    [Google::Cloud::Translate::Service::API::DetectionsResource.new(attrs)]
+  end
+  Google::Cloud::Translate::Service::API::ListDetectionsResponse.new detections: detections
+end
+
+def list_languages_response attrs
+  languages_resources = (1..104).map do
+    Google::Cloud::Translate::Service::API::LanguagesResource.new attrs
+  end
+  Google::Cloud::Translate::Service::API::ListLanguagesResponse.new languages: languages_resources
+end
+
+
+
+

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -59,6 +59,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud/Rakefile
+++ b/google-cloud/Rakefile
@@ -33,6 +33,10 @@ namespace :acceptance do
   end
 end
 
+desc "Runs yard-doctest example tests."
+task :doctest do
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end


### PR DESCRIPTION
This PR adds [yard-doctest](https://github.com/p0deje/yard-doctest) to `google-cloud-translate` in order to test the example code in the Translate documentation. 

The PR contains a `doctest_helper.rb` containing configuration for minitest mocks, and makes a few small changes to the examples for compatibility with yard-doctest (specifically, removing `puts` calls, since they return `nil`.)
 
To run the tests, pull my branch, then:

```sh
cd google-cloud-translate
bundle install
bundle exec yard doctest
```

[refs #226]