### PR TITLE
Convert Datastore to GAPIC

### DIFF
--- a/google-cloud-datastore/acceptance/datastore_helper.rb
+++ b/google-cloud-datastore/acceptance/datastore_helper.rb
@@ -19,7 +19,7 @@ require "minitest/rg"
 require "google/cloud/datastore"
 
 # Create shared dataset object so we don't create new for each test
-$dataset = Google::Cloud.new.datastore retries: 10
+$dataset = Google::Cloud.new.datastore
 
 module Acceptance
   ##

--- a/google-cloud-datastore/lib/google-cloud-datastore.rb
+++ b/google-cloud-datastore/lib/google-cloud-datastore.rb
@@ -38,8 +38,9 @@ module Google
     #   The default scope is:
     #
     #   * `https://www.googleapis.com/auth/datastore`
-    # @param [Integer] retries This option is not currently supported.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
+    # @param [Hash] client_config A hash of values to override the default
+    #   behavior of the API client. See Google::Gax::CallSettings. Optional.
     #
     # @return [Google::Cloud::Datastore::Dataset]
     #
@@ -65,10 +66,10 @@ module Google
     #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
     #   datastore = gcloud.datastore scope: platform_scope
     #
-    def datastore scope: nil, retries: nil, timeout: nil
+    def datastore scope: nil, timeout: nil, client_config: nil
       Google::Cloud.datastore @project, @keyfile,
-                              scope: scope, retries: retries,
-                              timeout: (timeout || @timeout)
+                              scope: scope, timeout: (timeout || @timeout),
+                              client_config: client_config
     end
 
     ##
@@ -90,8 +91,9 @@ module Google
     #   The default scope is:
     #
     #   * `https://www.googleapis.com/auth/datastore`
-    # @param [Integer] retries This option is not currently supported.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
+    # @param [Hash] client_config A hash of values to override the default
+    #   behavior of the API client. See Google::Gax::CallSettings. Optional.
     #
     # @return [Google::Cloud::Datastore::Dataset]
     #
@@ -106,16 +108,16 @@ module Google
     #     t["done"] = false
     #     t["priority"] = 4
     #     t["description"] = "Learn Cloud Datastore"
-    #   end
+    #   end                                                                  ``
     #
     #   datastore.save task
     #
-    def self.datastore project = nil, keyfile = nil, scope: nil, retries: nil,
-                       timeout: nil
+    def self.datastore project = nil, keyfile = nil, scope: nil, timeout: nil,
+                       client_config: nil
       require "google/cloud/datastore"
       Google::Cloud::Datastore.new project: project, keyfile: keyfile,
-                                   scope: scope, retries: retries,
-                                   timeout: timeout
+                                   scope: scope, timeout: timeout,
+                                   client_config: client_config
     end
   end
 end

--- a/google-cloud-datastore/lib/google-cloud-datastore.rb
+++ b/google-cloud-datastore/lib/google-cloud-datastore.rb
@@ -38,8 +38,7 @@ module Google
     #   The default scope is:
     #
     #   * `https://www.googleapis.com/auth/datastore`
-    # @param [Integer] retries Number of times to retry requests on server
-    #   error. The default value is `3`. Optional.
+    # @param [Integer] retries This option is not currently supported.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     #
     # @return [Google::Cloud::Datastore::Dataset]
@@ -68,7 +67,7 @@ module Google
     #
     def datastore scope: nil, retries: nil, timeout: nil
       Google::Cloud.datastore @project, @keyfile,
-                              scope: scope, retries: (retries || @retries),
+                              scope: scope, retries: retries,
                               timeout: (timeout || @timeout)
     end
 
@@ -91,8 +90,7 @@ module Google
     #   The default scope is:
     #
     #   * `https://www.googleapis.com/auth/datastore`
-    # @param [Integer] retries Number of times to retry requests on server
-    #   error. The default value is `3`. Optional.
+    # @param [Integer] retries This option is not currently supported.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     #
     # @return [Google::Cloud::Datastore::Dataset]

--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -518,9 +518,9 @@ module Google
       #   The default scope is:
       #
       #   * `https://www.googleapis.com/auth/datastore`
-      # @param [Integer] retries Number of times to retry requests on server
-      #   error. The default value is `3`. Optional.
       # @param [Integer] timeout Default timeout to use in requests. Optional.
+      # @param [Hash] client_config A hash of values to override the default
+      #   behavior of the API client. See Google::Gax::CallSettings. Optional.
       #
       # @return [Google::Cloud::Datastore::Dataset]
       #
@@ -541,8 +541,8 @@ module Google
       #
       #   datastore.save task
       #
-      def self.new project: nil, keyfile: nil, scope: nil, retries: nil,
-                   timeout: nil
+      def self.new project: nil, keyfile: nil, scope: nil, timeout: nil,
+                   client_config: nil
         project ||= Google::Cloud::Datastore::Dataset.default_project
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
@@ -551,20 +551,24 @@ module Google
           return Google::Cloud::Datastore::Dataset.new(
             Google::Cloud::Datastore::Service.new(
               project, :this_channel_is_insecure,
-              host: ENV["DATASTORE_EMULATOR_HOST"], retries: retries))
+              host: ENV["DATASTORE_EMULATOR_HOST"],
+              client_config: client_config))
         end
