### PR TITLE
Add client_config to Speech factory methods

### DIFF
--- a/google-cloud-speech/acceptance/speech_helper.rb
+++ b/google-cloud-speech/acceptance/speech_helper.rb
@@ -19,7 +19,7 @@ require "minitest/rg"
 require "google/cloud/speech"
 
 # Create shared speech object so we don't create new for each test
-$speech = Google::Cloud.speech retries: 10
+$speech = Google::Cloud.speech
 
 require "google/cloud/storage"
 

--- a/google-cloud-speech/lib/google-cloud-speech.rb
+++ b/google-cloud-speech/lib/google-cloud-speech.rb
@@ -38,9 +38,9 @@ module Google
     #   The default scope is:
     #
     #   * `https://www.googleapis.com/auth/speech`
-    # @param [Integer] retries Number of times to retry requests on server
-    #   error. The default value is `3`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
+    # @param [Hash] client_config A hash of values to override the default
+    #   behavior of the API client. See Google::Gax::CallSettings. Optional.
     #
     # @return [Google::Cloud::Speech::Project]
     #
@@ -59,10 +59,10 @@ module Google
     #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
     #   speech = gcloud.speech scope: platform_scope
     #
-    def speech scope: nil, retries: nil, timeout: nil
+    def speech scope: nil, timeout: nil, client_config: nil
       Google::Cloud.speech @project, @keyfile, scope: scope,
-                                               retries: (retries || @retries),
-                                               timeout: (timeout || @timeout)
+                                               timeout: (timeout || @timeout),
+                                               client_config: client_config
     end
 
     ##
@@ -84,9 +84,9 @@ module Google
     #   The default scope is:
     #
     #   * `https://www.googleapis.com/auth/speech`
-    # @param [Integer] retries Number of times to retry requests on server
-    #   error. The default value is `3`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
+    # @param [Hash] client_config A hash of values to override the default
+    #   behavior of the API client. See Google::Gax::CallSettings. Optional.
     #
     # @return [Google::Cloud::Speech::Project]
     #
@@ -98,8 +98,8 @@ module Google
     #   topic = speech.topic "my-topic"
     #   topic.publish "task completed"
     #
-    def self.speech project = nil, keyfile = nil, scope: nil, retries: nil,
-                    timeout: nil
+    def self.speech project = nil, keyfile = nil, scope: nil, timeout: nil,
+                    client_config: nil
       require "google/cloud/speech"
       project ||= Google::Cloud::Speech::Project.default_project
       if keyfile.nil?
@@ -110,7 +110,7 @@ module Google
       end
       Google::Cloud::Speech::Project.new(
         Google::Cloud::Speech::Service.new(
-          project, credentials, retries: retries, timeout: timeout))
+          project, credentials, timeout: timeout, client_config: client_config))
     end
   end
 end

--- a/google-cloud-speech/lib/google/cloud/speech/service.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/service.rb
@@ -25,17 +25,17 @@ module Google
       # @private Represents the gRPC Speech service, including all the API
       # methods.
       class Service
-        attr_accessor :project, :credentials, :host, :retries, :timeout
+        attr_accessor :project, :credentials, :host, :timeout, :client_config
 
         ##
         # Creates a new Service instance.
-        def initialize project, credentials, host: nil, retries: nil,
-                       timeout: nil
+        def initialize project, credentials, host: nil, timeout: nil,
+                       client_config: nil
           @project = project
           @credentials = credentials
           @host = host || V1beta1::SpeechApi::SERVICE_ADDRESS
-          @retries = retries
           @timeout = timeout
+          @client_config = client_config || {}
         end
 
         def channel
@@ -55,6 +55,7 @@ module Google
               service_path: host,
               channel: channel,
               timeout: timeout,
+              client_config: client_config,
               app_name: "google-cloud-speech",
               app_version: Google::Cloud::Speech::VERSION)
         end

--- a/google-cloud-speech/test/google/cloud/speech_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech_test.rb
@@ -18,12 +18,12 @@ describe Google::Cloud do
   describe "#speech" do
     it "calls out to Google::Cloud.speech" do
       gcloud = Google::Cloud.new
-      stubbed_speech = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_speech = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal nil
         keyfile.must_equal nil
         scope.must_be :nil?
-        retries.must_be :nil?
         timeout.must_be :nil?
+        client_config.must_be :nil?
         "speech-project-object-empty"
       }
       Google::Cloud.stub :speech, stubbed_speech do
@@ -34,12 +34,12 @@ describe Google::Cloud do
 
     it "passes project and keyfile to Google::Cloud.speech" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_speech = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_speech = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_be :nil?
-        retries.must_be :nil?
         timeout.must_be :nil?
+        client_config.must_be :nil?
         "speech-project-object"
       }
       Google::Cloud.stub :speech, stubbed_speech do
@@ -50,16 +50,16 @@ describe Google::Cloud do
 
     it "passes project and keyfile and options to Google::Cloud.speech" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_speech = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_speech = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_equal "http://example.com/scope"
-        retries.must_equal 5
         timeout.must_equal 60
+        client_config.must_equal({ "gax" => "options" })
         "speech-project-object-scoped"
       }
       Google::Cloud.stub :speech, stubbed_speech do
-        project = gcloud.speech scope: "http://example.com/scope", retries: 5, timeout: 60
+        project = gcloud.speech scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
         project.must_equal "speech-project-object-scoped"
       end
     end
@@ -90,11 +90,11 @@ describe Google::Cloud do
         scope.must_equal nil
         "speech-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "speech-credentials"
-        retries.must_equal nil
-        timeout.must_equal nil
+        timeout.must_be :nil?
+        client_config.must_be :nil?
         OpenStruct.new project: project
       }
 


### PR DESCRIPTION
Add client_config to Speech since it uses GAPIC/GAX, and remove non-functional retries.