### PR TITLE
Add new service factory methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ $ gem install google-cloud-bigquery
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/bigquery"
 
-gcloud = Google::Cloud.new "my-todo-project-id",
-                    "/path/to/keyfile.json"
-bigquery = gcloud.bigquery
+bigquery = Google::Cloud::Bigquery.new(
+  project: "my-todo-project",
+  keyfile: "/path/to/keyfile.json"
+)
 
 # Create a new table to archive todos
 dataset = bigquery.dataset "my-todo-archive"
@@ -104,11 +105,12 @@ $ gem install google-cloud-datastore
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/datastore"
 
-gcloud = Google::Cloud.new "my-todo-project-id",
-                    "/path/to/keyfile.json"
-datastore = gcloud.datastore
+datastore = Google::Cloud::Datastore.new(
+  project: "my-todo-project",
+  keyfile: "/path/to/keyfile.json"
+)
 
 # Create a new task to demo datastore
 task = datastore.entity "Task", "sampleTask" do |t|
@@ -143,10 +145,9 @@ $ gem install google-cloud-dns
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/dns"
 
-gcloud = Google::Cloud.new
-dns = gcloud.dns
+dns = Google::Cloud::Dns.new
 
 # Retrieve a zone
 zone = dns.zone "example-com"
@@ -180,10 +181,9 @@ $ gem install google-cloud-logging
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/logging"
 
-gcloud = Google::Cloud.new
-logging = gcloud.logging
+logging = Google::Cloud::Logging.new
 
 # List all log entries
 logging.entries.each do |e|
@@ -220,10 +220,9 @@ $ gem install google-cloud-language
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/language"
 
-gcloud = Google::Cloud.new
-language = gcloud.language
+language = Google::Cloud::Language.new
 
 content = "Darth Vader is the best villain in Star Wars."
 document = language.document content
@@ -252,11 +251,12 @@ $ gem install google-cloud-pubsub
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/pubsub"
 
-gcloud = Google::Cloud.new "my-todo-project-id",
-                    "/path/to/keyfile.json"
-pubsub = gcloud.pubsub
+pubsub = Google::Cloud::Pubsub.new(
+  project: "my-todo-project",
+  keyfile: "/path/to/keyfile.json"
+)
 
 # Retrieve a topic
 topic = pubsub.topic "my-topic"
@@ -287,10 +287,9 @@ $ gem install google-cloud-resource_manager
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/resource_manager"
 
-gcloud = Google::Cloud.new
-resource_manager = gcloud.resource_manager
+resource_manager = Google::Cloud::ResourceManager.new
 
 # List all projects
 resource_manager.projects.each do |project|
@@ -323,10 +322,9 @@ $ gem install google-cloud-speech
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/speech"
 
-gcloud = Google::Cloud.new
-speech = gcloud.speech
+speech = Google::Cloud::Speech.new
 
 audio = speech.audio "path/to/audio.raw",
                      encoding: :raw, sample_rate: 16000
@@ -353,11 +351,12 @@ $ gem install google-cloud-storage
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/storage"
 
-gcloud = Google::Cloud.new "my-todo-project-id",
-                    "/path/to/keyfile.json"
-storage = gcloud.storage
+storage = Google::Cloud::Storage.new(
+  project: "my-todo-project",
+  keyfile: "/path/to/keyfile.json"
+)
 
 bucket = storage.bucket "task-attachments"
 
@@ -387,10 +386,9 @@ $ gem install google-cloud-translate
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/translate"
 
-gcloud = Google::Cloud.new
-translate = gcloud.translate
+translate = Google::Cloud::Translate.new
 
 translation = translate.translate "Hello world!", to: "la"
 
@@ -418,10 +416,9 @@ $ gem install google-cloud-vision
 #### Preview
 
 ```ruby
-require "google/cloud"
+require "google/cloud/vision"
 
-gcloud = Google::Cloud.new
-vision = gcloud.vision
+vision = Google::Cloud::Vision.new
 
 image = vision.image "path/to/landmark.jpg"
 

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -21,11 +21,12 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/bigquery"
 
-gcloud = Google::Cloud.new "my-todo-project-id",
-                    "/path/to/keyfile.json"
-bigquery = gcloud.bigquery
+bigquery = Google::Cloud::Bigquery.new(
+  project: "my-todo-project",
+  keyfile: "/path/to/keyfile.json"
+)
 
 # Create a new table to archive todos
 dataset = bigquery.dataset "my-todo-archive"

--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -103,9 +103,9 @@ module Google
     def self.bigquery project = nil, keyfile = nil, scope: nil, retries: nil,
                       timeout: nil
       require "google/cloud/bigquery"
-      Google::Cloud::Bigquery.new project, keyfile, scope: scope,
-                                                    retries: retries,
-                                                    timeout: timeout
+      Google::Cloud::Bigquery.new project: project, keyfile: keyfile,
+                                  scope: scope, retries: retries,
+                                  timeout: timeout
     end
   end
 end

--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -94,7 +94,7 @@ module Google
     # @return [Google::Cloud::Bigquery::Project]
     #
     # @example
-    #   require "google/cloud/bigquery"
+    #   require "google/cloud"
     #
     #   bigquery = Google::Cloud.bigquery
     #   dataset = bigquery.dataset "my_dataset"
@@ -103,20 +103,9 @@ module Google
     def self.bigquery project = nil, keyfile = nil, scope: nil, retries: nil,
                       timeout: nil
       require "google/cloud/bigquery"
-      project ||= Google::Cloud::Bigquery::Project.default_project
-      project = project.to_s # Always cast to a string
-      fail ArgumentError, "project is missing" if project.empty?
-
-      if keyfile.nil?
-        credentials = Google::Cloud::Bigquery::Credentials.default scope: scope
-      else
-        credentials = Google::Cloud::Bigquery::Credentials.new(
-          keyfile, scope: scope)
-      end
-
-      Google::Cloud::Bigquery::Project.new(
-        Google::Cloud::Bigquery::Service.new(
-          project, credentials, retries: retries, timeout: timeout))
+      Google::Cloud::Bigquery.new project, keyfile, scope: scope,
+                                                    retries: retries,
+                                                    timeout: timeout
     end
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -48,10 +48,9 @@ module Google
     # let's connect to Google's `publicdata` project, and see what you find.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new "publicdata"
-    # bigquery = gcloud.bigquery
+    # bigquery = Google::Cloud::Bigquery.new "publicdata"
     #
     # bigquery.datasets.count #=> 1
     # bigquery.datasets.first.dataset_id #=> "samples"
@@ -69,10 +68,9 @@ module Google
     # every play written by Shakespeare.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new "publicdata"
-    # bigquery = gcloud.bigquery
+    # bigquery = Google::Cloud::Bigquery.new "publicdata"
     #
     # dataset = bigquery.dataset "samples"
     # table = dataset.table "shakespeare"
@@ -97,10 +95,9 @@ module Google
     # results.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new
-    # bigquery = gcloud.bigquery
+    # bigquery = Google::Cloud::Bigquery.new
     #
     # sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " +
     #       "FROM publicdata:samples.shakespeare"
@@ -126,10 +123,9 @@ module Google
     # of {Google::Cloud::Bigquery::QueryData}.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new
-    # bigquery = gcloud.bigquery
+    # bigquery = Google::Cloud::Bigquery.new
     #
     # sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " +
     #       "FROM publicdata:samples.shakespeare"
@@ -172,10 +168,9 @@ module Google
     # BigQuery](https://cloud.google.com/bigquery/preparing-data-for-bigquery).)
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new
-    # bigquery = gcloud.bigquery
+    # bigquery = Google::Cloud::Bigquery.new
     # dataset = bigquery.dataset "my_dataset"
     #
     # table = dataset.create_table "people" do |schema|
@@ -207,10 +202,9 @@ module Google
     # application is a great approach.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new
-    # bigquery = gcloud.bigquery
+    # bigquery = Google::Cloud::Bigquery.new
     # dataset = bigquery.dataset "my_dataset"
     # table = dataset.table "people"
     #
@@ -254,10 +248,9 @@ module Google
     # also contained in the archive specifies the schema used below.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new
-    # bigquery = gcloud.bigquery
+    # bigquery = Google::Cloud::Bigquery.new
     # dataset = bigquery.dataset "my_dataset"
     # table = dataset.create_table "baby_names" do |schema|
     #   schema.string "name", mode: :required
@@ -284,10 +277,9 @@ module Google
     # setting up billing.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new
-    # bigquery = gcloud.bigquery
+    # bigquery = Google::Cloud::Bigquery.new
     # dataset = bigquery.dataset "my_dataset"
     # source_table = dataset.table "baby_names"
     # result_table = dataset.create_table "baby_names_results"
@@ -337,10 +329,9 @@ module Google
     # You can also set the request `timeout` value in seconds.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new
-    # bigquery = gcloud.bigquery retries: 10, timeout: 120
+    # bigquery = Google::Cloud::Bigquery.new retries: 10, timeout: 120
     # ```
     #
     # See the [BigQuery error

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -50,7 +50,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new "publicdata"
+    # bigquery = Google::Cloud::Bigquery.new project: "publicdata"
     #
     # bigquery.datasets.count #=> 1
     # bigquery.datasets.first.dataset_id #=> "samples"
@@ -70,7 +70,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new "publicdata"
+    # bigquery = Google::Cloud::Bigquery.new project: "publicdata"
     #
     # dataset = bigquery.dataset "samples"
     # table = dataset.table "shakespeare"
@@ -371,7 +371,7 @@ module Google
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.table "my_table"
       #
-      def self.new project = nil, keyfile = nil, scope: nil, retries: nil,
+      def self.new project: nil, keyfile: nil, scope: nil, retries: nil,
                    timeout: nil
         project ||= Google::Cloud::Bigquery::Project.default_project
         project = project.to_s # Always cast to a string

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -348,6 +348,56 @@ module Google
     # for a list of error conditions.
     #
     module Bigquery
+      # Creates a new `Project` instance connected to the BigQuery service.
+      # Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String] project Identifier for a BigQuery project. If not
+      #   present, the default project for the credentials is used.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See # [Using OAuth 2.0 to Access Google #
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `https://www.googleapis.com/auth/bigquery`
+      # @param [Integer] retries Number of times to retry requests on server
+      #   error. The default value is `3`. Optional.
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::Bigquery::Project]
+      #
+      # @example
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #   dataset = bigquery.dataset "my_dataset"
+      #   table = dataset.table "my_table"
+      #
+      def self.new project = nil, keyfile = nil, scope: nil, retries: nil,
+                   timeout: nil
+        project ||= Google::Cloud::Bigquery::Project.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
+        if keyfile.nil?
+          credentials = Google::Cloud::Bigquery::Credentials.default(
+            scope: scope)
+        else
+          credentials = Google::Cloud::Bigquery::Credentials.new(
+            keyfile, scope: scope)
+        end
+
+        Google::Cloud::Bigquery::Project.new(
+          Google::Cloud::Bigquery::Service.new(
+            project, credentials, retries: retries, timeout: timeout))
+      end
     end
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -155,8 +155,8 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # gcloud = Google::Cloud.new
-    # bigquery = gcloud.bigquery
+    # bigquery = Google::Cloud::Bigquery.new
+    #
     # dataset = bigquery.create_dataset "my_dataset"
     # ```
     #
@@ -294,7 +294,9 @@ module Google
     #
     # if !query_job.failed?
     #
-    #   storage = gcloud.storage
+    #   require "google/cloud/bigquery"
+    #
+    #   storage = Google::Cloud::Storage.new
     #   bucket_id = "bigquery-exports-#{SecureRandom.uuid}"
     #   bucket = storage.create_bucket bucket_id
     #   extract_url = "gs://#{bucket.id}/baby-names-sam.csv"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -71,10 +71,9 @@ module Google
         # @return [Boolean]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   table = dataset.table "my_table"
         #
         #   data = table.data
@@ -92,10 +91,9 @@ module Google
         # @return [Data]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   table = dataset.table "my_table"
         #
         #   data = table.data
@@ -128,10 +126,9 @@ module Google
         # @return [Enumerator]
         #
         # @example Iterating each rows by passing a block:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   table = dataset.table "my_table"
         #
         #   table.data.all do |row|
@@ -139,10 +136,9 @@ module Google
         #   end
         #
         # @example Using the enumerator by not passing a block:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   table = dataset.table "my_table"
         #
         #   words = table.data.all.map do |row|
@@ -150,10 +146,9 @@ module Google
         #   end
         #
         # @example Limit the number of API calls made:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   table = dataset.table "my_table"
         #
         #   table.data.all(request_limit: 10) do |row|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -33,10 +33,9 @@ module Google
       # within a specific project.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/bigquery"
       #
-      #   gcloud = Google::Cloud.new
-      #   bigquery = gcloud.bigquery
+      #   bigquery = Google::Cloud::Bigquery.new
       #
       #   dataset = bigquery.create_dataset "my_dataset",
       #                                     name: "My Dataset",
@@ -225,10 +224,9 @@ module Google
         # @return [Google::Cloud::Bigquery::Dataset::Access]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   dataset.access #=> [{"role"=>"OWNER",
@@ -241,10 +239,9 @@ module Google
         #                  #     "userByEmail"=>"123456789-...com"}]
         #
         # @example Manage the access rules by passing a block:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   dataset.access do |access|
@@ -279,10 +276,9 @@ module Google
         # @return [Boolean] Returns `true` if the dataset was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #   dataset.delete
@@ -315,28 +311,25 @@ module Google
         # @return [Google::Cloud::Bigquery::Table]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table"
         #
         # @example You can also pass name and description options.
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table"
         #                                name: "My Table",
         #                                description: "A description of table."
         #
         # @example The table's schema fields can be passed as an argument.
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   schema_fields = [
@@ -354,10 +347,9 @@ module Google
         #   table = dataset.create_table "my_table", fields: schema_fields
         #
         # @example Or the table's schema can be configured with the block.
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   table = dataset.create_table "my_table" do |t|
@@ -369,10 +361,9 @@ module Google
         #   end
         #
         # @example You can define the schema using a nested block.
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table" do |t|
         #     t.name = "My Table",
@@ -420,19 +411,17 @@ module Google
         # @return [Google::Cloud::Bigquery::View]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   view = dataset.create_view "my_view",
         #             "SELECT name, age FROM [proj:dataset.users]"
         #
         # @example A name and description can be provided:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   view = dataset.create_view "my_view",
         #             "SELECT name, age FROM [proj:dataset.users]",
@@ -467,10 +456,9 @@ module Google
         #   not exist
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #   puts table.name
@@ -497,10 +485,9 @@ module Google
         #   {Google::Cloud::Bigquery::Table::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   tables = dataset.tables
         #   tables.each do |table|
@@ -508,10 +495,9 @@ module Google
         #   end
         #
         # @example Retrieve all tables: (See {Table::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   tables = dataset.tables
         #   tables.all do |table|
@@ -576,10 +562,9 @@ module Google
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   job = bigquery.query_job "SELECT name FROM my_table"
         #
@@ -639,10 +624,9 @@ module Google
         # @return [Google::Cloud::Bigquery::QueryData]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name FROM my_table"
         #   data.each do |row|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
@@ -26,10 +26,9 @@ module Google
         #   Control
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   dataset.access do |access|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
@@ -42,10 +42,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   datasets = bigquery.datasets
           #   if datasets.next?
@@ -61,10 +60,9 @@ module Google
           # @return [Dataset::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   datasets = bigquery.datasets
           #   if datasets.next?
@@ -97,30 +95,27 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each result by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   bigquery.datasets.all do |dataset|
           #     puts dataset.name
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   all_names = bigquery.datasets.all.map do |dataset|
           #     dataset.name
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   bigquery.datasets.all(request_limit: 10) do |dataset|
           #     puts dataset.name

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -40,10 +40,9 @@ module Google
       #   reference
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/bigquery"
       #
-      #   gcloud = Google::Cloud.new
-      #   bigquery = gcloud.bigquery
+      #   bigquery = Google::Cloud::Bigquery.new
       #
       #   q = "SELECT COUNT(word) as count FROM publicdata:samples.shakespeare"
       #   job = bigquery.query_job q
@@ -228,10 +227,9 @@ module Google
         # The delay between refreshes will incrementally increase.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
@@ -42,10 +42,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   jobs = bigquery.jobs
           #   if jobs.next?
@@ -61,10 +60,9 @@ module Google
           # @return [Job::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   jobs = bigquery.jobs
           #   if jobs.next?
@@ -97,30 +95,27 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each job by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   bigquery.jobs.all do |job|
           #     puts job.state
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   all_states = bigquery.jobs.all.map do |job|
           #     job.state
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   bigquery.jobs.all(request_limit: 10) do |job|
           #     puts job.state

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -44,10 +44,9 @@ module Google
       #   Can only be present if the project was retrieved with {#projects}.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/bigquery"
       #
-      #   gcloud = Google::Cloud.new
-      #   bigquery = gcloud.bigquery
+      #   bigquery = Google::Cloud::Bigquery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.table "my_table"
       #
@@ -70,11 +69,10 @@ module Google
         # The BigQuery project connected to.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new "my-todo-project",
-        #                              "/path/to/keyfile.json"
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new "my-todo-project",
+        #                                          "/path/to/keyfile.json"
         #
         #   bigquery.project #=> "my-todo-project"
         #
@@ -139,10 +137,9 @@ module Google
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "[my_proj:my_data.my_table]"
@@ -206,10 +203,9 @@ module Google
         # @return [Google::Cloud::Bigquery::QueryData]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name FROM [my_proj:my_data.my_table]"
         #   data.each do |row|
@@ -217,10 +213,9 @@ module Google
         #   end
         #
         # @example Retrieve all rows: (See {QueryData#all})
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name FROM [my_proj:my_data.my_table]"
         #   data.all do |row|
@@ -245,10 +240,9 @@ module Google
         #   dataset does not exist.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #   puts dataset.name
@@ -282,37 +276,33 @@ module Google
         # @return [Google::Cloud::Bigquery::Dataset]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   dataset = bigquery.create_dataset "my_dataset"
         #
         # @example A name and description can be provided:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   dataset = bigquery.create_dataset "my_dataset",
         #                                     name: "My Dataset",
         #                                     description: "This is my Dataset"
         #
         # @example Access rules can be provided with the `access` option:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   dataset = bigquery.create_dataset "my_dataset",
         #     access: [{"role"=>"WRITER", "userByEmail"=>"writers@example.com"}]
         #
         # @example Or, configure access with a block: (See {Dataset::Access})
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   dataset = bigquery.create_dataset "my_dataset" do |access|
         #     access.add_writer_user "writers@example.com"
@@ -357,10 +347,9 @@ module Google
         #   {Google::Cloud::Bigquery::Dataset::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   datasets = bigquery.datasets
         #   datasets.each do |dataset|
@@ -368,18 +357,16 @@ module Google
         #   end
         #
         # @example Retrieve hidden datasets with the `all` optional arg:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   all_datasets = bigquery.datasets all: true
         #
         # @example Retrieve all datasets: (See {Dataset::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   datasets = bigquery.datasets
         #   datasets.all do |dataset|
@@ -402,10 +389,9 @@ module Google
         #   does not exist.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   job = bigquery.job "my_job"
         #
@@ -437,10 +423,9 @@ module Google
         #   {Google::Cloud::Bigquery::Job::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   jobs = bigquery.jobs
         #   jobs.each do |job|
@@ -448,10 +433,9 @@ module Google
         #   end
         #
         # @example Retrieve only running jobs using the `filter` optional arg:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   running_jobs = bigquery.jobs filter: "running"
         #   running_jobs.each do |job|
@@ -459,10 +443,9 @@ module Google
         #   end
         #
         # @example Retrieve all jobs: (See {Job::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   jobs = bigquery.jobs
         #   jobs.all do |job|
@@ -491,10 +474,9 @@ module Google
         #   {Google::Cloud::Bigquery::Project::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   projects = bigquery.projects
         #   projects.each do |project|
@@ -505,10 +487,9 @@ module Google
         #   end
         #
         # @example Retrieve all projects: (See {Project::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   projects = bigquery.projects
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -71,8 +71,10 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new "my-todo-project",
-        #                                          "/path/to/keyfile.json"
+        #   bigquery = Google::Cloud::Bigquery.new(
+        #     project: "my-todo-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
         #   bigquery.project #=> "my-todo-project"
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
@@ -43,10 +43,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   projects = bigquery.projects
           #   if projects.next?
@@ -62,10 +61,9 @@ module Google
           # @return [Project::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   projects = bigquery.projects
           #   if projects.next?
@@ -98,30 +96,27 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each result by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   bigquery.projects.all do |project|
           #     puts project.name
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   all_project_ids = bigquery.projects.all.map do |project|
           #     project.name
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #
           #   bigquery.projects.all(request_limit: 10) do |project|
           #     puts project.name

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_data.rb
@@ -79,10 +79,9 @@ module Google
         # @return [Boolean]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   job = bigquery.job "my_job"
         #
         #   data = job.query_results
@@ -100,10 +99,9 @@ module Google
         # @return [QueryData]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   job = bigquery.job "my_job"
         #
         #   data = job.query_results
@@ -137,10 +135,9 @@ module Google
         # @return [Enumerator]
         #
         # @example Iterating each row by passing a block:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   job = bigquery.job "my_job"
         #
         #   data = job.query_results
@@ -149,10 +146,9 @@ module Google
         #   end
         #
         # @example Using the enumerator by not passing a block:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   job = bigquery.job "my_job"
         #
         #   data = job.query_results
@@ -161,10 +157,9 @@ module Google
         #   end
         #
         # @example Limit the number of API calls made:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   job = bigquery.job "my_job"
         #
         #   data = job.query_results

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -112,10 +112,9 @@ module Google
         # @return [Google::Cloud::Bigquery::QueryData]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #
         #   q = "SELECT word FROM publicdata:samples.shakespeare"
         #   job = bigquery.query_job q

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -27,10 +27,9 @@ module Google
       #   Preparing Data for BigQuery
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/bigquery"
       #
-      #   gcloud = Google::Cloud.new
-      #   bigquery = gcloud.bigquery
+      #   bigquery = Google::Cloud::Bigquery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.create_table "my_table"
       #
@@ -202,10 +201,9 @@ module Google
         #   nested schema
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table"
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -36,10 +36,9 @@ module Google
       #   Preparing Data for BigQuery
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/bigquery"
       #
-      #   gcloud = Google::Cloud.new
-      #   bigquery = gcloud.bigquery
+      #   bigquery = Google::Cloud::Bigquery.new
       #   dataset = bigquery.dataset "my_dataset"
       #
       #   table = dataset.create_table "my_table" do |schema|
@@ -139,10 +138,9 @@ module Google
         # Useful in queries.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -330,10 +328,9 @@ module Google
         # @return [Google::Cloud::Bigquery::Schema]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table"
         #
@@ -396,10 +393,9 @@ module Google
         # @return [Google::Cloud::Bigquery::Data]
         #
         # @example Paginate rows of data: (See {Data#next})
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -412,10 +408,9 @@ module Google
         #   end
         #
         # @example Retrieve all rows of data: (See {Data#all})
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -463,10 +458,9 @@ module Google
         # @return [Google::Cloud::Bigquery::CopyJob]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #   destination_table = dataset.table "my_destination_table"
@@ -474,10 +468,9 @@ module Google
         #   copy_job = table.copy destination_table
         #
         # @example Passing a string identifier for the destination table:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -523,10 +516,9 @@ module Google
         # @return [Google::Cloud::Bigquery::ExtractJob]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -634,34 +626,31 @@ module Google
         # @return [Google::Cloud::Bigquery::LoadJob]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
         #   load_job = table.load "gs://my-bucket/file-name.csv"
         #
         # @example Pass a google-cloud storage file instance:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-bucket"
         #   file = bucket.file "file-name.csv"
         #   load_job = table.load file
         #
         # @example Upload a file directly:
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -708,10 +697,9 @@ module Google
         # @return [Google::Cloud::Bigquery::InsertResponse]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -738,10 +726,9 @@ module Google
         # @return [Boolean] Returns `true` if the table was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -886,10 +873,9 @@ module Google
           # @return [Google::Cloud::Bigquery::Schema]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |t|
           #     t.name = "My Table",
@@ -936,10 +922,9 @@ module Google
           #   `:nullable`.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.string "first_name", mode: :required
@@ -965,10 +950,9 @@ module Google
           #   `:nullable`.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.integer "age", mode: :required
@@ -994,10 +978,9 @@ module Google
           #   `:nullable`.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.float "price", mode: :required
@@ -1023,10 +1006,9 @@ module Google
           #   `:nullable`.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.boolean "active", mode: :required
@@ -1052,10 +1034,9 @@ module Google
           #   `:nullable`.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.timestamp "creation_date", mode: :required
@@ -1087,10 +1068,9 @@ module Google
           #   nested schema
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.record "cities_lived", mode: :repeated do |cities_lived|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
@@ -45,10 +45,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   tables = dataset.tables
@@ -66,10 +65,9 @@ module Google
           # @return [Table::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   tables = dataset.tables
@@ -104,10 +102,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each result by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.tables.all do |table|
@@ -115,10 +112,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   all_names = dataset.tables.all.map do |table|
@@ -126,10 +122,9 @@ module Google
           #   end
           #
           # @example Limit the number of API requests made:
-          #   require "google/cloud"
+          #   require "google/cloud/bigquery"
           #
-          #   gcloud = Google::Cloud.new
-          #   bigquery = gcloud.bigquery
+          #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.tables.all(request_limit: 10) do |table|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -35,10 +35,9 @@ module Google
       # query.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/bigquery"
       #
-      #   gcloud = Google::Cloud.new
-      #   bigquery = gcloud.bigquery
+      #   bigquery = Google::Cloud::Bigquery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   view = dataset.create_view "my_view",
       #            "SELECT name, age FROM [proj:dataset.users]"
@@ -117,10 +116,9 @@ module Google
         # Useful in queries.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -310,10 +308,9 @@ module Google
         # @param [String] new_query The query that defines the view.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   view = dataset.table "my_view"
         #
@@ -356,10 +353,9 @@ module Google
         # @return [Google::Cloud::Bigquery::QueryData]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   view = dataset.table "my_view"
         #
@@ -385,10 +381,9 @@ module Google
         # @return [Boolean] Returns `true` if the table was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/bigquery"
         #
-        #   gcloud = Google::Cloud.new
-        #   bigquery = gcloud.bigquery
+        #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -156,7 +156,7 @@ describe Google::Cloud do
           File.stub :read, found_credentials, ["path/to/keyfile.json"] do
             Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
-                bigquery = Google::Cloud::Bigquery.new "project-id", "path/to/keyfile.json"
+                bigquery = Google::Cloud::Bigquery.new project: "project-id", keyfile: "path/to/keyfile.json"
                 bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
                 bigquery.project.must_equal "project-id"
                 bigquery.service.must_be_kind_of OpenStruct

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -116,4 +116,55 @@ describe Google::Cloud do
       end
     end
   end
+
+  describe "Bigquery.new" do
+    let(:default_credentials) { OpenStruct.new empty: true }
+    let(:found_credentials) { "{}" }
+
+    it "gets defaults for project_id and keyfile" do
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+          Google::Cloud::Bigquery::Credentials.stub :default, default_credentials do
+            bigquery = Google::Cloud::Bigquery.new
+            bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+            bigquery.project.must_equal "project-id"
+            bigquery.service.credentials.must_equal default_credentials
+          end
+        end
+      end
+    end
+
+    it "uses provided project_id and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_equal nil
+        "bigquery-credentials"
+      }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "bigquery-credentials"
+        retries.must_equal nil
+        timeout.must_equal nil
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
+                bigquery = Google::Cloud::Bigquery.new "project-id", "path/to/keyfile.json"
+                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+                bigquery.project.must_equal "project-id"
+                bigquery.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -23,11 +23,12 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/datastore"
 
