### PR TITLE
Update language acceptance tests

### DIFF
--- a/google-cloud-language/acceptance/language/html_test.rb
+++ b/google-cloud-language/acceptance/language/html_test.rb
@@ -164,7 +164,7 @@ describe "Language (HTML)", :language do
 
       annotation.entities.must_be :empty?
 
-      annotation.sentences.must_be :empty?
+      annotation.sentences.wont_be :empty?
       annotation.tokens.must_be :empty?
     end
 

--- a/google-cloud-language/acceptance/language/storage/html_file_test.rb
+++ b/google-cloud-language/acceptance/language/storage/html_file_test.rb
@@ -203,7 +203,7 @@ describe "Language (HTML/Storage File)", :language do
 
       annotation.entities.must_be :empty?
 
-      annotation.sentences.must_be :empty?
+      annotation.sentences.wont_be :empty?
       annotation.tokens.must_be :empty?
     end
 

--- a/google-cloud-language/acceptance/language/storage/html_url_test.rb
+++ b/google-cloud-language/acceptance/language/storage/html_url_test.rb
@@ -203,7 +203,7 @@ describe "Language (HTML/Storage URL)", :language do
 
       annotation.entities.must_be :empty?
 
-      annotation.sentences.must_be :empty?
+      annotation.sentences.wont_be :empty?
       annotation.tokens.must_be :empty?
     end
 

--- a/google-cloud-language/acceptance/language/storage/text_file_test.rb
+++ b/google-cloud-language/acceptance/language/storage/text_file_test.rb
@@ -201,7 +201,7 @@ describe "Language (TEXT/Storage File)", :language do
 
       annotation.entities.must_be :empty?
 
-      annotation.sentences.must_be :empty?
+      annotation.sentences.wont_be :empty?
       annotation.tokens.must_be :empty?
     end
 

--- a/google-cloud-language/acceptance/language/storage/text_url_test.rb
+++ b/google-cloud-language/acceptance/language/storage/text_url_test.rb
@@ -202,7 +202,7 @@ describe "Language (TEXT/Storage URL)", :language do
 
       annotation.entities.must_be :empty?
 
-      annotation.sentences.must_be :empty?
+      annotation.sentences.wont_be :empty?
       annotation.tokens.must_be :empty?
     end
 

--- a/google-cloud-language/acceptance/language/text_test.rb
+++ b/google-cloud-language/acceptance/language/text_test.rb
@@ -188,7 +188,7 @@ describe "Language (TEXT)", :language do
       doc.must_be :text?
       doc.wont_be :html?
 
-      annotation = doc.annotate sentiment: true
+      annotation = doc.annotate sentiment: true, syntax: false
 
       annotation.language.must_equal "en"
 
@@ -198,7 +198,7 @@ describe "Language (TEXT)", :language do
 
       annotation.entities.must_be :empty?
 
-      annotation.sentences.must_be :empty?
+      annotation.sentences.wont_be :empty?
       annotation.tokens.must_be :empty?
     end
 


### PR DESCRIPTION
Running the extract_document_sentiment feature used to not return sentences, but now it does.
This looks to be a change in the behavior of the API.
Update the acceptance tests to match the behavior of the API.