-
-        if keyfile.nil?
-          credentials = Google::Cloud::Datastore::Credentials.default(
-            scope: scope)
-        else
-          credentials = Google::Cloud::Datastore::Credentials.new(
-            keyfile, scope: scope)
-        end
-
+        credentials = credentials_with_scope keyfile, scope
         Google::Cloud::Datastore::Dataset.new(
           Google::Cloud::Datastore::Service.new(
-            project, credentials, retries: retries, timeout: timeout))
+            project, credentials, timeout: timeout,
+                                  client_config: client_config))
+      end
+
+      ##
+      # @private
+      def self.credentials_with_scope keyfile, scope
+        if keyfile.nil?
+          Google::Cloud::Datastore::Credentials.default(scope: scope)
+        else
+          Google::Cloud::Datastore::Credentials.new(keyfile, scope: scope)
+        end
       end
     end
   end

--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -444,28 +444,15 @@ module Google
     # end
     # ```
     #
-    # ## Configuring retries and timeout
+    # ## Configuring timeout
     #
-    # You can configure how many times API requests may be automatically
-    # retried. When an API request fails, the response will be inspected to see
-    # if the request meets criteria indicating that it may succeed on retry,
-    # such as `500` and `503` status codes or a specific internal error code
-    # such as `rateLimitExceeded`. If it meets the criteria, the request will be
-    # retried after a delay. If another error occurs, the delay will be
-    # increased before a subsequent attempt, until the `retries` limit is
-    # reached.
-    #
-    # You can also set the request `timeout` value in seconds.
+    # You can configure the request `timeout` value in seconds.
     #
     # ```ruby
     # require "google/cloud/datastore"
     #
-    # datastore = Google::Cloud::Datastore.new retries: 10, timeout: 120
+    # datastore = Google::Cloud::Datastore.new timeout: 120
     # ```
-    #
-    # See the [Datastore error
-    # codes](https://cloud.google.com/datastore/docs/concepts/errors#error_codes)
-    # for a list of error conditions.
     #
     # ## The Cloud Datastore Emulator
     #

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -54,7 +54,7 @@ module Google
       #
       class Dataset
         ##
-        # @private The gRPC Service object.
+        # @private The Service object.
         attr_accessor :service
 
         ##

--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -32,7 +32,7 @@ module Google
                        timeout: nil
           @project = project
           @credentials = credentials
-          @host = host || "datastore.googleapis.com"
+          @host = host || V1::DatastoreApi::SERVICE_ADDRESS
           @retries = retries
           @timeout = timeout
         end
@@ -43,8 +43,8 @@ module Google
             GRPC::Core::CallCredentials.new credentials.client.updater_proc
         end
 
-        def datastore
-          return mocked_datastore if mocked_datastore
+        def service
+          return mocked_service if mocked_service
           @datastore ||= begin
             require "google/datastore/v1/datastore_services_pb"
 
@@ -52,7 +52,7 @@ module Google
               host, creds, timeout: timeout)
           end
         end
-        attr_accessor :mocked_datastore
+        attr_accessor :mocked_service
 
         def insecure?
           credentials == :this_channel_is_insecure
@@ -67,7 +67,7 @@ module Google
             keys: incomplete_keys
           )
 
-          execute { datastore.allocate_ids allocate_req }
+          execute { service.allocate_ids allocate_req }
         end
 
         ##
@@ -80,7 +80,7 @@ module Google
           lookup_req.read_options = generate_read_options consistency,
                                                           transaction
 
-          execute { datastore.lookup lookup_req }
+          execute { service.lookup lookup_req }
         end
 
         # Query for entities.
@@ -99,7 +99,7 @@ module Google
           run_req.partition_id = Google::Datastore::V1::PartitionId.new(
             namespace_id: namespace) if namespace
 
-          execute { datastore.run_query run_req }
+          execute { service.run_query run_req }
         end
 
         ##
@@ -109,7 +109,7 @@ module Google
             project_id: project
           )
 
-          execute { datastore.begin_transaction tx_req }
+          execute { service.begin_transaction tx_req }
         end
 
         ##
@@ -126,7 +126,7 @@ module Google
             commit_req.transaction = transaction
           end
 
-          execute { datastore.commit commit_req }
+          execute { service.commit commit_req }
         end
 
         ##
@@ -137,7 +137,7 @@ module Google
             transaction: transaction
           )
 
-          execute { datastore.rollback rb_req }
+          execute { service.rollback rb_req }
         end
 
         def inspect

--- a/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
@@ -59,7 +59,7 @@ module Google
 
         ##
         # @private Creates a new Transaction instance.
-        # Takes a Connection and Service instead of project and Credentials.
+        # Takes a Service instead of project and Credentials.
         def initialize service
           @service = service
           reset!

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1.rb
@@ -14,3 +14,5 @@
 
 
 require "google/cloud/datastore/v1/datastore_api"
+# Require the protobufs so we can create objects before GRPC is loaded.
+require "google/datastore/v1/datastore_pb"

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -72,11 +72,11 @@ describe Google::Cloud::Datastore::Dataset do
   end
 
   before do
-    dataset.service.mocked_datastore = Minitest::Mock.new
+    dataset.service.mocked_service = Minitest::Mock.new
   end
 
   after do
-    dataset.service.mocked_datastore.verify
+    dataset.service.mocked_service.verify
   end
 
   it "allocate_ids returns complete keys" do
@@ -87,7 +87,7 @@ describe Google::Cloud::Datastore::Dataset do
     allocate_res = Google::Datastore::V1::AllocateIdsResponse.new(
       keys: [Google::Cloud::Datastore::Key.new("ds-test", 1234).to_grpc]
     )
-    dataset.service.mocked_datastore.expect :allocate_ids, allocate_res, [allocate_req]
+    dataset.service.mocked_service.expect :allocate_ids, allocate_res, [allocate_req]
 
     incomplete_key = Google::Cloud::Datastore::Key.new "ds-test"
     incomplete_key.must_be :incomplete?