-gcloud = Google::Cloud.new "my-todo-project-id",
-                    "/path/to/keyfile.json"
-datastore = gcloud.datastore
+datastore = Google::Cloud::Datastore.new(
+  project: "my-todo-project",
+  keyfile: "/path/to/keyfile.json"
+)
 
 # Create a new task to demo datastore
 task = datastore.entity "Task", "sampleTask" do |t|

--- a/google-cloud-datastore/lib/google-cloud-datastore.rb
+++ b/google-cloud-datastore/lib/google-cloud-datastore.rb
@@ -98,7 +98,7 @@ module Google
     # @return [Google::Cloud::Datastore::Dataset]
     #
     # @example
-    #   require "google/cloud/datastore"
+    #   require "google/cloud"
     #
     #   datastore = Google::Cloud.datastore "my-todo-project",
     #                              "/path/to/keyfile.json"
@@ -115,27 +115,9 @@ module Google
     def self.datastore project = nil, keyfile = nil, scope: nil, retries: nil,
                        timeout: nil
       require "google/cloud/datastore"
-      project ||= Google::Cloud::Datastore::Dataset.default_project
-      project = project.to_s # Always cast to a string
-      fail ArgumentError, "project is missing" if project.empty?
-
-      if ENV["DATASTORE_EMULATOR_HOST"]
-        return Google::Cloud::Datastore::Dataset.new(
-          Google::Cloud::Datastore::Service.new(
-            project, :this_channel_is_insecure,
-            host: ENV["DATASTORE_EMULATOR_HOST"], retries: retries))
-      end
-
-      if keyfile.nil?
-        credentials = Google::Cloud::Datastore::Credentials.default scope: scope
-      else
-        credentials = Google::Cloud::Datastore::Credentials.new(
-          keyfile, scope: scope)
-      end
-
-      Google::Cloud::Datastore::Dataset.new(
-        Google::Cloud::Datastore::Service.new(
-          project, credentials, retries: retries, timeout: timeout))
+      Google::Cloud::Datastore.new project: project, keyfile: keyfile,
+                                   scope: scope, retries: retries,
+                                   timeout: timeout
     end
   end
 end

--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -36,11 +36,12 @@ module Google
     # is taken care of for you.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new "my-todo-project",
-    #                     "/path/to/keyfile.json"
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new(
+    #   project: "my-todo-project",
+    #   keyfile: "/path/to/keyfile.json"
+    # )
     #
     # task = datastore.find "Task", "sampleTask"
     # task["priority"] = 5
@@ -65,10 +66,9 @@ module Google
     # {Google::Cloud::Datastore::Dataset#find} and passing the parts of the key:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task = datastore.find "Task", "sampleTask"
     # ```
@@ -77,10 +77,9 @@ module Google
     # object:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task_key = datastore.key "Task", 123456
     # task = datastore.find task_key
@@ -94,10 +93,9 @@ module Google
     # (See {Google::Cloud::Datastore::Query#where})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # query = datastore.query("Task").
     #   where("done", "=", false)
@@ -108,10 +106,9 @@ module Google
     # Records can also be ordered. (See {Google::Cloud::Datastore::Query#order})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # query = datastore.query("Task").
     #   order("created")
@@ -123,10 +120,9 @@ module Google
     # (See {Google::Cloud::Datastore::Query#limit})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # query = datastore.query("Task").
     #   limit(5)
@@ -138,10 +134,9 @@ module Google
     # (See {Google::Cloud::Datastore::Query#ancestor})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task_list_key = datastore.key "TaskList", "default"
     #
@@ -160,10 +155,9 @@ module Google
     # Datastore to return them all.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # query = datastore.query("Task")
     # tasks = datastore.run query
@@ -182,10 +176,9 @@ module Google
     # saved. If the key is incomplete then it will be completed when saved.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task = datastore.entity "Task" do |t|
     #   t["type"] = "Personal"
@@ -201,10 +194,9 @@ module Google
     # Multiple new entities may be created in a batch.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task1 = datastore.entity "Task" do |t|
     #   t["type"] = "Personal"
@@ -251,10 +243,9 @@ module Google
     # {Google::Cloud::Datastore::Dataset#save}.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task = datastore.find "Task", "sampleTask"
     # # Read the priority property
@@ -268,10 +259,9 @@ module Google
     # Array properties can be used to store more than one value.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task = datastore.entity "Task", "sampleTask" do |t|
     #   t["tags"] = ["fun", "programming"]
@@ -286,10 +276,9 @@ module Google
     # or the entity's key object.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task = datastore.find "Task", "sampleTask"
     # datastore.delete task
@@ -298,10 +287,9 @@ module Google
     # Multiple entities may be deleted in a batch.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task_key1 = datastore.key "Task", "sampleTask1"
     # task_key2 = datastore.key "Task", "sampleTask2"
@@ -316,10 +304,9 @@ module Google
     # block completes.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task_key = datastore.key "Task", "sampleTask"
     #
@@ -340,10 +327,9 @@ module Google
     # allowing you to commit or rollback manually.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new
     #
     # task_key = datastore.key "Task", "sampleTask"
     #
@@ -472,10 +458,9 @@ module Google
     # You can also set the request `timeout` value in seconds.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
-    # gcloud = Google::Cloud.new
-    # datastore = gcloud.datastore retries: 10, timeout: 120
+    # datastore = Google::Cloud::Datastore.new retries: 10, timeout: 120
     # ```
     #
     # See the [Datastore error
@@ -508,13 +493,12 @@ module Google
     # environment variable:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/datastore"
     #
     # # Make Datastore use the emulator
     # ENV["DATASTORE_EMULATOR_HOST"] = "localhost:8978"
     #
-    # gcloud = Google::Cloud.new "emulator-project-id"
-    # datastore = gcloud.datastore
+    # datastore = Google::Cloud::Datastore.new project: "emulator-project-id"
     #
     # task = datastore.entity "Task", "emulatorTask" do |t|
     #   t["type"] = "Testing"
@@ -527,6 +511,74 @@ module Google
     # ```
     #
     module Datastore
+      ##
+      # Creates a new object for connecting to the Datastore service.
+      # Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String] project Dataset identifier for the Datastore you are
+      #   connecting to.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `https://www.googleapis.com/auth/datastore`
+      # @param [Integer] retries Number of times to retry requests on server
+      #   error. The default value is `3`. Optional.
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::Datastore::Dataset]
+      #
+      # @example
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new(
+      #     project: "my-todo-project",
+      #     keyfile: "/path/to/keyfile.json"
+      #   )
+      #
+      #   task = datastore.entity "Task", "sampleTask" do |t|
+      #     t["type"] = "Personal"
+      #     t["done"] = false
+      #     t["priority"] = 4
+      #     t["description"] = "Learn Cloud Datastore"
+      #   end
+      #
+      #   datastore.save task
+      #
+      def self.new project: nil, keyfile: nil, scope: nil, retries: nil,
+                   timeout: nil
+        project ||= Google::Cloud::Datastore::Dataset.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
+        if ENV["DATASTORE_EMULATOR_HOST"]
+          return Google::Cloud::Datastore::Dataset.new(
+            Google::Cloud::Datastore::Service.new(
+              project, :this_channel_is_insecure,
+              host: ENV["DATASTORE_EMULATOR_HOST"], retries: retries))
+        end
+
+        if keyfile.nil?
+          credentials = Google::Cloud::Datastore::Credentials.default(
+            scope: scope)
+        else
+          credentials = Google::Cloud::Datastore::Credentials.new(
+            keyfile, scope: scope)
+        end
+
+        Google::Cloud::Datastore::Dataset.new(
+          Google::Cloud::Datastore::Service.new(
+            project, credentials, retries: retries, timeout: timeout))
+      end
     end
   end
 end

--- a/google-cloud-datastore/lib/google/cloud/datastore/commit.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/commit.rb
@@ -23,8 +23,7 @@ module Google
       # made in a single commit.
       #
       # @example
-      #   gcloud = Google::Cloud.new
-      #   datastore = gcloud.datastore
+      #   datastore = Google::Cloud::Datastore.new
       #   datastore.commit do |c|
       #     c.save task1, task2
       #     c.delete entity1, entity2
@@ -48,8 +47,7 @@ module Google
         # @param [Entity] entities One or more Entity objects to save.
         #
         # @example
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   datastore.commit do |c|
         #     c.save task1, task2
         #   end
@@ -68,8 +66,7 @@ module Google
         # @param [Entity] entities One or more Entity objects to insert.
         #
         # @example
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   datastore.commit do |c|
         #     c.insert task1, task2
         #   end
@@ -87,8 +84,7 @@ module Google
         # @param [Entity] entities One or more Entity objects to update.
         #
         # @example
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   datastore.commit do |c|
         #     c.update task1, task2
         #   end
@@ -107,8 +103,7 @@ module Google
         #   objects to remove.
         #
         # @example
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   datastore.commit do |c|
         #     c.delete task1, task2
         #   end

--- a/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
@@ -23,10 +23,9 @@ module Google
       # QueryResults.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/datastore"
       #
-      #   gcloud = Google::Cloud.new
-      #   datastore = gcloud.datastore
+      #   datastore = Google::Cloud::Datastore.new
       #
       #   query = datastore.query("Task").
       #     where("done", "=", false)

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -43,10 +43,9 @@ module Google
       # See {Google::Cloud#datastore}
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/datastore"
       #
-      #   gcloud = Google::Cloud.new
-      #   datastore = gcloud.datastore
+      #   datastore = Google::Cloud::Datastore.new
       #
       #   query = datastore.query("Task").
       #     where("done", "=", false)
@@ -70,12 +69,13 @@ module Google
         # The Datastore project connected to.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new "my-todo-project",
-        #                       "/path/to/keyfile.json"
+        #   datastore = Google::Cloud::Datastore.new(
+        #     project: "my-todo-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
-        #   datastore = gcloud.datastore
         #   datastore.project #=> "my-todo-project"
         #
         def project
@@ -233,8 +233,7 @@ module Google
         # @return [Boolean] Returns `true` if successful
         #
         # @example
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   datastore.delete task1, task2
         #
         def delete *entities_or_keys
@@ -252,8 +251,7 @@ module Google
         #   were persisted.
         #
         # @example
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   datastore.commit do |c|
         #     c.save task3, task4
         #     c.delete task1, task2
@@ -326,8 +324,7 @@ module Google
         # @return [Google::Cloud::Datastore::Dataset::LookupResults]
         #
         # @example
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   task_key1 = datastore.key "Task", "sampleTask1"
         #   task_key2 = datastore.key "Task", "sampleTask2"
@@ -405,10 +402,9 @@ module Google
         # @yieldparam [Transaction] tx the transaction object
         #
         # @example Runs the given block in a database transaction:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   task = datastore.entity "Task", "sampleTask" do |t|
         #     t["type"] = "Personal"
@@ -424,10 +420,9 @@ module Google
         #   end
         #
         # @example If no block is given, a Transaction object is returned:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   task = datastore.entity "Task", "sampleTask" do |t|
         #     t["type"] = "Personal"

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
@@ -65,8 +65,7 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"
           #   task_key2 = datastore.key "Task", "sampleTask2"
@@ -85,8 +84,7 @@ module Google
           # @return [LookupResults]
           #
           # @example
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"
           #   task_key2 = datastore.key "Task", "sampleTask2"
@@ -123,8 +121,7 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each result by passing a block:
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"
           #   task_key2 = datastore.key "Task", "sampleTask2"
@@ -134,8 +131,7 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"
           #   task_key2 = datastore.key "Task", "sampleTask2"
@@ -145,8 +141,7 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"
           #   task_key2 = datastore.key "Task", "sampleTask2"

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -29,10 +29,9 @@ module Google
         # Many common Array methods will return a new Array instance.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   query = datastore.query("Task")
         #   tasks = datastore.run query
@@ -41,10 +40,9 @@ module Google
         #   tasks.cursor #=> Cursor(c3VwZXJhd2Vzb21lIQ)
         #
         # @example Caution, many Array methods will return a new Array instance:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   query = datastore.query("Task")
         #   tasks = datastore.run query
@@ -122,10 +120,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #
@@ -143,10 +140,9 @@ module Google
           # @return [QueryResults]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #
@@ -171,10 +167,9 @@ module Google
           # @return [Cursor]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #
@@ -201,10 +196,9 @@ module Google
           # @return [Enumerator]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.each_with_cursor do |task, cursor|
@@ -235,10 +229,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each query result by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all do |task|
@@ -246,10 +239,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all.map(&:key).each do |key|
@@ -257,10 +249,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all(request_limit: 10) do |task|
@@ -306,10 +297,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating all results and cursors by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all_with_cursor do |task, cursor|
@@ -317,19 +307,17 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all_with_cursor.count #=> number of result/cursor pairs
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/datastore"
           #
-          #   gcloud = Google::Cloud.new
-          #   datastore = gcloud.datastore
+          #   datastore = Google::Cloud::Datastore.new
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all_with_cursor(request_limit: 10) do |task, cursor|

--- a/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
@@ -81,43 +81,38 @@ module Google
         # @return [Object, nil] Returns `nil` if the property doesn't exist
         #
         # @example Properties can be retrieved with a string name:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   task = datastore.find "Task", "sampleTask"
         #   task["description"] #=> "Learn Cloud Datastore"
         #
         # @example Or with a symbol name:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   task = datastore.find "Task", "sampleTask"
         #   task[:description] #=> "Learn Cloud Datastore"
         #
         # @example Getting a blob value returns a StringIO object:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   user = datastore.find "User", "alice"
         #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
         #
         # @example Getting a geo point value returns a Hash:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   user = datastore.find "User", "alice"
         #   user["location"] #=> { longitude: -122.0862462,
         #                    #     latitude: 37.4220041 }
         #
         # @example Getting a blob value returns a StringIO object:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   user = datastore.find "User", "alice"
         #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
         #
@@ -139,45 +134,40 @@ module Google
         # @param [Object] prop_value The value of the property.
         #
         # @example Properties can be set with a string name:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   task = datastore.find "Task", "sampleTask"
         #   task["description"] = "Learn Cloud Datastore"
         #   task["tags"] = ["fun", "programming"]
         #
         # @example Or with a symbol name:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   task = datastore.find "Task", "sampleTask"
         #   task[:description] = "Learn Cloud Datastore"
         #   task[:tags] = ["fun", "programming"]
         #
         # @example Setting a blob value using an IO:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   user = datastore.find "User", "alice"
         #   user["avatar"] = File.open "/avatars/alice.png"
         #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
         #
         # @example Setting a geo point value using a Hash:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   user = datastore.find "User", "alice"
         #   user["location"] = { longitude: -122.0862462, latitude: 37.4220041 }
         #
         # @example Setting a blob value using an IO:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   user = datastore.find "User", "alice"
         #   user["avatar"] = File.open "/avatars/alice.png"
         #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
@@ -221,19 +211,17 @@ module Google
         # set a key when immutable will raise a `RuntimeError`.
         #
         # @example The key can be set before the entity is saved:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   task = Google::Cloud::Datastore::Entity.new
         #   task.key = datastore.key "Task"
         #   datastore.save task
         #
         # @example Once the entity is saved, the key is frozen and immutable:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   task = datastore.find "Task", "sampleTask"
         #   task.persisted? #=> true
         #   task.key = datastore.key "Task" #=> RuntimeError
@@ -249,10 +237,9 @@ module Google
         # Indicates if the record is persisted. Default is false.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   task = Google::Cloud::Datastore::Entity.new
         #   task.persisted? #=> false

--- a/google-cloud-datastore/lib/google/cloud/datastore/key.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/key.rb
@@ -46,12 +46,13 @@ module Google
         # @return [String]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new "my-todo-project",
-        #                       "/path/to/keyfile.json"
+        #   datastore = Google::Cloud::Datastore.new(
+        #     project: "my-todo-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
-        #   datastore = gcloud.datastore
         #   task = datastore.find "Task", "sampleTask"
         #   task.key.project #=> "my-todo-project"
         #
@@ -65,12 +66,13 @@ module Google
         # @return [String, nil]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new "my-todo-project",
-        #                       "/path/to/keyfile.json"
+        #   datastore = Google::Cloud::Datastore.new(
+        #     project: "my-todo-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
-        #   datastore = gcloud.datastore
         #   task = datastore.find "Task", "sampleTask"
         #   task.key.namespace #=> "ns~todo-project"
         #
@@ -186,10 +188,9 @@ module Google
         # @return [Key, nil]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   task_list = datastore.find "TaskList", "default"
         #   query = datastore.query("Task").

--- a/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
@@ -191,8 +191,7 @@ module Google
         # @return [Google::Cloud::Datastore::Dataset::LookupResults]
         #
         # @example
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #   task_key1 = datastore.key "Task", 123456
         #   task_key2 = datastore.key "Task", 987654
         #   tasks = datastore.find_all task_key1, task_key2
@@ -259,10 +258,9 @@ module Google
         # @yieldparam [Commit] commit The object that changes are made on
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   task = datastore.entity "Task" do |t|
         #     t["type"] = "Personal"
@@ -282,10 +280,9 @@ module Google
         #   end
         #
         # @example Commit can be passed a block, same as {Dataset#commit}:
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   tx = datastore.transaction
         #   begin
@@ -321,10 +318,9 @@ module Google
         # Rolls a transaction back.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/datastore"
         #
-        #   gcloud = Google::Cloud.new
-        #   datastore = gcloud.datastore
+        #   datastore = Google::Cloud::Datastore.new
         #
         #   task = datastore.entity "Task" do |t|
         #     t["type"] = "Personal"

--- a/google-cloud-datastore/test/google/cloud/datastore_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore_test.rb
@@ -116,4 +116,55 @@ describe Google::Cloud do
       end
     end
   end
+
+  describe "Datastore.new" do
+    let(:default_credentials) { OpenStruct.new empty: true }
+    let(:found_credentials) { "{}" }
+
+    it "gets defaults for project_id and keyfile" do
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+          Google::Cloud::Datastore::Credentials.stub :default, default_credentials do
+            datastore = Google::Cloud::Datastore.new
+            datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
+            datastore.project.must_equal "project-id"
+            datastore.service.credentials.must_equal default_credentials
+          end
+        end
+      end
+    end
+
+    it "uses provided project_id and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_equal nil
+        "datastore-credentials"
+      }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "datastore-credentials"
+        retries.must_equal nil
+        timeout.must_equal nil
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Datastore::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Datastore::Service.stub :new, stubbed_service do
+                datastore = Google::Cloud::Datastore.new project: "project-id", keyfile: "path/to/keyfile.json"
+                datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
+                datastore.project.must_equal "project-id"
+                datastore.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/google-cloud-dns/README.md
+++ b/google-cloud-dns/README.md
@@ -21,10 +21,9 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/dns"
 
-gcloud = Google::Cloud.new
-dns = gcloud.dns
+dns = Google::Cloud::Dns.new
 
 # Retrieve a zone
 zone = dns.zone "example-com"

--- a/google-cloud-dns/lib/google-cloud-dns.rb
+++ b/google-cloud-dns/lib/google-cloud-dns.rb
@@ -103,19 +103,8 @@ module Google
     def self.dns project = nil, keyfile = nil, scope: nil, retries: nil,
                  timeout: nil
       require "google/cloud/dns"
-      project ||= Google::Cloud::Dns::Project.default_project
-      project = project.to_s # Always cast to a string
-      fail ArgumentError, "project is missing" if project.empty?
-
-      if keyfile.nil?
-        credentials = Google::Cloud::Dns::Credentials.default scope: scope
-      else
-        credentials = Google::Cloud::Dns::Credentials.new keyfile, scope: scope
-      end
-
-      Google::Cloud::Dns::Project.new(
-        Google::Cloud::Dns::Service.new(
-          project, credentials, retries: retries, timeout: timeout))
+      Google::Cloud::Dns.new project: project, keyfile: keyfile, scope: scope,
+                             retries: retries, timeout: timeout
     end
   end
 end

--- a/google-cloud-dns/lib/google/cloud/dns.rb
+++ b/google-cloud-dns/lib/google/cloud/dns.rb
@@ -48,10 +48,9 @@ module Google
     # you follow along with these examples.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.create_zone "example-com", "example.com."
     # puts zone.id # unique identifier defined by the server
     # ```
@@ -64,10 +63,9 @@ module Google
     # You can retrieve all the zones in your project.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zones = dns.zones
     # zones.each do |zone|
     #   puts "#{zone.name} - #{zone.dns}"
@@ -77,10 +75,9 @@ module Google
     # You can also retrieve a single zone by either name or id.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # ```
     #
@@ -91,10 +88,9 @@ module Google
     # nameservers. Let's take a look at these records.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # records = zone.records
     # records.count #=> 2
@@ -114,10 +110,9 @@ module Google
     # {Google::Cloud::Dns::Zone#add} results in a new Cloud DNS Change instance.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # change = zone.add "www", "A", 86400, ["1.2.3.4"]
     # change.additions.map &:type #=> ["A", "SOA"]
@@ -136,10 +131,9 @@ module Google
     # retrieved record's domain name is always fully-qualified.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # records = zone.records "www", "A"
     # records.first.name #=> "www.example.com."
@@ -149,10 +143,9 @@ module Google
     # `data` for a record.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # change = zone.replace "www", "A", 86400, ["5.6.7.8"]
     # ```
@@ -162,10 +155,9 @@ module Google
     # to leave unchanged.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # change = zone.modify "www", "A" do |r|
     #   r.ttl = 3600 # change only the TTL
@@ -175,10 +167,9 @@ module Google
     # You can also delete records by name and type.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # change = zone.remove "www", "A"
     # record = change.deletions.first
@@ -190,10 +181,9 @@ module Google
     # {Google::Cloud::Dns::Zone::Transaction}.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # change = zone.update do |tx|
     #   tx.add     "www", "A",  86400, "1.2.3.4"
@@ -210,10 +200,9 @@ module Google
     # {Google::Cloud::Dns::Zone#update}.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # to_add = zone.record "www", "AAAA", 86400, ["2607:f8b0:400a:801::1005"]
     # to_delete = zone.records "www", "A"
@@ -226,10 +215,9 @@ module Google
     # complete immediately, you can retrieve and inspect changes.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # changes = zone.changes
     # changes.each do |change|
@@ -244,10 +232,9 @@ module Google
     # lines may be merged as needed into records with multiple `data` values.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     # change = zone.import "path/to/db.example.com"
     # ```
@@ -255,10 +242,9 @@ module Google
     # You can also export to a zone file.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns
+    # dns = Google::Cloud::Dns.new
     # zone = dns.zone "example-com"
     #
     # zone.export "path/to/db.example.com"
