### PR TITLE
Add AsyncWriter#logger

### DIFF
--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -233,4 +233,106 @@ describe Google::Cloud::Logging, :logging do
       entries
     end
   end
+
+  describe "Ruby Async Logger" do
+    let(:log_name) { "#{prefix}-logger" }
+    let(:resource) { logging.resource "gce_instance", labels: { zone: "global", instance_id: "3" } }
+    let(:labels) { { env: :production } }
+
+    before do
+      @sleep = 0
+    end
+
+    it "writes to a log with add and a symbol" do
+      logger = logging.async_writer.logger "#{log_name}-symbol", resource, labels: labels
+
+      logger.add :debug,   "Danger Will Robinson (:debug)!"
+      logger.add :info,    "Danger Will Robinson (:info)!"
+      logger.add :warn,    "Danger Will Robinson (:warn)!"
+      logger.add :error,   "Danger Will Robinson (:error)!"
+      logger.add :fatal,   "Danger Will Robinson (:fatal)!"
+      logger.add :unknown, "Danger Will Robinson (:unknown)!"
+
+      written_entries = entries_via_backoff("symbol").map &:payload
+
+      written_entries.must_include "Danger Will Robinson (:debug)!"
+      written_entries.must_include "Danger Will Robinson (:info)!"
+      written_entries.must_include "Danger Will Robinson (:warn)!"
+      written_entries.must_include "Danger Will Robinson (:error)!"
+      written_entries.must_include "Danger Will Robinson (:fatal)!"
+      written_entries.must_include "Danger Will Robinson (:unknown)!"
+    end
+
+    it "writes to a log with add and a string" do
+      logger = logging.async_writer.logger "#{log_name}-string", resource, labels: labels
+
+      logger.add "debug",   "Danger Will Robinson ('debug')!"
+      logger.add "info",    "Danger Will Robinson ('info')!"
+      logger.add "warn",    "Danger Will Robinson ('warn')!"
+      logger.add "error",   "Danger Will Robinson ('error')!"
+      logger.add "fatal",   "Danger Will Robinson ('fatal')!"
+      logger.add "unknown", "Danger Will Robinson ('unknown')!"
+
+      written_entries = entries_via_backoff("string").map &:payload
+
+      written_entries.must_include "Danger Will Robinson ('debug')!"
+      written_entries.must_include "Danger Will Robinson ('info')!"
+      written_entries.must_include "Danger Will Robinson ('warn')!"
+      written_entries.must_include "Danger Will Robinson ('error')!"
+      written_entries.must_include "Danger Will Robinson ('fatal')!"
+      written_entries.must_include "Danger Will Robinson ('unknown')!"
+    end
+
+    it "writes to a log with add and a constant" do
+      logger = logging.async_writer.logger "#{log_name}-constant", resource, labels: labels
+
+      logger.add ::Logger::DEBUG,   "Danger Will Robinson (DEBUG)!"
+      logger.add ::Logger::INFO,    "Danger Will Robinson (INFO)!"
+      logger.add ::Logger::WARN,    "Danger Will Robinson (WARN)!"
+      logger.add ::Logger::ERROR,   "Danger Will Robinson (ERROR)!"
+      logger.add ::Logger::FATAL,   "Danger Will Robinson (FATAL)!"
+      logger.add ::Logger::UNKNOWN, "Danger Will Robinson (UNKNOWN)!"
+
+      written_entries = entries_via_backoff("constant").map &:payload
+
+      written_entries.must_include "Danger Will Robinson (DEBUG)!"
+      written_entries.must_include "Danger Will Robinson (INFO)!"
+      written_entries.must_include "Danger Will Robinson (WARN)!"
+      written_entries.must_include "Danger Will Robinson (ERROR)!"
+      written_entries.must_include "Danger Will Robinson (FATAL)!"
+      written_entries.must_include "Danger Will Robinson (UNKNOWN)!"
+    end
+
+    it "writes to a log with named functions" do
+      logger = logging.async_writer.logger "#{log_name}-method", resource, labels: labels
+
+      logger.debug   "Danger Will Robinson (debug)!"
+      logger.info    "Danger Will Robinson (info)!"
+      logger.warn    "Danger Will Robinson (warn)!"
+      logger.error   "Danger Will Robinson (error)!"
+      logger.fatal   "Danger Will Robinson (fatal)!"
+      logger.unknown "Danger Will Robinson (unknown)!"
+
+      written_entries = entries_via_backoff("method").map &:payload
+
+      written_entries.must_include "Danger Will Robinson (debug)!"
+      written_entries.must_include "Danger Will Robinson (info)!"
+      written_entries.must_include "Danger Will Robinson (warn)!"
+      written_entries.must_include "Danger Will Robinson (error)!"
+      written_entries.must_include "Danger Will Robinson (fatal)!"
+      written_entries.must_include "Danger Will Robinson (unknown)!"
+    end
+
+    def entries_via_backoff type
+      filter = "log_name = projects/#{logging.project}/logs/#{log_name}-#{type}"
+      entries = logging.entries filter: filter
+      if entries.count < 6 && @sleep < 5
+        @sleep += 1
+        puts "sleeping for #{@sleep} seconds to and retry pulling #{type} log entries"
+        sleep @sleep
+        return entries_via_backoff type
+      end
+      entries
+    end
+  end
 end