@@ -118,7 +118,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: [mutation]
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -143,7 +143,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: [mutation]
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -169,7 +169,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: [mutation]
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -193,7 +193,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: [mutation]
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -223,7 +223,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -257,7 +257,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -287,7 +287,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: [mutation]
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -311,7 +311,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: [mutation]
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -341,7 +341,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -375,7 +375,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -405,7 +405,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: [mutation]
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -437,7 +437,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -473,7 +473,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -495,7 +495,7 @@ describe Google::Cloud::Datastore::Dataset do
       project_id: project,
       keys: [Google::Cloud::Datastore::Key.new("ds-test", 123).to_grpc]
     )
-    dataset.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     entity = dataset.find "ds-test", 123
     entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -506,7 +506,7 @@ describe Google::Cloud::Datastore::Dataset do
       project_id: project,
       keys: [Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc]
     )
-    dataset.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     entity = dataset.find "ds-test", "thingie"
     entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -517,7 +517,7 @@ describe Google::Cloud::Datastore::Dataset do
       project_id: project,
       keys: [Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc]
     )
-    dataset.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     entity = dataset.find key
@@ -529,7 +529,7 @@ describe Google::Cloud::Datastore::Dataset do
       project_id: project,
       keys: [Google::Cloud::Datastore::Key.new("ds-test", 123).to_grpc]
     )
-    dataset.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     entity = dataset.get "ds-test", 123
     entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -541,7 +541,7 @@ describe Google::Cloud::Datastore::Dataset do
       keys: [Google::Cloud::Datastore::Key.new("ds-test", 123).to_grpc],
       read_options: Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
     )
-    dataset.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     entity = dataset.find "ds-test", 123, consistency: :eventual
     entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -560,7 +560,7 @@ describe Google::Cloud::Datastore::Dataset do
       keys: [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
              Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
     )
-    dataset.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -579,7 +579,7 @@ describe Google::Cloud::Datastore::Dataset do
       keys: [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
              Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
     )
-    dataset.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -599,7 +599,7 @@ describe Google::Cloud::Datastore::Dataset do
              Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc],
       read_options: Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
     )
-    dataset.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -648,7 +648,7 @@ describe Google::Cloud::Datastore::Dataset do
         keys: [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
                Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
       )
-      dataset.service.mocked_datastore.expect :lookup, lookup_res_deferred, [lookup_req]
+      dataset.service.mocked_service.expect :lookup, lookup_res_deferred, [lookup_req]
 
       key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
       key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -670,7 +670,7 @@ describe Google::Cloud::Datastore::Dataset do
         keys: [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
                Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
       )
-      dataset.service.mocked_datastore.expect :lookup, lookup_res_missing, [lookup_req]
+      dataset.service.mocked_service.expect :lookup, lookup_res_missing, [lookup_req]
 
       key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
       key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -696,7 +696,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: [mutation]
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -716,7 +716,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -740,7 +740,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -762,7 +762,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: [mutation]
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     dataset.delete key
@@ -779,7 +779,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -803,7 +803,7 @@ describe Google::Cloud::Datastore::Dataset do
       mutations: [mutation1, mutation2]
     )
 
-    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [commit_req]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -821,7 +821,7 @@ describe Google::Cloud::Datastore::Dataset do
       project_id: project,
       query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [run_query_req]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run query
@@ -864,7 +864,7 @@ describe Google::Cloud::Datastore::Dataset do
       mode: :NON_TRANSACTIONAL,
       mutations: mutations
     )
-    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    dataset.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity_to_be_saved = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "to-be-saved"
@@ -888,7 +888,7 @@ describe Google::Cloud::Datastore::Dataset do
       project_id: project,
       query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [run_query_req]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run_query query
@@ -925,7 +925,7 @@ describe Google::Cloud::Datastore::Dataset do
       ),
       query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [run_query_req]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run_query query, namespace: "foobar"
@@ -960,7 +960,7 @@ describe Google::Cloud::Datastore::Dataset do
       gql_query: Google::Datastore::V1::GqlQuery.new(
         query_string: "SELECT * FROM Task")
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [run_query_req]
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run gql
@@ -999,7 +999,7 @@ describe Google::Cloud::Datastore::Dataset do
       gql_query: Google::Datastore::V1::GqlQuery.new(
         query_string: "SELECT * FROM Task")
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [run_query_req]
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run gql, namespace: "foobar"
@@ -1035,7 +1035,7 @@ describe Google::Cloud::Datastore::Dataset do
       gql_query: Google::Datastore::V1::GqlQuery.new(
         query_string: "SELECT * FROM Task")
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [run_query_req]
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run_query gql
@@ -1074,7 +1074,7 @@ describe Google::Cloud::Datastore::Dataset do
       gql_query: Google::Datastore::V1::GqlQuery.new(
         query_string: "SELECT * FROM Task")
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [run_query_req]
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run_query gql, namespace: "foobar"
@@ -1248,7 +1248,7 @@ describe Google::Cloud::Datastore::Dataset do
   it "transaction will return a Transaction" do
     tx_id = "giterdone".encode("ASCII-8BIT")
     begin_tx_res = Google::Datastore::V1::BeginTransactionResponse.new(transaction: tx_id)
-    dataset.service.mocked_datastore.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
 
     tx = dataset.transaction
     tx.must_be_kind_of Google::Cloud::Datastore::Transaction
@@ -1263,8 +1263,8 @@ describe Google::Cloud::Datastore::Dataset do
         key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc
       )]
     )
