### PR TITLE
Fix Logging Build

### DIFF
--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -121,7 +121,7 @@ describe Google::Cloud::Logging, :logging do
     let(:entry2) { logging.entry.tap { |e| e.log_name = "#{prefix}-otherlog"; e.payload = {env: :production} } }
     #let(:entry3) { logging.entry.tap { |e| e.log_name = "#{prefix}-thislog"; e.payload = proto_payload; e.severity = :WARNING } }
 
-    let(:resource) { logging.resource "gce_instance", zone: "global", instance_id: "3" }
+    let(:resource) { logging.resource "gce_instance", labels: { zone: "global", instance_id: "3" } }
 
     it "writes and lists log entries" do
       # logging.write_entries [entry1, entry2, entry3], resource: resource
@@ -134,7 +134,7 @@ describe Google::Cloud::Logging, :logging do
 
   describe "Ruby Logger" do
     let(:log_name) { "#{prefix}-logger" }
-    let(:resource) { logging.resource "gce_instance", zone: "global", instance_id: "3" }
+    let(:resource) { logging.resource "gce_instance", labels: { zone: "global", instance_id: "3" } }
     let(:labels) { { env: :production } }
 
     before do

--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -142,7 +142,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with add and a symbol" do
-      logger = logging.logger "#{log_name}-symbol", resource, labels
+      logger = logging.logger "#{log_name}-symbol", resource, labels: labels
 
       logger.add :debug,   "Danger Will Robinson (:debug)!"
       logger.add :info,    "Danger Will Robinson (:info)!"
@@ -162,7 +162,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with add and a string" do
-      logger = logging.logger "#{log_name}-string", resource, labels
+      logger = logging.logger "#{log_name}-string", resource, labels: labels
 
       logger.add "debug",   "Danger Will Robinson ('debug')!"
       logger.add "info",    "Danger Will Robinson ('info')!"
@@ -182,7 +182,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with add and a constant" do
-      logger = logging.logger "#{log_name}-constant", resource, labels
+      logger = logging.logger "#{log_name}-constant", resource, labels: labels
 
       logger.add ::Logger::DEBUG,   "Danger Will Robinson (DEBUG)!"
       logger.add ::Logger::INFO,    "Danger Will Robinson (INFO)!"
@@ -202,7 +202,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with named functions" do
-      logger = logging.logger "#{log_name}-method", resource, labels
+      logger = logging.logger "#{log_name}-method", resource, labels: labels
 
       logger.debug   "Danger Will Robinson (debug)!"
       logger.info    "Danger Will Robinson (info)!"

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -299,7 +299,8 @@ module Google
     #                             module_id: "1",
     #                             version_id: "20150925t173233"
     #
-    # logger = logging.logger "my_app_log", resource, env: :production
+    # logger = logging.logger "my_app_log", resource,
+    #                         labels: {env: :production}
     # logger.info "Job started."
     # ```
     #
@@ -318,7 +319,8 @@ module Google
     #                             module_id: "1",
     #                             version_id: "20150925t173233"
     #
-    # logger = logging.logger "my_app_log", resource, {env: :production},
+    # logger = logging.logger "my_app_log", resource,
+    #                         labels: {env: :production},
     #                         async_writer: false
     # logger.info "Log entry written synchronously."
     # ```

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -241,9 +241,10 @@ module Google
     # entry2.payload = "Job completed."
     # labels = { job_size: "large", job_code: "red" }
     #
-    # resource = logging.resource "gae_app",
-    #                             "module_id" => "1",
-    #                             "version_id" => "20150925t173233"
+    # resource = logging.resource "gae_app", labels: {
+    #                               "module_id" => "1",
+    #                               "version_id" => "20150925t173233"
+    #                             }
     #
     # logging.write_entries [entry1, entry2],
     #                       log_name: "my_app_log",
@@ -272,9 +273,10 @@ module Google
     # entry2.payload = "Job completed."
     # labels = { job_size: "large", job_code: "red" }
     #
-    # resource = logging.resource "gae_app",
-    #                             "module_id" => "1",
-    #                             "version_id" => "20150925t173233"
+    # resource = logging.resource "gae_app", labels: {
+    #                               "module_id" => "1",
+    #                               "version_id" => "20150925t173233" }
+    #                             }
     #
     # async.write_entries [entry1, entry2],
     #                     log_name: "my_app_log",
@@ -295,9 +297,10 @@ module Google
     # gcloud = Google::Cloud.new
     # logging = gcloud.logging
     #
-    # resource = logging.resource "gae_app",
-    #                             module_id: "1",
-    #                             version_id: "20150925t173233"
+    # resource = logging.resource "gae_app", labels: {
+    #                               "module_id" => "1",
+    #                               "version_id" => "20150925t173233" }
+    #                             }
     #
     # logger = logging.logger "my_app_log", resource,
     #                         labels: {env: :production}
