### PR TITLE
Gcloud jsondoc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,46 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### To generate JSON docs
 
-## Development
+Run `yard` task to create `.yardoc` with content. Then run the following lines
+(probably in a Rake task) to generate JSON doc files for gcloud-common/site
+deployment.
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`rake test` to run the tests. You can also run `bin/console` for an interactive
-prompt that will allow you to experiment.
+```ruby
+require "gcloud/jsondoc"
 
-To install this gem onto your local machine, run `bundle exec rake install`.
+registry = YARD::Registry.load! ".yardoc"
+generator = Gcloud::Jsondoc::Generator.new registry
+generator.write_to "jsondoc"
+```
+
+Note: If the source code lives in a sub-directory of the main repo, as it
+currently does for `google-cloud-*` gems, be sure to provide the subdirectory
+name to the `Generator` initializer:
+
+```ruby
+require "gcloud/jsondoc"
+
+registry = YARD::Registry.load! ".yardoc"
+generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-bigquery"
+generator.write_to "jsondoc"
+```
+
+Without this configuration, the `source` URLs for the code on GitHub will be
+incorrect. You don't need it if `lib` is in the repo root.
+
+### To test documentation examples
+
+Run `yard` task to create `.yardoc` with content. Then run the following lines
+(probably in a Rake task) to generate JSON doc files for gcloud-common/site
+deployment.
+
+```ruby
+require "gcloud/jsondoc"
+
+registry = YARD::Registry.load! ".yardoc"
+examples = Gcloud::Jsondoc::Examples.new registry
+examples.test_all
+```
+

--- a/lib/gcloud/jsondoc/doc.rb
+++ b/lib/gcloud/jsondoc/doc.rb
@@ -8,14 +8,16 @@ module Gcloud
 
       # object is API defined by YARD's HtmlHelper
       attr_reader :name, :title, :full_name, :filepath, :jbuilder, :object,
-                  :methods, :subtree, :descendants, :types, :types_subtree
+                  :methods, :subtree, :descendants, :types, :types_subtree,
+                  :source_path
 
-      def initialize object
+      def initialize object, source_path
         @object = object
         @name = object.name.to_s
         @title = object.title
         @full_name = get_full_name #JsonHelper
         @filepath = "#{@full_name}.json"
+        @source_path = source_path
         set_methods
         build!
         set_children
@@ -45,7 +47,7 @@ module Gcloud
             !c.has_tag?(:private)
             # TODO: handle aliases
         end
-        @methods = method_objects.map { |mo| Method.new mo, self }
+        @methods = method_objects.map { |mo| Method.new mo, self, source_path }
       end
 
       def set_children
@@ -60,7 +62,7 @@ module Gcloud
       def set_descendants
         @descendants = []
         @children.each do |child|
-          @descendants += Doc.new(child).subtree
+          @descendants += Doc.new(child, source_path).subtree
         end
       end
 

--- a/lib/gcloud/jsondoc/generator.rb
+++ b/lib/gcloud/jsondoc/generator.rb
@@ -4,16 +4,17 @@ require "gcloud/jsondoc/doc"
 module Gcloud
   module Jsondoc
     class Generator
-      attr_reader :input, :docs, :registry
+      attr_reader :input, :docs, :registry, :types
 
       ##
       # Creates a new builder to output documentation in JSON
       #
       # @param [YARD::Registry] registry The YARD registry instance containing
       #   the source code objects
-      def initialize registry
+      def initialize registry, source_path = nil
         @registry = registry
         @docs = []
+        @source_path = source_path
       end
 
       def write_to base_path
@@ -43,7 +44,7 @@ module Gcloud
           c.visibility == :public && !c.has_tag?(:private)
         end
         modules.each do |object|
-          @docs += Doc.new(object).subtree
+          @docs += Doc.new(object, @source_path).subtree
         end
         @registry.clear
       end

--- a/lib/gcloud/jsondoc/json_helper.rb
+++ b/lib/gcloud/jsondoc/json_helper.rb
@@ -2,11 +2,12 @@ module Gcloud
   module Jsondoc
     module JsonHelper
       # object is API defined by YARD's HtmlHelper, so depend on it here too
+      # source_path is available in Doc
       def metadata json
         json.name object.name.to_s
         json.title object.title.split("::") # Array of namespaces + name
         json.description md(object.docstring, true)
-        json.source object.files.first.join("#L")
+        json.source get_source
 
         json.resources object.docstring.tags(:see) do |t|
           json.title md(t.text)
@@ -20,6 +21,14 @@ module Gcloud
 
       def get_full_name
         object.path.gsub("::", "/").downcase
+      end
+
+      protected
+
+      def get_source
+        s = object.files.first.join("#L")
+        s.prepend "#{source_path}/" if source_path
+        s
       end
     end
   end

--- a/lib/gcloud/jsondoc/markup_helper.rb
+++ b/lib/gcloud/jsondoc/markup_helper.rb
@@ -9,9 +9,16 @@ module Gcloud
 
       def md s, multi_paragraph = false
         html = Kramdown::Document.new(s.to_s, input: "GFM", hard_wrap: false).to_html.strip
+        html = add_anchor_link_directives(html)
         html = unwrap_paragraph(html) unless multi_paragraph
         html = resolve_links(html) if html # in YARD's HtmlHelper
         html
+      end
+
+      # Because the gcloud-common Angular app depends on a `data-anchor` attr
+      # to navigate to anchors, add it to anchor links now.
+      def add_anchor_link_directives html
+        html.gsub(/<a href=\"#(.+)\">/, "<a data-anchor=\"\\1\" href=\"#\\1\">")
       end
 
       def remove_line_breaks html