@@ -278,13 +264,65 @@ module Google
     # You can also set the request `timeout` value in seconds.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/dns"
     #
-    # gcloud = Google::Cloud.new
-    # dns = gcloud.dns retries: 10, timeout: 120
+    # dns = Google::Cloud::Dns.new retries: 10, timeout: 120
     # ```
     #
     module Dns
+      ##
+      # Creates a new `Project` instance connected to the DNS service.
+      # Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String] project Identifier for a DNS project. If not present,
+      #   the default project for the credentials is used.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
+      # @param [Integer] retries Number of times to retry requests on server
+      #   error. The default value is `3`. Optional.
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::Dns::Project]
+      #
+      # @example
+      #   require "google/cloud/dns"
+      #
+      #   dns = Google::Cloud::Dns.new(
+      #           project: "my-dns-project",
+      #           keyfile: "/path/to/keyfile.json"
+      #         )
+      #
+      #   zone = dns.zone "example-com"
+      #
+      def self.new project: nil, keyfile: nil, scope: nil, retries: nil,
+                   timeout: nil
+        project ||= Google::Cloud::Dns::Project.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
+        if keyfile.nil?
+          credentials = Google::Cloud::Dns::Credentials.default scope: scope
+        else
+          credentials = Google::Cloud::Dns::Credentials.new(
+            keyfile, scope: scope)
+        end
+
+        Google::Cloud::Dns::Project.new(
+          Google::Cloud::Dns::Service.new(
+            project, credentials, retries: retries, timeout: timeout))
+      end
     end
   end
 end

--- a/google-cloud-dns/lib/google/cloud/dns/change.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/change.rb
@@ -28,10 +28,9 @@ module Google
       # server.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/dns"
       #
-      #   gcloud = Google::Cloud.new
-      #   dns = gcloud.dns
+      #   dns = Google::Cloud::Dns.new
       #   zone = dns.zone "example-com"
       #   zone.changes.each do |change|
       #     puts "Change includes #{change.additions.count} additions " \
@@ -118,10 +117,9 @@ module Google
         # The delay between refreshes will incrementally increase.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   change = zone.change 1234567890
         #   change.done? #=> false

--- a/google-cloud-dns/lib/google/cloud/dns/change/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/change/list.rb
@@ -40,10 +40,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #
           #   changes = zone.changes
@@ -61,10 +60,9 @@ module Google
           # @return [Change::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #
           #   changes = zone.changes
@@ -97,10 +95,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each change by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #   changes = zone.changes
           #
@@ -109,10 +106,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #   changes = zone.changes
           #
@@ -121,10 +117,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #   changes = zone.changes
           #

--- a/google-cloud-dns/lib/google/cloud/dns/project.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/project.rb
@@ -30,10 +30,9 @@ module Google
       # Console](https://console.developers.google.com).
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/dns"
       #
-      #   gcloud = Google::Cloud.new
-      #   dns = gcloud.dns
+      #   dns = Google::Cloud::Dns.new
       #   zone = dns.zone "example-com"
       #   zone.records.each do |record|
       #     puts record.name
@@ -62,11 +61,12 @@ module Google
         # The unique ID string for the current project.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new "my-todo-project",
-        #                              "/path/to/keyfile.json"
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new(
+        #           project: "my-todo-project",
+        #           keyfile: "/path/to/keyfile.json"
+        #  )
         #
         #   dns.project #=> "my-todo-project"
         #
@@ -142,10 +142,9 @@ module Google
         #   not exist.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   puts zone.name
         #
@@ -170,20 +169,18 @@ module Google
         # {Google::Cloud::Dns::Zone::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zones = dns.zones
         #   zones.each do |zone|
         #     puts zone.name
         #   end
         #
         # @example Retrieve all zones: (See {Zone::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zones = dns.zones
         #   zones.all do |zone|
         #     puts zone.name
@@ -215,10 +212,9 @@ module Google
         # @return [Google::Cloud::Dns::Zone]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.create_zone "example-com", "example.com."
         #
         def create_zone zone_name, zone_dns, description: nil,

--- a/google-cloud-dns/lib/google/cloud/dns/record.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/record.rb
@@ -31,10 +31,9 @@ module Google
       # or `Record.new` to create new records.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/dns"
       #
-      #   gcloud = Google::Cloud.new
-      #   dns = gcloud.dns
+      #   dns = Google::Cloud::Dns.new
       #   zone = dns.zone "example-com"
       #
       #   zone.records.count #=> 2

--- a/google-cloud-dns/lib/google/cloud/dns/record/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/record/list.rb
@@ -40,10 +40,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #
           #   records = zone.records "example.com."
@@ -61,10 +60,9 @@ module Google
           # @return [Record::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #
           #   records = zone.records "example.com."
@@ -97,10 +95,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each record by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #   records = zone.records "example.com."
           #
@@ -109,10 +106,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #   records = zone.records "example.com."
           #
@@ -121,10 +117,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #   records = zone.records "example.com."
           #

--- a/google-cloud-dns/lib/google/cloud/dns/zone.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone.rb
@@ -32,10 +32,9 @@ module Google
       # have a unique name.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/dns"
       #
-      #   gcloud = Google::Cloud.new
-      #   dns = gcloud.dns
+      #   dns = Google::Cloud::Dns.new
       #   zone = dns.zone "example-com"
       #   zone.records.each do |record|
       #     puts record.name
@@ -127,18 +126,16 @@ module Google
         # @return [Boolean] Returns `true` if the zone was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   zone.delete
         #
         # @example The zone can be forcefully deleted with the `force` option:
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   zone.delete force: true
         #
@@ -155,10 +152,9 @@ module Google
         # will be kept.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   zone.clear!
         #
@@ -177,10 +173,9 @@ module Google
         #   does not exist.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   change = zone.change "2"
         #   if change
@@ -214,10 +209,9 @@ module Google
         #   {Google::Cloud::Dns::Change::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   changes = zone.changes
         #   changes.each do |change|
@@ -225,18 +219,16 @@ module Google
         #   end
         #
         # @example The changes can be sorted by change sequence:
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   changes = zone.changes order: :desc
         #
         # @example Retrieve all changes: (See {Change::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   changes = zone.changes
         #   changes.all do |change|
@@ -274,10 +266,9 @@ module Google
         #   {Google::Cloud::Dns::Record::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   records = zone.records
         #   records.each do |record|
@@ -285,19 +276,17 @@ module Google
         #   end
         #
         # @example Records can be filtered by name and type:
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   records = zone.records "www", "A"
         #   records.first.name #=> "www.example.com."
         #
         # @example Retrieve all records:
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   records = zone.records "example.com."
         #
@@ -321,10 +310,9 @@ module Google
         # @return [Google::Cloud::Dns::Record]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
         #   zone.add record
@@ -344,10 +332,9 @@ module Google
         # @return [File] An object on the local file system.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #
         #   zone.export "path/to/db.example.com"
@@ -400,10 +387,9 @@ module Google
         #   Record instances.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   change = zone.import "path/to/db.example.com"
         #
@@ -447,10 +433,9 @@ module Google
         # @return [Google::Cloud::Dns::Change]
         #
         # @example Using a block:
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   change = zone.update do |tx|
         #     tx.add     "example.com.", "A",  86400, "1.2.3.4"
@@ -463,20 +448,18 @@ module Google
         #   end
         #
         # @example Or you can provide the record objects to add and remove:
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   new_record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
         #   old_record = zone.record "example.com.", "A", 18600, ["1.2.3.4"]
         #   change = zone.update [new_record], [old_record]
         #
         # @example Using a lambda or Proc to update current SOA serial number:
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   new_record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
         #   change = zone.update new_record, soa_serial: lambda { |sn| sn + 10 }
@@ -542,10 +525,9 @@ module Google
         # @return [Google::Cloud::Dns::Change]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   change = zone.add "example.com.", "A", 86400, ["1.2.3.4"]
         #
@@ -577,10 +559,9 @@ module Google
         # @return [Google::Cloud::Dns::Change]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   change = zone.remove "example.com.", "A"
         #
@@ -619,10 +600,9 @@ module Google
         # @return [Google::Cloud::Dns::Change]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   change = zone.replace "example.com.", "A", 86400, ["5.6.7.8"]
         #
@@ -661,10 +641,9 @@ module Google
         # @return [Google::Cloud::Dns::Change]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   change = zone.modify "example.com.", "MX" do |mx|
         #     mx.ttl = 3600 # change only the TTL
@@ -690,10 +669,9 @@ module Google
         # @return [String] A fully qualified domain name.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   zone.fqdn "www" #=> "www.example.com."
         #   zone.fqdn "@" #=> "example.com."

--- a/google-cloud-dns/lib/google/cloud/dns/zone/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone/list.rb
@@ -39,10 +39,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #
           #   zones = dns.zones
           #   if zones.next?
@@ -59,10 +58,9 @@ module Google
           # @return [Zone::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #
           #   zones = dns.zones
           #   if zones.next?
@@ -95,10 +93,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each zone by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zones = dns.zones
           #
           #   zones.all do |zone|
@@ -106,10 +103,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zones = dns.zones
           #
           #   all_names = zones.all.map do |zone|
@@ -117,10 +113,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zones = dns.zones
           #
           #   zones.all(request_limit: 10) do |zone|

--- a/google-cloud-dns/lib/google/cloud/dns/zone/transaction.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone/transaction.rb
@@ -25,10 +25,9 @@ module Google
         # Cloud DNS API.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/dns"
         #
-        #   gcloud = Google::Cloud.new
-        #   dns = gcloud.dns
+        #   dns = Google::Cloud::Dns.new
         #   zone = dns.zone "example-com"
         #   zone.update do |tx|
         #     tx.add     "example.com.", "A",  86400, "1.2.3.4"
@@ -70,10 +69,9 @@ module Google
           #   example: `192.0.2.1` or `example.com.`.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #   zone.update do |tx|
           #     tx.add     "example.com.", "A",  86400, "1.2.3.4"
@@ -94,10 +92,9 @@ module Google
           #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #   zone.update do |tx|
           #     tx.remove  "example.com.", "TXT"
@@ -126,10 +123,9 @@ module Google
           #   example: `192.0.2.1` or `example.com.`.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone = dns.zone "example-com"
           #   zone.update do |tx|
           #     tx.replace "example.com.",
@@ -156,10 +152,9 @@ module Google
           # @yieldparam [Record] record the record to be modified
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/dns"
           #
-          #   gcloud = Google::Cloud.new
-          #   dns = gcloud.dns
+          #   dns = Google::Cloud::Dns.new
           #   zone.update do |tx|
           #     tx.modify "www.example.com.", "CNAME" do |cname|
           #       cname.ttl = 86400 # only change the TTL

--- a/google-cloud-dns/test/google/cloud/dns_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns_test.rb
@@ -116,4 +116,55 @@ describe Google::Cloud do
       end
     end
   end
+
+  describe "Dns.new" do
+    let(:default_credentials) { OpenStruct.new empty: true }
+    let(:found_credentials) { "{}" }
+
+    it "gets defaults for project_id and keyfile" do
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+          Google::Cloud::Dns::Credentials.stub :default, default_credentials do
+            dns = Google::Cloud::Dns.new
+            dns.must_be_kind_of Google::Cloud::Dns::Project
+            dns.project.must_equal "project-id"
+            dns.service.credentials.must_equal default_credentials
+          end
+        end
+      end
+    end
+
+    it "uses provided project_id and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_equal nil
+        "dns-credentials"
+      }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "dns-credentials"
+        retries.must_equal nil
+        timeout.must_equal nil
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Dns::Service.stub :new, stubbed_service do
+                dns = Google::Cloud::Dns.new project: "project-id", keyfile: "path/to/keyfile.json"
+                dns.must_be_kind_of Google::Cloud::Dns::Project
+                dns.project.must_equal "project-id"
+                dns.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -23,10 +23,9 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/language"
 
-gcloud = Google::Cloud.new
-language = gcloud.language
+language = Google::Cloud::Language.new
 
 content = "Darth Vader is the best villain in Star Wars."
 document = language.document content
@@ -65,4 +64,3 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
 Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
-

--- a/google-cloud-language/lib/google-cloud-language.rb
+++ b/google-cloud-language/lib/google-cloud-language.rb
@@ -40,7 +40,7 @@ module Google
     #   * `"https://www.googleapis.com/auth/cloud-platform"`
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     # @param [Hash] client_config A hash of values to override the default
-    #   behavior of the API client. See Google::Gax::CallSettings. Optional.
+    #   behavior of the API client. Optional.
     #
     # @return [Google::Cloud::Language::Project]
     #
@@ -88,12 +88,12 @@ module Google
     #   * `"https://www.googleapis.com/auth/cloud-platform"`
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     # @param [Hash] client_config A hash of values to override the default
-    #   behavior of the API client. See Google::Gax::CallSettings. Optional.
+    #   behavior of the API client. Optional.
     #
     # @return [Google::Cloud::Language::Project]
     #
     # @example
-    #   require "google/cloud/language"
+    #   require "google/cloud"
     #
     #   language = Google::Cloud.language
     #
@@ -104,16 +104,9 @@ module Google
     def self.language project = nil, keyfile = nil, scope: nil, timeout: nil,
                       client_config: nil
       require "google/cloud/language"
-      project ||= Google::Cloud::Language::Project.default_project
-      if keyfile.nil?
-        credentials = Google::Cloud::Language::Credentials.default scope: scope
-      else
-        credentials = Google::Cloud::Language::Credentials.new(
-          keyfile, scope: scope)
-      end
-      Google::Cloud::Language::Project.new(
-        Google::Cloud::Language::Service.new(
-          project, credentials, timeout: timeout, client_config: client_config))
+      Google::Cloud::Language.new project: project, keyfile: keyfile,
+                                  scope: scope, timeout: timeout,
+                                  client_config: client_config
     end
   end
 end

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -64,10 +64,9 @@ module Google
     # Language service. You can provide text or HTML content as a string:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/language"
     #
-    # gcloud = Google::Cloud.new
-    # language = gcloud.language
+    # language = Google::Cloud::Language.new
     #
     # document = language.document "It was the best of times, it was..."
     # ```
@@ -75,10 +74,9 @@ module Google
     # Or, you can pass a Google Cloud Storage URI for a text or HTML file:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/language"
     #
-    # gcloud = Google::Cloud.new
-    # language = gcloud.language
+    # language = Google::Cloud::Language.new
     #
     # document = language.document "gs://bucket-name/path/to/document"
     # ```
@@ -86,7 +84,7 @@ module Google
     # Or, you can initialize it with a Google Cloud Storage File object:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/language"
     #
     # gcloud = Google::Cloud.new
     # storage = gcloud.storage
@@ -102,10 +100,9 @@ module Google
     # You can specify the format and language of the content:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/language"
     #
-    # gcloud = Google::Cloud.new
-    # language = gcloud.language
+    # language = Google::Cloud::Language.new
     #
     # document = language.document "<p>El viejo y el mar</p>",
     #                              format: :html, language: "es"
@@ -130,10 +127,9 @@ module Google
     # English is supported for sentiment analysis.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/language"
     #
-    # gcloud = Google::Cloud.new
-    # language = gcloud.language
+    # language = Google::Cloud::Language.new
     #
     # content = "Darth Vader is the best villain in Star Wars."
     # document = language.document content
@@ -149,10 +145,9 @@ module Google
     # {Language::Document#entities} method.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/language"
     #
-    # gcloud = Google::Cloud.new
-    # language = gcloud.language
+    # language = Google::Cloud::Language.new
     #
     # content = "Darth Vader is the best villain in Star Wars."
     # document = language.document content
@@ -171,10 +166,9 @@ module Google
     # performed with the {Language::Document#syntax} method.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/language"
     #
-    # gcloud = Google::Cloud.new
-    # language = gcloud.language
+    # language = Google::Cloud::Language.new
     #
     # content = "Darth Vader is the best villain in Star Wars."
     # document = language.document content
@@ -188,10 +182,9 @@ module Google
     # for each desired feature to {Language::Document#annotate}:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/language"
     #
-    # gcloud = Google::Cloud.new
-    # language = gcloud.language
+    # language = Google::Cloud::Language.new
     #
     # content = "Darth Vader is the best villain in Star Wars."
     # document = language.document content
@@ -207,10 +200,9 @@ module Google
     # the document with **all** features:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/language"
     #
-    # gcloud = Google::Cloud.new
-    # language = gcloud.language
+    # language = Google::Cloud::Language.new
     #
     # content = "Darth Vader is the best villain in Star Wars."
     # document = language.document content
@@ -224,6 +216,57 @@ module Google
     # ```
     #
     module Language
+      ##
+      # Creates a new object for connecting to the Language service.
+      # Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String] project Project identifier for the Language service you
+      #   are connecting to.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.goorequire
+      #   "google/cloud"gle.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `"https://www.googleapis.com/auth/cloud-platform"`
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      # @param [Hash] client_config A hash of values to override the default
+      #   behavior of the API client. Optional.
+      #
+      # @return [Google::Cloud::Language::Project]
+      #
+      # @example
+      #   require "google/cloud/language"
+      #
+      #   language = Google::Cloud::Language.new
+      #
+      #   content = "Darth Vader is the best villain in Star Wars."
+      #   document = language.document content
+      #   annotation = document.annotate
+      #
+      def self.new project: nil, keyfile: nil, scope: nil, timeout: nil,
+                   client_config: nil
+        project ||= Google::Cloud::Language::Project.default_project
+        if keyfile.nil?
+          credentials = Google::Cloud::Language::Credentials.default(
+            scope: scope)
+        else
+          credentials = Google::Cloud::Language::Credentials.new(
+            keyfile, scope: scope)
+        end
+        Google::Cloud::Language::Project.new(
+          Google::Cloud::Language::Service.new(
+            project, credentials, timeout: timeout,
+                                  client_config: client_config))
+      end
     end
   end
 end

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -84,15 +84,16 @@ module Google
     # Or, you can initialize it with a Google Cloud Storage File object:
     #
     # ```ruby
-    # require "google/cloud/language"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "bucket-name"
     # file = bucket.file "path/to/document"
     #
-    # language = gcloud.language
+    # require "google/cloud/language"
+    #
+    # language = Google::Cloud::Language.new
     #
     # document = language.document file
     # ```

--- a/google-cloud-language/lib/google/cloud/language/annotation.rb
+++ b/google-cloud-language/lib/google/cloud/language/annotation.rb
@@ -26,10 +26,9 @@ module Google
       # See {Project#annotate} and {Document#annotate}.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/language"
       #
-      #   gcloud = Google::Cloud.new
-      #   language = gcloud.language
+      #   language = Google::Cloud::Language.new
       #
       #   content = "Darth Vader is the best villain in Star Wars."
       #   document = language.document content
@@ -59,10 +58,9 @@ module Google
         #   relative location
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "I love dogs. I hate cats."
         #   document = language.document content
@@ -85,10 +83,9 @@ module Google
         #   blocks of the text
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content
@@ -114,10 +111,9 @@ module Google
         # @return [Entities]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content
@@ -145,10 +141,9 @@ module Google
         # @return [Sentiment]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content
@@ -172,10 +167,9 @@ module Google
         # @return [String] the language code
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content
@@ -214,10 +208,9 @@ module Google
         #   specified in the API request.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "I love dogs. I hate cats."
         #   document = language.document content
@@ -263,10 +256,9 @@ module Google
         #   of the token.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content
@@ -325,10 +317,9 @@ module Google
         #   BCP-47 language codes are supported.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content
@@ -450,10 +441,9 @@ module Google
         #   the input document. The API currently supports proper noun mentions.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content
@@ -591,10 +581,9 @@ module Google
         #   BCP-47 language codes are supported.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content

--- a/google-cloud-language/lib/google/cloud/language/document.rb
+++ b/google-cloud-language/lib/google/cloud/language/document.rb
@@ -34,10 +34,9 @@ module Google
       # See {Project#document}.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/language"
       #
-      #   gcloud = Google::Cloud.new
-      #   language = gcloud.language
+      #   language = Google::Cloud::Language.new
       #
       #   content = "Darth Vader is the best villain in Star Wars."
       #   document = language.document content
@@ -186,10 +185,9 @@ module Google
         # @return [Annotation>] The results of the content analysis.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content
@@ -202,10 +200,9 @@ module Google
         #   annotation.tokens.count #=> 10
         #
         # @example With feature flags:
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   document = language.document content
@@ -239,10 +236,9 @@ module Google
         # @return [Annotation>] The results for the content analysis.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   document = language.document "Hello world!"
         #
@@ -264,10 +260,9 @@ module Google
         # @return [Annotation::Entities>] The results for the entities analysis.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         # content = "Darth Vader is the best villain in Star Wars."
         # document = language.document content
@@ -295,10 +290,9 @@ module Google
         #   analysis.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         # content = "Darth Vader is the best villain in Star Wars."
         # document = language.document content

--- a/google-cloud-language/lib/google/cloud/language/project.rb
+++ b/google-cloud-language/lib/google/cloud/language/project.rb
@@ -33,10 +33,9 @@ module Google
       # See {Google::Cloud#language}
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/language"
       #
-      #   gcloud = Google::Cloud.new
-      #   language = gcloud.language
+      #   language = Google::Cloud::Language.new
       #
       #   content = "Darth Vader is the best villain in Star Wars."
       #   annotation = language.annotate content
@@ -61,11 +60,12 @@ module Google
         # The Language project connected to.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new "my-project-id",
-        #                              "/path/to/keyfile.json"
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new(
+        #     project: "my-project-id",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
         #   language.project #=> "my-project-id"
         #
@@ -98,39 +98,35 @@ module Google
         # @return [Document] An document for the Language service.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   document = language.document "It was the best of times, it was..."
         #
         # @example With a Google Cloud Storage URI:
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   document = language.document "gs://bucket-name/path/to/document"
         #
         # @example With a Google Cloud Storage File object:
-        #   require "google/cloud"
-        #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   require "google/cloud/storage"
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "bucket-name"
         #   file = bucket.file "path/to/document"
         #
-        #   language = gcloud.language
+        #   require "google/cloud/language"
+        #   language = Google::Cloud::Language.new
         #
         #   document = language.document file
         #
         # @example With `format` and `language` options:
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   document = language.document "<p>El viejo y el mar</p>",
         #                           format: :html, language: "es"
@@ -216,10 +212,9 @@ module Google
         # @return [Annotation>] The results for the content analysis.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   content = "Darth Vader is the best villain in Star Wars."
         #   annotation = language.annotate content
@@ -263,10 +258,9 @@ module Google
         # @return [Annotation>] The results for the content syntax analysis.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   document = language.document "Hello world!"
         #
@@ -297,10 +291,9 @@ module Google
         # @return [Annotation::Entities>] The results for the entities analysis.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   document = language.document "Hello Chris and Mike!"
         #
@@ -333,10 +326,9 @@ module Google
         #   analysis.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/language"
         #
-        #   gcloud = Google::Cloud.new
-        #   language = gcloud.language
+        #   language = Google::Cloud::Language.new
         #
         #   document = language.document "Hello Chris and Mike!"
         #

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -21,10 +21,9 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/logging"
 
-gcloud = Google::Cloud.new
-logging = gcloud.logging
+logging = Google::Cloud::Logging.new
 
 # List all log entries
 logging.entries.each do |e|

--- a/google-cloud-logging/lib/google-cloud-logging.rb
+++ b/google-cloud-logging/lib/google-cloud-logging.rb
@@ -90,7 +90,7 @@ module Google
     # @return [Google::Cloud::Logging::Project]
     #
     # @example
-    #   require "google/cloud/logging"
+    #   require "google/cloud"
     #
     #   gcloud = Google::Cloud.new
     #   logging = gcloud.logging
@@ -99,21 +99,9 @@ module Google
     def self.logging project = nil, keyfile = nil, scope: nil, retries: nil,
                      timeout: nil
       require "google/cloud/logging"
-      project ||= Google::Cloud::Logging::Project.default_project
-      project = project.to_s # Always cast to a string
-      fail ArgumentError, "project is missing" if project.empty?
-
-      if keyfile.nil?
-        credentials = Google::Cloud::Logging::Credentials.default(
-          scope: scope)
-      else
-        credentials = Google::Cloud::Logging::Credentials.new(
-          keyfile, scope: scope)
-      end
-
-      Google::Cloud::Logging::Project.new(
-        Google::Cloud::Logging::Service.new(
-          project, credentials, retries: retries, timeout: timeout))
+      Google::Cloud::Logging.new project: project, keyfile: keyfile,
+                                 scope: scope, retries: retries,
+                                 timeout: timeout
     end
   end
 end

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -346,6 +346,56 @@ module Google
     # ```
     #
     module Logging
+      ##
+      # Creates a new object for connecting to the Stackdriver Logging service.
+      # Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String] project Project identifier for the Stackdriver Logging
+      #   service.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `https://www.googleapis.com/auth/logging.admin`
+      # @param [Integer] retries Number of times to retry requests on server
+      #   error. The default value is `3`. Optional.
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::Logging::Project]
+      #
+      # @example
+      #   require "google/cloud/logging"
+      #
+      #   logging = Google::Cloud::Logging.new
+      #   # ...
+      #
+      def self.new project: nil, keyfile: nil, scope: nil, retries: nil,
+                   timeout: nil
+        project ||= Google::Cloud::Logging::Project.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
+        if keyfile.nil?
+          credentials = Google::Cloud::Logging::Credentials.default(
+            scope: scope)
+        else
+          credentials = Google::Cloud::Logging::Credentials.new(
+            keyfile, scope: scope)
+        end
+
+        Google::Cloud::Logging::Project.new(
+          Google::Cloud::Logging::Service.new(
+            project, credentials, retries: retries, timeout: timeout))
+      end
     end
   end
 end

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -60,10 +60,9 @@ module Google
     # {Google::Cloud::Logging::Entry} records belonging to your project:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     # entries = logging.entries
     # entries.each do |e|
     #   puts "[#{e.timestamp}] #{e.log_name} #{e.payload.inspect}"