--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -121,7 +121,7 @@ describe Google::Cloud::Logging, :logging do
     let(:entry2) { logging.entry.tap { |e| e.log_name = "#{prefix}-otherlog"; e.payload = {env: :production} } }
     #let(:entry3) { logging.entry.tap { |e| e.log_name = "#{prefix}-thislog"; e.payload = proto_payload; e.severity = :WARNING } }
 
-    let(:resource) { logging.resource "gce_instance", labels: { zone: "global", instance_id: "3" } }
+    let(:resource) { logging.resource "gce_instance", zone: "global", instance_id: "3" }
 
     it "writes and lists log entries" do
       # logging.write_entries [entry1, entry2, entry3], resource: resource
@@ -134,7 +134,7 @@ describe Google::Cloud::Logging, :logging do
 
   describe "Ruby Logger" do
     let(:log_name) { "#{prefix}-logger" }
-    let(:resource) { logging.resource "gce_instance", labels: { zone: "global", instance_id: "3" } }
+    let(:resource) { logging.resource "gce_instance", zone: "global", instance_id: "3" }
     let(:labels) { { env: :production } }
 
     before do
@@ -142,7 +142,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with add and a symbol" do
-      logger = logging.logger "#{log_name}-symbol", resource, labels: labels
+      logger = logging.logger "#{log_name}-symbol", resource, labels
 
       logger.add :debug,   "Danger Will Robinson (:debug)!"
       logger.add :info,    "Danger Will Robinson (:info)!"
@@ -162,7 +162,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with add and a string" do
-      logger = logging.logger "#{log_name}-string", resource, labels: labels
+      logger = logging.logger "#{log_name}-string", resource, labels
 
       logger.add "debug",   "Danger Will Robinson ('debug')!"
       logger.add "info",    "Danger Will Robinson ('info')!"
@@ -182,7 +182,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with add and a constant" do
-      logger = logging.logger "#{log_name}-constant", resource, labels: labels
+      logger = logging.logger "#{log_name}-constant", resource, labels
 
       logger.add ::Logger::DEBUG,   "Danger Will Robinson (DEBUG)!"
       logger.add ::Logger::INFO,    "Danger Will Robinson (INFO)!"
@@ -202,7 +202,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with named functions" do
-      logger = logging.logger "#{log_name}-method", resource, labels: labels
+      logger = logging.logger "#{log_name}-method", resource, labels
 
       logger.debug   "Danger Will Robinson (debug)!"
       logger.info    "Danger Will Robinson (info)!"
@@ -244,7 +244,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with add and a symbol" do
-      logger = logging.async_writer.logger "#{log_name}-symbol", resource, labels: labels
+      logger = logging.async_writer.logger "#{log_name}-symbol", resource, labels
 
       logger.add :debug,   "Danger Will Robinson (:debug)!"
       logger.add :info,    "Danger Will Robinson (:info)!"
@@ -264,7 +264,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with add and a string" do
-      logger = logging.async_writer.logger "#{log_name}-string", resource, labels: labels
+      logger = logging.async_writer.logger "#{log_name}-string", resource, labels
 
       logger.add "debug",   "Danger Will Robinson ('debug')!"
       logger.add "info",    "Danger Will Robinson ('info')!"
