### PR TITLE
Introduce AsyncWriter which batches and transmits entries in the background

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -246,6 +246,37 @@ module Google
     #                       labels: labels
     # ```
     #
+    # Normally, writing log entries is done synchronously; the call to
+    # {Google::Cloud::Logging::Project#write_entries} will block until it has
+    # either completed transmitting the data or encountered an error. To "fire
+    # and forget" without blocking, use {Google::Cloud::Logging::AsyncWriter};
+    # it spins up a background thread that writes log entries in batches. Calls
+    # to {Google::Cloud::Logging::AsyncWriter#write_entries} simply add entries
+    # to its work queue and return immediately.
+    #
+    # ```ruby
+    # require "google/cloud"
+    #
+    # gcloud = Google::Cloud.new
+    # logging = gcloud.logging
+    # async = logging.async_writer
+    #
+    # entry1 = logging.entry
+    # entry1.payload = "Job started."
+    # entry2 = logging.entry
+    # entry2.payload = "Job completed."
+    # labels = { job_size: "large", job_code: "red" }
+    #
+    # resource = logging.resource "gae_app",
+    #                             "module_id" => "1",
+    #                             "version_id" => "20150925t173233"
+    #
+    # async.write_entries [entry1, entry2],
+    #                     log_name: "my_app_log",
+    #                     resource: resource,
+    #                     labels: labels
+    # ```
+    #
     # ### Creating a Ruby Logger implementation
     #
     # If your environment requires a logger instance that is API-compatible with
@@ -265,6 +296,26 @@ module Google
     #
     # logger = logging.logger "my_app_log", resource, env: :production
     # logger.info "Job started."
+    # ```
+    #
+    # By default, the logger instance writes log entries asynchronously in a
+    # background thread using an {Google::Cloud::Logging::AsyncWriter}. If you
+    # want to customize or disable asynchronous writing, you may do so when
+    # creating a logger.
+    #
+    # ```ruby
+    # require "google/cloud"
+    #
+    # gcloud = Google::Cloud.new
+    # logging = gcloud.logging
+    #
+    # resource = logging.resource "gae_app",
+    #                             module_id: "1",
+    #                             version_id: "20150925t173233"
+    #
+    # logger = logging.logger "my_app_log", resource, {env: :production},
+    #                         async_writer: false
+    # logger.info "Log entry written synchronously."
     # ```
     #
     # ## Configuring retries and timeout

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -44,6 +44,11 @@ module Google
     # about the options for connecting in the [Authentication
     # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
     #
+    # If you just want to write your application's logs to the Stackdriver
+    # Logging service, you may find it easiest to use the [Ruby Logger
+    # implementation](#creating-a-ruby-logger-implementation) provided by this
+    # library. Otherwise, read on to learn more about the Logging API.
+    #
     # ## Listing log entries
     #
     # Stackdriver Logging gathers log entries from many services, including

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -304,7 +304,7 @@ module Google
         #
         def ensure_thread
           @startup_lock.synchronize do