-    dataset.service.mocked_datastore.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
-    dataset.service.mocked_datastore.expect :commit, commit_res, [Google::Datastore::V1::CommitRequest]
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
+    dataset.service.mocked_service.expect :commit, commit_res, [Google::Datastore::V1::CommitRequest]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -1279,8 +1279,8 @@ describe Google::Cloud::Datastore::Dataset do
     tx_id = "giterdone".encode("ASCII-8BIT")
     begin_tx_res = Google::Datastore::V1::BeginTransactionResponse.new(transaction: tx_id)
     rollback_res = Google::Datastore::V1::RollbackResponse.new
-    dataset.service.mocked_datastore.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
-    dataset.service.mocked_datastore.expect :rollback, rollback_res, [Google::Datastore::V1::RollbackRequest]
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
+    dataset.service.mocked_service.expect :rollback, rollback_res, [Google::Datastore::V1::RollbackRequest]
 
     error = assert_raises Google::Cloud::Datastore::TransactionError do
       dataset.transaction do |tx|

--- a/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
@@ -65,11 +65,11 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
   end
 
   before do
-    dataset.service.mocked_datastore = Minitest::Mock.new
+    dataset.service.mocked_service = Minitest::Mock.new
   end
 
   after do
-    dataset.service.mocked_datastore.verify
+    dataset.service.mocked_service.verify
   end
 
   it "paginates" do
@@ -81,8 +81,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       project_id: project,
       keys: [key3, key4].map(&:to_grpc)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     first_entities = dataset.find_all keys
     first_entities.count.must_equal 2
@@ -118,8 +118,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       keys: [key3, key4].map(&:to_grpc),
       read_options: Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     first_entities = dataset.find_all keys, consistency: :eventual
     first_entities.count.must_equal 2
@@ -152,8 +152,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       #   key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc
       # )]
     )
-    dataset.service.mocked_datastore.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
-    dataset.service.mocked_datastore.expect :commit, commit_res, [Google::Datastore::V1::CommitRequest]
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
+    dataset.service.mocked_service.expect :commit, commit_res, [Google::Datastore::V1::CommitRequest]
 
     first_lookup_req = Google::Datastore::V1::LookupRequest.new(
       project_id: project,
@@ -165,8 +165,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       keys: [key3, key4].map(&:to_grpc),
       read_options: Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     dataset.transaction do |tx|
       first_entities = tx.find_all keys
@@ -202,8 +202,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       project_id: project,
       keys: [key3, key4].map(&:to_grpc)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     first_entities = dataset.find_all keys
     first_entities.next?.must_equal true
@@ -241,8 +241,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       keys: [key3, key4].map(&:to_grpc),
       read_options: Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     first_entities = dataset.find_all keys, consistency: :eventual
     first_entities.next?.must_equal true
@@ -277,8 +277,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       #   key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc
       # )]
     )
-    dataset.service.mocked_datastore.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
-    dataset.service.mocked_datastore.expect :commit, commit_res, [Google::Datastore::V1::CommitRequest]
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
+    dataset.service.mocked_service.expect :commit, commit_res, [Google::Datastore::V1::CommitRequest]
 
     first_lookup_req = Google::Datastore::V1::LookupRequest.new(
       project_id: project,
@@ -290,8 +290,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       keys: [key3, key4].map(&:to_grpc),
       read_options: Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     dataset.transaction do |tx|
       first_entities = tx.find_all keys
@@ -329,8 +329,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       project_id: project,
       keys: [key3, key4].map(&:to_grpc)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     entities = dataset.find_all(keys).all.to_a
     entities.count.must_equal 4
@@ -350,8 +350,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       keys: [key3, key4].map(&:to_grpc),
       read_options: Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     entities = dataset.find_all(keys, consistency: :eventual).all.to_a
     entities.count.must_equal 4
@@ -368,8 +368,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       #   key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc
       # )]
     )
-    dataset.service.mocked_datastore.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
-    dataset.service.mocked_datastore.expect :commit, commit_res, [Google::Datastore::V1::CommitRequest]
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
+    dataset.service.mocked_service.expect :commit, commit_res, [Google::Datastore::V1::CommitRequest]
 
     first_lookup_req = Google::Datastore::V1::LookupRequest.new(
       project_id: project,
@@ -381,8 +381,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       keys: [key3, key4].map(&:to_grpc),
       read_options: Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     dataset.transaction do |tx|
       entities = tx.find_all(keys).all.to_a
@@ -402,8 +402,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       project_id: project,
       keys: [key3, key4].map(&:to_grpc)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     entities = dataset.find_all(keys).all.take(3)
     entities.count.must_equal 3
@@ -421,8 +421,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       project_id: project,
       keys: [key3, key4].map(&:to_grpc)
     )
-    dataset.service.mocked_datastore.expect :lookup, first_lookup_res,  [first_lookup_req]
-    dataset.service.mocked_datastore.expect :lookup, second_lookup_res, [second_lookup_req]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [first_lookup_req]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [second_lookup_req]
 
     # This test is a bit handwavy, as there aren't more results to lookup.
     # But if you reduce the limit it will not make additional call.

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
@@ -18,12 +18,7 @@ describe Google::Cloud::Datastore::Dataset, :all do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
   let(:dataset)     { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
-  let(:first_run_query_req) do
-    Google::Datastore::V1::RunQueryRequest.new(
-      project_id: project,
-      query: Google::Cloud::Datastore::Query.new.kind("Task").to_grpc
-    )
-  end
+  let(:first_run_query) { Google::Cloud::Datastore::Query.new.kind("Task").to_grpc }
   let(:first_run_query_res) do
     run_query_res_entities = 25.times.map do |i|
       Google::Datastore::V1::EntityResult.new(
@@ -42,13 +37,10 @@ describe Google::Cloud::Datastore::Dataset, :all do
       )
     )
   end