@@ -80,10 +79,9 @@ module Google
     # Stackdriver Logging API.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     # entries = logging.entries filter: "log:syslog"
     # entries.each do |e|
     #   puts "[#{e.timestamp}] #{e.payload.inspect}"
@@ -93,10 +91,9 @@ module Google
     # You can also order the log entries by `timestamp`.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     # entries = logging.entries order: "timestamp desc"
     # entries.each do |e|
     #   puts "[#{e.timestamp}] #{e.log_name} #{e.payload.inspect}"
@@ -126,17 +123,19 @@ module Google
     # logs](https://cloud.google.com/logging/docs/export/configure_export#setting_product_name_short_permissions_for_writing_exported_logs).
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.create_bucket "my-logs-bucket"
     #
     # # Grant owner permission to Stackdriver Logging service
     # email = "cloud-logs@google.com"
     # bucket.acl.add_owner "group-#{email}"
+    #
+    # require "google/cloud/logging"
+    #
+    # logging = Google::Cloud::Logging.new
     #
     # sink = logging.create_sink "my-sink",
     #                            "storage.googleapis.com/#{bucket.id}"
@@ -152,10 +151,9 @@ module Google
     # {Google::Cloud::Logging::Project#sinks}.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     # sinks = logging.sinks
     # sinks.each do |s|
     #   puts "#{s.name}: #{s.filter} -> #{s.destination}"
@@ -177,10 +175,9 @@ module Google
     # filter](https://cloud.google.com/logging/docs/view/advanced_filters).
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     # metric = logging.create_metric "errors", "severity>=ERROR"
     # ```
     #
@@ -190,10 +187,9 @@ module Google
     # {Google::Cloud::Logging::Project#metrics}.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     # metrics = logging.metrics
     # metrics.each do |m|
     #   puts "#{m.name}: #{m.filter}"
@@ -210,10 +206,9 @@ module Google
     # contain a log name and a resource.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     #
     # entry = logging.entry
     # entry.payload = "Job started."
@@ -230,10 +225,9 @@ module Google
     # these values from the individual entries.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     #
     # entry1 = logging.entry
     # entry1.payload = "Job started."
@@ -260,10 +254,9 @@ module Google
     # to its work queue and return immediately.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     # async = logging.async_writer
     #
     # entry1 = logging.entry
@@ -290,10 +283,9 @@ module Google
     # {Google::Cloud::Logging::Project#logger} to create one.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     #
     # resource = logging.resource "gae_app",
     #                             module_id: "1",
@@ -309,10 +301,9 @@ module Google
     # Logger constructor directly.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging
+    # logging = Google::Cloud::Logging.new
     #
     # resource = logging.resource "gae_app",
     #                             module_id: "1",
@@ -339,10 +330,9 @@ module Google
     # You can also set the request `timeout` value in seconds.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/logging"
     #
-    # gcloud = Google::Cloud.new
-    # logging = gcloud.logging retries: 10, timeout: 120
+    # logging = Google::Cloud::Logging.new retries: 10, timeout: 120
     # ```
     #
     module Logging

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -31,10 +31,9 @@ module Google
       # executing in the background thread.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/logging"
       #
-      #   gcloud = Google::Cloud.new
-      #   logging = gcloud.logging
+      #   logging = Google::Cloud::Logging.new
       #
       #   async = logging.async_writer
       #
@@ -123,10 +122,9 @@ module Google
         # @return [Google::Cloud::Logging::AsyncWriter] Returns self.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   async = logging.async_writer
         #
         #   entry = logging.entry payload: "Job started.",
@@ -173,10 +171,9 @@ module Google
         #   used in place of a ruby standard library logger object.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   resource = logging.resource "gae_app",
         #                               module_id: "1",

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -45,10 +45,9 @@ module Google
       #   Types
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/logging"
       #
-      #   gcloud = Google::Cloud.new
-      #   logging = gcloud.logging
+      #   logging = Google::Cloud::Logging.new
       #
       #   entry = logging.entry payload: "Job started.", log_name: "my_app_log"
       #   entry.resource.type = "gae_app"
@@ -112,10 +111,9 @@ module Google
         # Sets the severity level to `:DEFAULT`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry
         #   entry.severity = :DEBUG
@@ -137,10 +135,9 @@ module Google
         # Sets the severity level to `:DEBUG`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry
         #   entry.severity #=> :DEFAULT
@@ -162,10 +159,9 @@ module Google
         # Sets the severity level to `:INFO`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry
         #   entry.severity #=> :DEFAULT
@@ -187,10 +183,9 @@ module Google
         # Sets the severity level to `:NOTICE`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry
         #   entry.severity #=> :DEFAULT
@@ -212,10 +207,9 @@ module Google
         # Sets the severity level to `:WARNING`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry
         #   entry.severity #=> :DEFAULT
@@ -237,10 +231,9 @@ module Google
         # Sets the severity level to `:ERROR`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry
         #   entry.severity #=> :DEFAULT
@@ -262,10 +255,9 @@ module Google
         # Sets the severity level to `:CRITICAL`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry
         #   entry.severity #=> :DEFAULT
@@ -287,10 +279,9 @@ module Google
         # Sets the severity level to `:ALERT`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry
         #   entry.severity #=> :DEFAULT
@@ -312,10 +303,9 @@ module Google
         # Sets the severity level to `:EMERGENCY`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry
         #   entry.severity #=> :DEFAULT

--- a/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
@@ -39,10 +39,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #
           #   entries = logging.entries
           #   if entries.next?
@@ -59,10 +58,9 @@ module Google
           # @return [Sink::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #
           #   entries = dataset.entries
           #   if entries.next?
@@ -97,10 +95,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each log entry by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   entries = logging.entries order: "timestamp desc"
           #
           #   entries.all do |entry|
@@ -108,10 +105,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   entries = logging.entries order: "timestamp desc"
           #
           #   all_payloads = entries.all.map do |entry|
@@ -119,10 +115,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   entries = logging.entries order: "timestamp desc"
           #
           #   entries.all(request_limit: 10) do |entry|

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -22,10 +22,9 @@ module Google
       # A (mostly) API-compatible logger for ruby's Logger.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/logging"
       #
-      #   gcloud = Google::Cloud.new
-      #   logging = gcloud.logging
+      #   logging = Google::Cloud::Logging.new
       #
       #   resource = logging.resource "gae_app",
       #                               module_id: "1",
@@ -71,10 +70,9 @@ module Google
         #   used in place of a ruby standard library logger object.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   writer = logging.async_writer max_queue_size: 1000
         #
@@ -279,10 +277,9 @@ module Google
         #   name of the severity level
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   resource = logging.resource "gae_app",
         #                               module_id: "1",

--- a/google-cloud-logging/lib/google/cloud/logging/metric.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/metric.rb
@@ -32,10 +32,9 @@ module Google
       # @see https://cloud.google.com/monitoring/docs Google Cloud Monitoring
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/logging"
       #
-      #   gcloud = Google::Cloud.new
-      #   logging = gcloud.logging
+      #   logging = Google::Cloud::Logging.new
       #   metric = logging.create_metric "errors", "severity>=ERROR"
       #
       class Metric
@@ -95,10 +94,9 @@ module Google
         # Updates the logs-based metric.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   metric = logging.metric "severe_errors"
         #   metric.filter = "logName:syslog AND severity>=ERROR"
         #   metric.save
@@ -114,10 +112,9 @@ module Google
         # service.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   metric = logging.metric "severe_errors"
         #   metric.filter = "Unwanted value"
         #   metric.reload!
@@ -136,10 +133,9 @@ module Google
         # @return [Boolean] Returns `true` if the metric was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   metric = logging.metric "severe_errors"
         #   metric.delete
         #

--- a/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
@@ -40,10 +40,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #
           #   metrics = logging.metrics
           #   if metrics.next?
@@ -60,10 +59,9 @@ module Google
           # @return [Sink::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #
           #   metrics = dataset.metrics
           #   if metrics.next?
@@ -96,10 +94,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each metric by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   metrics = logging.metrics
           #
           #   metrics.all do |metric|
@@ -107,10 +104,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   metrics = logging.metrics
           #
           #   all_names = metrics.all.map do |metric|
@@ -118,10 +114,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   metrics = logging.metrics
           #
           #   metrics.all(request_limit: 10) do |metric|

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -543,16 +543,19 @@ module Google
         # @return [Google::Cloud::Logging::Sink] a project sink
         #
         # @example
-        #   require "google/cloud/logging"
+        #   require "google/cloud/storage"
         #
-        #   logging = Google::Cloud::Logging.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.create_bucket "my-logs-bucket"
         #
         #   # Grant owner permission to Stackdriver Logging service
         #   email = "cloud-logs@google.com"
         #   bucket.acl.add_owner "group-#{email}"
+        #
+        #   require "google/cloud/logging"
+        #
+        #   logging = Google::Cloud::Logging.new
         #
         #   sink = logging.create_sink "my-sink",
         #                              "storage.googleapis.com/#{bucket.id}"

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -38,10 +38,9 @@ module Google
       # {Google::Cloud#logging}.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/logging"
       #
-      #   gcloud = Google::Cloud.new
-      #   logging = gcloud.logging
+      #   logging = Google::Cloud::Logging.new
       #   entries = logging.entries
       #
       # See Google::Cloud#logging
@@ -62,10 +61,12 @@ module Google
         # @return [String] the Google Cloud project ID
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new "my-project", "/path/to/keyfile.json"
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new(
+        #     project: "my-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
         #   logging.project #=> "my-project"
         #
@@ -105,40 +106,36 @@ module Google
         #   {Google::Cloud::Logging::Entry::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   entries = logging.entries
         #   entries.each do |e|
         #     puts "[#{e.timestamp}] #{e.log_name} #{e.payload.inspect}"
         #   end
         #
         # @example You can use a filter to narrow results to a single log.
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   entries = logging.entries filter: "log:syslog"
         #   entries.each do |e|
         #     puts "[#{e.timestamp}] #{e.payload.inspect}"
         #   end
         #
         # @example You can also order the results by timestamp.
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   entries = logging.entries order: "timestamp desc"
         #   entries.each do |e|
         #     puts "[#{e.timestamp}] #{e.log_name} #{e.payload.inspect}"
         #   end
         #
         # @example Retrieve all log entries: (See {Entry::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   entries = logging.entries
         #
         #   entries.all do |e|
@@ -185,10 +182,9 @@ module Google
         # @return [Google::Cloud::Logging::Entry] a new Entry instance
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry severity: :INFO, payload: "Job started."
         #
@@ -233,10 +229,9 @@ module Google
         # @return [Boolean] Returns `true` if the entries were written.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry = logging.entry payload: "Job started.",
         #                         log_name: "my_app_log"
@@ -247,10 +242,9 @@ module Google
         #   logging.write_entries entry
         #
         # @example Optionally pass log name, resource, and labels for entries.
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   entry1 = logging.entry payload: "Job started."
         #   entry2 = logging.entry payload: "Job completed."
@@ -292,10 +286,9 @@ module Google
         #   keep up with requests.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   async = logging.async_writer
         #
@@ -321,10 +314,9 @@ module Google
         # called multiple times, it will return the same object.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   async = logging.shared_async_writer
         #
@@ -363,10 +355,9 @@ module Google
         #   used in place of a ruby standard library logger object.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   resource = logging.resource "gae_app",
         #                               module_id: "1",
@@ -393,10 +384,9 @@ module Google
         #   were deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   logging.delete_log "my_app_log"
         #
         def delete_log name
@@ -420,10 +410,9 @@ module Google
         #   {Google::Cloud::Logging::ResourceDescriptor::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   resource_descriptors = logging.resource_descriptors
         #   resource_descriptors.each do |rd|
         #     label_keys = rd.labels.map(&:key).join(", ")
@@ -431,10 +420,9 @@ module Google
         #   end
         #
         # @example Pagination:
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   resource_descriptors = logging.resource_descriptors
         #
         #   resource_descriptors.all do |rd|
@@ -459,10 +447,9 @@ module Google
         # @return [Google::Cloud::Logging::Resource]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #
         #   resource = logging.resource "gae_app",
         #                               "module_id" => "1",
@@ -487,20 +474,18 @@ module Google
         #   {Google::Cloud::Logging::Sink::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   sinks = logging.sinks
         #   sinks.each do |s|
         #     puts "#{s.name}: #{s.filter} -> #{s.destination}"
         #   end
         #
         # @example Retrieve all sinks: (See {Sink::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   sinks = logging.sinks
         #
         #   sinks.all do |s|
@@ -558,10 +543,9 @@ module Google
         # @return [Google::Cloud::Logging::Sink] a project sink
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   storage = gcloud.storage
         #
         #   bucket = storage.create_bucket "my-logs-bucket"
@@ -590,17 +574,15 @@ module Google
         #   does not exist.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   sink = logging.sink "existing-sink"
         #
         # @example By default `nil` will be returned if the sink does not exist.
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   sink = logging.sink "non-existing-sink" #=> nil
         #
         def sink sink_name
@@ -624,20 +606,18 @@ module Google
         #   {Google::Cloud::Logging::Metric::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   metrics = logging.metrics
         #   metrics.each do |m|
         #     puts "#{m.name}: #{m.filter}"
         #   end
         #
         # @example Retrieve all metrics: (See {Metric::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   metrics = logging.metrics
         #
         #   metrics.all do |m|
@@ -672,10 +652,9 @@ module Google
         # @return [Google::Cloud::Logging::Metric]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   metric = logging.create_metric "errors", "severity>=ERROR"
         #
         def create_metric name, filter, description: nil
@@ -694,17 +673,15 @@ module Google
         #   does not exist.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   metric = logging.metric "existing_metric"
         #
         # @example By default `nil` will be returned if metric does not exist.
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   metric = logging.metric "non_existing_metric" #=> nil
         #
         def metric name

--- a/google-cloud-logging/lib/google/cloud/logging/resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource.rb
@@ -30,10 +30,9 @@ module Google
       # {Google::Cloud::Logging::Project#write_entries}.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/logging"
       #
-      #   gcloud = Google::Cloud.new
-      #   logging = gcloud.logging
+      #   logging = Google::Cloud::Logging.new
       #   resource = logging.resource "gae_app",
       #                               "module_id" => "1",
       #                               "version_id" => "20150925t173233"

--- a/google-cloud-logging/lib/google/cloud/logging/resource_descriptor.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource_descriptor.rb
@@ -31,10 +31,9 @@ module Google
       # instances, but you can list them with {Project#resource_descriptors}.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/logging"
       #
-      #   gcloud = Google::Cloud.new
-      #   logging = gcloud.logging
+      #   logging = Google::Cloud::Logging.new
       #   resource_descriptor = logging.resource_descriptors.first
       #   resource_descriptor.type #=> "cloudsql_database"
       #   resource_descriptor.name #=> "Cloud SQL Database"
@@ -93,10 +92,9 @@ module Google
         # their `database_id`. See {ResourceDescriptor#labels}.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   resource_descriptor = logging.resource_descriptors.first
         #   label_descriptor = resource_descriptor.labels.first
         #   label_descriptor.key #=> "database_id"

--- a/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
@@ -41,10 +41,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #
           #   resource_descriptors = logging.resource_descriptors
           #   if resource_descriptors.next?
@@ -61,10 +60,9 @@ module Google
           # @return [Sink::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #
           #   resource_descriptors = logging.resource_descriptors
           #   if resource_descriptors.next?
@@ -100,10 +98,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each resource descriptor by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   resource_descriptors = logging.resource_descriptors
           #
           #   resource_descriptors.all do |rd|
@@ -111,10 +108,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   resource_descriptors = logging.resource_descriptors
           #
           #   all_types = resource_descriptors.all.map do |rd|
@@ -122,10 +118,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   resource_descriptors = logging.resource_descriptors
           #
           #   resource_descriptors.all(request_limit: 10) do |rd|

--- a/google-cloud-logging/lib/google/cloud/logging/sink.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/sink.rb
@@ -41,18 +41,18 @@ module Google
       #   Permissions for writing exported logs
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/storage"
       #
-      #   gcloud = Google::Cloud.new
-      #   logging = gcloud.logging
-      #   storage = gcloud.storage
-      #
+      #   storage = Google::Cloud::Storage.new
       #   bucket = storage.create_bucket "my-logs-bucket"
       #
       #   # Grant owner permission to Stackdriver Logging service
       #   email = "cloud-logs@google.com"
       #   bucket.acl.add_owner "group-#{email}"
       #
+      #   require "google/cloud/logging"
+      #
+      #   logging = Google::Cloud::Logging.new
       #   sink = logging.create_sink "my-sink",
       #                              "storage.googleapis.com/#{bucket.id}"
       #
@@ -156,10 +156,9 @@ module Google
         # Updates the logs-based sink.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   sink = logging.sink "severe_errors"
         #   sink.filter = "logName:syslog AND severity>=ERROR"
         #   sink.save
@@ -184,10 +183,9 @@ module Google
         # @return [Boolean] Returns `true` if the sink was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/logging"
         #
-        #   gcloud = Google::Cloud.new
-        #   logging = gcloud.logging
+        #   logging = Google::Cloud::Logging.new
         #   sink = logging.sink "severe_errors"
         #   sink.delete
         #

--- a/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
@@ -39,10 +39,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #
           #   sinks = logging.sinks
           #   if sinks.next?
@@ -59,10 +58,9 @@ module Google
           # @return [Sink::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #
           #   sinks = dataset.sinks
           #   if sinks.next?
@@ -95,10 +93,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each sink by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   sinks = logging.sinks
           #
           #   sinks.all do |sink|
@@ -106,10 +103,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   sinks = logging.sinks
           #
           #   all_names = sinks.all.map do |sink|
@@ -117,10 +113,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/logging"
           #
-          #   gcloud = Google::Cloud.new
-          #   logging = gcloud.logging
+          #   logging = Google::Cloud::Logging.new
           #   sinks = logging.sinks
           #
           #   sinks.all(request_limit: 10) do |sink|

--- a/google-cloud-logging/test/google/cloud/logging_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging_test.rb
@@ -116,4 +116,55 @@ describe Google::Cloud do
       end
     end
   end
+
+  describe "Logging.new" do
+    let(:default_credentials) { OpenStruct.new empty: true }
+    let(:found_credentials) { "{}" }
+
+    it "gets defaults for project_id and keyfile" do
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+          Google::Cloud::Logging::Credentials.stub :default, default_credentials do
+            logging = Google::Cloud::Logging.new
+            logging.must_be_kind_of Google::Cloud::Logging::Project
+            logging.project.must_equal "project-id"
+            logging.service.credentials.must_equal default_credentials
+          end
+        end
+      end
+    end
+
+    it "uses provided project_id and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_equal nil
+        "logging-credentials"
+      }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "logging-credentials"
+        retries.must_equal nil
+        timeout.must_equal nil
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Logging::Service.stub :new, stubbed_service do
+                logging = Google::Cloud::Logging.new project: "project-id", keyfile: "path/to/keyfile.json"
+                logging.must_be_kind_of Google::Cloud::Logging::Project
+                logging.project.must_equal "project-id"
+                logging.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -21,11 +21,12 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/pubsub"
 
-gcloud = Google::Cloud.new "my-todo-project-id",
-                    "/path/to/keyfile.json"
-pubsub = gcloud.pubsub
+pubsub = Google::Cloud::Pubsub.new(
+  project: "my-todo-project",
+  keyfile: "/path/to/keyfile.json"
+)
 
 # Retrieve a topic
 topic = pubsub.topic "my-topic"

--- a/google-cloud-pubsub/lib/google-cloud-pubsub.rb
+++ b/google-cloud-pubsub/lib/google-cloud-pubsub.rb
@@ -91,7 +91,7 @@ module Google
     # @return [Google::Cloud::Pubsub::Project]
     #
     # @example
-    #   require "google/cloud/pubsub"
+    #   require "google/cloud"
     #
     #   pubsub = Google::Cloud.pubsub
     #
@@ -101,23 +101,9 @@ module Google
     def self.pubsub project = nil, keyfile = nil, scope: nil, retries: nil,
                     timeout: nil
       require "google/cloud/pubsub"
-      project ||= Google::Cloud::Pubsub::Project.default_project
-      if ENV["PUBSUB_EMULATOR_HOST"]
-        ps = Google::Cloud::Pubsub::Project.new(
-          Google::Cloud::Pubsub::Service.new(
-            project, :this_channel_is_insecure))
-        ps.service.host = ENV["PUBSUB_EMULATOR_HOST"]
-        return ps
-      end
-      if keyfile.nil?
-        credentials = Google::Cloud::Pubsub::Credentials.default scope: scope
-      else
-        credentials = Google::Cloud::Pubsub::Credentials.new(
-          keyfile, scope: scope)
-      end
-      Google::Cloud::Pubsub::Project.new(
-        Google::Cloud::Pubsub::Service.new(
-          project, credentials, retries: retries, timeout: timeout))
+      Google::Cloud::Pubsub.new project: project, keyfile: keyfile,
+                                scope: scope, retries: retries,
+                                timeout: timeout
     end
   end
 end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb
@@ -35,10 +35,9 @@ module Google
     # is taken care of for you.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # topic = pubsub.topic "my-topic"
     # topic.publish "task completed"
@@ -53,10 +52,9 @@ module Google
     # A Topic is found by its name. (See {Google::Cloud::Pubsub::Project#topic})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     # topic = pubsub.topic "my-topic"
     # ```
     #
@@ -66,10 +64,9 @@ module Google
     # {Google::Cloud::Pubsub::Project#create_topic})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     # topic = pubsub.create_topic "my-topic"
     # ```
     #
@@ -81,10 +78,9 @@ module Google
     # {Google::Cloud::Pubsub::Topic#subscription})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # topic = pubsub.topic "my-topic"
     # subscription = topic.subscription "my-topic-subscription"
@@ -98,10 +94,9 @@ module Google
     # {Google::Cloud::Pubsub::Project#subscribe})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # topic = pubsub.topic "my-topic"
     # sub = topic.subscribe "my-topic-sub"
@@ -113,10 +108,9 @@ module Google
     # to:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # topic = pubsub.topic "my-topic"
     # sub = topic.subscribe "my-topic-sub",
@@ -132,10 +126,9 @@ module Google
     # {Google::Cloud::Pubsub::Project#publish})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # topic = pubsub.topic "my-topic"
     # msg = topic.publish "new-message"
@@ -144,10 +137,9 @@ module Google
     # Messages can also be published with attributes:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # topic = pubsub.topic "my-topic"
     # msg = topic.publish "new-message",
@@ -158,10 +150,9 @@ module Google
     # Multiple messages can be published at the same time by passing a block:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # topic = pubsub.topic "my-topic"
     # msgs = topic.publish do |batch|
@@ -177,10 +168,9 @@ module Google
     # {Google::Cloud::Pubsub::Subscription#pull})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # msgs = sub.pull
@@ -189,10 +179,9 @@ module Google
     # A maximum number of messages returned can also be specified:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub", max: 10
     # msgs = sub.pull
@@ -202,10 +191,9 @@ module Google
     # (See {Google::Cloud::Pubsub::Subscription#wait_for_messages})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # msgs = sub.wait_for_messages
@@ -221,10 +209,9 @@ module Google
     # (See {Google::Cloud::Pubsub::ReceivedMessage#acknowledge!})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # sub.pull.each { |msg| msg.acknowledge! }
@@ -234,10 +221,9 @@ module Google
     # (See {Google::Cloud::Pubsub::Subscription#acknowledge})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # received_messages = sub.pull
@@ -253,10 +239,9 @@ module Google
     # {Google::Cloud::Pubsub::ReceivedMessage#delay!})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # received_message = sub.pull.first
@@ -270,10 +255,9 @@ module Google
     # The message can also be made available for immediate redelivery:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # received_message = sub.pull.first
@@ -288,10 +272,9 @@ module Google
     # redelivery: (See {Google::Cloud::Pubsub::Subscription#delay})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # received_messages = sub.pull
@@ -305,10 +288,9 @@ module Google
     # {Google::Cloud::Pubsub::Subscription#listen})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # sub.listen do |msg|
@@ -320,10 +302,9 @@ module Google
     # pulled per batch can be limited with the `max` option:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # sub.listen max: 20 do |msg|
@@ -336,10 +317,9 @@ module Google
     # `autoack` option:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new
     #
     # sub = pubsub.subscription "my-topic-sub"
     # sub.listen autoack: true do |msg|