-            if (@thread.nil? || @thread.stop?) && @state != :stopped
+            if (@thread.nil? || !@thread.alive?) && @state != :stopped
               @queue_size = 0
               @queue = []
               @lock = Monitor.new

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -1,0 +1,337 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Logging
+      ##
+      # # AsyncWriter
+      #
+      # An object that batches and transmits log entries asynchronously.
+      #
+      # Use this object to transmit log entries efficiently. It keeps a queue
+      # of log entries, and runs a background thread that transmits them to
+      # the logging service in batches. Generally, adding to the queue will
+      # not block.
+      #
+      # This object is thread-safe; it may accept write requests from
+      # multiple threads simultaneously, and will serialize them when
+      # executing in the background thread.
+      #
+      # @example
+      #   require "google/cloud"
+      #
+      #   gcloud = Google::Cloud.new
+      #   logging = gcloud.logging
+      #
+      #   async = logging.async_writer
+      #
+      #   resource = logging.resource "gae_app",
+      #                               module_id: "1",
+      #                               version_id: "20150925t173233"
+      #   logger = logging.logger "my_app_log", resource, async_writer: async
+      #   logger.info "First log entry."
+      #   logger.info "Another entry."
+      #
+      class AsyncWriter
+        DEFAULT_MAX_QUEUE_SIZE = 10000
+
+        ##
+        # @private Item in the log entries queue.
+        QueueItem = Struct.new(:entries, :log_name, :resource, :labels) do
+          def try_combine next_item
+            if log_name == next_item.log_name &&
+               resource == next_item.resource &&
+               labels == next_item.labels
+              entries.concat(next_item.entries)
+              true
+            else
+              false
+            end
+          end
+        end
+
+        ##
+        # @private The logging object.
+        attr_accessor :logging
+
+        ##
+        # @private The maximum size of the entries queue, or nil if not set.
+        attr_accessor :max_queue_size
+
+        ##
+        # The current state. Either :running, :suspended, :stopping, or :stopped
+        attr_reader :state
+
+        ##
+        # The last exception thrown by the background thread, or nil if nothing
+        # has been thrown.
+        attr_reader :last_exception
+
+        ##
+        # @private Creates a new AsyncWriter instance.
+        def initialize logging, max_queue_size = DEFAULT_MAX_QUEUE_SIZE
+          @logging = logging
+          @max_queue_size = max_queue_size
+          @queue_size = 0
+          @queue = []
+          @state = :running
+          @lock = Monitor.new
+          @lock_cond = @lock.new_cond
+          @thread = Thread.new { run_backgrounder }
+        end
+
+        ##
+        # Asynchronously write one or more log entries to the Stackdriver
+        # Logging service.
+        #
+        # Unlike the main write_entries method, this method usually does not
+        # block. The actual write RPCs will happen in the background, and may
+        # be batched with related calls. However, if the queue is full, this
+        # method will block until enough space has cleared out.
+        #
+        # @param [Google::Cloud::Logging::Entry,
+        #   Array<Google::Cloud::Logging::Entry>] entries One or more entry
+        #   objects to write. The log entries must have values for all required
+        #   fields.
+        # @param [String] log_name A default log ID for those log entries in
+        #   `entries` that do not specify their own `log_name`. See also
+        #   {Entry#log_name=}.
+        # @param [Resource] resource A default monitored resource for those log
+        #   entries in entries that do not specify their own resource. See also
+        #   {Entry#resource}.
+        # @param [Hash{Symbol,String => String}] labels User-defined `key:value`
+        #   items that are added to the `labels` field of each log entry in
+        #   `entries`, except when a log entry specifies its own `key:value`
+        #   item with the same key. See also {Entry#labels=}.
+        #
+        # @return [Google::Cloud::Logging::AsyncWriter] Returns self.
+        #
+        # @example
+        #   require "google/cloud"
+        #
+        #   gcloud = Google::Cloud.new
+        #   logging = gcloud.logging
+        #   async = logging.async_writer
+        #
+        #   entry = logging.entry payload: "Job started.",
+        #                         log_name: "my_app_log"
+        #   entry.resource.type = "gae_app"
+        #   entry.resource.labels[:module_id] = "1"
+        #   entry.resource.labels[:version_id] = "20150925t173233"
+        #
+        #   async.write_entries entry
+        #
+        def write_entries entries, log_name: nil, resource: nil, labels: nil
+          entries = Array(entries)
+          @lock.synchronize do
+            fail "AsyncWriter has been stopped" unless writable?
+            queue_item = QueueItem.new entries, log_name, resource, labels
+            if @queue.empty? || !@queue.last.try_combine(queue_item)
+              @queue.push queue_item
+            end
+            @queue_size += entries.size
+            @lock_cond.broadcast
+            while @max_queue_size && @queue_size > @max_queue_size
+              @lock_cond.wait
+            end
+          end
+          self
+        end
+
+        ##
+        # Stops this asynchronous writer.
+        #
+        # After this call succeeds, the state will change to :stopping, and
+        # you may not issue any additional write_entries calls. Any previously
+        # issued writes will complete. Once any existing backlog has been
+        # cleared, the state will change to :stopped.
+        #
+        # @return [Boolean] Returns true if the writer was running, or false
+        #   if the writer had already been stopped.
+        #
+        def stop
+          @lock.synchronize do
+            if state != :stopped
+              @state = :stopping
+              @lock_cond.broadcast
+              true
+            else
+              false
+            end
+          end
+        end
+
+        ##
+        # Suspends this asynchronous writer.
+        #
+        # After this call succeeds, the state will change to :suspended, and
+        # the writer will stop sending RPCs until resumed.
+        #
+        # @return [Boolean] Returns true if the writer had been running and was
+        #   suspended, otherwise false.
+        #
+        def suspend
+          @lock.synchronize do
+            if state == :running
+              @state = :suspended
+              @lock_cond.broadcast
+              true
+            else
+              false
+            end
+          end
+        end
+
+        ##
+        # Resumes this suspended asynchronous writer.
+        #
+        # After this call succeeds, the state will change to :running, and
+        # the writer will resume sending RPCs.
+        #
+        # @return [Boolean] Returns true if the writer had been suspended and
+        #   is now running, otherwise false.
+        #
+        def resume
+          @lock.synchronize do
+            if state == :suspended
+              @state = :running
+              @lock_cond.broadcast
+              true
+            else
+              false
+            end
+          end
+        end
+
+        ##
+        # Returns true if this writer is running.
+        #
+        # @return [Boolean] Returns true if the writer is currently running.
+        #
+        def running?
+          @lock.synchronize do
+            state == :running
+          end
+        end
+
+        ##
+        # Returns true if this writer is suspended.
+        #
+        # @return [Boolean] Returns true if the writer is currently suspended.
+        #
+        def suspended?
+          @lock.synchronize do
+            state == :suspended
+          end
+        end
+
+        ##
+        # Returns true if this writer is still accepting writes. This means
+        # it is either running or suspended.
+        #
+        # @return [Boolean] Returns true if the writer is accepting writes.
+        #
+        def writable?
+          @lock.synchronize do
+            state == :suspended || state == :running
+          end
+        end
+
+        ##
+        # Returns true if this writer is fully stopped.
+        #
+        # @return [Boolean] Returns true if the writer is fully stopped.
+        #
+        def stopped?
+          @lock.synchronize do
+            state == :stopped
+          end
+        end
+
+        ##
+        # Blocks until this asynchronous writer has been stopped, or the given
+        # timeout (if present) has elapsed.
+        #
+        # @param [Number] timeout Timeout in seconds, or nil for no timeout.
+        #
+        # @return [Boolean] Returns true if the writer is stopped, or false
+        #   if the timeout expired.
+        #
+        def wait_until_stopped timeout = nil
+          deadline = timeout ? ::Time.new.to_f + timeout : nil
+          @lock.synchronize do
+            until state == :stopped
+              cur_time = ::Time.new.to_f
+              return false if deadline && cur_time >= deadline
+              @lock_cond.wait(deadline ? deadline - cur_time : nil)
+            end
+          end
+          true
+        end
+
+        protected
+
+        ##
+        # @private The background thread implementation, which continuously
+        # waits for performs work, and returns only when fully stopped.
+        #
+        def run_backgrounder
+          loop do
+            queue_item = wait_next_item
+            return unless queue_item
+            begin
+              logging.write_entries(
+                queue_item.entries,
+                log_name: queue_item.log_name,
+                resource: queue_item.resource,
+                labels: queue_item.labels
+              )
+            rescue => e
+              # Ignore any exceptions thrown from the background thread, but
+              # keep running to ensure its state behavior remains consistent.
+              @last_exception = e
+            end
+          end
+        end
+
+        ##
+        # @private Wait for and dequeue the next set of log entries to transmit.
+        #
+        # @return [QueueItem,NilClass] Returns the next set of entries. If
+        #   the writer has been stopped and no more entries are left in the
+        #   queue, returns nil.
+        #
+        def wait_next_item
+          @lock.synchronize do
+            while state == :suspended ||
+                  (state == :running && @queue.empty?)
+              @lock_cond.wait
+            end
+            if @queue.empty?
+              @state = :stopped
+              nil
+            else
+              queue_item = @queue.shift
+              @queue_size -= queue_item.entries.size
+              @lock_cond.broadcast
+              queue_item
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -40,6 +40,10 @@ module Google
         attr_accessor :logging
 
         ##