-  let(:next_run_query_req) do
-    Google::Datastore::V1::RunQueryRequest.new(
-      project_id: project,
-      query: Google::Cloud::Datastore::Query.new.kind("Task").start(
-        Google::Cloud::Datastore::Cursor.from_grpc("second-page-cursor")
-      ).to_grpc
-    )
+  let(:next_run_query) do
+    Google::Cloud::Datastore::Query.new.kind("Task").start(
+      Google::Cloud::Datastore::Cursor.from_grpc("second-page-cursor")
+    ).to_grpc
   end
   let(:next_run_query_res) do
     run_query_res_entities = 25.times.map do |i|
@@ -70,8 +62,8 @@ describe Google::Cloud::Datastore::Dataset, :all do
 
   before do
     dataset.service.mocked_service = Minitest::Mock.new
-    dataset.service.mocked_service.expect :run_query, first_run_query_res, [first_run_query_req]
-    dataset.service.mocked_service.expect :run_query, next_run_query_res, [next_run_query_req]
+    dataset.service.mocked_service.expect :run_query, first_run_query_res, [project, nil, nil, query: first_run_query, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, next_run_query_res, [project, nil, nil, query: next_run_query, gql_query: nil]
   end
 
   after do

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
@@ -69,13 +69,13 @@ describe Google::Cloud::Datastore::Dataset, :all do
   end
 
   before do
-    dataset.service.mocked_datastore = Minitest::Mock.new
-    dataset.service.mocked_datastore.expect :run_query, first_run_query_res, [first_run_query_req]
-    dataset.service.mocked_datastore.expect :run_query, next_run_query_res, [next_run_query_req]
+    dataset.service.mocked_service = Minitest::Mock.new
+    dataset.service.mocked_service.expect :run_query, first_run_query_res, [first_run_query_req]
+    dataset.service.mocked_service.expect :run_query, next_run_query_res, [next_run_query_req]
   end
 
   after do
-    dataset.service.mocked_datastore.verify
+    dataset.service.mocked_service.verify
   end
 
   it "run will fulfill a query and return an object that can paginate" do

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
@@ -70,13 +70,13 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more do
   end
 
   before do
-    dataset.service.mocked_datastore = Minitest::Mock.new
-    dataset.service.mocked_datastore.expect :run_query, first_run_query_res, [first_run_query_req]
-    dataset.service.mocked_datastore.expect :run_query, next_run_query_res, [next_run_query_req]
+    dataset.service.mocked_service = Minitest::Mock.new
+    dataset.service.mocked_service.expect :run_query, first_run_query_res, [first_run_query_req]
+    dataset.service.mocked_service.expect :run_query, next_run_query_res, [next_run_query_req]
   end
 
   after do
-    dataset.service.mocked_datastore.verify
+    dataset.service.mocked_service.verify
   end
 
   it "run will fulfill a query and can use the all and limit api calls" do

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
@@ -18,12 +18,7 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
   let(:dataset)     { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
-  let(:first_run_query_req) do
-    Google::Datastore::V1::RunQueryRequest.new(
-      project_id: project,
-      query: Google::Cloud::Datastore::Query.new.kind("Task").to_grpc
-    )
-  end
+  let(:first_run_query) { Google::Cloud::Datastore::Query.new.kind("Task").to_grpc }
   let(:first_run_query_res) do
     run_query_res_entities = 25.times.map do |i|
       Google::Datastore::V1::EntityResult.new(
@@ -42,14 +37,11 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more do
       )
     )
   end
-  let(:next_run_query_req) do
-    Google::Datastore::V1::RunQueryRequest.new(
-      project_id: project,
-      query: Google::Cloud::Datastore::Query.new.kind("Task").start(
+  let(:next_run_query) do
+      Google::Cloud::Datastore::Query.new.kind("Task").start(
         Google::Cloud::Datastore::Cursor.from_grpc("second-page-cursor")
       ).to_grpc
-    )
-  end
+    end
   let(:next_run_query_res) do
     run_query_res_entities = 25.times.map do |i|
       Google::Datastore::V1::EntityResult.new(
@@ -71,8 +63,8 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more do
 
   before do
     dataset.service.mocked_service = Minitest::Mock.new
-    dataset.service.mocked_service.expect :run_query, first_run_query_res, [first_run_query_req]
-    dataset.service.mocked_service.expect :run_query, next_run_query_res, [next_run_query_req]
+    dataset.service.mocked_service.expect :run_query, first_run_query_res, [project, nil, nil, query: first_run_query, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, next_run_query_res, [project, nil, nil, query: next_run_query, gql_query: nil]
   end
 
   after do

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
@@ -58,11 +58,11 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
   end
 
   before do
-    dataset.service.mocked_datastore = Minitest::Mock.new
+    dataset.service.mocked_service = Minitest::Mock.new
   end
 
   after do
-    dataset.service.mocked_datastore.verify
+    dataset.service.mocked_service.verify
   end
 
   it "has more_results not_finished" do
@@ -70,7 +70,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
       project_id: project,
       query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res_not_finished, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res_not_finished, [run_query_req]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run query
@@ -104,7 +104,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
       project_id: project,
       query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res_more_after_limit, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_limit, [run_query_req]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run query
@@ -138,7 +138,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
       project_id: project,
       query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res_more_after_cursor, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_cursor, [run_query_req]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run query
@@ -172,7 +172,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
       project_id: project,
       query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
     )
-    dataset.service.mocked_datastore.expect :run_query, run_query_res_no_more, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res_no_more, [run_query_req]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run query

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
@@ -18,6 +18,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
   let(:dataset)     { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
+  let(:query)       { Google::Cloud::Datastore::Query.new.kind("User") }
   let(:run_query_res) do
     run_query_res_entities = 2.times.map do |i|
       Google::Datastore::V1::EntityResult.new(
@@ -66,13 +67,9 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
   end
 
   it "has more_results not_finished" do
-    run_query_req = Google::Datastore::V1::RunQueryRequest.new(
-      project_id: project,
-      query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
-    )
-    dataset.service.mocked_service.expect :run_query, run_query_res_not_finished, [run_query_req]
-
     query = Google::Cloud::Datastore::Query.new.kind("User")
+    dataset.service.mocked_service.expect :run_query, run_query_res_not_finished, [project, nil, nil, query: query.to_grpc, gql_query: nil]
+
     entities = dataset.run query
     entities.count.must_equal 2
     entities.each do |entity|
@@ -100,13 +97,8 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
   end
 
   it "has more_results more_after_limit" do
-    run_query_req = Google::Datastore::V1::RunQueryRequest.new(
-      project_id: project,
-      query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
-    )
-    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_limit, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_limit, [project, nil, nil, query: query.to_grpc, gql_query: nil]
 
-    query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run query
     entities.count.must_equal 2
     entities.each do |entity|
@@ -134,13 +126,8 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
   end
 
   it "has more_results more_after_cursor" do
-    run_query_req = Google::Datastore::V1::RunQueryRequest.new(
-      project_id: project,
-      query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
-    )
-    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_cursor, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_cursor, [project, nil, nil, query: query.to_grpc, gql_query: nil]
 
-    query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run query
     entities.count.must_equal 2
     entities.each do |entity|
@@ -168,13 +155,8 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
   end
 
   it "has more_results no_more" do
-    run_query_req = Google::Datastore::V1::RunQueryRequest.new(
-      project_id: project,
-      query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc
-    )
-    dataset.service.mocked_service.expect :run_query, run_query_res_no_more, [run_query_req]
+    dataset.service.mocked_service.expect :run_query, run_query_res_no_more, [project, nil, nil, query: query.to_grpc, gql_query: nil]
 
-    query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = dataset.run query
     entities.count.must_equal 2
     entities.each do |entity|

--- a/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
@@ -15,8 +15,8 @@
 require "helper"
 
 describe Google::Cloud::Datastore::Query do
+  let(:query) { Google::Cloud::Datastore::Query.new }
   it "can query on kind" do
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
 
     grpc = query.to_grpc
@@ -32,7 +32,6 @@ describe Google::Cloud::Datastore::Query do
   end
 
   it "can filter properties" do
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
     query.where "completed", "=", true
 
@@ -71,7 +70,6 @@ describe Google::Cloud::Datastore::Query do
   end
 
   it "can order results" do
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
     query.order "due"
 
@@ -90,7 +88,6 @@ describe Google::Cloud::Datastore::Query do
   end
 
   it "accepts any string that starts with 'd' for DESCENDING" do
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
     query.order "completed", "DOWN"
 
@@ -101,7 +98,6 @@ describe Google::Cloud::Datastore::Query do
   end
 
   it "can limit and offset" do
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
 
     grpc = query.to_grpc
@@ -124,7 +120,6 @@ describe Google::Cloud::Datastore::Query do
     raw_cursor = "\x13\xE0\x01\x00\xEB".force_encoding Encoding::ASCII_8BIT
     encoded_cursor = "E+ABAOs="
 
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
 
     grpc = query.to_grpc
@@ -137,7 +132,6 @@ describe Google::Cloud::Datastore::Query do
   end
 
   it "can select the properties to return" do
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
 
     grpc = query.to_grpc
@@ -152,7 +146,6 @@ describe Google::Cloud::Datastore::Query do
   end
 
   it "can select the properties using projection alias" do
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
 
     grpc = query.to_grpc
@@ -168,7 +161,6 @@ describe Google::Cloud::Datastore::Query do
   end
 
   it "can group on properties" do
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
 
     grpc = query.to_grpc
@@ -183,7 +175,6 @@ describe Google::Cloud::Datastore::Query do
   end
 
   it "can group on properties using distinct_on" do
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
 
     grpc = query.to_grpc
@@ -199,7 +190,6 @@ describe Google::Cloud::Datastore::Query do
 
   it "can query ancestor" do
     ancestor_key = Google::Cloud::Datastore::Key.new("User", "username")
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
     query.ancestor ancestor_key
 
@@ -218,7 +208,6 @@ describe Google::Cloud::Datastore::Query do
 
   it "can manually filter on ancestor" do
     ancestor_key = Google::Cloud::Datastore::Key.new("User", "username")
-    query = Google::Cloud::Datastore::Query.new
     query.kind "Task"
     query.filter "__key__", "~", ancestor_key
 
@@ -236,7 +225,6 @@ describe Google::Cloud::Datastore::Query do
   end
 
   it "can chain query methods" do
-    query = Google::Cloud::Datastore::Query.new
     q2 = query.kind("Task").select("due", "completed").
       where("completed", "=", true).group_by("completed").
       order("due", :desc).limit(10).offset(20)

--- a/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
@@ -20,8 +20,8 @@ describe Google::Cloud::Datastore::Transaction do
   let(:dataset)     { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
   let(:service) do
     s = dataset.service
-    s.mocked_datastore = Minitest::Mock.new
-    s.mocked_datastore.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
+    s.mocked_service = Minitest::Mock.new
+    s.mocked_service.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
     s
   end
   let(:transaction) { Google::Cloud::Datastore::Transaction.new service }
@@ -65,7 +65,7 @@ describe Google::Cloud::Datastore::Transaction do
   let(:tx_id) { "giterdone".encode("ASCII-8BIT") }
 
   after do
-    transaction.service.mocked_datastore.verify
+    transaction.service.mocked_service.verify
   end
 
   it "save does not persist entities" do
@@ -307,7 +307,7 @@ describe Google::Cloud::Datastore::Transaction do
         end.to_grpc), Google::Datastore::V1::Mutation.new(
           delete: Google::Cloud::Datastore::Key.new("ds-test", "to-be-deleted").to_grpc)]
     )
-    transaction.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    transaction.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity_to_be_saved = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "to-be-saved"
@@ -342,7 +342,7 @@ describe Google::Cloud::Datastore::Transaction do
       keys: [Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc],
       read_options: Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
     )
-    transaction.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    transaction.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     entity = transaction.find key
@@ -356,7 +356,7 @@ describe Google::Cloud::Datastore::Transaction do
              Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc],
       read_options: Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
     )