@@ -361,10 +341,9 @@ module Google
     # You can also set the request `timeout` value in seconds.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new
-    # pubsub = gcloud.pubsub retries: 10, timeout: 120
+    # pubsub = Google::Cloud::Pubsub.new retries: 10, timeout: 120
     # ```
     #
     # See the [Pub/Sub error codes](https://cloud.google.com/pubsub/error-codes)
@@ -379,10 +358,9 @@ module Google
     # to the topics and subscriptions in other projects.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new # my-project-id
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new # my-project-id
     #
     # # Get a topic in the current project
     # my_topic = pubsub.topic "my-topic"
@@ -396,10 +374,9 @@ module Google
     # from a topic in another project:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
-    # gcloud = Google::Cloud.new # my-project-id
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new # my-project-id
     #
     # # Get a topic in another project
     # topic = pubsub.topic "other-topic", project: "other-project-id"
@@ -426,13 +403,12 @@ module Google
     # as shown below.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/pubsub"
     #
     # # Make Pub/Sub use the emulator
     # ENV["PUBSUB_EMULATOR_HOST"] = "localhost:8918"
     #
-    # gcloud = Google::Cloud.new "emulator-project-id"
-    # pubsub = gcloud.pubsub
+    # pubsub = Google::Cloud::Pubsub.new "emulator-project-id"
     #
     # # Get a topic in the current project
     # my_topic = pubsub.new_topic "my-topic"
@@ -440,6 +416,60 @@ module Google
     # ```
     #
     module Pubsub
+      ##
+      # Creates a new object for connecting to the Pub/Sub service.
+      # Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String] project Project identifier for the Pub/Sub service you
+      #   are connecting to.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `https://www.googleapis.com/auth/pubsub`
+      # @param [Integer] retries Number of times to retry requests on server
+      #   error. The default value is `3`. Optional.
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::Pubsub::Project]
+      #
+      # @example
+      #   require "google/cloud/pubsub"
+      #
+      #   pubsub = Google::Cloud.pubsub
+      #
+      #   topic = pubsub.topic "my-topic"
+      #   topic.publish "task completed"
+      #
+      def self.new project: nil, keyfile: nil, scope: nil, retries: nil,
+                   timeout: nil
+        project ||= Google::Cloud::Pubsub::Project.default_project
+        if ENV["PUBSUB_EMULATOR_HOST"]
+          ps = Google::Cloud::Pubsub::Project.new(
+            Google::Cloud::Pubsub::Service.new(
+              project, :this_channel_is_insecure))
+          ps.service.host = ENV["PUBSUB_EMULATOR_HOST"]
+          return ps
+        end
+        if keyfile.nil?
+          credentials = Google::Cloud::Pubsub::Credentials.default scope: scope
+        else
+          credentials = Google::Cloud::Pubsub::Credentials.new(
+            keyfile, scope: scope)
+        end
+        Google::Cloud::Pubsub::Project.new(
+          Google::Cloud::Pubsub::Service.new(
+            project, credentials, retries: retries, timeout: timeout))
+      end
     end
   end
 end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
@@ -29,10 +29,9 @@ module Google
       # delayed.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/pubsub"
       #
-      #   gcloud = Google::Cloud.new
-      #   pubsub = gcloud.pubsub
+      #   pubsub = Google::Cloud::Pubsub.new
       #
       #   # Publish a message
       #   topic = pubsub.topic "my-topic"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/policy.rb
@@ -56,10 +56,9 @@ module Google
       #   for a listing of values and patterns for members.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/pubsub"
       #
-      #   gcloud = Google::Cloud.new
-      #   pubsub = gcloud.pubsub
+      #   pubsub = Google::Cloud::Pubsub.new
       #   topic = pubsub.topic "my-topic"
       #
       #   policy = topic.policy # API call
@@ -94,10 +93,9 @@ module Google
         #   `"user:owner@example.com"`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "my-topic"
         #
         #   policy = topic.policy # API call
@@ -124,10 +122,9 @@ module Google
         #   `"user:owner@example.com"`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "my-topic"
         #
         #   policy = topic.policy # API call
@@ -152,10 +149,9 @@ module Google
         # @return [Array<String>] The members strings, or an empty array.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "my-topic"
         #
         #   policy = topic.policy

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -36,10 +36,9 @@ module Google
       # See {Google::Cloud#pubsub}
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/pubsub"
       #
-      #   gcloud = Google::Cloud.new
-      #   pubsub = gcloud.pubsub
+      #   pubsub = Google::Cloud::Pubsub.new
       #
       #   topic = pubsub.topic "my-topic"
       #   topic.publish "task completed"
@@ -58,11 +57,12 @@ module Google
         # The Pub/Sub project connected to.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new "my-todo-project",
-        #                       "/path/to/keyfile.json"
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new(
+        #     project: "my-todo-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
         #   pubsub.project #=> "my-todo-project"
         #
@@ -103,38 +103,33 @@ module Google
         #   `autocreate` is set to `true`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "existing-topic"
         #
         # @example By default `nil` will be returned if topic does not exist.
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "non-existing-topic" #=> nil
         #
         # @example With the `autocreate` option set to `true`.
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "non-existing-topic", autocreate: true
         #
         # @example Create topic in a different project with the `project` flag.
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "another-topic", project: "another-project"
         #
         # @example Skip the lookup against the service with `skip_lookup`:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "another-topic", skip_lookup: true
         #
         def topic topic_name, autocreate: nil, project: nil, skip_lookup: nil
@@ -158,10 +153,9 @@ module Google
         # @return [Google::Cloud::Pubsub::Topic]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.create_topic "my-topic"
         #
         def create_topic topic_name
@@ -183,10 +177,9 @@ module Google
         #   {Google::Cloud::Pubsub::Topic::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topics = pubsub.topics
         #   topics.each do |topic|
@@ -194,10 +187,9 @@ module Google
         #   end
         #
         # @example Retrieve all topics: (See {Topic::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topics = pubsub.topics
         #   topics.all do |topic|
@@ -235,35 +227,31 @@ module Google
         #   block.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   msg = pubsub.publish "my-topic", "new-message"
         #
         # @example A message can be published using a File object:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   msg = pubsub.publish "my-topic", File.open("message.txt")
         #
         # @example Additionally, a message can be published with attributes:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   msg = pubsub.publish "my-topic", "new-message", foo: :bar,
         #                                                   this: :that
         #
         # @example Multiple messages can be sent at the same time using a block:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   msgs = pubsub.publish "my-topic" do |p|
         #     p.publish "new-message-1", foo: :bar
@@ -272,10 +260,9 @@ module Google
         #   end
         #
         # @example With `autocreate`:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   msg = pubsub.publish "new-topic", "new-message", autocreate: true
         #
@@ -316,38 +303,34 @@ module Google
         # @return [Google::Cloud::Pubsub::Subscription]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscribe "my-topic", "my-topic-sub"
         #   puts sub.name # => "my-topic-sub"
         #
         # @example The name is optional, and will be generated if not given.
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscribe "my-topic"
         #   puts sub.name # => "generated-sub-name"
         #
         # @example Wait 2 minutes for acknowledgement and push all to endpoint:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscribe "my-topic", "my-topic-sub",
         #                          deadline: 120,
         #                          endpoint: "https://example.com/push"
         #
         # @example With `autocreate`:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscribe "new-topic", "new-topic-sub",
         #                          autocreate: true
@@ -387,19 +370,17 @@ module Google
         #   the subscription does not exist
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   subscription = pubsub.subscription "my-sub"
         #   puts subscription.name
         #
         # @example Skip the lookup against the service with `skip_lookup`:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   # No API call is made to retrieve the subscription information.
         #   subscription = pubsub.subscription "my-sub", skip_lookup: true
@@ -430,10 +411,9 @@ module Google
         #   {Google::Cloud::Pubsub::Subscription::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   subscriptions = pubsub.subscriptions
         #   subscriptions.each do |subscription|
@@ -441,10 +421,9 @@ module Google
         #   end
         #
         # @example Retrieve all subscriptions: (See {Subscription::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   subscriptions = pubsub.subscriptions
         #   subscriptions.all do |subscription|

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -25,10 +25,9 @@ module Google
       # Represents a Pub/Sub {Message} that can be acknowledged or delayed.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/pubsub"
       #
-      #   gcloud = Google::Cloud.new
-      #   pubsub = gcloud.pubsub
+      #   pubsub = Google::Cloud::Pubsub.new
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   received_message = sub.pull.first
@@ -90,10 +89,9 @@ module Google
         # Acknowledges receipt of the message.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   received_message = sub.pull.first
@@ -121,10 +119,9 @@ module Google
         #   the message available for another pull request.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   received_message = sub.pull.first

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -27,10 +27,9 @@ module Google
       # specific {Topic}, to be delivered to the subscribing application.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/pubsub"
       #
-      #   gcloud = Google::Cloud.new
-      #   pubsub = gcloud.pubsub
+      #   pubsub = Google::Cloud::Pubsub.new
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   msgs = sub.pull
@@ -77,10 +76,9 @@ module Google
         # @return [Topic]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   sub.topic.name #=> "projects/my-project/topics/my-topic"
@@ -122,10 +120,9 @@ module Google
         # Determines whether the subscription exists in the Pub/Sub service.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   sub.exists? #=> true
@@ -147,10 +144,9 @@ module Google
         # HTTP call.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.get_subscription "my-topic-sub"
         #   sub.lazy? #=> false
@@ -166,10 +162,9 @@ module Google
         # @return [Boolean] Returns `true` if the subscription was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   sub.delete
@@ -200,28 +195,25 @@ module Google
         # @return [Array<Google::Cloud::Pubsub::ReceivedMessage>]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   sub.pull.each { |msg| msg.acknowledge! }
         #
         # @example A maximum number of messages returned can also be specified:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub", max: 10
         #   sub.pull.each { |msg| msg.acknowledge! }
         #
         # @example The call can block until messages are available:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   msgs = sub.pull immediate: false
@@ -255,10 +247,9 @@ module Google
         # @return [Array<Google::Cloud::Pubsub::ReceivedMessage>]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   msgs = sub.wait_for_messages
@@ -285,10 +276,9 @@ module Google
         # @yieldparam [ReceivedMessage] msg the newly received message
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   sub.listen do |msg|
@@ -296,10 +286,9 @@ module Google
         #   end
         #
         # @example Limit number of messages pulled per API request with `max`:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   sub.listen max: 20 do |msg|
@@ -307,10 +296,9 @@ module Google
         #   end
         #
         # @example Automatically acknowledge messages with `autoack`:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   sub.listen autoack: true do |msg|
@@ -340,10 +328,9 @@ module Google
         #   {ReceivedMessage} objects or ack_id values.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   messages = sub.pull
@@ -374,10 +361,9 @@ module Google
         #   {ReceivedMessage} objects or ack_id values.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
         #   messages = sub.pull
@@ -412,30 +398,27 @@ module Google
         # @return [Policy] the current Cloud IAM Policy for this subscription
         #
         # @example Policy values are memoized to reduce the number of API calls:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   sub = pubsub.subscription "my-subscription"
         #
         #   policy = sub.policy # API call
         #   policy_2 = sub.policy # No API call
         #
         # @example Use `force` to retrieve the latest policy from the service:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   sub = pubsub.subscription "my-subscription"
         #
         #   policy = sub.policy force: true # API call
         #   policy_2 = sub.policy force: true # API call
         #
         # @example Update the policy by passing a block:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   sub = pubsub.subscription "my-subscription"
         #
         #   policy = sub.policy do |p|
@@ -471,10 +454,9 @@ module Google
         #   subscription
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   sub = pubsub.subscription "my-subscription"
         #
         #   policy = sub.policy # API call
@@ -512,10 +494,9 @@ module Google
         # @return [Array<String>] The permissions that have access.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   sub = pubsub.subscription "my-subscription"
         #   perms = sub.test_permissions "pubsub.subscriptions.get",
         #                                "pubsub.subscriptions.consume"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
@@ -44,10 +44,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   subscriptions = pubsub.subscriptions
           #   if subscriptions.next?
@@ -64,10 +63,9 @@ module Google
           # @return [Subscription::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   subscriptions = pubsub.subscriptions
           #   if subscriptions.next?
@@ -103,10 +101,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each subscription by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   subscriptions = pubsub.subscriptions
           #   subscriptions.all do |subscription|
@@ -114,10 +111,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   subscriptions = pubsub.subscriptions
           #   all_names = subscriptions.all.map do |subscription|
@@ -125,10 +121,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   subscriptions = pubsub.subscriptions
           #   subscriptions.all(request_limit: 10) do |subscription|

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -28,10 +28,9 @@ module Google
       # A named resource to which messages are published.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/pubsub"
       #
-      #   gcloud = Google::Cloud.new
-      #   pubsub = gcloud.pubsub
+      #   pubsub = Google::Cloud::Pubsub.new
       #
       #   topic = pubsub.topic "my-topic"
       #   topic.publish "task completed"
@@ -77,10 +76,9 @@ module Google
         # @return [Boolean] Returns `true` if the topic was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   topic.delete
@@ -108,30 +106,27 @@ module Google
         # @return [Google::Cloud::Pubsub::Subscription]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   sub = topic.subscribe "my-topic-sub"
         #   puts sub.name # => "my-topic-sub"
         #
         # @example The name is optional, and will be generated if not given:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   sub = topic.subscribe "my-topic-sub"
         #   puts sub.name # => "generated-sub-name"
         #
         # @example Wait 2 minutes for acknowledgement and push all to endpoint:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   sub = topic.subscribe "my-topic-sub",
@@ -160,20 +155,18 @@ module Google
         #   the subscription does not exist.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   subscription = topic.subscription "my-topic-subscription"
         #   puts subscription.name
         #
         # @example Skip the lookup against the service with `skip_lookup`:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   # No API call is made to retrieve the subscription information.
         #   subscription = pubsub.subscription "my-sub", skip_lookup: true
@@ -201,10 +194,9 @@ module Google
         # @return [Array<Subscription>] (See {Subscription::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   subscription = topic.subscriptions
@@ -213,10 +205,9 @@ module Google
         #   end
         #
         # @example Retrieve all subscriptions: (See {Subscription::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   subscription = topic.subscriptions
@@ -247,28 +238,25 @@ module Google
         #   block.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   msg = topic.publish "new-message"
         #
         # @example A message can be published using a File object:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   msg = topic.publish File.open("message.txt")
         #
         # @example Additionally, a message can be published with attributes:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   msg = topic.publish "new-message",
@@ -276,10 +264,9 @@ module Google
         #                       this: :that
         #
         # @example Multiple messages can be sent at the same time using a block:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   msgs = topic.publish do |t|
@@ -318,30 +305,27 @@ module Google
         # @return [Policy] the current Cloud IAM Policy for this topic
         #
         # @example Policy values are memoized to reduce the number of API calls:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "my-topic"
         #
         #   policy = topic.policy # API call
         #   policy_2 = topic.policy # No API call
         #
         # @example Use `force` to retrieve the latest policy from the service:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "my-topic"
         #
         #   policy = topic.policy force: true # API call
         #   policy_2 = topic.policy force: true # API call
         #
         # @example Update the policy by passing a block:
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "my-topic"
         #
         #   policy = topic.policy do |p|
@@ -377,10 +361,9 @@ module Google
         #   topic
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "my-topic"
         #
         #   policy = topic.policy # API call
@@ -419,10 +402,9 @@ module Google
         # @return [Array<Strings>] The permissions that have access.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "my-topic"
         #   perms = topic.test_permissions "pubsub.topics.get",
         #                                  "pubsub.topics.publish"
@@ -441,10 +423,9 @@ module Google
         # Determines whether the topic exists in the Pub/Sub service.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   topic.exists? #=> true
@@ -463,10 +444,9 @@ module Google
         # Determines whether the topic object was created with an HTTP call.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   topic.lazy? #=> false

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
@@ -40,10 +40,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   topics = pubsub.topics
           #   if topics.next?
@@ -60,10 +59,9 @@ module Google
           # @return [Topic::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   topics = pubsub.topics
           #   if topics.next?
@@ -97,10 +95,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each topic by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   topics = pubsub.topics
           #   topics.all do |topic|
@@ -108,10 +105,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   topics = pubsub.topics
           #   all_names = topics.all.map do |topic|
@@ -119,10 +115,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/pubsub"
           #
-          #   gcloud = Google::Cloud.new
-          #   pubsub = gcloud.pubsub
+          #   pubsub = Google::Cloud::Pubsub.new
           #
           #   topics = pubsub.topics
           #   topics.all(request_limit: 10) do |topic|

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/publisher.rb
@@ -21,10 +21,9 @@ module Google
         # Topic Publisher object used to publish multiple messages at once.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/pubsub"
         #
-        #   gcloud = Google::Cloud.new
-        #   pubsub = gcloud.pubsub
+        #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
         #   msgs = topic.publish do |t|

--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -53,10 +53,9 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/resource_manager"
 
-gcloud = Google::Cloud.new
-resource_manager = gcloud.resource_manager
+resource_manager = Google::Cloud::ResourceManager.new
 
 # List all projects
 resource_manager.projects.each do |project|

--- a/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
@@ -91,7 +91,7 @@ module Google
     # @return [Google::Cloud::ResourceManager::Manager]
     #
     # @example
-    #   require "google/cloud/resource_manager"
+    #   require "google/cloud"
     #
     #   resource_manager = Google::Cloud.resource_manager
     #   resource_manager.projects.each do |project|
@@ -101,16 +101,8 @@ module Google
     def self.resource_manager keyfile = nil, scope: nil, retries: nil,
                               timeout: nil
       require "google/cloud/resource_manager"
-      if keyfile.nil?
-        credentials = Google::Cloud::ResourceManager::Credentials.default(
-          scope: scope)
-      else
-        credentials = Google::Cloud::ResourceManager::Credentials.new(
-          keyfile, scope: scope)
-      end
-      Google::Cloud::ResourceManager::Manager.new(
-        Google::Cloud::ResourceManager::Service.new(
-          credentials, retries: retries, timeout: timeout))
+      Google::Cloud::ResourceManager.new keyfile: keyfile, scope: scope,
+                                         retries: retries, timeout: timeout
     end
   end
 end

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
@@ -64,10 +64,9 @@ module Google
     # authentication and connect with those credentials.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # ```
     #
     # ## Listing Projects
@@ -78,10 +77,9 @@ module Google
     # {Google::Cloud::ResourceManager::Manager#projects})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # resource_manager.projects.each do |project|
     #   puts projects.project_id
     # end
@@ -93,10 +91,9 @@ module Google
     # {Google::Cloud::ResourceManager::Project#labels})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # project = resource_manager.project "tokyo-rain-123"
     # # Label the project as production
     # project.update do |p|
@@ -108,10 +105,9 @@ module Google
     # {Google::Cloud::ResourceManager::Manager#projects})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # # Find only the productions projects
     # projects = resource_manager.projects filter: "labels.env:production"
     # projects.each do |project|
@@ -125,10 +121,9 @@ module Google
     # {Google::Cloud::ResourceManager::Manager#create_project})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # project = resource_manager.create_project "tokyo-rain-123",
     #                                           name: "Todos Development",
     #                                           labels: {env: :development}
@@ -141,10 +136,9 @@ module Google
     # {Google::Cloud::ResourceManager::Project#delete})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # resource_manager.delete "tokyo-rain-123"
     # ```
     #
@@ -157,10 +151,9 @@ module Google
     # {Google::Cloud::ResourceManager::Project#undelete})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # resource_manager.undelete "tokyo-rain-123"
     # ```
     #
@@ -178,10 +171,10 @@ module Google
     # You can also set the request `timeout` value in seconds.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager retries: 10, timeout: 120
+    # resource_manager = Google::Cloud::ResourceManager.new retries: 10,
+    #                                                       timeout: 120
     # ```
     #
     # See the [Resource Manager error
@@ -202,10 +195,9 @@ module Google
     # {Google::Cloud::ResourceManager::Policy}.)
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # project = resource_manager.project "tokyo-rain-123"
     # policy = project.policy
     # ```
@@ -213,10 +205,9 @@ module Google
     # A project's access control policy can also be updated:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # project = resource_manager.project "tokyo-rain-123"
     #
     # policy = project.policy do |p|
@@ -228,10 +219,9 @@ module Google
     # {Google::Cloud::ResourceManager::Project#test_permissions})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/resource_manager"
     #
-    # gcloud = Google::Cloud.new
-    # resource_manager = gcloud.resource_manager
+    # resource_manager = Google::Cloud::ResourceManager.new
     # project = resource_manager.project "tokyo-rain-123"
     # perms = project.test_permissions "resourcemanager.projects.get",
     #                                  "resourcemanager.projects.delete"
@@ -243,6 +233,50 @@ module Google
     # Policies](https://cloud.google.com/iam/docs/managing-policies).
     #
     module ResourceManager
+      ##
+      # Creates a new `Project` instance connected to the Resource Manager
+      # service. Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `https://www.googleapis.com/auth/cloud-platform`
+      # @param [Integer] retries Number of times to retry requests on server
+      #   error. The default value is `3`. Optional.
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::ResourceManager::Manager]
+      #
+      # @example
+      #   require "google/cloud/resource_manager"
+      #
+      #   resource_manager = Google::Cloud::ResourceManager.new
+      #   resource_manager.projects.each do |project|
+      #     puts projects.project_id
+      #   end
+      #
+      def self.new keyfile: nil, scope: nil, retries: nil, timeout: nil
+        if keyfile.nil?
+          credentials = Google::Cloud::ResourceManager::Credentials.default(
+            scope: scope)
+        else
+          credentials = Google::Cloud::ResourceManager::Credentials.new(
+            keyfile, scope: scope)
+        end
+        Google::Cloud::ResourceManager::Manager.new(
+          Google::Cloud::ResourceManager::Service.new(
+            credentials, retries: retries, timeout: timeout))
+      end
     end
   end
 end

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/manager.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/manager.rb
@@ -27,10 +27,9 @@ module Google
       # Provides methods for creating, retrieving, and updating projects.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/resource_manager"
       #
-      #   gcloud = Google::Cloud.new
-      #   resource_manager = gcloud.resource_manager
+      #   resource_manager = Google::Cloud::ResourceManager.new
       #   resource_manager.projects.each do |project|
       #     puts projects.project_id
       #   end
@@ -82,10 +81,9 @@ module Google
         #   {Google::Cloud::ResourceManager::Project::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   projects = resource_manager.projects
         #
         #   projects.each do |project|
@@ -93,10 +91,9 @@ module Google
         #   end
         #
         # @example Projects can be filtered using the `filter` option:
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   projects = resource_manager.projects filter: "labels.env:production"
         #
         #   projects.each do |project|
@@ -104,10 +101,9 @@ module Google
         #   end
         #
         # @example Retrieve all projects: (See {Project::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   projects = resource_manager.projects
         #
         #   projects.all do |project|
@@ -128,10 +124,9 @@ module Google
         #   if the project does not exist
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.project_id #=> "tokyo-rain-123"
         #
@@ -175,17 +170,15 @@ module Google
         # @return [Google::Cloud::ResourceManager::Project]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.create_project "tokyo-rain-123"
         #
         # @example A project can also be created with a `name` and `labels`:
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.create_project "tokyo-rain-123",
         #     name: "Todos Development", labels: {env: :development}
         #
@@ -217,10 +210,9 @@ module Google
         # @param [String] project_id The ID of the project.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   resource_manager.delete "tokyo-rain-123"
         #
         def delete project_id
@@ -239,10 +231,9 @@ module Google
         # @param [String] project_id The ID of the project.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   resource_manager.undelete "tokyo-rain-123"
         #
         def undelete project_id

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
@@ -57,10 +57,9 @@ module Google
       #   for a listing of values and patterns for members.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/resource_manager"
       #
-      #   gcloud = Google::Cloud.new
-      #   resource_manager = gcloud.resource_manager
+      #   resource_manager = Google::Cloud::ResourceManager.new
       #   project = resource_manager.project "tokyo-rain-123"
       #
       #   policy = project.policy # API call
@@ -98,10 +97,9 @@ module Google
         #   `"user:owner@example.com"`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #
         #   policy = project.policy # API call
@@ -127,10 +125,9 @@ module Google
         #   `"user:owner@example.com"`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #
         #   policy = project.policy # API call
@@ -155,10 +152,9 @@ module Google
         # @return [Array<String>] The members strings, or an empty array.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #
         #   policy = project.policy

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project.rb
@@ -29,10 +29,9 @@ module Google
       # resources.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/resource_manager"
       #
-      #   gcloud = Google::Cloud.new
-      #   resource_manager = gcloud.resource_manager
+      #   resource_manager = Google::Cloud::ResourceManager.new
       #   project = resource_manager.project "tokyo-rain-123"
       #   project.update do |p|
       #     p.name = "My Project"
@@ -86,10 +85,9 @@ module Google
         # hyphen, single-quote, double-quote, space, and exclamation point.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.name = "My Project"
         #
@@ -115,19 +113,17 @@ module Google
         # @yieldparam [Hash] labels the hash accepting labels
         #
         # @example Labels are read-only and cannot be changed:
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.labels["env"] #=> "dev" # read only
         #   project.labels["env"] = "production" # raises error
         #
         # @example Labels can be updated by passing a block, or with {#labels=}:
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.labels do |labels|
         #     labels["env"] = "production"