+        # @private The async writer object.
+        attr_accessor :async_writer
+
+        ##
         # @private The Google Cloud log_name to write the log entry with.
         attr_reader :log_name
 
@@ -53,8 +57,10 @@ module Google
 
         ##
         # @private Creates a new Logger instance.
-        def initialize logging, log_name, resource, labels = nil
+        def initialize logging, log_name, resource, labels = nil,
+                       async_writer = nil
           @logging = logging
+          @async_writer = async_writer
           @log_name = log_name
           @resource = resource
           @labels = labels
@@ -274,9 +280,9 @@ module Google
             e.payload = message
           end
 
-          logging.write_entries entry, log_name: log_name,
-                                       resource: resource,
-                                       labels: labels
+          (async_writer || logging).write_entries entry, log_name: log_name,
+                                                         resource: resource,
+                                                         labels: labels
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -299,12 +299,18 @@ module Google
         #
         #   async = logging.async_writer
         #
+        #   entry1 = logging.entry payload: "Job started."
+        #   entry2 = logging.entry payload: "Job completed."
+        #
+        #   labels = { job_size: "large", job_code: "red" }
         #   resource = logging.resource "gae_app",
-        #                               module_id: "1",
-        #                               version_id: "20150925t173233"
-        #   logger = logging.logger "my_app_log", resource, async_writer: async
-        #   logger.info "First log entry."
-        #   logger.info "Another entry."
+        #                               "module_id" => "1",
+        #                               "version_id" => "20150925t173233"
+        #
+        #   async.write_entries [entry1, entry2],
+        #                       log_name: "my_app_log",
+        #                       resource: resource,
+        #                       labels: labels
         #
         def async_writer max_queue_size: AsyncWriter::DEFAULT_MAX_QUEUE_SIZE
           AsyncWriter.new self, max_queue_size