@@ -284,7 +284,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with add and a constant" do
-      logger = logging.async_writer.logger "#{log_name}-constant", resource, labels: labels
+      logger = logging.async_writer.logger "#{log_name}-constant", resource, labels
 
       logger.add ::Logger::DEBUG,   "Danger Will Robinson (DEBUG)!"
       logger.add ::Logger::INFO,    "Danger Will Robinson (INFO)!"
@@ -304,7 +304,7 @@ describe Google::Cloud::Logging, :logging do
     end
 
     it "writes to a log with named functions" do
-      logger = logging.async_writer.logger "#{log_name}-method", resource, labels: labels
+      logger = logging.async_writer.logger "#{log_name}-method", resource, labels
 
       logger.debug   "Danger Will Robinson (debug)!"
       logger.info    "Danger Will Robinson (info)!"

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -241,10 +241,9 @@ module Google
     # entry2.payload = "Job completed."
     # labels = { job_size: "large", job_code: "red" }
     #
-    # resource = logging.resource "gae_app", labels: {
-    #                               "module_id" => "1",
-    #                               "version_id" => "20150925t173233"
-    #                             }
+    # resource = logging.resource "gae_app",
+    #                             "module_id" => "1",
+    #                             "version_id" => "20150925t173233"
     #
     # logging.write_entries [entry1, entry2],
     #                       log_name: "my_app_log",
@@ -273,10 +272,9 @@ module Google
     # entry2.payload = "Job completed."
     # labels = { job_size: "large", job_code: "red" }
     #
-    # resource = logging.resource "gae_app", labels: {
-    #                               "module_id" => "1",
-    #                               "version_id" => "20150925t173233" }
-    #                             }
+    # resource = logging.resource "gae_app",
+    #                             "module_id" => "1",
+    #                             "version_id" => "20150925t173233"
     #
     # async.write_entries [entry1, entry2],
     #                     log_name: "my_app_log",
@@ -297,13 +295,11 @@ module Google
     # gcloud = Google::Cloud.new
     # logging = gcloud.logging
     #
-    # resource = logging.resource "gae_app", labels: {
-    #                               "module_id" => "1",
-    #                               "version_id" => "20150925t173233" }
-    #                             }
+    # resource = logging.resource "gae_app",
+    #                             module_id: "1",
+    #                             version_id: "20150925t173233"
     #
-    # logger = logging.logger "my_app_log", resource,
-    #                         labels: {env: :production}
+    # logger = logging.logger "my_app_log", resource, env: :production
     # logger.info "Job started."
     # ```
     #
@@ -318,13 +314,11 @@ module Google
     # gcloud = Google::Cloud.new
     # logging = gcloud.logging
     #
-    # resource = logging.resource "gae_app", labels: {
-    #                               "module_id" => "1",
-    #                               "version_id" => "20150925t173233" }
-    #                             }
+    # resource = logging.resource "gae_app",
+    #                             module_id: "1",
+    #                             version_id: "20150925t173233"
     #
-    # logger = logging.logger "my_app_log", resource,
-    #                         labels: {env: :production},
+    # logger = logging.logger "my_app_log", resource, {env: :production},
     #                         async_writer: false
     # logger.info "Log entry written synchronously."
     # ```

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -157,6 +157,42 @@ module Google
         end
 
         ##
+        # Creates a logger instance that is API-compatible with Ruby's standard
+        # library [Logger](http://ruby-doc.org/stdlib/libdoc/logger/rdoc).
+        #
+        # The logger will use AsyncWriter to transmit log entries on a
+        # background thread.
+        #
+        # @param [String] log_name A log resource name to be associated with the
+        #   written log entries.
+        # @param [Google::Cloud::Logging::Resource] resource The monitored
+        #   resource to be associated with written log entries.
+        # @param [Hash] labels A set of user-defined data to be associated with
+        #   written log entries.
+        #
+        # @return [Google::Cloud::Logging::Logger] a Logger object that can be
+        #   used in place of a ruby standard library logger object.
+        #
+        # @example
+        #   require "google/cloud"
+        #
+        #   gcloud = Google::Cloud.new
+        #   logging = gcloud.logging
+        #
+        #   resource = logging.resource "gae_app", labels: {
+        #                                 "module_id" => "1",
+        #                                 "version_id" => "20150925t173233" }
+        #                               }
+        #
+        #   async = logging.async_writer
+        #   logger = async.logger "my_app_log", resource, env: :production
+        #   logger.info "Job started."
+        #
+        def logger log_name, resource, labels: {}
+          Logger.new self, log_name, resource, labels
+        end
+
+        ##
         # Stops this asynchronous writer.
         #
         # After this call succeeds, the state will change to :stopping, and

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -42,10 +42,9 @@ module Google
       #   entry2 = logging.entry payload: "Job completed."
       #
       #   labels = { job_size: "large", job_code: "red" }