--- a/lib/gcloud/jsondoc/method.rb
+++ b/lib/gcloud/jsondoc/method.rb
@@ -6,15 +6,16 @@ module Gcloud
       include MarkupHelper, JsonHelper
 
       # object is API defined by YARD's HtmlHelper
-      attr_reader :title, :type, :full_name, :filepath, :object, :parent
+      attr_reader :title, :type, :full_name, :filepath, :object, :parent, :source_path
 
-      def initialize object, parent
+      def initialize object, parent, source_path
         @object = object
         @parent = parent
         @title = parent.title
         @type = get_method_type @object # MarkupHelper
         @full_name = "#{object.name}-#{@type}"
         @filepath = @parent.filepath
+        @source_path = source_path
       end
 
       def build json

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -18,8 +18,24 @@ describe Gcloud::Jsondoc, :jsondoc_spec, :class do
 
     it "must have metadata" do
       @doc["name"].must_equal "MyClass"
-      @doc["description"].must_equal "<p>You can use MyClass for almost anything.</p>"
-      @doc["source"].must_equal "test/fixtures/my_module/my_class.rb#L4"
+      expected_html = <<EOT
+<p>You can use MyClass for almost anything.</p>
+
+<ul>
+  <li><a data-anchor=\"first-subheading\" href=\"#first-subheading\">First subheading</a></li>
+  <li><a data-anchor=\"second-subheading\" href=\"#second-subheading\">Second subheading</a></li>
+</ul>
+
+<h2 id=\"first-subheading\">First subheading</h2>
+
+<p>First usage description</p>
+
+<h2 id=\"second-subheading\">Second subheading</h2>
+
+<p>Second usage description</p>
+EOT
+      @doc["description"].must_equal expected_html.sub(/\n\Z/, "") # strip heredoc newline
+      @doc["source"].must_equal "test/fixtures/my_module/my_class.rb#L16"
     end
 
     it "should exclude exclude @private and protected methods" do
@@ -34,7 +50,7 @@ describe Gcloud::Jsondoc, :jsondoc_spec, :class do
         method["name"].must_equal "example_instance_method"
         method["type"].must_equal "instance"
         method["description"].must_equal "<p>Accepts many arguments for testing this library. Has no relation to\n<a data-custom-type=\"mymodule/myclass\" data-method=\"other_instance_method-instance\">#other_instance_method</a>. Also accepts a block if a block is given.</p>\n\n<p>Do not call this method until you have read all of its documentation.</p>"
-        method["source"].must_equal "test/fixtures/my_module/my_class.rb#L50"
+        method["source"].must_equal "test/fixtures/my_module/my_class.rb#L62"
       end
 
       it "must have method examples" do

--- a/test/fixtures/my_module/my_class.rb
+++ b/test/fixtures/my_module/my_class.rb
@@ -1,6 +1,18 @@
 module MyModule
   ##
   # You can use MyClass for almost anything.
+  #
+  # * [First subheading](#first-subheading)
+  # * [Second subheading](#second-subheading)
+  #
+  # ## First subheading
+  #
+  # First usage description
+  #
+  # ## Second subheading
+  #
+  # Second usage description
+  #
   class MyClass
     # @private This method should not appear in the output.
     def my_hidden_method

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -1,24 +1,44 @@
 require 'test_helper'
 
 describe Gcloud::Jsondoc, :generator do
-
-  before do
-    registry = YARD::Registry.load(["test/fixtures/**/*.rb"], true)
+  let(:registry) { YARD::Registry.load(["test/fixtures/**/*.rb"], true) }
+  let(:source_path) { "my-module-subdir" }
+  let(:generator) do
     generator = Gcloud::Jsondoc::Generator.new registry
     generator.build!
-    @docs = generator.docs
-    @types = generator.docs
+    generator.set_types
+    generator
   end
+  let(:docs) { generator.docs }
+  let(:types) { generator.types }
+  let(:generator_source_path) do
+    generator = Gcloud::Jsondoc::Generator.new registry, source_path
+    generator.build!
+    generator
+  end
+  let(:docs_source_path) { generator_source_path.docs }
 
   it "must have all docs" do
-    @docs.size.must_equal 5
+    docs.must_be_kind_of Array
+    docs.size.must_equal 5
+    docs[0].full_name.must_equal "mymodule"
+    docs[0].name.must_equal "MyModule"
+    docs[0].filepath.must_equal "mymodule.json"
   end
 
   it "must have all types" do
-    @types.must_be_kind_of Array
-    @types.size.must_equal 5
-    @types[0].full_name.must_equal "mymodule"
-    @types[0].name.must_equal "MyModule"
-    @types[0].filepath.must_equal "mymodule.json"
+    types.must_be_kind_of Array
+    types.size.must_equal 19
+    types[0].full_name.must_equal "mymodule"
+    types[0].name.must_equal "MyModule"
+    types[0].filepath.must_equal "mymodule.json"
+  end
+
+  describe "when given a source path" do
+    it "must produce module doc with source path prepended to source" do
+      doc_json = docs_source_path.first.jbuilder.attributes!
+      doc_json["id"].must_equal "mymodule"
+      doc_json["source"].must_equal "my-module-subdir/test/fixtures/my_module.rb#L15"
+    end
   end
 end


### PR DESCRIPTION
This PR updates JSON docs generation to:

* Support source links to `lib` directories located in subdirectories of the repo (`google-cloud-bigquery/lib`, etc) #908 
* Support new Angular app directive for internal anchor links #913