@@ -315,9 +318,10 @@ module Google
     # gcloud = Google::Cloud.new
     # logging = gcloud.logging
     #
-    # resource = logging.resource "gae_app",
-    #                             module_id: "1",
-    #                             version_id: "20150925t173233"
+    # resource = logging.resource "gae_app", labels: {
+    #                               "module_id" => "1",
+    #                               "version_id" => "20150925t173233" }
+    #                             }
     #
     # logger = logging.logger "my_app_log", resource,
     #                         labels: {env: :production},

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -42,9 +42,10 @@ module Google
       #   entry2 = logging.entry payload: "Job completed."
       #
       #   labels = { job_size: "large", job_code: "red" }
-      #   resource = logging.resource "gae_app",
-      #                               "module_id" => "1",
-      #                               "version_id" => "20150925t173233"
+      #   resource = logging.resource "gae_app", labels: {
+      #                                 "module_id" => "1",
+      #                                 "version_id" => "20150925t173233" }
+      #                               }
       #
       #   async.write_entries [entry1, entry2],
       #                       log_name: "my_app_log",

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -27,9 +27,10 @@ module Google
       #   gcloud = Google::Cloud.new
       #   logging = gcloud.logging
       #
-      #   resource = logging.resource "gae_app",
-      #                               module_id: "1",
-      #                               version_id: "20150925t173233"
+      #   resource = logging.resource "gae_app", labels: {
+      #                                 "module_id" => "1",
+      #                                 "version_id" => "20150925t173233" }
+      #                               }
       #
       #   logger = logging.logger "my_app_log", resource,
       #                            labels: {env: :production}
@@ -255,9 +256,10 @@ module Google
         #   gcloud = Google::Cloud.new
         #   logging = gcloud.logging
         #
-        #   resource = logging.resource "gae_app",
-        #                               module_id: "1",
-        #                               version_id: "20150925t173233"
+        #   resource = logging.resource "gae_app", labels: {
+        #                                 "module_id" => "1",
+        #                                 "version_id" => "20150925t173233" }
+        #                               }
         #
         #   logger = logging.logger "my_app_log", resource,
         #                           labels: {env: :production}

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -31,7 +31,8 @@ module Google
       #                               module_id: "1",
       #                               version_id: "20150925t173233"
       #
-      #   logger = logging.logger "my_app_log", resource, env: :production
+      #   logger = logging.logger "my_app_log", resource,
+      #                            labels: {env: :production}
       #   logger.info "Job started."
       #
       class Logger
@@ -258,7 +259,8 @@ module Google
         #                               module_id: "1",
         #                               version_id: "20150925t173233"
         #
-        #   logger = logging.logger "my_app_log", resource, env: :production
+        #   logger = logging.logger "my_app_log", resource,
+        #                           labels: {env: :production}
         #
         #   logger.level = "INFO"
         #   logger.debug "Job started." # No log entry written

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -349,10 +349,11 @@ module Google
         #                               module_id: "1",
         #                               version_id: "20150925t173233"
         #
-        #   logger = logging.logger "my_app_log", resource, env: :production
+        #   logger = logging.logger "my_app_log", resource,
+        #                           labels: {env: :production}
         #   logger.info "Job started."
         #
-        def logger log_name, resource, labels = {}, async_writer: true
+        def logger log_name, resource, labels: {}, async_writer: true
           async_writer = case async_writer
                          when true then self.async_writer
                          when false then nil

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -256,9 +256,10 @@ module Google
         #   entry2 = logging.entry payload: "Job completed."
         #
         #   labels = { job_size: "large", job_code: "red" }
-        #   resource = logging.resource "gae_app",
-        #                               "module_id" => "1",
-        #                               "version_id" => "20150925t173233"
+        #   resource = logging.resource "gae_app", labels: {
+        #                                 "module_id" => "1",
+        #                                 "version_id" => "20150925t173233" }
+        #                               }
         #
         #   logging.write_entries [entry1, entry2],
         #                         log_name: "my_app_log",
@@ -303,9 +304,10 @@ module Google
         #   entry2 = logging.entry payload: "Job completed."
         #
         #   labels = { job_size: "large", job_code: "red" }
-        #   resource = logging.resource "gae_app",
-        #                               "module_id" => "1",
-        #                               "version_id" => "20150925t173233"
+        #   resource = logging.resource "gae_app", labels: {
+        #                                 "module_id" => "1",
+        #                                 "version_id" => "20150925t173233" }
+        #                               }
         #
         #   async.write_entries [entry1, entry2],
         #                       log_name: "my_app_log",