@@ -157,10 +153,9 @@ module Google
         # (`Hash`)
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.labels = { "env" => "production" }
         #
@@ -232,10 +227,9 @@ module Google
         #   updating the project
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.update do |p|
         #     p.name = "My Project"
@@ -256,10 +250,9 @@ module Google
         # Resource Manager service.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.reload!
         #
@@ -289,10 +282,9 @@ module Google
         # The caller must have modify permissions for this project.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.active? #=> true
         #   project.delete
@@ -314,10 +306,9 @@ module Google
         # The caller must have modify permissions for this project.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.delete_requested? #=> true
         #   project.undelete
@@ -352,30 +343,27 @@ module Google
         # @return [Policy] the current Cloud IAM Policy for this project
         #
         # @example Policy values are memoized to reduce the number of API calls:
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #
         #   policy = project.policy # API call
         #   policy_2 = project.policy # No API call
         #
         # @example Use `force` to retrieve the latest policy from the service:
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #
         #   policy = project.policy force: true # API call
         #   policy_2 = project.policy force: true # API call
         #
         # @example Update the policy by passing a block:
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #
         #   policy = project.policy do |p|
@@ -413,10 +401,9 @@ module Google
         #   project
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #
         #   policy = project.policy # API call
@@ -447,10 +434,9 @@ module Google
         # @return [Array<String>] The permissions that have access
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   perms = project.test_permissions "resourcemanager.projects.get",
         #                                    "resourcemanager.projects.delete"

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/list.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/list.rb
@@ -38,10 +38,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/resource_manager"
           #
-          #   gcloud = Google::Cloud.new
-          #   resource_manager = gcloud.resource_manager
+          #   resource_manager = Google::Cloud::ResourceManager.new
           #
           #   projects = resource_manager.projects
           #   if projects.next?
@@ -58,10 +57,9 @@ module Google
           # @return [Project::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/resource_manager"
           #
-          #   gcloud = Google::Cloud.new
-          #   resource_manager = gcloud.resource_manager
+          #   resource_manager = Google::Cloud::ResourceManager.new
           #
           #   projects = resource_manager.projects
           #   if projects.next?
@@ -93,10 +91,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each project by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/resource_manager"
           #
-          #   gcloud = Google::Cloud.new
-          #   resource_manager = gcloud.resource_manager
+          #   resource_manager = Google::Cloud::ResourceManager.new
           #   projects = resource_manager.projects
           #
           #   projects.all do |project|
@@ -104,10 +101,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/resource_manager"
           #
-          #   gcloud = Google::Cloud.new
-          #   resource_manager = gcloud.resource_manager
+          #   resource_manager = Google::Cloud::ResourceManager.new
           #   projects = resource_manager.projects
           #
           #   all_project_ids = projects.all.map do |project|
@@ -115,10 +111,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/resource_manager"
           #
-          #   gcloud = Google::Cloud.new
-          #   resource_manager = gcloud.resource_manager
+          #   resource_manager = Google::Cloud::ResourceManager.new
           #   projects = resource_manager.projects
           #
           #   projects.all(request_limit: 10) do |project|

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/updater.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/updater.rb
@@ -26,10 +26,9 @@ module Google
         # methods are used to update the project data in a single API call.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/resource_manager"
         #
-        #   gcloud = Google::Cloud.new
-        #   resource_manager = gcloud.resource_manager
+        #   resource_manager = Google::Cloud::ResourceManager.new
         #   project = resource_manager.project "tokyo-rain-123"
         #   project.update do |p|
         #     p.name = "My Project"
@@ -51,10 +50,9 @@ module Google
           # hyphen, single-quote, double-quote, space, and exclamation point.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/resource_manager"
           #
-          #   gcloud = Google::Cloud.new
-          #   resource_manager = gcloud.resource_manager
+          #   resource_manager = Google::Cloud::ResourceManager.new
           #   project = resource_manager.project "tokyo-rain-123"
           #   project.update do |p|
           #     p.name = "My Project"
@@ -79,10 +77,9 @@ module Google
           # (`Hash`)
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/resource_manager"
           #
-          #   gcloud = Google::Cloud.new
-          #   resource_manager = gcloud.resource_manager
+          #   resource_manager = Google::Cloud::ResourceManager.new
           #   project = resource_manager.project "tokyo-rain-123"
           #   project.update do |p|
           #     p.labels["env"] = "production"
@@ -107,10 +104,9 @@ module Google
           # (`Hash`)
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/resource_manager"
           #
-          #   gcloud = Google::Cloud.new
-          #   resource_manager = gcloud.resource_manager
+          #   resource_manager = Google::Cloud::ResourceManager.new
           #   project = resource_manager.project "tokyo-rain-123"
           #   project.update do |p|
           #     p.labels = { "env" => "production" }

--- a/google-cloud-speech/README.md
+++ b/google-cloud-speech/README.md
@@ -21,10 +21,9 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/speech"
 
-gcloud = Google::Cloud.new
-speech = gcloud.speech
+speech = Google::Cloud::Speech.new
 
 audio = speech.audio "path/to/audio.raw",
                      encoding: :raw, sample_rate: 16000
@@ -61,4 +60,3 @@ This library is licensed under Apache 2.0. Full license text is available in [LI
 
 Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
 Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).
-

--- a/google-cloud-speech/lib/google-cloud-speech.rb
+++ b/google-cloud-speech/lib/google-cloud-speech.rb
@@ -92,7 +92,7 @@ module Google
     # @return [Google::Cloud::Speech::Project]
     #
     # @example
-    #   require "google/cloud/speech"
+    #   require "google/cloud"
     #
     #   speech = Google::Cloud.speech
     #
@@ -102,16 +102,9 @@ module Google
     def self.speech project = nil, keyfile = nil, scope: nil, timeout: nil,
                     client_config: nil
       require "google/cloud/speech"
-      project ||= Google::Cloud::Speech::Project.default_project
-      if keyfile.nil?
-        credentials = Google::Cloud::Speech::Credentials.default scope: scope
-      else
-        credentials = Google::Cloud::Speech::Credentials.new(
-          keyfile, scope: scope)
-      end
-      Google::Cloud::Speech::Project.new(
-        Google::Cloud::Speech::Service.new(
-          project, credentials, timeout: timeout, client_config: client_config))
+      Google::Cloud::Speech.new project: project, keyfile: keyfile,
+                                scope: scope, timeout: timeout,
+                                client_config: client_config
     end
   end
 end

--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -51,10 +51,9 @@ module Google
     # API. You can provide a file path:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/speech"
     #
-    # gcloud = Google::Cloud.new
-    # speech = gcloud.speech
+    # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio "path/to/audio.raw",
     #                      encoding: :raw, sample_rate: 16000
@@ -63,10 +62,9 @@ module Google
     # Or, you can initialize the audio instance with a Google Cloud Storage URI:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/speech"
     #
-    # gcloud = Google::Cloud.new
-    # speech = gcloud.speech
+    # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio "gs://bucket-name/path/to/audio.raw",
     #                      encoding: :raw, sample_rate: 16000
@@ -75,15 +73,16 @@ module Google
     # Or, with a Google Cloud Storage File object:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "bucket-name"
     # file = bucket.file "path/to/audio.raw"
     #
-    # speech = gcloud.speech
+    # require "google/cloud/speech"
+    #
+    # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio file, encoding: :raw, sample_rate: 16000
     # ```
@@ -101,10 +100,9 @@ module Google
     # supplied audio data.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/speech"
     #
-    # gcloud = Google::Cloud.new
-    # speech = gcloud.speech
+    # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio "path/to/audio.raw",
     #                      encoding: :raw, sample_rate: 16000
@@ -121,10 +119,9 @@ module Google
     # once the audio data has been processed.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/speech"
     #
-    # gcloud = Google::Cloud.new
-    # speech = gcloud.speech
+    # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio "path/to/audio.raw",
     #                      encoding: :raw, sample_rate: 16000
@@ -141,6 +138,54 @@ module Google
     # ```
     #
     module Speech
+      ##
+      # Creates a new object for connecting to the Speech service.
+      # Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String] project Project identifier for the Speech service you
+      #   are connecting to.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `https://www.googleapis.com/auth/speech`
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      # @param [Hash] client_config A hash of values to override the default
+      #   behavior of the API client. See Google::Gax::CallSettings. Optional.
+      #
+      # @return [Google::Cloud::Speech::Project]
+      #
+      # @example
+      #   require "google/cloud/speech"
+      #
+      #   speech = Google::Cloud::Speech.new
+      #
+      #   audio = speech.audio "path/to/audio.raw",
+      #                        encoding: :raw, sample_rate: 16000
+      #
+      def self.new project: nil, keyfile: nil, scope: nil, timeout: nil,
+                   client_config: nil
+        project ||= Google::Cloud::Speech::Project.default_project
+        if keyfile.nil?
+          credentials = Google::Cloud::Speech::Credentials.default scope: scope
+        else
+          credentials = Google::Cloud::Speech::Credentials.new(
+            keyfile, scope: scope)
+        end
+        Google::Cloud::Speech::Project.new(
+          Google::Cloud::Speech::Service.new(
+            project, credentials, timeout: timeout,
+                                  client_config: client_config))
+      end
     end
   end
 end

--- a/google-cloud-speech/lib/google/cloud/speech/audio.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/audio.rb
@@ -34,10 +34,9 @@ module Google
       #   Languages
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/speech"
       #
-      #   gcloud = Google::Cloud.new
-      #   speech = gcloud.speech
+      #   speech = Google::Cloud::Speech.new
       #
       #   audio = speech.audio "path/to/audio.raw",
       #                        encoding: :raw, sample_rate: 16000
@@ -74,10 +73,9 @@ module Google
         # @return [String,Symbol]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
         #                        encoding: :raw, sample_rate: 16000
@@ -93,10 +91,9 @@ module Google
         # @return [Integer]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
         #                        encoding: :raw, sample_rate: 16000
@@ -113,10 +110,9 @@ module Google
         # @return [String,Symbol]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
         #                        encoding: :raw, sample_rate: 16000,
@@ -176,10 +172,9 @@ module Google
         # @return [Array<Result>] The transcribed text of audio recognized.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
         #                        encoding: :raw, sample_rate: 16000
@@ -224,10 +219,9 @@ module Google
         #   processing of a speech-recognition operation.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
         #                        encoding: :raw, sample_rate: 16000

--- a/google-cloud-speech/lib/google/cloud/speech/job.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/job.rb
@@ -33,10 +33,9 @@ module Google
       #   Long-running Operation
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/speech"
       #
-      #   gcloud = Google::Cloud.new
-      #   speech = gcloud.speech
+      #   speech = Google::Cloud::Speech.new
       #
       #   job = speech.recognize_job "path/to/audio.raw",
       #                              encoding: :raw, sample_rate: 16000
@@ -69,10 +68,9 @@ module Google
         #   the job is not done this will return `nil`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   job = speech.recognize_job "path/to/audio.raw",
         #                              encoding: :raw, sample_rate: 16000
@@ -99,10 +97,9 @@ module Google
         # @return [boolean] `true` when complete, `false` otherwise.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   job = speech.recognize_job "path/to/audio.raw",
         #                              encoding: :raw, sample_rate: 16000
@@ -118,10 +115,9 @@ module Google
         # processing of a speech-recognition operation.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   job = speech.recognize_job "path/to/audio.raw",
         #                              encoding: :raw, sample_rate: 16000
@@ -141,10 +137,9 @@ module Google
         # reloads will incrementally increase.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   job = speech.recognize_job "path/to/audio.raw",
         #                              encoding: :raw, sample_rate: 16000

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -38,10 +38,9 @@ module Google
       # See {Google::Cloud#speech}
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/speech"
       #
-      #   gcloud = Google::Cloud.new
-      #   speech = gcloud.speech
+      #   speech = Google::Cloud::Speech.new
       #
       #   audio = speech.audio "path/to/audio.raw",
       #                        encoding: :raw, sample_rate: 16000
@@ -65,11 +64,12 @@ module Google
         # The Speech project connected to.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new "my-project-id",