@@ -314,12 +320,21 @@ module Google
         # Creates a logger instance that is API-compatible with Ruby's standard
         # library [Logger](http://ruby-doc.org/stdlib/libdoc/logger/rdoc).
         #
+        # By default, the logger will create an AsyncWriter to transmit log
+        # entries on a background thread. You may change this behavior using
+        # the async_writer parameter.
+        #
         # @param [String] log_name A log resource name to be associated with the
         #   written log entries.
         # @param [Google::Cloud::Logging::Resource] resource The monitored
         #   resource to be associated with written log entries.
         # @param [Hash] labels A set of user-defined data to be associated with
         #   written log entries.
+        # @param [Boolean|AsyncWriter] async_writer An AsyncWriter for the
+        #   logger to transmit log entries. You may also pass true to request
+        #   a new AsyncWriter for this logger, or false to request no
+        #   AsyncWriter (which will cause the logger to make blocking calls).
+        #   Default is true.
         #
         # @return [Google::Cloud::Logging::Logger] a Logger object that can be
         #   used in place of a ruby standard library logger object.
@@ -337,8 +352,13 @@ module Google
         #   logger = logging.logger "my_app_log", resource, env: :production
         #   logger.info "Job started."
         #
-        def logger log_name, resource, labels = {}
-          Logger.new self, log_name, resource, labels
+        def logger log_name, resource, labels = {}, async_writer: true
+          async_writer = case async_writer
+                         when true then self.async_writer
+                         when false then nil
+                         else async_writer
+                         end
+          Logger.new self, log_name, resource, labels, async_writer
         end
 
         ##

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -1,0 +1,139 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+
+describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
+  let(:log_name) { "web_app_log" }
+  let(:resource) do
+    Google::Cloud::Logging::Resource.new.tap do |r|
+      r.type = "gce_instance"
+      r.labels["zone"] = "global"
+      r.labels["instance_id"] = "abc123"
+    end
+  end
+  let(:labels1) { { "env" => "production" } }
+  let(:labels2) { { "env" => "staging" } }
+  let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
+  let(:async_writer) { Google::Cloud::Logging::AsyncWriter.new logging }
+
+  def entries payload, labels = labels1
+    Array(payload).map { |str|
+      logging.entry(
+        log_name: log_name,
+        resource: resource,
+        severity: :INFO,
+        labels: labels,
+        payload: str
+      )
+    }
+  end
+
+  def write_req payload, labels = labels1
+    full_log_name = "projects/test/logs/#{log_name}"
+    Google::Logging::V2::WriteLogEntriesRequest.new(
+      log_name: full_log_name,
+      resource: resource.to_grpc,
+      labels: labels,
+      entries: Array(payload).map { |str|
+        Google::Logging::V2::LogEntry.new(
+          text_payload: str,
+          severity: :INFO,
+          resource: resource.to_grpc,
+          log_name: full_log_name,
+          labels: labels
+        )
+      }
+    )
+  end
+
+  it "writes a single entry" do
+    mock = Minitest::Mock.new
+    logging.service.mocked_logging = mock
+
+    mock.expect :write_log_entries, write_res, [write_req("payload1")]
+
+    async_writer.write_entries(
+      entries("payload1"),
+      log_name: log_name,
+      resource: resource,
+      labels: labels1
+    )
+    async_writer.stop
+    async_writer.wait_until_stopped 1
+
+    mock.verify
+  end
+
+  it "combines related entries" do
+    mock = Minitest::Mock.new
+    logging.service.mocked_logging = mock
+
+    mock.expect(:write_log_entries, write_res,
+      [write_req(["payload1", "payload2"], labels1)]
+    )
+
+    async_writer.suspend
+    async_writer.write_entries(
+      entries("payload1"),
+      log_name: log_name,
+      resource: resource,
+      labels: labels1
+    )
+    async_writer.write_entries(
+      entries("payload2"),
+      log_name: log_name,
+      resource: resource,
+      labels: labels1
+    )
+    async_writer.resume
+    async_writer.stop
+    async_writer.wait_until_stopped 1
+
+    mock.verify
+  end
+
+  it "separates unrelated entries" do
+    mock = Minitest::Mock.new
+    logging.service.mocked_logging = mock
+
+    mock.expect(:write_log_entries, write_res,
+      [write_req(["payload1"], labels1)]
+    )
+    mock.expect(:write_log_entries, write_res,
+      [write_req("payload2", labels2)]
+    )
+
+    async_writer.suspend
+    async_writer.write_entries(
+      entries("payload1", labels1),
+      log_name: log_name,
+      resource: resource,
+      labels: labels1
+    )
+    async_writer.write_entries(
+      entries("payload2", labels2),
+      log_name: log_name,
+      resource: resource,
+      labels: labels2
+    )
+    async_writer.resume
+    async_writer.stop
+    async_writer.wait_until_stopped 1
+
+    mock.verify
+  end
+
+end

