### PR TITLE
Properly escape path in Storage signed_url

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+require "uri"
 require "google/cloud/storage/file/acl"
 require "google/cloud/storage/file/list"
 require "google/cloud/storage/file/verifier"
@@ -737,7 +738,7 @@ module Google
           ##
           # The external path to the file.
           def ext_path
-            "/#{@file.bucket}/#{@file.name}"
+            URI.escape "/#{@file.bucket}/#{@file.name}"
           end
 
           ##


### PR DESCRIPTION
This addresses a bug where the string used in the signature is not the same
as the string used on the server to grant access. This is because browsers
will escape characters like space. Escape before signing so the values match.

[refs #931]