-        #                              "/path/to/keyfile.json"
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new(
+        #     project: "my-project-id",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
         #   speech.project #=> "my-project-id"
         #
@@ -135,33 +135,32 @@ module Google
         # @return [Audio] The audio file to be recognized.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
         #                        encoding: :raw, sample_rate: 16000
         #
         # @example With a Google Cloud Storage URI:
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "gs://bucket-name/path/to/audio.raw",
         #                        encoding: :raw, sample_rate: 16000
         #
         # @example With a Google Cloud Storage File object:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "bucket-name"
         #   file = bucket.file "path/to/audio.raw"
         #
-        #   speech = gcloud.speech
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio file, encoding: :raw, sample_rate: 16000
         #
@@ -243,33 +242,32 @@ module Google
         # @return [Array<Result>] The transcribed text of audio recognized.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   results = speech.recognize "path/to/audio.raw",
         #                              encoding: :raw, sample_rate: 16000
         #
         # @example With a Google Cloud Storage URI:
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   results = speech.recognize "gs://bucket-name/path/to/audio.raw",
         #                              encoding: :raw, sample_rate: 16000
         #
         # @example With a Google Cloud Storage File object:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "bucket-name"
         #   file = bucket.file "path/to/audio.raw"
         #
-        #   speech = gcloud.speech
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
         #
         #   results = speech.recognize file, encoding: :raw,
         #                              sample_rate: 16000,
@@ -342,10 +340,9 @@ module Google
         #   processing of a speech-recognition operation.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   job = speech.recognize_job "path/to/audio.raw",
         #                              encoding: :raw, sample_rate: 16000
@@ -354,10 +351,9 @@ module Google
         #   job.reload!
         #
         # @example With a Google Cloud Storage URI:
-        #   require "google/cloud"
+        #   require "google/cloud/speech"
         #
-        #   gcloud = Google::Cloud.new
-        #   speech = gcloud.speech
+        #   speech = Google::Cloud::Speech.new
         #
         #   job = speech.recognize_job "gs://bucket-name/path/to/audio.raw",
         #                              encoding: :raw, sample_rate: 16000
@@ -366,15 +362,16 @@ module Google
         #   job.reload!
         #
         # @example With a Google Cloud Storage File object:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "bucket-name"
         #   file = bucket.file "path/to/audio.raw"
         #
-        #   speech = gcloud.speech
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
         #
         #   job = speech.recognize_job file, encoding: :raw,
         #                              sample_rate: 16000,

--- a/google-cloud-speech/lib/google/cloud/speech/result.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/result.rb
@@ -39,10 +39,9 @@ module Google
       #   hypotheses (up to the value specified in `max_alternatives`).
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/speech"
       #
-      #   gcloud = Google::Cloud.new
-      #   speech = gcloud.speech
+      #   speech = Google::Cloud::Speech.new
       #
       #   audio = speech.audio "path/to/audio.raw",
       #                        encoding: :raw, sample_rate: 16000

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -21,11 +21,12 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/storage"
 
-gcloud = Google::Cloud.new "my-todo-project-id",
-                    "/path/to/keyfile.json"
-storage = gcloud.storage
+storage = Google::Cloud::Storage.new(
+  project: "my-todo-project",
+  keyfile: "/path/to/keyfile.json"
+)
 
 bucket = storage.bucket "task-attachments"
 

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -34,11 +34,12 @@ module Google
     # is taken care of for you.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new "my-todo-project",
-    #                     "/path/to/keyfile.json"
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new(
+    #   project: "my-todo-project",
+    #   keyfile: "/path/to/keyfile.json"
+    # )
     #
     # bucket = storage.bucket "my-bucket"
     # file = bucket.file "path/to/my-file.ext"
@@ -61,10 +62,9 @@ module Google
     # {Google::Cloud::Storage::Project#bucket})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # ```
@@ -73,10 +73,9 @@ module Google
     # {Google::Cloud::Storage::Project#buckets})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # all_buckets = storage.buckets
     # ```
@@ -85,10 +84,9 @@ module Google
     # through them: (See {Google::Cloud::Storage::Bucket::List#token})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # all_buckets = []
     # tmp_buckets = storage.buckets
@@ -109,10 +107,9 @@ module Google
     # {Google::Cloud::Storage::Project#create_bucket})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.create_bucket "my-todo-app-attachments"
     # ```
@@ -128,10 +125,9 @@ module Google
     # bucket: (See {Google::Cloud::Storage::Bucket#file})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # file = bucket.file "avatars/heidi/400x400.png"
@@ -140,10 +136,9 @@ module Google
     # You can also retrieve all files in a bucket: (See Bucket#files)
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # all_files = bucket.files
@@ -152,10 +147,9 @@ module Google
     # Or you can retrieve all files in a specified path:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # avatar_files = bucket.files prefix: "avatars/"
@@ -165,10 +159,9 @@ module Google
     # through them: (See {Google::Cloud::Storage::File::List#token})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     #
@@ -192,10 +185,9 @@ module Google
     # bucket. (See {Google::Cloud::Storage::Bucket#create_file})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # bucket.create_file "/var/todo-app/avatars/heidi/400x400.png",
@@ -217,11 +209,10 @@ module Google
     # an encrypted file without providing the encryption key.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     # require "digest/sha2"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     # bucket = storage.bucket "my-todo-app"
     #
     # # Key generation shown for example purposes only. Write your own.
@@ -247,10 +238,9 @@ module Google
     # {Google::Cloud::Storage::File#download})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # file = bucket.file "avatars/heidi/400x400.png"
@@ -265,10 +255,9 @@ module Google
     # {Google::Cloud::Storage::File#signed_url})
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # file = bucket.file "avatars/heidi/400x400.png"
@@ -289,10 +278,9 @@ module Google
     # email address:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     #
@@ -304,10 +292,9 @@ module Google
     # the email address:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     #
@@ -319,10 +306,9 @@ module Google
     # permissions:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     #
@@ -340,10 +326,9 @@ module Google
     # email address:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # file = bucket.file "avatars/heidi/400x400.png"
@@ -356,10 +341,9 @@ module Google
     # email address:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # file = bucket.file "avatars/heidi/400x400.png"
@@ -371,10 +355,9 @@ module Google
     # Access to a file can also be granted to a predefined list of permissions:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage
+    # storage = Google::Cloud::Storage.new
     #
     # bucket = storage.bucket "my-todo-app"
     # file = bucket.file "avatars/heidi/400x400.png"
@@ -396,10 +379,9 @@ module Google
     # You can also set the request `timeout` value in seconds.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/storage"
     #
-    # gcloud = Google::Cloud.new
-    # storage = gcloud.storage retries: 10, timeout: 120
+    # storage = Google::Cloud::Storage.new retries: 10, timeout: 120
     # ```
     #
     # See the [Storage status and error
@@ -407,6 +389,60 @@ module Google
     # for a list of error conditions.
     #
     module Storage
+      ##
+      # Creates a new object for connecting to the Storage service.
+      # Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String] project Project identifier for the Storage service you
+      #   are connecting to.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `https://www.googleapis.com/auth/devstorage.full_control`
+      # @param [Integer] retries Number of times to retry requests on server
+      #   error. The default value is `3`. Optional.
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::Storage::Project]
+      #
+      # @example
+      #   require "google/cloud/storage"
+      #
+      #   storage = Google::Cloud::Storage.new(
+      #     project: "my-todo-project",
+      #     keyfile: "/path/to/keyfile.json"
+      #   )
+      #
+      #   bucket = storage.bucket "my-bucket"
+      #   file = bucket.file "path/to/my-file.ext"
+      #
+      def self.new project: nil, keyfile: nil, scope: nil, retries: nil,
+                   timeout: nil
+        project ||= Google::Cloud::Storage::Project.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
+        if keyfile.nil?
+          credentials = Google::Cloud::Storage::Credentials.default scope: scope
+        else
+          credentials = Google::Cloud::Storage::Credentials.new(
+            keyfile, scope: scope)
+        end
+
+        Google::Cloud::Storage::Project.new(
+          Google::Cloud::Storage::Service.new(
+            project, credentials, retries: retries, timeout: timeout))
+      end
     end
   end
 end

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -28,10 +28,9 @@ module Google
       # Represents a Storage bucket. Belongs to a Project and has many Files.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/storage"
       #
-      #   gcloud = Google::Cloud.new
-      #   storage = gcloud.storage
+      #   storage = Google::Cloud::Storage.new
       #
       #   bucket = storage.bucket "my-bucket"
       #   file = bucket.file "path/to/my-file.ext"
@@ -101,10 +100,9 @@ module Google
         # @yieldparam [Bucket::Cors] cors the object accepting CORS rules
         #
         # @example Retrieving the bucket's CORS rules.
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #   bucket.cors #=> [{"origin"=>["http://example.org"],
@@ -113,10 +111,9 @@ module Google
         #               #     "maxAgeSeconds"=>3600}]
         #
         # @example Updating the bucket's CORS rules inside a block.
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
         #   bucket.update do |b|
@@ -287,10 +284,9 @@ module Google
         #   file
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #   bucket.update do |b|
@@ -301,10 +297,9 @@ module Google
         #   end
         #
         # @example New CORS rules can also be added in a nested block:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
         #   bucket.update do |b|
@@ -334,10 +329,9 @@ module Google
         # @return [Boolean] Returns `true` if the bucket was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #   bucket.delete
@@ -374,10 +368,9 @@ module Google
         #   {Google::Cloud::Storage::File::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #   files = bucket.files
@@ -386,10 +379,9 @@ module Google
         #   end
         #
         # @example Retrieve all files: (See {File::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #   files = bucket.files
@@ -438,10 +430,9 @@ module Google
         #   not exist
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -539,20 +530,18 @@ module Google
         # @return [Google::Cloud::Storage::File]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.create_file "path/to/local.file.ext"
         #
         # @example Specifying a destination path:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -560,11 +549,10 @@ module Google
         #                      "destination/path/file.ext"
         #
         # @example Providing a customer-supplied encryption key:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #   require "digest/sha2"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-bucket"
         #
         #   # Key generation shown for example purposes only. Write your own.
@@ -615,10 +603,9 @@ module Google
         #   Control guide
         #
         # @example Grant access to a user by prepending `"user-"` to an email:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #
@@ -626,10 +613,9 @@ module Google
         #   bucket.acl.add_reader "user-#{email}"
         #
         # @example Grant access to a group by prepending `"group-"` to an email:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #
@@ -637,10 +623,9 @@ module Google
         #   bucket.acl.add_reader "group-#{email}"
         #
         # @example Or, grant access via a predefined permissions list:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #
@@ -662,10 +647,9 @@ module Google
         #   Control guide
         #
         # @example Grant access to a user by prepending `"user-"` to an email:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #
@@ -673,10 +657,9 @@ module Google
         #   bucket.default_acl.add_reader "user-#{email}"
         #
         # @example Grant access to a group by prepending `"group-"` to an email
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #
@@ -684,10 +667,9 @@ module Google
         #   bucket.default_acl.add_reader "group-#{email}"
         #
         # @example Or, grant access via a predefined permissions list:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
@@ -23,10 +23,9 @@ module Google
         # Represents a Bucket's Access Control List.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -64,10 +63,9 @@ module Google
           # Reloads all Access Control List data for the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -88,10 +86,9 @@ module Google
           # @return [Array<String>]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -108,10 +105,9 @@ module Google
           # @return [Array<String>]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -128,10 +124,9 @@ module Google
           # @return [Array<String>]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -158,10 +153,9 @@ module Google
           #   * allAuthenticatedUsers
           #
           # @example Grant access to a user by prepending `"user-"` to an email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -169,10 +163,9 @@ module Google
           #   bucket.acl.add_owner "user-#{email}"
           #
           # @example Grant access to a group by prepending `"group-"` to email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -202,10 +195,9 @@ module Google
           #   * allAuthenticatedUsers
           #
           # @example Grant access to a user by prepending `"user-"` to an email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -213,10 +205,9 @@ module Google
           #   bucket.acl.add_writer "user-#{email}"
           #
           # @example Grant access to a group by prepending `"group-"` to email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -246,10 +237,9 @@ module Google
           #   * allAuthenticatedUsers
           #
           # @example Grant access to a user by prepending `"user-"` to an email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -257,10 +247,9 @@ module Google
           #   bucket.acl.add_reader "user-#{email}"
           #
           # @example Grant access to a group by prepending `"group-"` to email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -291,10 +280,9 @@ module Google
           #   * allAuthenticatedUsers
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -321,10 +309,9 @@ module Google
           # rule to the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -343,10 +330,9 @@ module Google
           # rule to the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -361,10 +347,9 @@ module Google
           # rule to the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -380,10 +365,9 @@ module Google
           # rule to the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -399,10 +383,9 @@ module Google
           # rule to the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -440,10 +423,9 @@ module Google
         # Represents a Bucket's Default Access Control List.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -481,10 +463,9 @@ module Google
           # Reloads all Default Access Control List data for the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -510,10 +491,9 @@ module Google
           # @return [Array<String>]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -530,10 +510,9 @@ module Google
           # @return [Array<String>]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -560,10 +539,9 @@ module Google
           #   * allAuthenticatedUsers
           #
           # @example Grant access to a user by prepending `"user-"` to an email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -571,10 +549,9 @@ module Google
           #   bucket.default_acl.add_owner "user-#{email}"
           #
           # @example Grant access to a group by prepending `"group-"` to email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -604,10 +581,9 @@ module Google
           #   * allAuthenticatedUsers
           #
           # @example Grant access to a user by prepending `"user-"` to an email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -615,10 +591,9 @@ module Google
           #   bucket.default_acl.add_reader "user-#{email}"
           #
           # @example Grant access to a group by prepending `"group-"` to email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -649,10 +624,9 @@ module Google
           #   * allAuthenticatedUsers
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -678,10 +652,9 @@ module Google
           # predefined ACL rule to files in the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -700,10 +673,9 @@ module Google
           # predefined ACL rule to files in the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -719,10 +691,9 @@ module Google
           # predefined ACL rule to files in the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -738,10 +709,9 @@ module Google
           # predefined ACL rule to files in the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -756,10 +726,9 @@ module Google
           # predefined ACL rule to files in the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -775,10 +744,9 @@ module Google
           # predefined ACL rule to files in the bucket.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/cors.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/cors.rb
@@ -29,10 +29,9 @@ module Google
         #   Resource Sharing (CORS)
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-todo-app"
         #
         #   bucket = storage.bucket "my-bucket"
@@ -87,10 +86,9 @@ module Google
           #   minutes.)
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.create_bucket "my-bucket" do |c|
           #     c.add_rule ["http://example.org", "https://example.org"],

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
@@ -40,10 +40,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   buckets = storage.buckets
           #   if buckets.next?
@@ -60,10 +59,9 @@ module Google
           # @return [Bucket::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   buckets = storage.buckets
           #   if buckets.next?
@@ -97,10 +95,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each bucket by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   buckets = storage.buckets
           #   buckets.all do |bucket|
@@ -108,10 +105,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   buckets = storage.buckets
           #   all_names = buckets.all.map do |bucket|
@@ -119,10 +115,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   buckets = storage.buckets
           #   buckets.all(request_limit: 10) do |bucket|

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -37,10 +37,9 @@ module Google
       #   and Techniques
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/storage"
       #
-      #   gcloud = Google::Cloud.new
-      #   storage = gcloud.storage
+      #   storage = Google::Cloud::Storage.new
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -276,10 +275,9 @@ module Google
         # @yield [file] a block yielding a delegate object for updating the file
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -336,10 +334,9 @@ module Google
         # @return [File] Returns a `::File` object on the local file system
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -347,10 +344,9 @@ module Google
         #   file.download "path/to/downloaded/file.ext"
         #
         # @example Use the CRC32c digest by passing :crc32c.
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -358,10 +354,9 @@ module Google
         #   file.download "path/to/downloaded/file.ext", verify: :crc32c
         #
         # @example Use the MD5 and CRC32c digests by passing :all.
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -369,10 +364,9 @@ module Google
         #   file.download "path/to/downloaded/file.ext", verify: :all
         #
         # @example Disable the download verification by passing :none.
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -433,10 +427,9 @@ module Google
         # @return [Google::Cloud::Storage::File]
         #
         # @example The file can be copied to a new path in the current bucket:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -444,10 +437,9 @@ module Google
         #   file.copy "path/to/destination/file.ext"
         #
         # @example The file can also be copied to a different bucket:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -479,10 +471,9 @@ module Google
         # @return [Boolean] Returns `true` if the file was deleted.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -508,20 +499,18 @@ module Google
         #   `HTTPS`.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #   file = bucket.file "avatars/heidi/400x400.png"
         #   public_url = file.public_url
         #
         # @example Generate the URL with a protocol other than HTTPS:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #   file = bucket.file "avatars/heidi/400x400.png"
@@ -571,20 +560,18 @@ module Google
         #   Private Key.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #   file = bucket.file "avatars/heidi/400x400.png"
         #   shared_url = file.signed_url
         #
         # @example Any of the option parameters may be specified:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #   file = bucket.file "avatars/heidi/400x400.png"
@@ -625,10 +612,9 @@ module Google
         #   Control guide
         #
         # @example Grant access to a user by prepending `"user-"` to an email:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #   file = bucket.file "avatars/heidi/400x400.png"
@@ -637,10 +623,9 @@ module Google
         #   file.acl.add_reader "user-#{email}"
         #
         # @example Grant access to a group by prepending `"group-"` to an email:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #   file = bucket.file "avatars/heidi/400x400.png"
@@ -649,10 +634,9 @@ module Google
         #   file.acl.add_reader "group-#{email}"
         #
         # @example Or, grant access via a predefined permissions list:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #   file = bucket.file "avatars/heidi/400x400.png"

--- a/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
@@ -23,10 +23,9 @@ module Google
         # Represents a File's Access Control List.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -66,10 +65,9 @@ module Google
           # Reloads all Access Control List data for the file.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -96,10 +94,9 @@ module Google
           # @return [Array<String>]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -117,10 +114,9 @@ module Google
           # @return [Array<String>]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -151,10 +147,9 @@ module Google
           #   revision of this object. Default is the latest version.
           #
           # @example Grant access to a user by prepending `"user-"` to an email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -163,10 +158,9 @@ module Google
           #   file.acl.add_owner "user-#{email}"
           #
           # @example Grant access to a group by prepending `"group-"` to email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -202,10 +196,9 @@ module Google
           #   revision of this object. Default is the latest version.
           #
           # @example Grant access to a user by prepending `"user-"` to an email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -214,10 +207,9 @@ module Google
           #   file.acl.add_reader "user-#{email}"
           #
           # @example Grant access to a group by prepending `"group-"` to email:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -253,10 +245,9 @@ module Google
           #   revision of this object. Default is the latest version.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -284,10 +275,9 @@ module Google
           # rule to the file.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -307,10 +297,9 @@ module Google
           # ACL rule to the file.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -327,10 +316,9 @@ module Google
           # rule to the file.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -347,10 +335,9 @@ module Google
           # rule to the file.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -366,10 +353,9 @@ module Google
           # rule to the file.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #
@@ -386,10 +372,9 @@ module Google
           # rule to the file.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -44,10 +44,9 @@ module Google
           # @return [Boolean]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #   files = bucket.files
@@ -65,10 +64,9 @@ module Google
           # @return [File::List]
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #   files = bucket.files
@@ -107,10 +105,9 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each file by passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #   files = bucket.files
@@ -119,10 +116,9 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #   files = bucket.files
@@ -132,10 +128,9 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
-          #   require "google/cloud"
+          #   require "google/cloud/storage"
           #
-          #   gcloud = Google::Cloud.new
-          #   storage = gcloud.storage
+          #   storage = Google::Cloud::Storage.new
           #
           #   bucket = storage.bucket "my-bucket"
           #   files = bucket.files

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -39,10 +39,9 @@ module Google
       # See {Google::Cloud#storage}
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/storage"
       #
-      #   gcloud = Google::Cloud.new
-      #   storage = gcloud.storage
+      #   storage = Google::Cloud::Storage.new
       #
       #   bucket = storage.bucket "my-bucket"
       #   file = bucket.file "path/to/my-file.ext"
@@ -64,11 +63,12 @@ module Google
         # The Storage project connected to.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new "my-todo-project",
-        #                       "/path/to/keyfile.json"
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new(
+        #     project: "my-todo-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
         #   storage.project #=> "my-todo-project"
         #
@@ -98,10 +98,9 @@ module Google
         #   {Google::Cloud::Storage::Bucket::List})
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   buckets = storage.buckets
         #   buckets.each do |bucket|
@@ -109,10 +108,9 @@ module Google
         #   end
         #
         # @example Retrieve buckets with names that begin with a given prefix:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   user_buckets = storage.buckets prefix: "user-"
         #   user_buckets.each do |bucket|
@@ -120,10 +118,9 @@ module Google
         #   end
         #
         # @example Retrieve all buckets: (See {Bucket::List#all})
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   buckets = storage.buckets
         #   buckets.all do |bucket|
@@ -146,10 +143,9 @@ module Google
         #   does not exist
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-bucket"
         #   puts bucket.name
@@ -257,18 +253,16 @@ module Google
         # @return [Google::Cloud::Storage::Bucket]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.create_bucket "my-bucket"
         #
         # @example Configure the bucket in a block:
-        #   require "google/cloud"
+        #   require "google/cloud/storage"
         #
-        #   gcloud = Google::Cloud.new
-        #   storage = gcloud.storage
+        #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.create_bucket "my-bucket" do |b|
         #     b.website_main = "index.html"

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -29,10 +29,9 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/translate"
 
-gcloud = Google::Cloud.new
-translate = gcloud.translate
+translate = Google::Cloud::Translate.new
 
 translation = translate.translate "Hello world!", to: "la"
 

--- a/google-cloud-translate/lib/google-cloud-translate.rb
+++ b/google-cloud-translate/lib/google-cloud-translate.rb
@@ -106,16 +106,7 @@ module Google
     #
     def self.translate key = nil, retries: nil, timeout: nil
       require "google/cloud/translate"
-      key ||= ENV["TRANSLATE_KEY"]
-      key ||= ENV["GOOGLE_CLOUD_KEY"]
-      if key.nil?
-        key_missing_msg = "An API key is required to use the Translate API."
-        fail ArgumentError, key_missing_msg
-      end
-
-      Google::Cloud::Translate::Api.new(
-        Google::Cloud::Translate::Service.new(
-          key, retries: retries, timeout: timeout))
+      Google::Cloud::Translate.new key: key, retries: retries, timeout: timeout
     end
   end
 end

--- a/google-cloud-translate/lib/google/cloud/translate.rb
+++ b/google-cloud-translate/lib/google/cloud/translate.rb
@@ -53,10 +53,9 @@ module Google
     # language to which you wish to translate.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/translate"
     #
-    # gcloud = Google::Cloud.new
-    # translate = gcloud.translate
+    # translate = Google::Cloud::Translate.new
     #
     # translation = translate.translate "Hello world!", to: "la"
     #
@@ -73,10 +72,9 @@ module Google
     # give Translate API much to work with.)
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/translate"
     #
-    # gcloud = Google::Cloud.new
-    # translate = gcloud.translate
+    # translate = Google::Cloud::Translate.new
     #
     # translation = translate.translate "chat", to: "en"
     #
@@ -94,10 +92,9 @@ module Google
     # You can pass multiple texts to {Google::Cloud::Translate::Api#translate}.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/translate"
     #
-    # gcloud = Google::Cloud.new
-    # translate = gcloud.translate
+    # translate = Google::Cloud::Translate.new
     #
     # translations = translate.translate "chien", "chat", from: "fr", to: "en"
     #
@@ -111,10 +108,9 @@ module Google
     # By default, any HTML in your source text will be preserved.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/translate"
     #
-    # gcloud = Google::Cloud.new
-    # translate = gcloud.translate
+    # translate = Google::Cloud::Translate.new
     #
     # translation = translate.translate "<strong>Hello</strong> world!",
     #                                   to: :la
@@ -128,10 +124,9 @@ module Google
     # `confidence` score is a float value between `0` and `1`.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/translate"
     #
-    # gcloud = Google::Cloud.new
-    # translate = gcloud.translate
+    # translate = Google::Cloud::Translate.new
     #
     # detection = translate.detect "chat"
     #
@@ -143,10 +138,9 @@ module Google
     # You can pass multiple texts to {Google::Cloud::Translate::Api#detect}.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/translate"
     #
-    # gcloud = Google::Cloud.new
-    # translate = gcloud.translate
+    # translate = Google::Cloud::Translate.new
     #
     # detections = translate.detect "chien", "chat"
     #
@@ -166,10 +160,9 @@ module Google
     # languages.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/translate"
     #
-    # gcloud = Google::Cloud.new
-    # translate = gcloud.translate
+    # translate = Google::Cloud::Translate.new
     #
     # languages = translate.languages
     #
@@ -183,10 +176,9 @@ module Google
     # provide the code for the language in which you wish to receive the names.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/translate"
     #
-    # gcloud = Google::Cloud.new
-    # translate = gcloud.translate
+    # translate = Google::Cloud::Translate.new
     #
     # languages = translate.languages "en"
     #
@@ -209,13 +201,61 @@ module Google
     # You can also set the request `timeout` value in seconds.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/translate"
     #
-    # gcloud = Google::Cloud.new
-    # translate = gcloud.translate retries: 10, timeout: 120
+    # translate = Google::Cloud::Translate.new retries: 10, timeout: 120
     # ```
     #
     module Translate
+      ##
+      # Creates a new object for connecting to the Translate service.
+      # Each call creates a new connection.
+      #
+      # Unlike other Cloud Platform services, which authenticate using a project
+      # ID and OAuth 2.0 credentials, Google Translate API requires a public API
+      # access key. (This may change in future releases of Google Translate
+      # API.) Follow the general instructions at [Identifying your application
+      # to Google](https://cloud.google.com/translate/v2/using_rest#auth), and
+      # the specific instructions for [Server
+      # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
+      #
+      # @param [String] key a public API access key (not an OAuth 2.0 token)
+      # @param [Integer] retries Number of times to retry requests on server
+      #   error. The default value is `3`. Optional.
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::Translate::Api]
+      #
+      # @example
+      #   require "google/cloud/translate"
+      #
+      #   translate = Google::Cloud::Translate.new key: "api-key-abc123XYZ789"
+      #
+      #   translation = translate.translate "Hello world!", to: "la"
+      #   translation.text #=> "Salve mundi!"
+      #
+      # @example Using API Key from the environment variable.
+      #   require "google/cloud/translate"
+      #
+      #   ENV["TRANSLATE_KEY"] = "api-key-abc123XYZ789"
+      #
+      #   translate = Google::Cloud::Translate.new
+      #
+      #   translation = translate.translate "Hello world!", to: "la"
+      #   translation.text #=> "Salve mundi!"
+      #
+      def self.new key: nil, retries: nil, timeout: nil
+        key ||= ENV["TRANSLATE_KEY"]
+        key ||= ENV["GOOGLE_CLOUD_KEY"]
+        if key.nil?
+          key_missing_msg = "An API key is required to use the Translate API."
+          fail ArgumentError, key_missing_msg
+        end
+
+        Google::Cloud::Translate::Api.new(
+          Google::Cloud::Translate::Service.new(
+            key, retries: retries, timeout: timeout))
+      end
     end
   end
 end

--- a/google-cloud-translate/lib/google/cloud/translate/api.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/api.rb
@@ -36,10 +36,9 @@ module Google
       #   Getting Started
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/translate"
       #
-      #   gcloud = Google::Cloud.new
-      #   translate = gcloud.translate
+      #   translate = Google::Cloud::Translate.new
       #
       #   translation = translate.translate "Hello world!", to: "la"
       #
@@ -89,10 +88,9 @@ module Google
         #   objects if multiple texts were given.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/translate"
         #
-        #   gcloud = Google::Cloud.new
-        #   translate = gcloud.translate
+        #   translate = Google::Cloud::Translate.new
         #
         #   translation = translate.translate "Hello world!", to: "la"
         #
@@ -105,10 +103,9 @@ module Google
         #   translation.text #=> "Salve mundi!"
         #
         # @example Setting the `from` language.
-        #   require "google/cloud"
+        #   require "google/cloud/translate"
         #
-        #   gcloud = Google::Cloud.new
-        #   translate = gcloud.translate
+        #   translate = Google::Cloud::Translate.new
         #
         #   translation = translate.translate "Hello world!",
         #                                     from: :en, to: :la
@@ -116,10 +113,9 @@ module Google
         #   translation.text #=> "Salve mundi!"
         #
         # @example Retrieving multiple translations.
-        #   require "google/cloud"
+        #   require "google/cloud/translate"
         #
-        #   gcloud = Google::Cloud.new
-        #   translate = gcloud.translate
+        #   translate = Google::Cloud::Translate.new
         #
         #   translations = translate.translate "Hello my friend.",
         #                                      "See you soon.",
@@ -129,10 +125,9 @@ module Google
         #   translations[1].text #=> "Vide te mox."
         #
         # @example Preserving HTML tags.
-        #   require "google/cloud"
+        #   require "google/cloud/translate"
         #
-        #   gcloud = Google::Cloud.new
-        #   translate = gcloud.translate
+        #   translate = Google::Cloud::Translate.new
         #
         #   translation = translate.translate "<strong>Hello</strong> world!",
         #                                     to: :la
@@ -165,20 +160,18 @@ module Google
         #   multiple texts were given.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/translate"
         #
-        #   gcloud = Google::Cloud.new
-        #   translate = gcloud.translate
+        #   translate = Google::Cloud::Translate.new
         #
         #   detection = translate.detect "Hello world!"
         #   detection.language #=> "en"
         #   detection.confidence #=> 0.7100697
         #
         # @example Detecting multiple texts.
-        #   require "google/cloud"
+        #   require "google/cloud/translate"
         #
-        #   gcloud = Google::Cloud.new
-        #   translate = gcloud.translate
+        #   translate = Google::Cloud::Translate.new
         #
         #   detections = translate.detect "Hello world!",
         #                                 "Bonjour le monde!"
@@ -210,10 +203,9 @@ module Google
         #   the API.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/translate"
         #
-        #   gcloud = Google::Cloud.new
-        #   translate = gcloud.translate
+        #   translate = Google::Cloud::Translate.new
         #
         #   languages = translate.languages
         #   languages.count #=> 104
@@ -222,10 +214,9 @@ module Google
         #   english.name #=> nil
         #
         # @example Get all languages with their names in French.
-        #   require "google/cloud"
+        #   require "google/cloud/translate"
         #
-        #   gcloud = Google::Cloud.new
-        #   translate = gcloud.translate
+        #   translate = Google::Cloud::Translate.new
         #
         #   languages = translate.languages "fr"
         #   languages.count #=> 104

--- a/google-cloud-translate/lib/google/cloud/translate/detection.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/detection.rb
@@ -26,10 +26,9 @@ module Google
       #   Detect Language
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/translate"
       #
-      #   gcloud = Google::Cloud.new
-      #   translate = gcloud.translate
+      #   translate = Google::Cloud::Translate.new
       #
       #   detections = translate.detect "chien", "chat"
       #

--- a/google-cloud-translate/lib/google/cloud/translate/language.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/language.rb
@@ -26,10 +26,9 @@ module Google
       #   Discover Supported Languages
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/translate"
       #
-      #   gcloud = Google::Cloud.new
-      #   translate = gcloud.translate
+      #   translate = Google::Cloud::Translate.new
       #
       #   languages = translate.languages "en"
       #

--- a/google-cloud-translate/lib/google/cloud/translate/translation.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/translation.rb
@@ -26,10 +26,9 @@ module Google
       #   Translate Text
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/translate"
       #
-      #   gcloud = Google::Cloud.new
-      #   translate = gcloud.translate
+      #   translate = Google::Cloud::Translate.new
       #
       #   translation = translate.translate "Hello world!", to: "la"
       #

--- a/google-cloud-translate/support/doctest_helper.rb
+++ b/google-cloud-translate/support/doctest_helper.rb
@@ -14,34 +14,20 @@
 
 require "google/cloud/translate"
 
-# TODO: Pull up for reuse across services
 module Google
   module Cloud
-    def self.stub_service name
-      original_method = "__google_cloud_yard_doctest__#{name}"
-      raise "Method '#{name}' not found." unless respond_to?(name) && methods.map(&:to_s).include?(name.to_s)
-      alias_method original_method, name
-      define_method name do |*args|
-        yield *args
-      end
-    end
-
-    def self.unstub_service name
-      original_method = "__google_cloud_yard_doctest__#{name}"
-      if respond_to?(original_method) && methods.map(&:to_s).include?(original_method.to_s)
-        puts "undef_method #{name}"
-        undef_method name
-        alias_method name, original_method
-        undef_method original_method
+    module Translate
+      def self.stub_new
+        define_singleton_method :new do |*args|
+          yield *args
+        end
       end
     end
   end
 end
 
-# TODO: Pull up for reuse across services
-def mock_service name
-  #if name == :translate # TODO: case for each service
-  Google::Cloud.stub_service name do |*args|
+def mock_translate
+  Google::Cloud::Translate.stub_new do |*args|
     key = "test-api-key"
     translate = Google::Cloud::Translate::Api.new(Google::Cloud::Translate::Service.new(key))
 
@@ -51,100 +37,134 @@ def mock_service name
   end
 end
 
-# Mocks: setup and teardown for all tests
-
 YARD::Doctest.configure do |doctest|
-  doctest.skip "Google::Cloud.translate" # Do not unit test service factory class methods
-  doctest.before("Google::Cloud#translate") do
-    mock_service :translate do |mock|
+   doctest.before "Google::Cloud#translate" do
+    mock_translate do |mock|
       res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
       mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
     end
   end
-  doctest.before("Google::Cloud#translate@Using API Key from the environment variable.") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud#translate@Using API Key from the environment variable." do
+    mock_translate do |mock|
       res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
       mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
     end
   end
-  doctest.before("Google::Cloud::Translate::Api") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud.translate" do
+    mock_translate do |mock|
       res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
       mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
     end
   end
-  doctest.before("Google::Cloud::Translate::Api#translate") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud.translate@Using API Key from the environment variable." do
+    mock_translate do |mock|
       res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
       mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
     end
   end
-  doctest.before("Google::Cloud::Translate::Api#translate@Setting the `from` language.") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate.new" do
+    mock_translate do |mock|
+      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+
+   doctest.before "Google::Cloud::Translate.new@Using API Key from the environment variable." do
+    mock_translate do |mock|
+      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+
+   doctest.before "Google::Cloud::Translate::Api" do
+    mock_translate do |mock|
+      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+
+   doctest.before "Google::Cloud::Translate::Api#translate" do
+    mock_translate do |mock|
+      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
+      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+    end
+  end
+
+   doctest.before "Google::Cloud::Translate::Api#translate@Setting the `from` language." do
+    mock_translate do |mock|
       res_attrs = { detected_source_language: nil, translated_text: "Salve mundi!" }
       mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>"en"}]
     end
   end
-  doctest.before("Google::Cloud::Translate::Api#translate@Retrieving multiple translations.") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate::Api#translate@Retrieving multiple translations." do
+    mock_translate do |mock|
       res_attrs_1 = { detected_source_language: nil, translated_text: "Salve amice." }
       res_attrs_2 = { detected_source_language: nil, translated_text: "Vide te mox." }
       mock.expect :list_translations, list_translations_response([res_attrs_1, res_attrs_2]), [["Hello my friend.", "See you soon."], "la", {:cid=>nil, :format=>nil, :source=>"en"}]
     end
   end