@@ -345,9 +347,10 @@ module Google
         #   gcloud = Google::Cloud.new
         #   logging = gcloud.logging
         #
-        #   resource = logging.resource "gae_app",
-        #                               module_id: "1",
-        #                               version_id: "20150925t173233"
+        #   resource = logging.resource "gae_app", labels: {
+        #                                 "module_id" => "1",
+        #                                 "version_id" => "20150925t173233" }
+        #                               }
         #
         #   logger = logging.logger "my_app_log", resource,
         #                           labels: {env: :production}
@@ -434,6 +437,11 @@ module Google
         ##
         # Creates a new monitored resource instance.
         #
+        # @param [String] type The type of resource, as represented by a
+        #   {ResourceDescriptor}.
+        # @param [Hash] labels A set of labels that can be used to describe
+        #   instances of this monitored resource type.
+        #
         # @return [Google::Cloud::Logging::Resource]
         #
         # @example
@@ -442,11 +450,12 @@ module Google
         #   gcloud = Google::Cloud.new
         #   logging = gcloud.logging
         #
-        #   resource = logging.resource "gae_app",
-        #                               "module_id" => "1",
-        #                               "version_id" => "20150925t173233"
+        #   resource = logging.resource "gae_app", labels: {
+        #                                 "module_id" => "1",
+        #                                 "version_id" => "20150925t173233" }
+        #                               }
         #
-        def resource type, labels = {}
+        def resource type, labels: {}
           Resource.new.tap do |r|
             r.type = type
             r.labels = labels

--- a/google-cloud-logging/lib/google/cloud/logging/resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource.rb
@@ -34,9 +34,10 @@ module Google
       #
       #   gcloud = Google::Cloud.new
       #   logging = gcloud.logging
-      #   resource = logging.resource "gae_app",
-      #                               "module_id" => "1",
-      #                               "version_id" => "20150925t173233"
+      #   resource = logging.resource "gae_app", labels: {
+      #                                 "module_id" => "1",
+      #                                 "version_id" => "20150925t173233" }
+      #                               }
       #
       class Resource
         ##

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -22,7 +22,22 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     end
     labels = { "env" => "production" }
 
-    logger = logging.logger log_name, resource, labels
+    logger = logging.logger log_name, resource, labels: labels
+    logger.must_be_kind_of Google::Cloud::Logging::Logger
+    logger.log_name.must_equal log_name
+    logger.resource.must_equal resource
+    logger.labels.must_equal labels
+    logger.async_writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+  end
+
+  it "creates a ruby logger object with labels using symbols" do
+    log_name = "web_app_log"
+    resource = Google::Cloud::Logging::Resource.new.tap do |r|
+      r.type = "web_app_server"
+    end
+    labels = { env: "production" }
+
+    logger = logging.logger log_name, resource, labels: labels
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
@@ -48,9 +63,9 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     resource = Google::Cloud::Logging::Resource.new.tap do |r|
       r.type = "web_app_server"
     end
-    labels = { "env" => "production" }
+    labels = { env: "production" }
 
-    logger = logging.logger log_name, resource, labels, async_writer: false
+    logger = logging.logger log_name, resource, labels: labels, async_writer: false
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource

--- a/google-cloud-logging/test/google/cloud/logging/project_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project_test.rb
@@ -28,9 +28,9 @@ describe Google::Cloud::Logging::Project, :mock_logging do
 
   it "creates an entry with all attributes" do
     log_name = "log_name"
-    resource = logging.resource "gae_app",
+    resource = logging.resource "gae_app", labels: {
                                 "module_id" => "1",
-                                "version_id" => "20150925t173233"
+                                "version_id" => "20150925t173233" }
     timestamp = Time.now
     severity = "DEBUG"
     insert_id = "123456"
@@ -56,9 +56,9 @@ describe Google::Cloud::Logging::Project, :mock_logging do
   end
 
   it "creates a resource instance" do
-    resource = logging.resource "gae_app",
+    resource = logging.resource "gae_app", labels: {
                                 "module_id" => "1",
-                                "version_id" => "20150925t173233"
+                                "version_id" => "20150925t173233" }
     resource.must_be_kind_of Google::Cloud::Logging::Resource
     resource.type.must_equal   "gae_app"
     resource.labels["module_id"].must_equal "1"


### PR DESCRIPTION
The CI build is currently broken by changes made in #902. This PR fixes the build by making a _breaking change_ in the Logging API. Hashed parameters and optional named parameters do not mix, so we had to choose one over the other. We decided to choose the Ruby 2.0+ optional named parameters. This means that both `Logging::Project#logger` and `Logging::Project#resource` need to be changed.