### PR TITLE
Add acceptance tests to AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,3 +20,4 @@ test_script:
   - bundle exec rake rubocop[yes]
   - bundle exec rake jsondoc
   - bundle exec rake test
+  - bundle exec rake appveyor:acceptance

--- a/Rakefile
+++ b/Rakefile
@@ -372,7 +372,7 @@ task :console, :bundleupdate do |t, args|
 end
 
 namespace :travis do
-  desc "Runs acceptance tests for CI."
+  desc "Runs acceptance tests for Travis-CI."
   task :acceptance do
     if ENV["TRAVIS_BRANCH"] == "master" &&
        ENV["TRAVIS_PULL_REQUEST"] == "false"
@@ -386,7 +386,7 @@ namespace :travis do
     end
   end
 
-  desc "Runs post-build logic"
+  desc "Runs post-build logic on Travis-CI."
   task :post do
     # We don't run post-build on pull requests
     if ENV["TRAVIS_PULL_REQUEST"] == "false" && ENV["GCLOUD_BUILD_DOCS"] == "true"
@@ -436,6 +436,18 @@ namespace :travis do
       end
     else
       fail "Cannot build #{package} for version #{version}"
+    end
+  end
+end
+
+namespace :appveyor do
+  desc "Runs acceptance tests for AppVeyor CI."
+  task :acceptance do
+    if ENV["APPVEYOR_REPO_BRANCH"] == "master" && !ENV["APPVEYOR_PULL_REQUEST_NUMBER"]
+      header "Running acceptance tests on AppVeyor"
+      Rake::Task["acceptance"].invoke
+    else
+      header "Skipping acceptance tests on AppVeyor"
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -83,12 +83,18 @@ desc "Runs acceptance tests for all gems."
 task :acceptance, :project, :keyfile, :key do |t, args|
   project = args[:project] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile] || ENV["GCLOUD_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"]
+  end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or GCLOUD_TEST_PROJECT=test123 GCLOUD_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
   ENV["GOOGLE_CLOUD_PROJECT"] = project