-  doctest.before("Google::Cloud::Translate::Api#translate@Preserving HTML tags.") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate::Api#translate@Preserving HTML tags." do
+    mock_translate do |mock|
       res_attrs = { detected_source_language: nil, translated_text: "<strong>Salve</strong> mundi!" }
       mock.expect :list_translations, list_translations_response([res_attrs]), [["<strong>Hello</strong> world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
     end
   end
-  doctest.before("Google::Cloud::Translate::Api#detect") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate::Api#detect" do
+    mock_translate do |mock|
       res_attrs = { confidence: 0.7100697, language: "en", is_reliable: false }
       mock.expect :list_detections, list_detections_response([res_attrs]), [["Hello world!"]]
     end
   end
-  doctest.before("Google::Cloud::Translate::Api#detect@Detecting multiple texts.") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate::Api#detect@Detecting multiple texts." do
+    mock_translate do |mock|
       res_attrs = { confidence: 0.7100697, language: "en", is_reliable: false }
       res_attrs_2 = { confidence: 0.40440267, language: "fr", is_reliable: false }
       mock.expect :list_detections, list_detections_response([res_attrs, res_attrs_2]), [["Hello world!", "Bonjour le monde!"]]
     end
   end
-  doctest.before("Google::Cloud::Translate::Api#languages") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate::Api#languages" do
+    mock_translate do |mock|
       res_attrs = { language: "en", name: nil }
       mock.expect :list_languages, list_languages_response(res_attrs), [{:target=>nil}]
     end
   end
-  doctest.before("Google::Cloud::Translate::Api#languages@Get all languages with their names in French.") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate::Api#languages@Get all languages with their names in French." do
+    mock_translate do |mock|
       res_attrs = { language: "en", name: "Anglais" }
       mock.expect :list_languages, list_languages_response(res_attrs), [{:target=>"fr"}]
     end
   end
-  doctest.before("Google::Cloud::Translate::Detection") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate::Detection" do
+    mock_translate do |mock|
       res_attrs = { confidence: 0.7109375, language: "fr", is_reliable: false }
       res_attrs_2 = { confidence: 0.59922177, language: "en", is_reliable: false }
       mock.expect :list_detections, list_detections_response([res_attrs, res_attrs_2]), [["chien", "chat"]]
     end
   end
-  doctest.before("Google::Cloud::Translate::Language") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate::Language" do
+    mock_translate do |mock|
       res_attrs = { language: "af", name: "Afrikaans" }
       mock.expect :list_languages, list_languages_response(res_attrs), [{:target=>"en"}]
     end
   end
-  doctest.before("Google::Cloud::Translate::Translation") do
-    mock_service :translate do |mock|
+
+   doctest.before "Google::Cloud::Translate::Translation" do
+    mock_translate do |mock|
       res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
       mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
     end
-  end
-
-  doctest.after do
-    #Google::Cloud.unstub_service :translate  # TODO: Investigate why this has no effect, fix, and restore
   end
 end
 
@@ -170,7 +190,3 @@ def list_languages_response attrs
   end
   Google::Cloud::Translate::Service::API::ListLanguagesResponse.new languages: languages_resources
 end
-
-
-
-

--- a/google-cloud-translate/test/google/cloud/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate_test.rb
@@ -103,4 +103,48 @@ describe Google::Cloud do
       end
     end
   end
+
+  describe "Translate.new" do
+    it "gets defaults for api_key" do
+      stubbed_env = ->(name) {
+        "found-api-key" if name == "GOOGLE_CLOUD_KEY"
+      }
+      stubbed_service = ->(key, retries: nil, timeout: nil) {
+        key.must_equal "found-api-key"
+        retries.must_equal nil
+        timeout.must_equal nil
+        OpenStruct.new key: key
+      }
+
+      # Clear all environment variables
+      # ENV.stub :[], nil do
+      ENV.stub :[], stubbed_env do
+        Google::Cloud::Translate::Service.stub :new, stubbed_service do
+          translate = Google::Cloud::Translate.new
+          translate.must_be_kind_of Google::Cloud::Translate::Api
+          translate.service.must_be_kind_of OpenStruct
+          translate.service.key.must_equal "found-api-key"
+        end
+      end
+    end
+
+    it "uses provided project_id and keyfile" do
+      stubbed_service = ->(key, retries: nil, timeout: nil) {
+        key.must_equal "my-api-key"
+        retries.must_equal nil
+        timeout.must_equal nil
+        OpenStruct.new key: key
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        Google::Cloud::Translate::Service.stub :new, stubbed_service do
+          translate = Google::Cloud::Translate.new key: "my-api-key"
+          translate.must_be_kind_of Google::Cloud::Translate::Api
+          translate.service.must_be_kind_of OpenStruct
+          translate.service.key.must_equal "my-api-key"
+        end
+      end
+    end
+  end
 end

--- a/google-cloud-vision/README.md
+++ b/google-cloud-vision/README.md
@@ -21,10 +21,9 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ## Example
 
 ```ruby
-require "google/cloud"
+require "google/cloud/vision"
 
-gcloud = Google::Cloud.new
-vision = gcloud.vision
+vision = Google::Cloud::Vision.new
 
 image = vision.image "path/to/landmark.jpg"
 

--- a/google-cloud-vision/lib/google-cloud-vision.rb
+++ b/google-cloud-vision/lib/google-cloud-vision.rb
@@ -88,10 +88,9 @@ module Google
     # @return [Google::Cloud::Vision::Project]
     #
     # @example
-    #   require "google/cloud/vision"
+    #   require "google/cloud"
     #
-    #   gcloud = Google::Cloud.new
-    #   vision = gcloud.vision
+    #   vision = Google::Cloud.vision
     #
     #   image = vision.image "path/to/landmark.jpg"
     #

--- a/google-cloud-vision/lib/google/cloud/vision.rb
+++ b/google-cloud-vision/lib/google/cloud/vision.rb
@@ -55,10 +55,9 @@ module Google
     # You can provide a file path:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/vision"
     #
-    # gcloud = Google::Cloud.new
-    # vision = gcloud.vision
+    # vision = Google::Cloud::Vision.new
     #
     # image = vision.image "path/to/landmark.jpg"
     # ```
@@ -66,10 +65,9 @@ module Google
     # Or, you can initialize the image with a Google Cloud Storage URI:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/vision"
     #
-    # gcloud = Google::Cloud.new
-    # vision = gcloud.vision
+    # vision = Google::Cloud::Vision.new
     #
     # image = vision.image "gs://bucket-name/path_to_image_object"
     # ```
@@ -84,10 +82,9 @@ module Google
     # {Vision::Project#annotate}, below.)
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/vision"
     #
-    # gcloud = Google::Cloud.new
-    # vision = gcloud.vision
+    # vision = Google::Cloud::Vision.new
     #
     # image = vision.image "path/to/face.jpg"
     #
@@ -104,10 +101,9 @@ module Google
     # (or a string file path or Storage URI) to {Vision::Project#annotate}:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/vision"
     #
-    # gcloud = Google::Cloud.new
-    # vision = gcloud.vision
+    # vision = Google::Cloud::Vision.new
     #
     # image = vision.image "path/to/face.jpg"
     #
@@ -120,10 +116,9 @@ module Google
     # request:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/vision"
     #
-    # gcloud = Google::Cloud.new
-    # vision = gcloud.vision
+    # vision = Google::Cloud::Vision.new
     #
     # face_image = vision.image "path/to/face.jpg"
     # landmark_image = vision.image "path/to/landmark.jpg"
@@ -147,10 +142,9 @@ module Google
     # request to the Cloud Vision API:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/vision"
     #
-    # gcloud = Google::Cloud.new
-    # vision = gcloud.vision
+    # vision = Google::Cloud::Vision.new
     #
     # face_image = vision.image "path/to/face.jpg"
     # landmark_image = vision.image "path/to/landmark.jpg"
@@ -177,10 +171,9 @@ module Google
     # global defaults, you can update the configuration:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/vision"
     #
-    # gcloud = Google::Cloud.new
-    # vision = gcloud.vision
+    # vision = Google::Cloud::Vision.new
     #
     # Google::Cloud::Vision.default_max_faces = 1
     #
@@ -192,10 +185,9 @@ module Google
     # integer instead of a flag:
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/vision"
     #
-    # gcloud = Google::Cloud.new
-    # vision = gcloud.vision
+    # vision = Google::Cloud::Vision.new
     #
     # image = vision.image "path/to/face.jpg"
     #
@@ -219,10 +211,9 @@ module Google
     # You can also set the request `timeout` value in seconds.
     #
     # ```ruby
-    # require "google/cloud"
+    # require "google/cloud/vision"
     #
-    # gcloud = Google::Cloud.new
-    # vision = gcloud.vision retries: 10, timeout: 120
+    # vision = Google::Cloud::Vision.new retries: 10, timeout: 120
     # ```
     #
     module Vision
@@ -234,10 +225,9 @@ module Google
         # The default value is `100`.
         #
         # @example Using the default setting on {Project#annotate}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   Google::Cloud::Vision.default_max_faces #=> 100
         #
@@ -246,10 +236,9 @@ module Google
         #   # annotation = vision.annotate "path/to/faces.jpg", faces: 100
         #
         # @example Updating the default setting on {Project#annotate}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   # Set a new default
         #   Google::Cloud::Vision.default_max_faces = 5
@@ -260,10 +249,9 @@ module Google
         #
         #
         # @example Using the default setting on {Image#faces}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   Google::Cloud::Vision.default_max_faces #=> 100
         #
@@ -272,10 +260,9 @@ module Google
         #   # faces = vision.image("path/to/faces.jpg").faces 100
         #
         # @example Updating the default setting on {Image#faces}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   # Set a new default
         #   Google::Cloud::Vision.default_max_faces = 5
@@ -293,10 +280,9 @@ module Google
         # The default value is 100.
         #
         # @example Using the default setting on {Project#annotate}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   Google::Cloud::Vision.default_max_landmarks #=> 100
         #
@@ -306,10 +292,9 @@ module Google
         #   # annotation = vision.annotate img, landmarks: 100
         #
         # @example Updating the default setting on {Project#annotate}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   # Set a new default
         #   Google::Cloud::Vision.default_max_landmarks = 5
@@ -321,10 +306,9 @@ module Google
         #
         #
         # @example Using the default setting on {Image#landmarks}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   Google::Cloud::Vision.default_max_landmarks #=> 100
         #
@@ -333,10 +317,9 @@ module Google
         #   # landmarks = vision.image("path/to/landmarks.jpg").landmarks 100
         #
         # @example Updating the default setting on {Image#landmarks}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   # Set a new default
         #   Google::Cloud::Vision.default_max_landmarks = 5
@@ -354,10 +337,9 @@ module Google
         # The default value is 100.
         #
         # @example Using the default setting on {Project#annotate}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   Google::Cloud::Vision.default_max_logos #=> 100
         #
@@ -366,10 +348,9 @@ module Google
         #   # annotation = vision.annotate "path/to/logos.jpg", logos: 100
         #
         # @example Updating the default setting on {Project#annotate}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   # Set a new default
         #   Google::Cloud::Vision.default_max_logos = 5
@@ -380,10 +361,9 @@ module Google
         #
         #
         # @example Using the default setting on {Image#logos}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   Google::Cloud::Vision.default_max_logos #=> 100
         #
@@ -392,10 +372,9 @@ module Google
         #   # logos = vision.image("path/to/logos.jpg").logos 100
         #
         # @example Updating the default setting on {Image#logos}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   # Set a new default
         #   Google::Cloud::Vision.default_max_logos = 5
@@ -413,10 +392,9 @@ module Google
         # The default value is 100.
         #
         # @example Using the default setting on {Project#annotate}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   Google::Cloud::Vision.default_max_labels #=> 100
         #
@@ -425,10 +403,9 @@ module Google
         #   # annotation = vision.annotate "path/to/labels.jpg", labels: 100
         #
         # @example Updating the default setting on {Project#annotate}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   # Set a new default
         #   Google::Cloud::Vision.default_max_labels = 5
@@ -439,10 +416,9 @@ module Google
         #
         #
         # @example Using the default setting on {Image#labels}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   Google::Cloud::Vision.default_max_labels #=> 100
         #
@@ -451,10 +427,9 @@ module Google
         #   # labels = vision.image("path/to/labels.jpg").labels 100
         #
         # @example Updating the default setting on {Image#labels}:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   # Set a new default
         #   Google::Cloud::Vision.default_max_labels = 5
@@ -472,6 +447,56 @@ module Google
       self.default_max_landmarks = 100
       self.default_max_logos     = 100
       self.default_max_labels    = 100
+
+      ##
+      # Creates a new object for connecting to the Vision service.
+      # Each call creates a new connection.
+      #
+      # @param [String] project Project identifier for the Vision service you
+      #   are connecting to.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+      #   file path the file must be readable.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #
+      #   The default scope is:
+      #
+      #   * `https://www.googleapis.com/auth/cloud-platform`
+      # @param [Integer] retries Number of times to retry requests on server
+      #   error. The default value is `3`. Optional.
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::Vision::Project]
+      #
+      # @example
+      #   require "google/cloud/vision"
+      #
+      #   vision = Google::Cloud::Vision.new
+      #
+      #   image = vision.image "path/to/landmark.jpg"
+      #
+      #   landmark = image.landmark
+      #   landmark.description #=> "Mount Rushmore"
+      #
+      def self.new project: nil, keyfile: nil, scope: nil, retries: nil,
+                   timeout: nil
+        project ||= Google::Cloud::Vision::Project.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
+        if keyfile.nil?
+          credentials = Google::Cloud::Vision::Credentials.default scope: scope
+        else
+          credentials = Google::Cloud::Vision::Credentials.new \
+            keyfile, scope: scope
+        end
+
+        Google::Cloud::Vision::Project.new(
+          Google::Cloud::Vision::Service.new(
+            project, credentials, retries: retries, timeout: timeout))
+      end
     end
   end
 end

--- a/google-cloud-vision/lib/google/cloud/vision/annotate.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotate.rb
@@ -31,10 +31,9 @@ module Google
       # See {Project#annotate}.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/vision"
       #
-      #   gcloud = Google::Cloud.new
-      #   vision = gcloud.vision
+      #   vision = Google::Cloud::Vision.new
       #
       #   face_image = vision.image "path/to/face.jpg"
       #   landmark_image = vision.image "path/to/landmark.jpg"
@@ -118,10 +117,9 @@ module Google
         #   multiple images.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   face_image = vision.image "path/to/face.jpg"
         #   landmark_image = vision.image "path/to/landmark.jpg"

--- a/google-cloud-vision/lib/google/cloud/vision/annotation.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation.rb
@@ -30,10 +30,9 @@ module Google
       # See {Project#annotate} and {Image}.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/vision"
       #
-      #   gcloud = Google::Cloud.new
-      #   vision = gcloud.vision
+      #   vision = Google::Cloud::Vision.new
       #   image = vision.image "path/to/face.jpg"
       #
       #   annotation = vision.annotate image, faces: true, labels: true
@@ -58,10 +57,9 @@ module Google
         # @return [Array<Face>]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, faces: true
@@ -80,10 +78,9 @@ module Google
         # @return [Face]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, faces: 1
@@ -99,10 +96,9 @@ module Google
         # @return [Boolean]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, faces: 1
@@ -118,10 +114,9 @@ module Google
         # @return [Array<Entity>]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/landmark.jpg"
         #
         #   annotation = vision.annotate image, landmarks: 1
@@ -140,10 +135,9 @@ module Google
         # @return [Entity]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/landmark.jpg"
         #
         #   annotation = vision.annotate image, landmarks: 1
@@ -160,10 +154,9 @@ module Google
         # @return [Boolean]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/landmark.jpg"
         #
         #   annotation = vision.annotate image, landmarks: 1
@@ -179,10 +172,9 @@ module Google
         # @return [Array<Entity>]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/logo.jpg"
         #
         #   annotation = vision.annotate image, logos: 1
@@ -201,10 +193,9 @@ module Google
         # @return [Entity]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/logo.jpg"
         #
         #   annotation = vision.annotate image, logos: 1
@@ -221,10 +212,9 @@ module Google
         # @return [Boolean]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/logo.jpg"
         #
         #   annotation = vision.annotate image, logos: 1
@@ -240,10 +230,9 @@ module Google
         # @return [Array<Entity>]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, labels: 1
@@ -262,10 +251,9 @@ module Google
         # @return [Entity]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, labels: 1
@@ -282,10 +270,9 @@ module Google
         # @return [Boolean]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, labels: 1
@@ -301,10 +288,9 @@ module Google
         # @return [Text]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/text.png"
         #
         #   annotation = vision.annotate image, text: true
@@ -320,10 +306,9 @@ module Google
         # @return [Boolean]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/text.png"
         #
         #   annotation = vision.annotate image, text: true
@@ -339,10 +324,9 @@ module Google
         # @return [SafeSearch]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, safe_search: true
@@ -360,10 +344,9 @@ module Google
         # @return [Boolean]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, safe_search: true
@@ -379,10 +362,9 @@ module Google
         # @return [Properties]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, properties: true
@@ -400,10 +382,9 @@ module Google
         # @return [Boolean]
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   annotation = vision.annotate image, properties: true

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
@@ -30,10 +30,9 @@ module Google
         # @see https://developers.google.com/knowledge-graph/ Knowledge Graph
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/landmark.jpg"
         #
@@ -43,10 +42,9 @@ module Google
         #   landmark.mid #=> "/m/019dvv"
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/logo.jpg"
         #
@@ -56,10 +54,9 @@ module Google
         #   logo.mid #=> "/m/0b34hf"
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/face.jpg"
         #

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
@@ -27,10 +27,9 @@ module Google
         # See {Annotation#faces} and {Annotation#face}.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/face.jpg"
         #
@@ -131,10 +130,9 @@ module Google
           # See {Face}.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/vision"
           #
-          #   gcloud = Google::Cloud.new
-          #   vision = gcloud.vision
+          #   vision = Google::Cloud::Vision.new
           #
           #   image = vision.image "path/to/face.jpg"
           #   face = image.face
@@ -233,10 +231,9 @@ module Google
           # See {Face}.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/vision"
           #
-          #   gcloud = Google::Cloud.new
-          #   vision = gcloud.vision
+          #   vision = Google::Cloud::Vision.new
           #
           #   image = vision.image "path/to/face.jpg"
           #   face = image.face
@@ -333,10 +330,9 @@ module Google
           #   images.annotate Type
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/vision"
           #
-          #   gcloud = Google::Cloud.new
-          #   vision = gcloud.vision
+          #   vision = Google::Cloud::Vision.new
           #
           #   image = vision.image "path/to/face.jpg"
           #   face = image.face
@@ -380,10 +376,9 @@ module Google
             # @return [Landmark]
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -540,10 +535,9 @@ module Google
             # See {Features} and {Face}.
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -574,10 +568,9 @@ module Google
               # @return [String]
               #
               # @example
-              #   require "google/cloud"
+              #   require "google/cloud/vision"
               #
-              #   gcloud = Google::Cloud.new
-              #   vision = gcloud.vision
+              #   vision = Google::Cloud::Vision.new
               #
               #   image = vision.image "path/to/face.jpg"
               #   face = image.face
@@ -670,10 +663,9 @@ module Google
             # @attr_reader [Landmark] right The chin, right gonion.
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -742,10 +734,9 @@ module Google
             #   images.annotate Type
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -811,10 +802,9 @@ module Google
             #   images.annotate Type
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -883,10 +873,9 @@ module Google
             # @attr_reader [Landmark] right The eyebrow, right.
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -956,10 +945,9 @@ module Google
             # @attr_reader [Eye] right The right eye.
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -1031,10 +1019,9 @@ module Google
             # @attr_reader [Landmark] right The eye, right corner.
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -1105,10 +1092,9 @@ module Google
             # @attr_reader [Landmark] bottom The lower lip.
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -1179,10 +1165,9 @@ module Google
             # @attr_reader [Landmark] right TThe mouth, right.
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -1254,10 +1239,9 @@ module Google
             # @attr_reader [Landmark] right The nose, bottom right.
             #
             # @example
-            #   require "google/cloud"
+            #   require "google/cloud/vision"
             #
-            #   gcloud = Google::Cloud.new
-            #   vision = gcloud.vision
+            #   vision = Google::Cloud::Vision.new
             #
             #   image = vision.image "path/to/face.jpg"
             #   face = image.face
@@ -1327,10 +1311,9 @@ module Google
           #   images.annotate Likelihood
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/vision"
           #
-          #   gcloud = Google::Cloud.new
-          #   vision = gcloud.vision
+          #   vision = Google::Cloud::Vision.new
           #
           #   image = vision.image "path/to/face.jpg"
           #   face = image.face

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
@@ -26,10 +26,9 @@ module Google
         # See {Google::Cloud::Vision::Image#properties}.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/logo.jpg"
         #
@@ -100,10 +99,9 @@ module Google
           # image the color occupies in the image.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/vision"
           #
-          #   gcloud = Google::Cloud.new
-          #   vision = gcloud.vision
+          #   vision = Google::Cloud::Vision.new
           #
           #   image = vision.image "path/to/logo.jpg"
           #   properties = image.properties

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
@@ -27,10 +27,9 @@ module Google
         # adult, spoof, medical, violence).
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/face.jpg"
         #

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
@@ -25,10 +25,9 @@ module Google
         # The result of text, or optical character recognition (OCR), detection.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/text.png"
         #
@@ -136,10 +135,9 @@ module Google
           # A word within a detected text (OCR). See {Text}.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/vision"
           #
-          #   gcloud = Google::Cloud.new
-          #   vision = gcloud.vision
+          #   vision = Google::Cloud::Vision.new
           #
           #   image = vision.image "path/to/text.png"
           #   text = image.text

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
@@ -28,10 +28,9 @@ module Google
         # @attr_reader [Integer] y The Y coordinate.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/text.png"
         #   text = image.text

--- a/google-cloud-vision/lib/google/cloud/vision/image.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/image.rb
@@ -44,10 +44,9 @@ module Google
       #   Practices
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/vision"
       #
-      #   gcloud = Google::Cloud.new
-      #   vision = gcloud.vision
+      #   vision = Google::Cloud::Vision.new
       #
       #   image = vision.image "path/to/text.png"
       #
@@ -96,10 +95,9 @@ module Google
         # @return [Array<Annotation::Face>] The results of face detection.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   faces = image.faces
@@ -135,10 +133,9 @@ module Google
         # @return [Array<Annotation::Entity>] The results of landmark detection.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/landmark.jpg"
         #
         #   landmarks = image.landmarks
@@ -175,10 +172,9 @@ module Google
         # @return [Array<Annotation::Entity>] The results of logo detection.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/logo.jpg"
         #
         #   logos = image.logos
@@ -215,10 +211,9 @@ module Google
         # @return [Array<Annotation::Entity>] The results of label detection.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   labels = image.labels
@@ -253,10 +248,9 @@ module Google
         # @return [Annotation::Text] The results of text (OCR) detection.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/text.png"
         #
         #   text = image.text
@@ -281,10 +275,9 @@ module Google
         # @return [Annotation::SafeSearch] The results of safe search detection.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/face.jpg"
         #
         #   safe_search = image.safe_search
@@ -307,10 +300,9 @@ module Google
         #   detection.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #   image = vision.image "path/to/logo.jpg"
         #
         #   properties = image.properties
@@ -430,10 +422,9 @@ module Google
         #   great deal if the hint is wrong).
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/landmark.jpg"
         #   image.context.area.min = { longitude: -122.0862462,
@@ -482,10 +473,9 @@ module Google
           # A Lat/long rectangle that specifies the location of the image.
           #
           # @example
-          #   require "google/cloud"
+          #   require "google/cloud/vision"
           #
-          #   gcloud = Google::Cloud.new
-          #   vision = gcloud.vision
+          #   vision = Google::Cloud::Vision.new
           #
           #   image = vision.image "path/to/landmark.jpg"
           #

--- a/google-cloud-vision/lib/google/cloud/vision/location.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/location.rb
@@ -28,10 +28,9 @@ module Google
       #   standard](http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf).
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/vision"
       #
-      #   gcloud = Google::Cloud.new
-      #   vision = gcloud.vision
+      #   vision = Google::Cloud::Vision.new
       #
       #   image = vision.image "path/to/landmark.jpg"
       #   entity = image.landmark

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -33,10 +33,9 @@ module Google
       # of explicit content.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/vision"
       #
-      #   gcloud = Google::Cloud.new
-      #   vision = gcloud.vision
+      #   vision = Google::Cloud::Vision.new
       #
       #   image = vision.image "path/to/landmark.jpg"
       #
@@ -61,11 +60,12 @@ module Google
         # The Vision project connected to.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new "my-todo-project",
-        #                       "/path/to/keyfile.json"
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new(
+        #     project: "my-todo-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
         #
         #   vision.project #=> "my-todo-project"
         #
@@ -109,18 +109,16 @@ module Google
         # @return [Image] An image for the Vision service.
         #
         # @example With a Google Cloud Storage URI:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "gs://bucket-name/path_to_image_object"
         #
         # @example With a local file path:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/landmark.jpg"
         #
@@ -189,10 +187,9 @@ module Google
         #   multiple images.
         #
         # @example With a single image:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/landmark.jpg"
         #
@@ -203,10 +200,9 @@ module Google
         #   #=>  "monument", "landmark"]
         #
         # @example With multiple images:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   face_img = vision.image "path/to/face.jpg"
         #   landmark_img = vision.image "path/to/landmark.jpg"
@@ -217,10 +213,9 @@ module Google
         #   annotations[1].labels.count #=> 6
         #
         # @example With multiple images and configurations passed in a block:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   face_img = vision.image "path/to/face.jpg"
         #   landmark_img = vision.image "path/to/landmark.jpg"
@@ -238,10 +233,9 @@ module Google
         #   annotations[2].text.words.count #=> 28
         #
         # @example Maximum result values can also be provided:
-        #   require "google/cloud"
+        #   require "google/cloud/vision"
         #
-        #   gcloud = Google::Cloud.new
-        #   vision = gcloud.vision
+        #   vision = Google::Cloud::Vision.new
         #
         #   image = vision.image "path/to/landmark.jpg"
         #

--- a/google-cloud-vision/test/google/cloud/vision_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision_test.rb
@@ -117,4 +117,55 @@ describe Google::Cloud do
       end
     end
   end
+
+  describe "Vision.new" do
+    let(:default_credentials) { OpenStruct.new empty: true }
+    let(:found_credentials) { "{}" }
+
+    it "gets defaults for project_id and keyfile" do
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+          Google::Cloud::Vision::Credentials.stub :default, default_credentials do
+            vision = Google::Cloud::Vision.new
+            vision.must_be_kind_of Google::Cloud::Vision::Project
+            vision.project.must_equal "project-id"
+            vision.service.credentials.must_equal default_credentials
+          end
+        end
+      end
+    end
+
+    it "uses provided project_id and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_equal nil
+        "vision-credentials"
+      }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "vision-credentials"
+        retries.must_equal nil
+        timeout.must_equal nil
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Vision::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Vision::Service.stub :new, stubbed_service do
+                vision = Google::Cloud::Vision.new project: "project-id", keyfile: "path/to/keyfile.json"
+                vision.must_be_kind_of Google::Cloud::Vision::Project
+                vision.project.must_equal "project-id"
+                vision.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds new factory methods that do not use a top-level `gcloud` object or the `Google::Cloud` factory methods. 

- [x] BigQuery
- [x] Datastore
- [x] DNS
- [x] Language
- [x] Logging
- [x] Pub/Sub
- [x] Resource Manager
- [x] Speech
- [x] Translate
- [x] Vision

This PR enables the following:

```ruby
require "google/cloud/bigquery"

bigquery = Google::Cloud::Bigquery.new
dataset = bigquery.dataset "my_dataset"
table = dataset.table "my_table"
```

Thoughts? Is this the change that is wanted?

[refs #907, #927]