-      #   resource = logging.resource "gae_app", labels: {
-      #                                 "module_id" => "1",
-      #                                 "version_id" => "20150925t173233" }
-      #                               }
+      #   resource = logging.resource "gae_app",
+      #                               "module_id" => "1",
+      #                               "version_id" => "20150925t173233"
       #
       #   async.write_entries [entry1, entry2],
       #                       log_name: "my_app_log",
@@ -179,16 +178,15 @@ module Google
         #   gcloud = Google::Cloud.new
         #   logging = gcloud.logging
         #
-        #   resource = logging.resource "gae_app", labels: {
-        #                                 "module_id" => "1",
-        #                                 "version_id" => "20150925t173233" }
-        #                               }
+        #   resource = logging.resource "gae_app",
+        #                               module_id: "1",
+        #                               version_id: "20150925t173233"
         #
         #   async = logging.async_writer
         #   logger = async.logger "my_app_log", resource, env: :production
         #   logger.info "Job started."
         #
-        def logger log_name, resource, labels: {}
+        def logger log_name, resource, labels = {}
           Logger.new self, log_name, resource, labels
         end
 

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -52,7 +52,40 @@ module Google
         attr_reader :labels
 
         ##
-        # @private Creates a new Logger instance.
+        # Create a new Logger instance.
+        #
+        # @param [#write_entries] writer The object that will transmit log
+        #   entries. Usually an instance of Project or AsyncWriter, but any
+        #   object that implements #write_entries can be provided.
+        # @param [String] log_name A log resource name to be associated with the
+        #   written log entries.
+        # @param [Google::Cloud::Logging::Resource] resource The monitored
+        #   resource to be associated with written log entries.
+        # @param [Hash] labels A set of user-defined data to be associated with
+        #   written log entries.
+        #
+        # @return [Google::Cloud::Logging::Logger] a Logger object that can be
+        #   used in place of a ruby standard library logger object.
+        #
+        # @example
+        #   require "google/cloud"
+        #
+        #   gcloud = Google::Cloud.new
+        #   logging = gcloud.logging
+        #
+        #   writer = logging.async_writer max_queue_size: 1000
+        #
+        #   resource = logging.resource "gae_app", labels: {
+        #                                 "module_id" => "1",
+        #                                 "version_id" => "20150925t173233" }
+        #                               }
+        #
+        #   logger = Google::Cloud::Logging::Logger.new writer,
+        #                                               "my_app_log",
+        #                                               resource,
+        #                                               env: :production
+        #   logger.info "Job started."
+        #
         def initialize writer, log_name, resource, labels = nil
           @writer = writer
           @log_name = log_name

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -36,19 +36,20 @@ module Google
       #
       class Logger
         ##
-        # @private The logging writer object. Either Project or AsyncWriter.
+        # The Google Cloud writer object that calls to {#write_entries} are made
+        # on. Either an AsyncWriter or Project object.
         attr_reader :writer
 
         ##
-        # @private The Google Cloud log_name to write the log entry with.
+        # The Google Cloud log_name to write the log entry with.
         attr_reader :log_name
 
         ##
-        # @private The Google Cloud resource to write the log entry with.
+        # The Google Cloud resource to write the log entry with.
         attr_reader :resource
 
         ##
-        # @private The Google Cloud labels to write the log entry with.
+        # The Google Cloud labels to write the log entry with.
         attr_reader :labels
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -38,12 +38,8 @@ module Google
       #
       class Logger
         ##