-    transaction.service.mocked_datastore.expect :lookup, lookup_res, [lookup_req]
+    transaction.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
 
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -375,7 +375,7 @@ describe Google::Cloud::Datastore::Transaction do
       query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc,
       read_options: Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
     )
-    transaction.service.mocked_datastore.expect :run_query, run_query_res, [run_query_req]
+    transaction.service.mocked_service.expect :run_query, run_query_res, [run_query_req]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = transaction.run query
@@ -406,7 +406,7 @@ describe Google::Cloud::Datastore::Transaction do
           e["name"] = "thingamajig"
         end.to_grpc)]
     )
-    transaction.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    transaction.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -437,7 +437,7 @@ describe Google::Cloud::Datastore::Transaction do
           e["name"] = "thingamajig"
         end.to_grpc)]
     )
-    transaction.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+    transaction.service.mocked_service.expect :commit, commit_res, [commit_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -457,7 +457,7 @@ describe Google::Cloud::Datastore::Transaction do
       project_id: project,
       transaction: tx_id
     )
-    transaction.service.mocked_datastore.expect :rollback, rollback_res, [rollback_req]
+    transaction.service.mocked_service.expect :rollback, rollback_res, [rollback_req]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"

--- a/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Datastore::Transaction do
   let(:service) do
     s = dataset.service
     s.mocked_service = Minitest::Mock.new
