### PR TITLE
Add autodetect to bigquery load

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -322,7 +322,8 @@ module Google
             encoding: options[:encoding], field_delimiter: options[:delimiter],
             ignore_unknown_values: options[:ignore_unknown],
             max_bad_records: options[:max_bad_records], quote: options[:quote],
-            schema: options[:schema], skip_leading_rows: options[:skip_leading]
+            schema: options[:schema], skip_leading_rows: options[:skip_leading],
+            autodetect: options[:autodetect]
           }.delete_if { |_, v| v.nil? }
         end
 
@@ -350,7 +351,8 @@ module Google
             encoding: options[:encoding], field_delimiter: options[:delimiter],
             ignore_unknown_values: options[:ignore_unknown],
             max_bad_records: options[:max_bad_records], quote: options[:quote],
-            schema: options[:schema], skip_leading_rows: options[:skip_leading]
+            schema: options[:schema], skip_leading_rows: options[:skip_leading],
+            autodetect: options[:autodetect]
           }.delete_if { |_, v| v.nil? }
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -630,6 +630,8 @@ module Google
         #   file that BigQuery will skip when loading the data. The default
         #   value is `0`. This property is useful if you have header rows in the
         #   file that should be skipped.
+        # @param [Boolean] autodetect Indicates if we should automatically infer
+        #   the options and schema for CSV, JSON and AVRO sources.
         #
         # @return [Google::Cloud::Bigquery::LoadJob]
         #
@@ -674,7 +676,7 @@ module Google
                  projection_fields: nil, jagged_rows: nil, quoted_newlines: nil,
                  encoding: nil, delimiter: nil, ignore_unknown: nil,
                  max_bad_records: nil, quote: nil, skip_leading: nil,
-                 dryrun: nil
+                 dryrun: nil, autodetect: nil
           ensure_service!
           options = { format: format, create: create, write: write,
                       projection_fields: projection_fields,
@@ -682,7 +684,8 @@ module Google
                       quoted_newlines: quoted_newlines, encoding: encoding,
                       delimiter: delimiter, ignore_unknown: ignore_unknown,
                       max_bad_records: max_bad_records, quote: quote,
-                      skip_leading: skip_leading, dryrun: dryrun }
+                      skip_leading: skip_leading, dryrun: dryrun,
+                      autodetect: autodetect }
           return load_storage(file, options) if storage_url? file
           return load_local(file, options) if local_file? file
           fail Google::Cloud::Error, "Don't know how to load #{file}"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
@@ -59,7 +59,8 @@ describe Google::Cloud::Bigquery::Table, :load, :local, :mock_bigquery do
           ignore_unknown_values: true,
           max_bad_records: 42,
           quote: "'",
-          skip_leading_rows: 1
+          skip_leading_rows: 1,
+          autodetect: true
         ),
         dry_run: nil))
     table.service.mocked_service = mock
@@ -70,7 +71,7 @@ describe Google::Cloud::Bigquery::Table, :load, :local, :mock_bigquery do
 
       job = table.load file, format: :csv, jagged_rows: true, quoted_newlines: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42,
-        quote: "'", skip_leading: 1
+        quote: "'", skip_leading: 1, autodetect: true
       job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
@@ -115,7 +115,9 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
           allow_quoted_newlines: true,
           field_delimiter: "\t",
           ignore_unknown_values: true,
-          skip_leading_rows: 1),
+          skip_leading_rows: 1,
+          autodetect: true
+        ),
         dry_run: nil))
     mock.expect :insert_job, load_job_gapi(table, load_url),
       [project, insert_job]
@@ -123,7 +125,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
 
     job = table.load special_file, jagged_rows: true, quoted_newlines: true,
       encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42,
-      quote: "'", skip_leading: 1
+      quote: "'", skip_leading: 1, autodetect: true
     job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify


### PR DESCRIPTION
Hi folks:

I'm adding this experimental option because I need to [autodetect](https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.autodetect) the format for my AVRO files.

When I load my files I need to upload my schema too because some tables are dynamic so I need this feature. I open this PR because I don't know if you give support for experimental features or maybe because I'm doing something wrong.

The documentation says when `configuration.load.writeDisposition` is WRITE_TRUNCATE the schema is overwritten, I saw it in [`configuration.load.schemaUpdateOptions`](https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.schemaUpdateOptions) but when I load avro file and I use truncate for `write` option, the schema doesn't change :(
> For normal tables, WRITE_TRUNCATE will always overwrite the schema