### PR TITLE
Change Logger arguments async and writer

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -38,12 +38,8 @@ module Google
       #
       class Logger
         ##
-        # @private The logging object.
-        attr_accessor :logging
-
-        ##
-        # @private The async writer object.
-        attr_accessor :async_writer
+        # @private The logging writer object. Either Project or AsyncWriter.
+        attr_reader :writer
 
         ##
         # @private The Google Cloud log_name to write the log entry with.
@@ -59,10 +55,8 @@ module Google
 
         ##
         # @private Creates a new Logger instance.
-        def initialize logging, log_name, resource, labels = nil,
-                       async_writer = nil
-          @logging = logging
-          @async_writer = async_writer
+        def initialize writer, log_name, resource, labels = nil
+          @writer = writer
           @log_name = log_name
           @resource = resource
           @labels = labels
@@ -279,14 +273,13 @@ module Google
         ##
         # @private Write a log entry to the Stackdriver Logging service.
         def write_entry severity, message
-          entry = logging.entry.tap do |e|
+          entry = Entry.new.tap do |e|
             e.severity = gcloud_severity(severity)
             e.payload = message
           end
 
-          (async_writer || logging).write_entries entry, log_name: log_name,
-                                                         resource: resource,
-                                                         labels: labels
+          writer.write_entries entry, log_name: log_name, resource: resource,
+                                      labels: labels
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -332,11 +332,12 @@ module Google
         #   resource to be associated with written log entries.
         # @param [Hash] labels A set of user-defined data to be associated with
         #   written log entries.
-        # @param [Boolean|AsyncWriter] async_writer An AsyncWriter for the
-        #   logger to transmit log entries. You may also pass true to request
-        #   a new AsyncWriter for this logger, or false to request no
-        #   AsyncWriter (which will cause the logger to make blocking calls).
-        #   Default is true.
+        # @param [Boolean] async Whether entries are written asynchronously.
+        #   When `true` the logger will use use a new AsyncWriter instance. When
+        #   `false` it will write entries synchronously using
+        #   Project#write_entries. Default is true.
+        # @param [AsyncWriter|#write_entries] writer The object to write entries
+        #   to. If an object is not provided, the `async` argument will be used.
         #
         # @return [Google::Cloud::Logging::Logger] a Logger object that can be
         #   used in place of a ruby standard library logger object.
@@ -356,12 +357,8 @@ module Google
         #                           labels: {env: :production}
         #   logger.info "Job started."
         #
-        def logger log_name, resource, labels: {}, async_writer: true
-          writer = case async_writer
-                   when true then self.async_writer
-                   when false then self
-                   else async_writer
-                   end
+        def logger log_name, resource, labels: {}, async: true, writer: nil
+          writer ||= (async ? async_writer : self)
           Logger.new writer, log_name, resource, labels
         end
 

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -357,12 +357,12 @@ module Google
         #   logger.info "Job started."
         #
         def logger log_name, resource, labels: {}, async_writer: true
-          async_writer = case async_writer
-                         when true then self.async_writer
-                         when false then nil
-                         else async_writer
-                         end
-          Logger.new self, log_name, resource, labels, async_writer
+          writer = case async_writer
+                   when true then self.async_writer
+                   when false then self
+                   else async_writer
+                   end
+          Logger.new writer, log_name, resource, labels
         end
 
         ##

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -65,11 +65,27 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     end
     labels = { env: "production" }
 
-    logger = logging.logger log_name, resource, labels: labels, async_writer: false
+    logger = logging.logger log_name, resource, labels: labels, async: false
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
     logger.writer.must_be_kind_of Google::Cloud::Logging::Project
+  end
+
+  it "creates a ruby logger object with a custom writer" do
+    my_writer = Object.new
+    log_name = "web_app_log"
+    resource = Google::Cloud::Logging::Resource.new.tap do |r|
+      r.type = "web_app_server"
+    end
+    labels = { env: "production" }
+
+    logger = logging.logger log_name, resource, labels: labels, writer: my_writer
+    logger.must_be_kind_of Google::Cloud::Logging::Logger
+    logger.log_name.must_equal log_name
+    logger.resource.must_equal resource
+    logger.labels.must_equal labels
+    logger.writer.must_equal my_writer
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.async_writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object with labels using symbols" do
@@ -42,7 +42,7 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.async_writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object without labels" do
@@ -70,6 +70,6 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.async_writer.must_be_nil
+    logger.writer.must_be_kind_of Google::Cloud::Logging::Project
   end
 end


### PR DESCRIPTION
This PR splits the `async_writer` argument into two arguments: `async` and `writer`. The `async` argument is the boolean flag for controlling whether the logger is asynchronous or not. The `writer` argument is for providing a custom writer object. Its possible a custom writer object may not be asynchronous, so the `async_writer` label is a bit misleading. in that use-case.

This PR also simplifies the Logger implementation by collapsing the `logging` and `async_writer` objects to just `writer`.