-  ENV["GOOGLE_CLOUD_KEYFILE"] = keyfile
+  ENV["GOOGLE_CLOUD_KEYFILE"] = nil
+  ENV["GOOGLE_CLOUD_KEYFILE_JSON"] = keyfile
 
   key = args[:key] || ENV["GCLOUD_TEST_KEY"]
   if key.nil?

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -30,12 +30,18 @@ task :acceptance, :project, :keyfile do |t, args|
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["BIGQUERY_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["BIGQUERY_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["BIGQUERY_TEST_KEYFILE_JSON"]
+  end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or BIGQUERY_TEST_PROJECT=test123 BIGQUERY_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
   ENV["BIGQUERY_PROJECT"] = project
-  ENV["BIGQUERY_KEYFILE"] = keyfile
+  ENV["BIGQUERY_KEYFILE"] = nil
+  ENV["BIGQUERY_KEYFILE_JSON"] = keyfile
 
   $LOAD_PATH.unshift "lib", "acceptance"
   Dir.glob("acceptance/bigquery/**/*_test.rb").each { |file| require_relative file }
@@ -60,12 +66,18 @@ namespace :acceptance do
     project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["BIGQUERY_TEST_PROJECT"]
     keyfile = args[:keyfile]
     keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["BIGQUERY_TEST_KEYFILE"]
+    if keyfile
+      keyfile = File.read keyfile
+    else
+      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["BIGQUERY_TEST_KEYFILE_JSON"]
+    end
     if project.nil? || keyfile.nil?
-      fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
+      fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or BIGQUERY_TEST_PROJECT=test123 BIGQUERY_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
     # always overwrite when running tests
     ENV["BIGQUERY_PROJECT"] = project
-    ENV["BIGQUERY_KEYFILE"] = keyfile
+    ENV["BIGQUERY_KEYFILE"] = nil
+    ENV["BIGQUERY_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"
     require "google/cloud/bigquery"

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -30,12 +30,18 @@ task :acceptance, :project, :keyfile do |t, args|
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DATASTORE_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DATASTORE_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DATASTORE_TEST_KEYFILE_JSON"]
+  end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or DATASTORE_TEST_PROJECT=test123 DATASTORE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
   ENV["DATASTORE_PROJECT"] = project
-  ENV["DATASTORE_KEYFILE"] = keyfile
+  ENV["DATASTORE_KEYFILE"] = nil
+  ENV["DATASTORE_KEYFILE_JSON"] = keyfile
 
   $LOAD_PATH.unshift "lib", "acceptance"
   Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -30,12 +30,18 @@ task :acceptance, :project, :keyfile do |t, args|
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DNS_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DNS_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DNS_TEST_KEYFILE_JSON"]
+  end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance:dns[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:dns"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or DNS_TEST_PROJECT=test123 DNS_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
   ENV["DNS_PROJECT"] = project
-  ENV["DNS_KEYFILE"] = keyfile
+  ENV["DNS_KEYFILE"] = nil
+  ENV["DNS_KEYFILE_JSON"] = keyfile
 
   $LOAD_PATH.unshift "lib", "acceptance"
   Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
@@ -60,12 +66,18 @@ namespace :acceptance do
     project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DNS_TEST_PROJECT"]
     keyfile = args[:keyfile]
     keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DNS_TEST_KEYFILE"]
+    if keyfile
+      keyfile = File.read keyfile
+    else
+      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DNS_TEST_KEYFILE_JSON"]
+    end
     if project.nil? || keyfile.nil?
-      fail "You must provide a project and keyfile. e.g. rake acceptance:dns:cleanup[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:dns:cleanup"
+      fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or DNS_TEST_PROJECT=test123 DNS_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
     # always overwrite when running tests
     ENV["DNS_PROJECT"] = project
-    ENV["DNS_KEYFILE"] = keyfile
+    ENV["DNS_KEYFILE"] = nil
+    ENV["DNS_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"
     require "google/cloud/dns"

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -30,14 +30,21 @@ task :acceptance, :project, :keyfile do |t, args|
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["LANGUAGE_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["LANGUAGE_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["LANGUAGE_TEST_KEYFILE_JSON"]
+  end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or LANGUAGE_TEST_PROJECT=test123 LANGUAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
   ENV["LANGUAGE_PROJECT"] = project
-  ENV["LANGUAGE_KEYFILE"] = keyfile
+  ENV["LANGUAGE_KEYFILE"] = nil
+  ENV["LANGUAGE_KEYFILE_JSON"] = keyfile
   ENV["STORAGE_PROJECT"] = project
-  ENV["STORAGE_KEYFILE"] = keyfile
+  ENV["STORAGE_KEYFILE"] = nil
+  ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
   $LOAD_PATH.unshift "lib", "acceptance"
   Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -30,12 +30,18 @@ task :acceptance, :project, :keyfile do |t, args|
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["LOGGING_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["LOGGING_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["LOGGING_TEST_KEYFILE_JSON"]
+  end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance:logging[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:logging"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or LOGGING_TEST_PROJECT=test123 LOGGING_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
   ENV["LOGGING_PROJECT"] = project
-  ENV["LOGGING_KEYFILE"] = keyfile
+  ENV["LOGGING_KEYFILE"] = nil
+  ENV["LOGGING_KEYFILE_JSON"] = keyfile
 
   $LOAD_PATH.unshift "lib", "acceptance"
   Dir.glob("acceptance/logging/**/*_test.rb").each { |file| require_relative file }
@@ -60,12 +66,18 @@ namespace :acceptance do
     project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["LOGGING_TEST_PROJECT"]
     keyfile = args[:keyfile]
     keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["LOGGING_TEST_KEYFILE"]
+    if keyfile
+      keyfile = File.read keyfile
+    else
+      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["LOGGING_TEST_KEYFILE_JSON"]
+    end
     if project.nil? || keyfile.nil?
-      fail "You must provide a project and keyfile. e.g. rake acceptance:logging:cleanup[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:logging:cleanup"
+      fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or LOGGING_TEST_PROJECT=test123 LOGGING_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
     # always overwrite when running tests
     ENV["LOGGING_PROJECT"] = project
-    ENV["LOGGING_KEYFILE"] = keyfile
+    ENV["LOGGING_KEYFILE"] = nil
+    ENV["LOGGING_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"
     require "google/cloud/logging"

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -30,12 +30,18 @@ task :acceptance, :project, :keyfile do |t, args|
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["PUBSUB_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["PUBSUB_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["PUBSUB_TEST_KEYFILE_JSON"]
+  end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance:pubsub[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:pubsub"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
   ENV["PUBSUB_PROJECT"] = project
-  ENV["PUBSUB_KEYFILE"] = keyfile
+  ENV["PUBSUB_KEYFILE"] = nil
+  ENV["PUBSUB_KEYFILE_JSON"] = keyfile
 
   $LOAD_PATH.unshift "lib", "acceptance"
   Dir.glob("acceptance/pubsub/**/*_test.rb").each { |file| require_relative file }
@@ -59,13 +65,19 @@ namespace :acceptance do
     project = args[:project]
     project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["PUBSUB_TEST_PROJECT"]
     keyfile = args[:keyfile]
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["PUBSUB_TEST_PROJECT"]
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["PUBSUB_TEST_KEYFILE"]
+    if keyfile
+      keyfile = File.read keyfile
+    else
+      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["PUBSUB_TEST_KEYFILE_JSON"]
+    end
     if project.nil? || keyfile.nil?
-      fail "You must provide a project and keyfile. e.g. rake acceptance:pubsub:cleanup[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:pubsub:cleanup"
+      fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
     # always overwrite when running tests
     ENV["PUBSUB_PROJECT"] = project
-    ENV["PUBSUB_KEYFILE"] = keyfile
+    ENV["PUBSUB_KEYFILE"] = nil
+    ENV["PUBSUB_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"
     require "google/cloud/pubsub"

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -30,12 +30,18 @@ task :acceptance, :project, :keyfile do |t, args|
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["STORAGE_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["STORAGE_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["STORAGE_TEST_KEYFILE_JSON"]
+  end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance:storage[test123, /path/to/keyfile.json] or STORAGE_TEST_PROJECT=test123 STORAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:storage"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or STORAGE_TEST_PROJECT=test123 STORAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
   ENV["STORAGE_PROJECT"] = project
-  ENV["STORAGE_KEYFILE"] = keyfile
+  ENV["STORAGE_KEYFILE"] = nil
+  ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
   $LOAD_PATH.unshift "lib", "acceptance"
   Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
@@ -60,12 +66,18 @@ namespace :acceptance do
     project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["STORAGE_TEST_PROJECT"]
     keyfile = args[:keyfile]
     keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["STORAGE_TEST_KEYFILE"]
+    if keyfile
+      keyfile = File.read keyfile
+    else
+      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["STORAGE_TEST_KEYFILE_JSON"]
+    end
     if project.nil? || keyfile.nil?
-      fail "You must provide a project and keyfile. e.g. rake acceptance:storage:cleanup[test123, /path/to/keyfile.json] or STORAGE_TEST_PROJECT=test123 STORAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:storage:cleanup"
+      fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or STORAGE_TEST_PROJECT=test123 STORAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
     # always overwrite when running tests
     ENV["STORAGE_PROJECT"] = project
-    ENV["STORAGE_KEYFILE"] = keyfile
+    ENV["STORAGE_KEYFILE"] = nil
+    ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"
     require "google/cloud/storage"

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -30,12 +30,18 @@ task :acceptance, :project, :keyfile do |t, args|
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["VISION_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["VISION_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["VISION_TEST_KEYFILE_JSON"]
+  end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or VISION_TEST_PROJECT=test123 VISION_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
   ENV["VISION_PROJECT"] = project
-  ENV["VISION_KEYFILE"] = keyfile
+  ENV["VISION_KEYFILE"] = nil
+  ENV["VISION_KEYFILE_JSON"] = keyfile
 
   $LOAD_PATH.unshift "lib", "acceptance"
   Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }


### PR DESCRIPTION
This change should allow for acceptance tests to run on AppVeyor, but only on the master branch. Instead of using the encrypted keyfile that Travis-CI uses, the keyfile contents should be added to the `GCLOUD_TEST_KEYFILE_JSON` environment variable.