--- a/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
@@ -1,0 +1,34 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Logging::Project, :async_writer, :mock_logging do
+  it "creates an async writer object" do
+    async = logging.async_writer
+    async.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    async.logging.must_be_same_as logging
+    async.max_queue_size.must_equal \
+      Google::Cloud::Logging::AsyncWriter::DEFAULT_MAX_QUEUE_SIZE
+    async.state.must_equal :running
+  end
+
+  it "creates an async writer object with a max queue size" do
+    async = logging.async_writer max_queue_size: 42
+    async.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    async.logging.must_be_same_as logging
+    async.max_queue_size.must_equal 42
+    async.state.must_equal :running
+  end
+end

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -27,6 +27,7 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
+    logger.async_writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object without labels" do
@@ -40,5 +41,20 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_be :empty?
+  end
+
+  it "creates a ruby logger object without an async writer" do
+    log_name = "web_app_log"
+    resource = Google::Cloud::Logging::Resource.new.tap do |r|
+      r.type = "web_app_server"
+    end
+    labels = { "env" => "production" }
+
+    logger = logging.logger log_name, resource, labels, async_writer: false
+    logger.must_be_kind_of Google::Cloud::Logging::Logger
+    logger.log_name.must_equal log_name
+    logger.resource.must_equal resource
+    logger.labels.must_equal labels
+    logger.async_writer.must_be_nil
   end
 end


### PR DESCRIPTION
This is an attempt to address issue #898 by providing a way for Logger to make non-blocking calls. Please feel free to critique the approach. The idea is to provide an object that queues up log entries and writes them in batches from a background thread.