-        # @private The logging object.
-        attr_accessor :logging
-
-        ##
-        # @private The async writer object.
-        attr_accessor :async_writer
+        # @private The logging writer object. Either Project or AsyncWriter.
+        attr_reader :writer
 
         ##
         # @private The Google Cloud log_name to write the log entry with.
@@ -59,10 +55,8 @@ module Google
 
         ##
         # @private Creates a new Logger instance.
-        def initialize logging, log_name, resource, labels = nil,
-                       async_writer = nil
-          @logging = logging
-          @async_writer = async_writer
+        def initialize writer, log_name, resource, labels = nil
+          @writer = writer
           @log_name = log_name
           @resource = resource
           @labels = labels
@@ -279,14 +273,13 @@ module Google
         ##
         # @private Write a log entry to the Stackdriver Logging service.
         def write_entry severity, message
-          entry = logging.entry.tap do |e|
+          entry = Entry.new.tap do |e|
             e.severity = gcloud_severity(severity)
             e.payload = message
           end
 
-          (async_writer || logging).write_entries entry, log_name: log_name,
-                                                         resource: resource,
-                                                         labels: labels
+          writer.write_entries entry, log_name: log_name, resource: resource,
+                                      labels: labels
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -27,13 +27,11 @@ module Google
       #   gcloud = Google::Cloud.new
       #   logging = gcloud.logging
       #
-      #   resource = logging.resource "gae_app", labels: {
-      #                                 "module_id" => "1",
-      #                                 "version_id" => "20150925t173233" }
-      #                               }
+      #   resource = logging.resource "gae_app",
+      #                               module_id: "1",
+      #                               version_id: "20150925t173233"
       #
-      #   logger = logging.logger "my_app_log", resource,
-      #                            labels: {env: :production}
+      #   logger = logging.logger "my_app_log", resource, env: :production
       #   logger.info "Job started."
       #
       class Logger
@@ -250,13 +248,11 @@ module Google
         #   gcloud = Google::Cloud.new
         #   logging = gcloud.logging
         #
-        #   resource = logging.resource "gae_app", labels: {
-        #                                 "module_id" => "1",
-        #                                 "version_id" => "20150925t173233" }
-        #                               }
+        #   resource = logging.resource "gae_app",
+        #                               module_id: "1",
+        #                               version_id: "20150925t173233"
         #
-        #   logger = logging.logger "my_app_log", resource,
-        #                           labels: {env: :production}
+        #   logger = logging.logger "my_app_log", resource, env: :production
         #
         #   logger.level = "INFO"
         #   logger.debug "Job started." # No log entry written

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -256,10 +256,9 @@ module Google
         #   entry2 = logging.entry payload: "Job completed."
         #
         #   labels = { job_size: "large", job_code: "red" }
-        #   resource = logging.resource "gae_app", labels: {
-        #                                 "module_id" => "1",
-        #                                 "version_id" => "20150925t173233" }
-        #                               }
+        #   resource = logging.resource "gae_app",
+        #                               "module_id" => "1",
+        #                               "version_id" => "20150925t173233"
         #
         #   logging.write_entries [entry1, entry2],
         #                         log_name: "my_app_log",
@@ -304,10 +303,9 @@ module Google
         #   entry2 = logging.entry payload: "Job completed."
         #
         #   labels = { job_size: "large", job_code: "red" }
-        #   resource = logging.resource "gae_app", labels: {
-        #                                 "module_id" => "1",
-        #                                 "version_id" => "20150925t173233" }
-        #                               }
+        #   resource = logging.resource "gae_app",
+        #                               "module_id" => "1",
+        #                               "version_id" => "20150925t173233"
         #
         #   async.write_entries [entry1, entry2],
         #                       log_name: "my_app_log",
@@ -341,16 +339,14 @@ module Google
         #   gcloud = Google::Cloud.new
         #   logging = gcloud.logging
         #
-        #   resource = logging.resource "gae_app", labels: {
-        #                                 "module_id" => "1",
-        #                                 "version_id" => "20150925t173233" }
-        #                               }
+        #   resource = logging.resource "gae_app",
+        #                               module_id: "1",
+        #                               version_id: "20150925t173233"
         #
-        #   logger = logging.logger "my_app_log", resource,
-        #                           labels: {env: :production}
+        #   logger = logging.logger "my_app_log", resource, env: :production
         #   logger.info "Job started."
         #