-    s.mocked_service.expect :begin_transaction, begin_tx_res, [Google::Datastore::V1::BeginTransactionRequest]
+    s.mocked_service.expect :begin_transaction, begin_tx_res, [project]
     s
   end
   let(:transaction) { Google::Cloud::Datastore::Transaction.new service }
@@ -288,26 +288,27 @@ describe Google::Cloud::Datastore::Transaction do
         Google::Datastore::V1::MutationResult.new,
         Google::Datastore::V1::MutationResult.new]
     )
-    commit_req = Google::Datastore::V1::CommitRequest.new(
-      project_id: project,
-      mode: :TRANSACTIONAL,
-      transaction: tx_id,
-      mutations: [Google::Datastore::V1::Mutation.new(
+    mode = :TRANSACTIONAL
+    mutations = [
+      Google::Datastore::V1::Mutation.new(
         upsert: Google::Cloud::Datastore::Entity.new.tap do |e|
           e.key = Google::Cloud::Datastore::Key.new "ds-test", "to-be-saved"
           e["name"] = "Gonna be saved"
-        end.to_grpc), Google::Datastore::V1::Mutation.new(
+        end.to_grpc),
+      Google::Datastore::V1::Mutation.new(
         insert: Google::Cloud::Datastore::Entity.new.tap do |e|
           e.key = Google::Cloud::Datastore::Key.new "ds-test", "to-be-inserted"
           e["name"] = "Gonna be inserted"
-        end.to_grpc), Google::Datastore::V1::Mutation.new(
+        end.to_grpc),
+      Google::Datastore::V1::Mutation.new(
         update: Google::Cloud::Datastore::Entity.new.tap do |e|
           e.key = Google::Cloud::Datastore::Key.new "ds-test", "to-be-updated"
           e["name"] = "Gonna be updated"
-        end.to_grpc), Google::Datastore::V1::Mutation.new(
-          delete: Google::Cloud::Datastore::Key.new("ds-test", "to-be-deleted").to_grpc)]
-    )
-    transaction.service.mocked_service.expect :commit, commit_res, [commit_req]
+        end.to_grpc),
+      Google::Datastore::V1::Mutation.new(
+        delete: Google::Cloud::Datastore::Key.new("ds-test", "to-be-deleted").to_grpc)
+    ]
+    transaction.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: tx_id]
 
     entity_to_be_saved = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "to-be-saved"
@@ -337,12 +338,9 @@ describe Google::Cloud::Datastore::Transaction do
   end
 
   it "find can take a key" do
-    lookup_req = Google::Datastore::V1::LookupRequest.new(
-      project_id: project,
-      keys: [Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc],
-      read_options: Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
-    )
-    transaction.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
+    keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc]
+    read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
+    transaction.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys]
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     entity = transaction.find key
@@ -350,13 +348,10 @@ describe Google::Cloud::Datastore::Transaction do
   end
 
   it "find_all takes several keys" do
