### PR TITLE
Logger#info++ should not raise exceptions

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -233,8 +233,6 @@ module Google
             end
           end
 
-          
-
           begin
             write_entry severity, message
           rescue Google::Cloud::Error => e

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -233,7 +233,13 @@ module Google
             end
           end
 
-          write_entry severity, message
+          
+
+          begin
+            write_entry severity, message
+          rescue Google::Cloud::Error => e
+            #There was an error sending the data. 
+          end
         end
         alias_method :log, :add
 

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -235,8 +235,8 @@ module Google
 
           begin
             write_entry severity, message
-          rescue Google::Cloud::Error => e
-            #There was an error sending the data. 
+          rescue Google::Cloud::Error
+            # There was an error sending the data. 
           end
         end
         alias_method :log, :add

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -236,7 +236,7 @@ module Google
           begin
             write_entry severity, message
           rescue Google::Cloud::Error
-            # There was an error sending the data. 
+            # There was an error sending the data.
           end
         end
         alias_method :log, :add

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -98,4 +98,28 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
     mock.verify
   end
+
+  it "catches Google::Cloud::Error exceptions" do
+    mock = Minitest::Mock.new
+    def mock.write_log_entries message 
+      raise Google::Cloud::UnavailableError.new "This mock error should be caught"
+    end
+    # mock.expect :write_log_entries, write_res, [write_req(:INFO)]
+    logging.service.mocked_logging = mock
+
+    logger.info "Danger Will Robinson!"
+
+    mock.verify
+  end
+
+  it "should raise Standard exceptions" do
+    mock = Minitest::Mock.new
+    def mock.write_log_entries message 
+      raise "This mock error should not be caught"
+    end
+
+    logging.service.mocked_logging = mock
+
+    err = ->{ logger.info "Danger Will Robinson!" }.must_raise RuntimeError
+  end
 end

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -104,12 +104,10 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     def mock.write_log_entries message 
       raise Google::Cloud::UnavailableError.new "This mock error should be caught"
     end
-    # mock.expect :write_log_entries, write_res, [write_req(:INFO)]
+
     logging.service.mocked_logging = mock
 
     logger.info "Danger Will Robinson!"
-
-    mock.verify
   end
 
   it "should raise Standard exceptions" do
@@ -121,5 +119,6 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     logging.service.mocked_logging = mock
 
     err = ->{ logger.info "Danger Will Robinson!" }.must_raise RuntimeError
+    err.message.must_equal "This mock error should not be caught"
   end
 end


### PR DESCRIPTION
In some border-cases the `Logger#debug/info/warn/error/fatal` will raise exceptions, causing unexpected program flow. Example:

```
#...
logger = logging.logger "my_app", resource, env: :development

logger.debug "test"
#Can potentially raise the different kinds of Google::Cloud::Error
```

In my opinion, this is not to be expected of the logger class. This PR simply wraps the critical part of `logger#add` in a `begin/rescue` statement to prevent this.