-        def logger log_name, resource, labels: {}
+        def logger log_name, resource, labels = {}
           Logger.new self, log_name, resource, labels
         end
 
@@ -439,12 +435,11 @@ module Google
         #   gcloud = Google::Cloud.new
         #   logging = gcloud.logging
         #
-        #   resource = logging.resource "gae_app", labels: {
-        #                                 "module_id" => "1",
-        #                                 "version_id" => "20150925t173233" }
-        #                               }
+        #   resource = logging.resource "gae_app",
+        #                               "module_id" => "1",
+        #                               "version_id" => "20150925t173233"
         #
-        def resource type, labels: {}
+        def resource type, labels = {}
           Resource.new.tap do |r|
             r.type = type
             r.labels = labels

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -322,9 +322,8 @@ module Google
         # Creates a logger instance that is API-compatible with Ruby's standard
         # library [Logger](http://ruby-doc.org/stdlib/libdoc/logger/rdoc).
         #
-        # By default, the logger will create an AsyncWriter to transmit log
-        # entries on a background thread. You may change this behavior using
-        # the async_writer parameter.
+        # The logger will transmit log entries synchronously, blocking for every
+        # write. An asynchronous logger can be created using #async_writer.
         #
         # @param [String] log_name A log resource name to be associated with the
         #   written log entries.
@@ -332,11 +331,6 @@ module Google
         #   resource to be associated with written log entries.
         # @param [Hash] labels A set of user-defined data to be associated with
         #   written log entries.
-        # @param [Boolean|AsyncWriter] async_writer An AsyncWriter for the
-        #   logger to transmit log entries. You may also pass true to request
-        #   a new AsyncWriter for this logger, or false to request no
-        #   AsyncWriter (which will cause the logger to make blocking calls).
-        #   Default is true.
         #
         # @return [Google::Cloud::Logging::Logger] a Logger object that can be
         #   used in place of a ruby standard library logger object.
@@ -356,13 +350,8 @@ module Google
         #                           labels: {env: :production}
         #   logger.info "Job started."
         #
-        def logger log_name, resource, labels: {}, async_writer: true
-          writer = case async_writer
-                   when true then self.async_writer
-                   when false then self
-                   else async_writer
-                   end
-          Logger.new writer, log_name, resource, labels
+        def logger log_name, resource, labels: {}
+          Logger.new self, log_name, resource, labels
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -320,8 +320,8 @@ module Google
         # Creates a logger instance that is API-compatible with Ruby's standard
         # library [Logger](http://ruby-doc.org/stdlib/libdoc/logger/rdoc).
         #
-        # The logger will transmit log entries synchronously, blocking for every
-        # write. An asynchronous logger can be created using #async_writer.
+        # The logger will create a new AsyncWriter object to transmit log
+        # entries on a background thread.
         #
         # @param [String] log_name A log resource name to be associated with the
         #   written log entries.
@@ -347,7 +347,7 @@ module Google
         #   logger.info "Job started."
         #
         def logger log_name, resource, labels = {}
-          Logger.new self, log_name, resource, labels
+          Logger.new async_writer, log_name, resource, labels
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -357,12 +357,12 @@ module Google
         #   logger.info "Job started."
         #
         def logger log_name, resource, labels: {}, async_writer: true
-          async_writer = case async_writer
-                         when true then self.async_writer
-                         when false then nil
-                         else async_writer
-                         end
-          Logger.new self, log_name, resource, labels, async_writer
+          writer = case async_writer
+                   when true then self.async_writer
+                   when false then self
+                   else async_writer
+                   end
+          Logger.new writer, log_name, resource, labels
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource.rb
@@ -34,10 +34,9 @@ module Google
       #
       #   gcloud = Google::Cloud.new
       #   logging = gcloud.logging
-      #   resource = logging.resource "gae_app", labels: {
-      #                                 "module_id" => "1",
-      #                                 "version_id" => "20150925t173233" }
-      #                               }
+      #   resource = logging.resource "gae_app",
+      #                               "module_id" => "1",
+      #                               "version_id" => "20150925t173233"
       #
       class Resource
         ##

--- a/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Logging::Project, :logger, :mock_logging do
+describe Google::Cloud::Logging::AsyncWriter, :logger, :mock_logging do
   it "creates a ruby logger object" do
     log_name = "web_app_log"
     resource = Google::Cloud::Logging::Resource.new.tap do |r|