-    lookup_req = Google::Datastore::V1::LookupRequest.new(
-      project_id: project,
-      keys: [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
-             Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc],
-      read_options: Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
-    )
-    transaction.service.mocked_service.expect :lookup, lookup_res, [lookup_req]
+    keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
+             Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
+    read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
+    transaction.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys]
 
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -370,12 +365,9 @@ describe Google::Cloud::Datastore::Transaction do
   end
 
   it "run will fulfill a query" do
-    run_query_req = Google::Datastore::V1::RunQueryRequest.new(
-      project_id: project,
-      query: Google::Cloud::Datastore::Query.new.kind("User").to_grpc,
-      read_options: Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
-    )
-    transaction.service.mocked_service.expect :run_query, run_query_res, [run_query_req]
+    query_grpc = Google::Cloud::Datastore::Query.new.kind("User").to_grpc
+    read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
+    transaction.service.mocked_service.expect :run_query, run_query_res, [project, nil, read_options, query: query_grpc, gql_query: nil]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = transaction.run query
@@ -396,17 +388,15 @@ describe Google::Cloud::Datastore::Transaction do
     commit_res = Google::Datastore::V1::CommitResponse.new(
       mutation_results: [Google::Datastore::V1::MutationResult.new]
     )
-    commit_req = Google::Datastore::V1::CommitRequest.new(
-      project_id: project,
-      mode: :TRANSACTIONAL,
-      transaction: tx_id,
-      mutations: [Google::Datastore::V1::Mutation.new(
+    mode = :TRANSACTIONAL
+    mutations = [
+      Google::Datastore::V1::Mutation.new(
         upsert: Google::Cloud::Datastore::Entity.new.tap do |e|
           e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
           e["name"] = "thingamajig"
-        end.to_grpc)]
-    )
-    transaction.service.mocked_service.expect :commit, commit_res, [commit_req]
+        end.to_grpc)
+    ]
+    transaction.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: tx_id]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -427,17 +417,15 @@ describe Google::Cloud::Datastore::Transaction do
           key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc
         )]
     )
-    commit_req = Google::Datastore::V1::CommitRequest.new(
-      project_id: project,
-      mode: :TRANSACTIONAL,
-      transaction: tx_id,
-      mutations: [Google::Datastore::V1::Mutation.new(
+    mode = :TRANSACTIONAL
+    mutations = [
+      Google::Datastore::V1::Mutation.new(
         upsert: Google::Cloud::Datastore::Entity.new.tap do |e|
           e.key = Google::Cloud::Datastore::Key.new "ds-test"
           e["name"] = "thingamajig"
-        end.to_grpc)]
-    )
-    transaction.service.mocked_service.expect :commit, commit_res, [commit_req]
+        end.to_grpc)
+    ]
+    transaction.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: tx_id]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -453,11 +441,7 @@ describe Google::Cloud::Datastore::Transaction do
 
   it "rollback does not persist entities" do
     rollback_res = Google::Datastore::V1::RollbackResponse.new
-    rollback_req = Google::Datastore::V1::RollbackRequest.new(
-      project_id: project,
-      transaction: tx_id
-    )
-    transaction.service.mocked_service.expect :rollback, rollback_res, [rollback_req]
+    transaction.service.mocked_service.expect :rollback, rollback_res, [project, tx_id]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"

--- a/google-cloud-datastore/test/google/cloud/datastore_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore_test.rb
@@ -19,12 +19,12 @@ describe Google::Cloud do
   describe "#datastore" do
     it "calls out to Google::Cloud.datastore" do
       gcloud = Google::Cloud.new
-      stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_datastore = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal nil
         keyfile.must_equal nil
         scope.must_be :nil?
-        retries.must_be :nil?
         timeout.must_be :nil?
+        client_config.must_be :nil?
         "datastore-dataset-object-empty"
       }
       Google::Cloud.stub :datastore, stubbed_datastore do
@@ -35,12 +35,12 @@ describe Google::Cloud do
 
     it "passes project and keyfile to Google::Cloud.datastore" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_datastore = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_be :nil?
-        retries.must_be :nil?
         timeout.must_be :nil?
+        client_config.must_be :nil?
         "datastore-dataset-object"
       }
       Google::Cloud.stub :datastore, stubbed_datastore do
@@ -51,16 +51,16 @@ describe Google::Cloud do
 
     it "passes project and keyfile and options to Google::Cloud.datastore" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_datastore = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_equal "http://example.com/scope"
-        retries.must_equal 5
         timeout.must_equal 60
+        client_config.must_equal({ "gax" => "options" })
         "datastore-dataset-object-scoped"
       }
       Google::Cloud.stub :datastore, stubbed_datastore do
-        dataset = gcloud.datastore scope: "http://example.com/scope", retries: 5, timeout: 60
+        dataset = gcloud.datastore scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
         dataset.must_equal "datastore-dataset-object-scoped"
       end
     end
@@ -91,11 +91,11 @@ describe Google::Cloud do
         scope.must_equal nil
         "datastore-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "datastore-credentials"
-        retries.must_equal nil
         timeout.must_equal nil
+        client_config.must_equal nil
         OpenStruct.new project: project
       }
 
@@ -142,11 +142,11 @@ describe Google::Cloud do
         scope.must_equal nil
         "datastore-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "datastore-credentials"
-        retries.must_equal nil
         timeout.must_equal nil
+        client_config.must_equal nil
         OpenStruct.new project: project
       }
 


### PR DESCRIPTION
This PR converts all Datastore requests to the GAX client introduced in #884.

There is a breaking change: The `retries` parameter is no longer supported (although method signatures have not changed.) See #848 and #849 for proposals to add new configuration options for retry behavior.

Also, Datastore is one of the three services that still requires expanded acceptance testing (#759). I could add the needed tests as part of this PR if desired.