### PR TITLE
Update StackOverflow tag in docs

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -62,4 +62,4 @@ To configure your system for this, simply:
 
 ## Troubleshooting
 
-If you're having trouble authenticating open a [Github Issue](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/new?title=Authentication+question) to get help.  Also consider searching or asking [questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) on [StackOverflow](http://stackoverflow.com).
+If you're having trouble authenticating open a [Github Issue](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/new?title=Authentication+question) to get help.  Also consider searching or asking [questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) on [StackOverflow](http://stackoverflow.com).

--- a/README.md
+++ b/README.md
@@ -424,4 +424,4 @@ available in [LICENSE](LICENSE).
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/docs/json/home.html
+++ b/docs/json/home.html
@@ -41,7 +41,7 @@
         </a>
       </li>
       <li>
-        <a href="http://stackoverflow.com/questions/tagged/google-cloud-ruby" title="google-cloud-ruby on StackOverflow" class="ext-link">
+        <a href="http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby" title="google-cloud-ruby on StackOverflow" class="ext-link">
           <img src="src/images/icon-link-stackoverflow.svg" alt="StackOverflow icon" />
           StackOverflow
         </a>

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -64,4 +64,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -70,4 +70,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-core/README.md
+++ b/google-cloud-core/README.md
@@ -29,4 +29,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -71,4 +71,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-dns/README.md
+++ b/google-cloud-dns/README.md
@@ -66,4 +66,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -64,5 +64,5 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
 

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -70,4 +70,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -65,4 +65,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -98,4 +98,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -64,4 +64,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -69,4 +69,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-vision/README.md
+++ b/google-cloud-vision/README.md
@@ -57,4 +57,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -27,4 +27,4 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 ## Support
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).


### PR DESCRIPTION
This PR updates the StackOverflow tag used in links to `google-cloud-platform+ruby`, per the discussion in GoogleCloudPlatform/gcloud-common#185.

[closes #921]