@@ -22,12 +22,13 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     end
     labels = { "env" => "production" }
 
-    logger = logging.logger log_name, resource, labels: labels
+    async = logging.async_writer
+    logger = async.logger log_name, resource, labels: labels
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.writer.must_be_kind_of Google::Cloud::Logging::Project
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object with labels using symbols" do
@@ -37,12 +38,13 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     end
     labels = { env: "production" }
 
-    logger = logging.logger log_name, resource, labels: labels
+    async = logging.async_writer
+    logger = async.logger log_name, resource, labels: labels
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.writer.must_be_kind_of Google::Cloud::Logging::Project
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object without labels" do
@@ -51,11 +53,12 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
       r.type = "web_app_server"
     end
 
-    logger = logging.logger log_name, resource
+    async = logging.async_writer
+    logger = async.logger log_name, resource
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_be :empty?
-    logger.writer.must_be_kind_of Google::Cloud::Logging::Project
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Logging::AsyncWriter, :logger, :mock_logging do
     labels = { "env" => "production" }
 
     async = logging.async_writer
-    logger = async.logger log_name, resource, labels: labels
+    logger = async.logger log_name, resource, labels
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
@@ -39,7 +39,7 @@ describe Google::Cloud::Logging::AsyncWriter, :logger, :mock_logging do
     labels = { env: "production" }
 
     async = logging.async_writer
-    logger = async.logger log_name, resource, labels: labels
+    logger = async.logger log_name, resource, labels
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.writer.must_be_kind_of Google::Cloud::Logging::Project
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object with labels using symbols" do
@@ -42,7 +42,7 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.writer.must_be_kind_of Google::Cloud::Logging::Project
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object without labels" do
@@ -56,6 +56,6 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_be :empty?
-    logger.writer.must_be_kind_of Google::Cloud::Logging::Project
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.async_writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object with labels using symbols" do
@@ -42,7 +42,7 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.async_writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object without labels" do
@@ -70,6 +70,6 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
     logger.labels.must_equal labels
-    logger.async_writer.must_be_nil
+    logger.writer.must_be_kind_of Google::Cloud::Logging::Project
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     end
     labels = { "env" => "production" }
 
-    logger = logging.logger log_name, resource, labels: labels
+    logger = logging.logger log_name, resource, labels
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource
@@ -37,7 +37,7 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     end
     labels = { env: "production" }
 
-    logger = logging.logger log_name, resource, labels: labels
+    logger = logging.logger log_name, resource, labels
     logger.must_be_kind_of Google::Cloud::Logging::Logger
     logger.log_name.must_equal log_name
     logger.resource.must_equal resource

--- a/google-cloud-logging/test/google/cloud/logging/project_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project_test.rb
@@ -28,9 +28,9 @@ describe Google::Cloud::Logging::Project, :mock_logging do
 
   it "creates an entry with all attributes" do
     log_name = "log_name"
-    resource = logging.resource "gae_app", labels: {
+    resource = logging.resource "gae_app",
                                 "module_id" => "1",
-                                "version_id" => "20150925t173233" }
+                                "version_id" => "20150925t173233"
     timestamp = Time.now
     severity = "DEBUG"
     insert_id = "123456"
@@ -56,9 +56,9 @@ describe Google::Cloud::Logging::Project, :mock_logging do
   end
 
   it "creates a resource instance" do
-    resource = logging.resource "gae_app", labels: {
+    resource = logging.resource "gae_app",
                                 "module_id" => "1",
-                                "version_id" => "20150925t173233" }
+                                "version_id" => "20150925t173233"
     resource.must_be_kind_of Google::Cloud::Logging::Resource
     resource.type.must_equal   "gae_app"
     resource.labels["module_id"].must_equal "1"


### PR DESCRIPTION
This PR attempts to resolve design issues around the `async_writer` optional argument by adding the `AsyncWriter#logger` method and removing the `async_writer` optional argument from `Project#logger`. `Project#logger` continues the current behavior of returning a synchronous logger, and `AsyncWriter#logger` returns an asynchronous logger. The previous breaking changes made to current public API because of the `async_writer` optional argument have been reverted.