### PR TITLE
Switch Vision to use GAPIC/gRPC/GAX

### DIFF
--- a/google-cloud-vision/acceptance/vision/vision_test.rb
+++ b/google-cloud-vision/acceptance/vision/vision_test.rb
@@ -93,9 +93,9 @@ describe "Vision", :vision do
       face.bounds.head.must_be_kind_of Array
       face.bounds.head[0].must_be_kind_of Google::Cloud::Vision::Annotation::Vertex
       face.bounds.head[0].x.must_equal 122
-      face.bounds.head[0].y.must_equal nil
-      face.bounds.head[0].to_a.must_equal [122, nil]
-      face.bounds.head[1].to_a.must_equal [336, nil]
+      face.bounds.head[0].y.must_equal 0
+      face.bounds.head[0].to_a.must_equal [122, 0]
+      face.bounds.head[1].to_a.must_equal [336, 0]
       face.bounds.head[2].to_a.must_equal [336, 203]
       face.bounds.head[3].to_a.must_equal [122, 203]
 
@@ -107,55 +107,55 @@ describe "Vision", :vision do
 
       face.features.wont_be :nil?
 
-      face.features.confidence.must_equal 0.42813218
+      face.features.confidence.must_be_close_to 0.42813218
       face.features.chin.center.must_be_kind_of Google::Cloud::Vision::Annotation::Face::Features::Landmark
-      face.features.chin.center.x.must_equal 233.21977
-      face.features.chin.center.y.must_equal 189.47475
-      face.features.chin.center.z.must_equal 19.487228
-      face.features.chin.left.to_a.must_equal   [166.70468, 145.37173, 71.187653]
-      face.features.chin.right.to_a.must_equal  [299.02509, 135.58951, 61.98719]
+      face.features.chin.center.x.must_be_close_to 233.21977
+      face.features.chin.center.y.must_be_close_to 189.47475
+      face.features.chin.center.z.must_be_close_to 19.487228
+      face.features.chin.left.to_a.must_be_close_to_array   [166.70468, 145.37173, 71.187653]
+      face.features.chin.right.to_a.must_be_close_to_array  [299.02509, 135.58951, 61.98719]
 
-      face.features.ears.left.to_a.must_equal  [157.35168, 99.431313, 87.90876]
-      face.features.ears.right.to_a.must_equal [303.81198, 88.5782, 77.719193]
+      face.features.ears.left.to_a.must_be_close_to_array  [157.35168, 99.431313, 87.90876]
+      face.features.ears.right.to_a.must_be_close_to_array [303.81198, 88.5782, 77.719193]
 
-      face.features.eyebrows.left.left.to_a.must_equal  [168.85481, 69.338295, 3.9220245]
-      face.features.eyebrows.left.right.to_a.must_equal [206.07896, 70.761108, -16.882086]
-      face.features.eyebrows.left.top.to_a.must_equal   [186.34938, 63.386711, -12.43734]
+      face.features.eyebrows.left.left.to_a.must_be_close_to_array  [168.85481, 69.338295, 3.9220245]
+      face.features.eyebrows.left.right.to_a.must_be_close_to_array [206.07896, 70.761108, -16.882086]
+      face.features.eyebrows.left.top.to_a.must_be_close_to_array   [186.34938, 63.386711, -12.43734]
 
-      face.features.eyebrows.right.left.to_a.must_equal  [237.42259, 68.241989, -19.10948]
-      face.features.eyebrows.right.right.to_a.must_equal [276.57953, 61.42263, -3.5625641]
-      face.features.eyebrows.right.top.to_a.must_equal   [256.3194, 58.222664, -17.299419]
+      face.features.eyebrows.right.left.to_a.must_be_close_to_array  [237.42259, 68.241989, -19.10948]
+      face.features.eyebrows.right.right.to_a.must_be_close_to_array [276.57953, 61.42263, -3.5625641]
+      face.features.eyebrows.right.top.to_a.must_be_close_to_array   [256.3194, 58.222664, -17.299419]
 
-      face.features.eyes.left.bottom.to_a.must_equal [192.65559, 87.8156, 0.42953849]
-      face.features.eyes.left.center.to_a.must_equal [189.72849, 82.965874, -0.00075325265]
-      face.features.eyes.left.left.to_a.must_equal   [179.03802, 83.742157, 6.790463]
-      face.features.eyes.left.pupil.to_a.must_equal  [190.41544, 84.4557, -1.3682901]
-      face.features.eyes.left.right.to_a.must_equal  [201.79512, 83.127563, -0.33577749]
-      face.features.eyes.left.top.to_a.must_equal    [190.90974, 80.660713, -5.1845775]
+      face.features.eyes.left.bottom.to_a.must_be_close_to_array [192.65559, 87.8156, 0.42953849]
+      face.features.eyes.left.center.to_a.must_be_close_to_array [189.72849, 82.965874, -0.00075325265]
+      face.features.eyes.left.left.to_a.must_be_close_to_array   [179.03802, 83.742157, 6.790463]
+      face.features.eyes.left.pupil.to_a.must_be_close_to_array  [190.41544, 84.4557, -1.3682901]
+      face.features.eyes.left.right.to_a.must_be_close_to_array  [201.79512, 83.127563, -0.33577749]
+      face.features.eyes.left.top.to_a.must_be_close_to_array    [190.90974, 80.660713, -5.1845775]
 
-      face.features.eyes.right.bottom.to_a.must_equal [257.98438, 83.214119, -3.9316273]
-      face.features.eyes.right.center.to_a.must_equal [258.15857, 78.317787, -4.6232729]
-      face.features.eyes.right.left.to_a.must_equal   [244.01581, 81.332283, -3.0447886]
-      face.features.eyes.right.pupil.to_a.must_equal  [256.63464, 79.641411, -6.0731235]
-      face.features.eyes.right.right.to_a.must_equal  [268.5871, 77.159126, 0.41419673]
-      face.features.eyes.right.top.to_a.must_equal    [255.46104, 75.925194, -9.6693773]
+      face.features.eyes.right.bottom.to_a.must_be_close_to_array [257.98438, 83.214119, -3.9316273]
+      face.features.eyes.right.center.to_a.must_be_close_to_array [258.15857, 78.317787, -4.6232729]
+      face.features.eyes.right.left.to_a.must_be_close_to_array   [244.01581, 81.332283, -3.0447886]
+      face.features.eyes.right.pupil.to_a.must_be_close_to_array  [256.63464, 79.641411, -6.0731235]
+      face.features.eyes.right.right.to_a.must_be_close_to_array  [268.5871, 77.159126, 0.41419673]
+      face.features.eyes.right.top.to_a.must_be_close_to_array    [255.46104, 75.925194, -9.6693773]
 
-      face.features.forehead.to_a.must_equal [221.5365, 69.323875, -20.554575]
+      face.features.forehead.to_a.must_be_close_to_array [221.5365, 69.323875, -20.554575]
 
-      face.features.lips.bottom.to_a.must_equal [230.27597, 163.10367, 3.8628895]
-      face.features.lips.lower.to_a.must_equal  [230.27597, 163.10367, 3.8628895]
-      face.features.lips.top.to_a.must_equal    [228.54768, 143.2952, -5.6550336]
-      face.features.lips.upper.to_a.must_equal  [228.54768, 143.2952, -5.6550336]
+      face.features.lips.bottom.to_a.must_be_close_to_array [230.27597, 163.10367, 3.8628895]
+      face.features.lips.lower.to_a.must_be_close_to_array  [230.27597, 163.10367, 3.8628895]
+      face.features.lips.top.to_a.must_be_close_to_array    [228.54768, 143.2952, -5.6550336]
+      face.features.lips.upper.to_a.must_be_close_to_array  [228.54768, 143.2952, -5.6550336]
 
-      face.features.mouth.center.to_a.must_equal [228.53499, 150.29066, 1.1069832]
-      face.features.mouth.left.to_a.must_equal   [204.32407, 149.64627, 15.126297]
-      face.features.mouth.right.to_a.must_equal  [255.67624, 145.21121, 11.706608]
+      face.features.mouth.center.to_a.must_be_close_to_array [228.53499, 150.29066, 1.1069832]
+      face.features.mouth.left.to_a.must_be_close_to_array   [204.32407, 149.64627, 15.126297]
+      face.features.mouth.right.to_a.must_be_close_to_array  [255.67624, 145.21121, 11.706608]
 
-      face.features.nose.bottom.to_a.must_equal [226.5867, 130.57584, -8.9499149]
-      face.features.nose.left.to_a.must_equal   [209.35193, 126.05315, 1.0702859]
-      face.features.nose.right.to_a.must_equal  [244.11844, 123.26714, -1.5220336]
-      face.features.nose.tip.to_a.must_equal    [225.23511, 122.47372, -25.817825]
-      face.features.nose.top.to_a.must_equal    [222.40179, 83.179443, -15.773396]
+      face.features.nose.bottom.to_a.must_be_close_to_array [226.5867, 130.57584, -8.9499149]
+      face.features.nose.left.to_a.must_be_close_to_array   [209.35193, 126.05315, 1.0702859]
+      face.features.nose.right.to_a.must_be_close_to_array  [244.11844, 123.26714, -1.5220336]
+      face.features.nose.tip.to_a.must_be_close_to_array    [225.23511, 122.47372, -25.817825]
+      face.features.nose.top.to_a.must_be_close_to_array    [222.40179, 83.179443, -15.773396]
 
       face.likelihood.wont_be :nil?
       face.likelihood.joy?.must_equal false
@@ -166,13 +166,13 @@ describe "Vision", :vision do
       face.likelihood.blurred?.must_equal false
       face.likelihood.headwear?.must_equal false
 
-      face.likelihood.joy.must_equal "VERY_UNLIKELY"
-      face.likelihood.sorrow.must_equal "VERY_UNLIKELY"
-      face.likelihood.anger.must_equal "VERY_UNLIKELY"
-      face.likelihood.surprise.must_equal "VERY_UNLIKELY"
-      face.likelihood.under_exposed.must_equal "VERY_UNLIKELY"
-      face.likelihood.blurred.must_equal "VERY_UNLIKELY"
-      face.likelihood.headwear.must_equal "VERY_UNLIKELY"
+      face.likelihood.joy.must_equal :VERY_UNLIKELY
+      face.likelihood.sorrow.must_equal :VERY_UNLIKELY
+      face.likelihood.anger.must_equal :VERY_UNLIKELY
+      face.likelihood.surprise.must_equal :VERY_UNLIKELY
+      face.likelihood.under_exposed.must_equal :VERY_UNLIKELY
+      face.likelihood.blurred.must_equal :VERY_UNLIKELY
+      face.likelihood.headwear.must_equal :VERY_UNLIKELY
     end
 
     it "detects faces from an image with location context" do
@@ -218,11 +218,11 @@ describe "Vision", :vision do
       landmark.must_be_kind_of Google::Cloud::Vision::Annotation::Entity
 
       landmark.mid.must_equal "/m/019dvv"
-      landmark.locale.must_be :nil?
+      landmark.locale.must_be :empty?
       landmark.description.must_equal "Mount Rushmore"
-      landmark.score.must_equal 0.91912264
-      landmark.confidence.must_be :nil?
-      landmark.topicality.must_be :nil?
+      landmark.score.must_be_close_to 0.91912264
+      landmark.confidence.must_be :zero?
+      landmark.topicality.must_be :zero?
       landmark.bounds[0].must_be_kind_of Google::Cloud::Vision::Annotation::Vertex
       landmark.bounds[0].x.must_equal 9
       landmark.bounds[0].y.must_equal 35
@@ -230,8 +230,8 @@ describe "Vision", :vision do
       landmark.bounds[2].to_a.must_equal [492, 325]
       landmark.bounds[3].to_a.must_equal [9, 325]
       landmark.locations[0].must_be_kind_of Google::Cloud::Vision::Location
-      landmark.locations[0].latitude.must_equal 43.878264
-      landmark.locations[0].longitude.must_equal -103.45700740814209
+      landmark.locations[0].latitude.must_be_close_to 43.878264
+      landmark.locations[0].longitude.must_be_close_to -103.45700740814209
       landmark.properties.must_be :empty?
     end
 
@@ -271,11 +271,11 @@ describe "Vision", :vision do
       logo.must_be_kind_of Google::Cloud::Vision::Annotation::Entity
 
       logo.mid.must_equal "/m/0b34hf"
-      logo.locale.must_be :nil?
+      logo.locale.must_be :empty?
       logo.description.must_equal "Google"
-      logo.score.must_equal 0.70057315
-      logo.confidence.must_be :nil?
-      logo.topicality.must_be :nil?
+      logo.score.must_be_close_to 0.70057315
+      logo.confidence.must_be :zero?
+      logo.topicality.must_be :zero?
       logo.bounds[0].must_be_kind_of Google::Cloud::Vision::Annotation::Vertex
       logo.bounds[0].x.must_equal 14
       logo.bounds[0].y.must_equal 16
@@ -322,11 +322,11 @@ describe "Vision", :vision do
       label.must_be_kind_of Google::Cloud::Vision::Annotation::Entity
 
       label.mid.must_be_kind_of String
-      label.locale.must_be :nil?
+      label.locale.must_be :empty?
       label.description.must_be_kind_of String
       label.score.must_be_kind_of Float
-      label.confidence.must_be :nil?
-      label.topicality.must_be :nil?
+      label.confidence.must_be :zero?
+      label.topicality.must_be :zero?
       label.bounds.must_be :empty?
       label.locations.must_be :empty?
       label.properties.must_be :empty?
@@ -468,16 +468,16 @@ describe "Vision", :vision do
       annotation.properties.colors[0].blue.must_equal 254
       annotation.properties.colors[0].alpha.must_equal 1.0
       annotation.properties.colors[0].rgb.must_equal "91c1fe"
-      annotation.properties.colors[0].score.must_equal 0.65757853
-      annotation.properties.colors[0].pixel_fraction.must_equal 0.16903226
+      annotation.properties.colors[0].score.must_be_close_to 0.65757853
+      annotation.properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
       annotation.properties.colors[9].red.must_equal 156
       annotation.properties.colors[9].green.must_equal 214
       annotation.properties.colors[9].blue.must_equal 255
       annotation.properties.colors[9].alpha.must_equal 1.0
       annotation.properties.colors[9].rgb.must_equal "9cd6ff"
-      annotation.properties.colors[9].score.must_equal 0.00096750073
-      annotation.properties.colors[9].pixel_fraction.must_equal 0.00064516132
+      annotation.properties.colors[9].score.must_be_close_to 0.00096750073
+      annotation.properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
     end
 
     it "detects properties from multiple images" do
@@ -613,16 +613,16 @@ describe "Vision", :vision do
         properties.colors[0].blue.must_equal 254
         properties.colors[0].alpha.must_equal 1.0
         properties.colors[0].rgb.must_equal "91c1fe"
-        properties.colors[0].score.must_equal 0.65757853
-        properties.colors[0].pixel_fraction.must_equal 0.16903226
+        properties.colors[0].score.must_be_close_to 0.65757853
+        properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
         properties.colors[9].red.must_equal 156
         properties.colors[9].green.must_equal 214
         properties.colors[9].blue.must_equal 255
         properties.colors[9].alpha.must_equal 1.0
         properties.colors[9].rgb.must_equal "9cd6ff"
-        properties.colors[9].score.must_equal 0.00096750073
-        properties.colors[9].pixel_fraction.must_equal 0.00064516132
+        properties.colors[9].score.must_be_close_to 0.00096750073
+        properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
       end
     end
   end

--- a/google-cloud-vision/acceptance/vision_helper.rb
+++ b/google-cloud-vision/acceptance/vision_helper.rb
@@ -19,12 +19,12 @@ require "minitest/rg"
 require "google/cloud/vision"
 
 # Create shared vision object so we don't create new for each test
-$vision = Google::Cloud.vision retries: 10
+$vision = Google::Cloud::Vision.new
 
 require "google/cloud/storage"
 
 # Create shared storage object so we don't create new for each test
-$storage = Google::Cloud.new.storage retries: 10
+$storage = Google::Cloud::Storage.new retries: 10
 
 module Acceptance
   ##
@@ -64,6 +64,15 @@ module Acceptance
       addl.include? :vision
     end
 
+    def assert_array_in_delta exp, act, msg = nil
+      assert_kind_of Array, exp
+      assert_kind_of Array, act
+      assert_equal exp.length, act.length, "Arrays being compared must be the same length"
+      exp.zip(act).each do |exp_val, act_val|
+        assert_in_delta exp_val, act_val
+      end
+    end
+
     def self.run_one_method klass, method_name, reporter
       result = nil
       (1..3).each do |try|
@@ -94,4 +103,8 @@ end
 
 Minitest.after_run do
   clean_up_vision_storage_objects
+end
+
+module MiniTest::Expectations
+  infect_an_assertion :assert_array_in_delta, :must_be_close_to_array
 end

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -18,7 +18,10 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.20.0"
-  gem.add_dependency "google-api-client", "~> 0.9.11"
+  gem.add_dependency "grpc", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 0.5.0"
+  gem.add_dependency "google-protobuf", "~> 3.0"
+  gem.add_dependency "googleapis-common-protos", "~> 1.3"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-vision/lib/google-cloud-vision.rb
+++ b/google-cloud-vision/lib/google-cloud-vision.rb
@@ -35,9 +35,9 @@ module Google
     #   The default scope is:
     #
     #   * `https://www.googleapis.com/auth/cloud-platform`
-    # @param [Integer] retries Number of times to retry requests on server
-    #   error. The default value is `3`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
+    # @param [Hash] client_config A hash of values to override the default
+    #   behavior of the API client. Optional.
     #
     # @return [Google::Cloud::Vision::Project]
     #
@@ -59,10 +59,10 @@ module Google
     #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
     #   vision = gcloud.vision scope: platform_scope
     #
-    def vision scope: nil, retries: nil, timeout: nil
+    def vision scope: nil, timeout: nil, client_config: nil
       Google::Cloud.vision @project, @keyfile, scope: scope,
-                                               retries: (retries || @retries),
-                                               timeout: (timeout || @timeout)
+                                               timeout: (timeout || @timeout),
+                                               client_config: client_config
     end
 
     ##
@@ -81,9 +81,9 @@ module Google
     #   The default scope is:
     #
     #   * `https://www.googleapis.com/auth/cloud-platform`
-    # @param [Integer] retries Number of times to retry requests on server
-    #   error. The default value is `3`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
+    # @param [Hash] client_config A hash of values to override the default
+    #   behavior of the API client. Optional.
     #
     # @return [Google::Cloud::Vision::Project]
     #
@@ -97,8 +97,8 @@ module Google
     #   landmark = image.landmark
     #   landmark.description #=> "Mount Rushmore"
     #
-    def self.vision project = nil, keyfile = nil, scope: nil, retries: nil,
-                    timeout: nil
+    def self.vision project = nil, keyfile = nil, scope: nil, timeout: nil,
+                    client_config: nil
       require "google/cloud/vision"
       project ||= Google::Cloud::Vision::Project.default_project
       project = project.to_s # Always cast to a string
@@ -113,7 +113,7 @@ module Google
 
       Google::Cloud::Vision::Project.new(
         Google::Cloud::Vision::Service.new(
-          project, credentials, retries: retries, timeout: timeout))
+          project, credentials, timeout: timeout, client_config: client_config))
     end
   end
 end

--- a/google-cloud-vision/lib/google/cloud/vision.rb
+++ b/google-cloud-vision/lib/google/cloud/vision.rb
@@ -464,9 +464,9 @@ module Google
       #   The default scope is:
       #
       #   * `https://www.googleapis.com/auth/cloud-platform`
-      # @param [Integer] retries Number of times to retry requests on server
-      #   error. The default value is `3`. Optional.
       # @param [Integer] timeout Default timeout to use in requests. Optional.
+      # @param [Hash] client_config A hash of values to override the default
+      #   behavior of the API client. Optional.
       #
       # @return [Google::Cloud::Vision::Project]
       #
@@ -480,8 +480,8 @@ module Google
       #   landmark = image.landmark
       #   landmark.description #=> "Mount Rushmore"
       #
-      def self.new project: nil, keyfile: nil, scope: nil, retries: nil,
-                   timeout: nil
+      def self.new project: nil, keyfile: nil, scope: nil, timeout: nil,
+                   client_config: nil
         project ||= Google::Cloud::Vision::Project.default_project
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
@@ -495,7 +495,8 @@ module Google
 
         Google::Cloud::Vision::Project.new(
           Google::Cloud::Vision::Service.new(
-            project, credentials, retries: retries, timeout: timeout))
+            project, credentials, timeout: timeout,
+                                  client_config: client_config))
       end
     end
   end

--- a/google-cloud-vision/lib/google/cloud/vision.rb
+++ b/google-cloud-vision/lib/google/cloud/vision.rb
@@ -197,23 +197,14 @@ module Google
     # annotation = vision.annotate image, faces: 5
     # ```
     #
-    # ## Configuring retries and timeout
+    # ## Configuring timeout
     #
-    # You can configure how many times API requests may be automatically
-    # retried. When an API request fails, the response will be inspected to see
-    # if the request meets criteria indicating that it may succeed on retry,
-    # such as `500` and `503` status codes or a specific internal error code
-    # such as `rateLimitExceeded`. If it meets the criteria, the request will be
-    # retried after a delay. If another error occurs, the delay will be
-    # increased before a subsequent attempt, until the `retries` limit is
-    # reached.
-    #
-    # You can also set the request `timeout` value in seconds.
+    # You can configure the request `timeout` value in seconds.
     #
     # ```ruby
     # require "google/cloud/vision"
     #
-    # vision = Google::Cloud::Vision.new retries: 10, timeout: 120
+    # vision = Google::Cloud::Vision.new timeout: 120
     # ```
     #
     module Vision

--- a/google-cloud-vision/lib/google/cloud/vision/annotate.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotate.rb
@@ -157,10 +157,10 @@ module Google
 
           Array(images).flatten.each do |img|
             i = image(img)
-            @requests << Google::Apis::VisionV1::AnnotateImageRequest.new(
-              image: i.to_gapi,
+            @requests << Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+              image: i.to_grpc,
               features: features,
-              imageContext: i.context.to_gapi
+              image_context: i.context.to_grpc
             )
           end
         end
@@ -174,18 +174,18 @@ module Google
             faces, landmarks, logos, labels)
 
           f = []
-          f << feature("FACE_DETECTION", faces) unless faces.zero?
-          f << feature("LANDMARK_DETECTION", landmarks) unless landmarks.zero?
-          f << feature("LOGO_DETECTION", logos) unless logos.zero?
-          f << feature("LABEL_DETECTION", labels) unless labels.zero?
-          f << feature("TEXT_DETECTION", 1) if text
-          f << feature("SAFE_SEARCH_DETECTION", 1) if safe_search
-          f << feature("IMAGE_PROPERTIES", 1) if properties
+          f << feature(:FACE_DETECTION, faces) unless faces.zero?
+          f << feature(:LANDMARK_DETECTION, landmarks) unless landmarks.zero?
+          f << feature(:LOGO_DETECTION, logos) unless logos.zero?
+          f << feature(:LABEL_DETECTION, labels) unless labels.zero?
+          f << feature(:TEXT_DETECTION, 1) if text
+          f << feature(:SAFE_SEARCH_DETECTION, 1) if safe_search
+          f << feature(:IMAGE_PROPERTIES, 1) if properties
           f
         end
 
         def feature type, max_results
-          Google::Apis::VisionV1::Feature.new(
+          Google::Cloud::Vision::V1::Feature.new(
             type: type, max_results: max_results)
         end
 
@@ -198,15 +198,15 @@ module Google
 
         def default_features
           [
-            feature("FACE_DETECTION", Google::Cloud::Vision.default_max_faces),
-            feature("LANDMARK_DETECTION",
+            feature(:FACE_DETECTION, Google::Cloud::Vision.default_max_faces),
+            feature(:LANDMARK_DETECTION,
                     Google::Cloud::Vision.default_max_landmarks),
-            feature("LOGO_DETECTION", Google::Cloud::Vision.default_max_logos),
-            feature("LABEL_DETECTION",
+            feature(:LOGO_DETECTION, Google::Cloud::Vision.default_max_logos),
+            feature(:LABEL_DETECTION,
                     Google::Cloud::Vision.default_max_labels),
-            feature("TEXT_DETECTION", 1),
-            feature("SAFE_SEARCH_DETECTION", 1),
-            feature("IMAGE_PROPERTIES", 1)
+            feature(:TEXT_DETECTION, 1),
+            feature(:SAFE_SEARCH_DETECTION, 1),
+            feature(:IMAGE_PROPERTIES, 1)
           ]
         end
 

--- a/google-cloud-vision/lib/google/cloud/vision/annotation.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation.rb
@@ -42,13 +42,13 @@ module Google
       #
       class Annotation
         ##
-        # @private The AnnotateImageResponse Google API Client object.
-        attr_accessor :gapi
+        # @private The AnnotateImageResponse GRPC object.
+        attr_accessor :grpc
 
         ##
         # @private Creates a new Annotation instance.
         def initialize
-          @gapi = nil
+          @grpc = nil
         end
 
         ##
@@ -67,8 +67,8 @@ module Google
         #   face = annotation.faces.first
         #
         def faces
-          @faces ||= Array(@gapi.face_annotations).map do |fa|
-            Face.from_gapi fa
+          @faces ||= Array(@grpc.face_annotations).map do |fa|
+            Face.from_grpc fa
           end
         end
 
@@ -124,8 +124,8 @@ module Google
         #   landmark = annotation.landmarks.first
         #
         def landmarks
-          @landmarks ||= Array(@gapi.landmark_annotations).map do |lm|
-            Entity.from_gapi lm
+          @landmarks ||= Array(@grpc.landmark_annotations).map do |lm|
+            Entity.from_grpc lm
           end
         end
 
@@ -182,8 +182,8 @@ module Google
         #   logo = annotation.logos.first
         #
         def logos
-          @logos ||= Array(@gapi.logo_annotations).map do |lg|
-            Entity.from_gapi lg
+          @logos ||= Array(@grpc.logo_annotations).map do |lg|
+            Entity.from_grpc lg
           end
         end
 
@@ -240,8 +240,8 @@ module Google
         #   label = annotation.labels.first
         #
         def labels
-          @labels ||= Array(@gapi.label_annotations).map do |lb|
-            Entity.from_gapi lb
+          @labels ||= Array(@grpc.label_annotations).map do |lb|
+            Entity.from_grpc lb
           end
         end
 
@@ -297,7 +297,7 @@ module Google
         #   text = annotation.text
         #
         def text
-          @text ||= Text.from_gapi(@gapi.text_annotations)
+          @text ||= Text.from_grpc(@grpc.text_annotations)
         end
 
         ##
@@ -333,8 +333,8 @@ module Google
         #   safe_search = annotation.safe_search
         #
         def safe_search
-          return nil unless @gapi.safe_search_annotation
-          @safe_search ||= SafeSearch.from_gapi(@gapi.safe_search_annotation)
+          return nil unless @grpc.safe_search_annotation
+          @safe_search ||= SafeSearch.from_grpc(@grpc.safe_search_annotation)
         end
 
         ##
@@ -371,9 +371,9 @@ module Google
         #   properties = annotation.properties
         #
         def properties
-          return nil unless @gapi.image_properties_annotation
-          @properties ||= Properties.from_gapi(
-            @gapi.image_properties_annotation)
+          return nil unless @grpc.image_properties_annotation
+          @properties ||= Properties.from_grpc(
+            @grpc.image_properties_annotation)
         end
 
         ##
@@ -420,9 +420,9 @@ module Google
         end
 
         ##
-        # @private New Annotation from a Google API Client object.
-        def self.from_gapi gapi
-          new.tap { |a| a.instance_variable_set :@gapi, gapi }
+        # @private New Annotation from a GRPC object.
+        def self.from_grpc grpc
+          new.tap { |a| a.instance_variable_set :@grpc, grpc }
         end
       end
     end

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
@@ -70,13 +70,13 @@ module Google
         #
         class Entity
           ##
-          # @private The EntityAnnotation Google API Client object.
-          attr_accessor :gapi
+          # @private The EntityAnnotation GRPC object.
+          attr_accessor :grpc
 
           ##
           # @private Creates a new Entity instance.
           def initialize
-            @gapi = {}
+            @grpc = nil
           end
 
           ##
@@ -88,7 +88,7 @@ module Google
           # @return [String] The opaque entity ID.
           #
           def mid
-            @gapi.mid
+            @grpc.mid
           end
 
           ##
@@ -100,7 +100,7 @@ module Google
           #   language code.
           #
           def locale
-            @gapi.locale
+            @grpc.locale
           end
 
           ##
@@ -109,7 +109,7 @@ module Google
           # @return [String] A description of the entity.
           #
           def description
-            @gapi.description
+            @grpc.description
           end
 
           ##
@@ -118,7 +118,7 @@ module Google
           # @return [Float] A value in the range [0, 1].
           #
           def score
-            @gapi.score
+            @grpc.score
           end
 
           ##
@@ -129,7 +129,7 @@ module Google
           # @return [Float] A value in the range [0, 1].
           #
           def confidence
-            @gapi.confidence
+            @grpc.confidence
           end
 
           ##
@@ -142,7 +142,7 @@ module Google
           # @return [Float] A value in the range [0, 1].
           #
           def topicality
-            @gapi.topicality
+            @grpc.topicality
           end
 
           ##
@@ -152,9 +152,9 @@ module Google
           # @return [Array<Vertex>] An array of vertices.
           #
           def bounds
-            return [] unless @gapi.bounding_poly
-            @bounds ||= Array(@gapi.bounding_poly.vertices).map do |v|
-              Vertex.from_gapi v
+            return [] unless @grpc.bounding_poly
+            @bounds ||= Array(@grpc.bounding_poly.vertices).map do |v|
+              Vertex.from_grpc v
             end
           end
 
@@ -169,8 +169,8 @@ module Google
           #   and longitude.
           #
           def locations
-            @locations ||= Array(@gapi.locations).map do |l|
-              Location.from_gapi l.lat_lng
+            @locations ||= Array(@grpc.locations).map do |l|
+              Location.from_grpc l.lat_lng
             end
           end
 
@@ -183,7 +183,7 @@ module Google
           #
           def properties
             @properties ||=
-              Hash[Array(@gapi.properties).map { |p| [p.name, p.value] }]
+              Hash[Array(@grpc.properties).map { |p| [p.name, p.value] }]
           end
 
           ##
@@ -214,9 +214,9 @@ module Google
           end
 
           ##
-          # @private New Annotation::Entity from a Google API Client object.
-          def self.from_gapi gapi
-            new.tap { |f| f.instance_variable_set :@gapi, gapi }
+          # @private New Annotation::Entity from a GRPC object.
+          def self.from_grpc grpc
+            new.tap { |f| f.instance_variable_set :@grpc, grpc }
           end
         end
       end

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
@@ -38,13 +38,13 @@ module Google
         #
         class Face
           ##
-          # @private The FaceAnnotation Google API Client object.
-          attr_accessor :gapi
+          # @private The FaceAnnotation GRPC object.
+          attr_accessor :grpc
 
           ##
           # @private Creates a new Face instance.
           def initialize
-            @gapi = {}
+            @grpc = nil
           end
 
           ##
@@ -53,7 +53,7 @@ module Google
           # @return [Angles]
           #
           def angles
-            @angles ||= Angles.from_gapi @gapi
+            @angles ||= Angles.from_grpc @grpc
           end
 
           ##
@@ -63,7 +63,7 @@ module Google
           # @return [Bounds]
           #
           def bounds
-            @bounds ||= Bounds.from_gapi @gapi
+            @bounds ||= Bounds.from_grpc @grpc
           end
 
           ##
@@ -73,7 +73,7 @@ module Google
           # @return [Features]
           #
           def features
-            @features ||= Features.from_gapi @gapi
+            @features ||= Features.from_grpc @grpc
           end
 
           ##
@@ -83,7 +83,7 @@ module Google
           # @return [Likelihood]
           #
           def likelihood
-            @likelihood ||= Likelihood.from_gapi @gapi
+            @likelihood ||= Likelihood.from_grpc @grpc
           end
 
           ##
@@ -92,7 +92,7 @@ module Google
           # @return [Float] A value in the range [0, 1].
           #
           def confidence
-            @gapi.detection_confidence
+            @grpc.detection_confidence
           end
 
           ##
@@ -117,9 +117,9 @@ module Google
           end
 
           ##
-          # @private New Annotation::Face from a Google API Client object.
-          def self.from_gapi gapi
-            new.tap { |f| f.instance_variable_set :@gapi, gapi }
+          # @private New Annotation::Face from a GRPC object.
+          def self.from_grpc grpc
+            new.tap { |f| f.instance_variable_set :@grpc, grpc }
           end
 
           ##
@@ -143,13 +143,13 @@ module Google
           #
           class Angles
             ##
-            # @private The FaceAnnotation Google API Client object.
-            attr_accessor :gapi
+            # @private The FaceAnnotation GRPC object.
+            attr_accessor :grpc
 
             ##
             # @private Creates a new Angles instance.
             def initialize
-              @gapi = {}
+              @grpc = nil
             end
 
             ##
@@ -160,7 +160,7 @@ module Google
             # @return [Float] A value in the range [-180,180].
             #
             def roll
-              @gapi.roll_angle
+              @grpc.roll_angle
             end
 
             ##
@@ -171,7 +171,7 @@ module Google
             # @return [Float] A value in the range [-180,180].
             #
             def yaw
-              @gapi.pan_angle
+              @grpc.pan_angle
             end
             alias_method :pan, :yaw
 
@@ -182,7 +182,7 @@ module Google
             # @return [Float] A value in the range [-180,180].
             #
             def pitch
-              @gapi.tilt_angle
+              @grpc.tilt_angle
             end
             alias_method :tilt, :pitch
 
@@ -216,10 +216,10 @@ module Google
             end
 
             ##
-            # @private New Annotation::Face::Angles from a Google API Client
+            # @private New Annotation::Face::Angles from a GRPC
             # object.
-            def self.from_gapi gapi
-              new.tap { |f| f.instance_variable_set :@gapi, gapi }
+            def self.from_grpc grpc
+              new.tap { |f| f.instance_variable_set :@grpc, grpc }
             end
           end
 
@@ -243,13 +243,13 @@ module Google
           #
           class Bounds
             ##
-            # @private The FaceAnnotation Google API Client object.
-            attr_accessor :gapi
+            # @private The FaceAnnotation GRPC object.
+            attr_accessor :grpc
 
             ##
             # @private Creates a new Bounds instance.
             def initialize
-              @gapi = {}
+              @grpc = nil
             end
 
             ##
@@ -261,9 +261,9 @@ module Google
             # generated in the BoundingPoly (the polygon will be unbounded) if
             # only a partial face appears in the image to be annotated.
             def head
-              return [] unless @gapi.bounding_poly
-              @head ||= Array(@gapi.bounding_poly.vertices).map do |v|
-                Vertex.from_gapi v
+              return [] unless @grpc.bounding_poly
+              @head ||= Array(@grpc.bounding_poly.vertices).map do |v|
+                Vertex.from_grpc v
               end
             end
 
@@ -274,9 +274,9 @@ module Google
             # skin" visible in an image. It is not based on the landmarks, only
             # on the initial face detection.
             def face
-              return [] unless @gapi.fd_bounding_poly
-              @face ||= Array(@gapi.fd_bounding_poly.vertices).map do |v|
-                Vertex.from_gapi v
+              return [] unless @grpc.fd_bounding_poly
+              @face ||= Array(@grpc.fd_bounding_poly.vertices).map do |v|
+                Vertex.from_grpc v
               end
             end
 
@@ -309,10 +309,10 @@ module Google
             end
 
             ##
-            # @private New Annotation::Face::Angles from a Google API Client
+            # @private New Annotation::Face::Angles from a GRPC
             # object.
-            def self.from_gapi gapi
-              new.tap { |f| f.instance_variable_set :@gapi, gapi }
+            def self.from_grpc grpc
+              new.tap { |f| f.instance_variable_set :@grpc, grpc }
             end
           end
 
@@ -345,13 +345,13 @@ module Google
           #
           class Features
             ##
-            # @private The FaceAnnotation Google API Client object.
-            attr_accessor :gapi
+            # @private The FaceAnnotation GRPC object.
+            attr_accessor :grpc
 
             ##
             # @private Creates a new Features instance.
             def initialize
-              @gapi = {}
+              @grpc = nil
             end
 
             ##
@@ -360,7 +360,7 @@ module Google
             # @return [Float] A value in the range [0,1].
             #
             def confidence
-              @gapi.landmarking_confidence
+              @grpc.landmarking_confidence
             end
 
             ##
@@ -387,11 +387,11 @@ module Google
             #   #=> #<Landmark (x: 303.81198, y: 88.5782, z: 77.719193)>
             #
             def [] landmark_type
-              landmark = Array(@gapi.landmarks).detect do |l|
+              landmark = Array(@grpc.landmarks).detect do |l|
                 l.type == landmark_type
               end
               return nil if landmark.nil?
-              Landmark.from_gapi landmark
+              Landmark.from_grpc landmark
             end
 
             ##
@@ -400,9 +400,9 @@ module Google
             # @return [Chin]
             #
             def chin
-              @chin ||= Chin.new self["CHIN_LEFT_GONION"],
-                                 self["CHIN_GNATHION"],
-                                 self["CHIN_RIGHT_GONION"]
+              @chin ||= Chin.new self[:CHIN_LEFT_GONION],
+                                 self[:CHIN_GNATHION],
+                                 self[:CHIN_RIGHT_GONION]
             end
 
             ##
@@ -411,8 +411,8 @@ module Google
             # @return [Ears]
             #
             def ears
-              @ears ||= Ears.new self["LEFT_EAR_TRAGION"],
-                                 self["RIGHT_EAR_TRAGION"]
+              @ears ||= Ears.new self[:LEFT_EAR_TRAGION],
+                                 self[:RIGHT_EAR_TRAGION]
             end
 
             ##
@@ -422,12 +422,12 @@ module Google
             #
             def eyebrows
               @eyebrows ||= begin
-                left = Eyebrow.new self["LEFT_OF_LEFT_EYEBROW"],
-                                   self["LEFT_EYEBROW_UPPER_MIDPOINT"],
-                                   self["RIGHT_OF_LEFT_EYEBROW"]
-                right = Eyebrow.new self["LEFT_OF_RIGHT_EYEBROW"],
-                                    self["RIGHT_EYEBROW_UPPER_MIDPOINT"],
-                                    self["RIGHT_OF_RIGHT_EYEBROW"]
+                left = Eyebrow.new self[:LEFT_OF_LEFT_EYEBROW],
+                                   self[:LEFT_EYEBROW_UPPER_MIDPOINT],
+                                   self[:RIGHT_OF_LEFT_EYEBROW]
+                right = Eyebrow.new self[:LEFT_OF_RIGHT_EYEBROW],
+                                    self[:RIGHT_EYEBROW_UPPER_MIDPOINT],
+                                    self[:RIGHT_OF_RIGHT_EYEBROW]
                 Eyebrows.new left, right
               end
             end
@@ -439,16 +439,16 @@ module Google
             #
             def eyes
               @eyes ||= begin
-                left = Eye.new self["LEFT_EYE_LEFT_CORNER"],
-                               self["LEFT_EYE_BOTTOM_BOUNDARY"],
-                               self["LEFT_EYE"], self["LEFT_EYE_PUPIL"],
-                               self["LEFT_EYE_TOP_BOUNDARY"],
-                               self["LEFT_EYE_RIGHT_CORNER"]
-                right = Eye.new self["RIGHT_EYE_LEFT_CORNER"],
-                                self["RIGHT_EYE_BOTTOM_BOUNDARY"],
-                                self["RIGHT_EYE"], self["RIGHT_EYE_PUPIL"],
-                                self["RIGHT_EYE_TOP_BOUNDARY"],
-                                self["RIGHT_EYE_RIGHT_CORNER"]
+                left = Eye.new self[:LEFT_EYE_LEFT_CORNER],
+                               self[:LEFT_EYE_BOTTOM_BOUNDARY],
+                               self[:LEFT_EYE], self[:LEFT_EYE_PUPIL],
+                               self[:LEFT_EYE_TOP_BOUNDARY],
+                               self[:LEFT_EYE_RIGHT_CORNER]
+                right = Eye.new self[:RIGHT_EYE_LEFT_CORNER],
+                                self[:RIGHT_EYE_BOTTOM_BOUNDARY],
+                                self[:RIGHT_EYE], self[:RIGHT_EYE_PUPIL],
+                                self[:RIGHT_EYE_TOP_BOUNDARY],
+                                self[:RIGHT_EYE_RIGHT_CORNER]
                 Eyes.new left, right
               end
             end
@@ -459,7 +459,7 @@ module Google
             # @return [Landmark]
             #
             def forehead
-              @forehead ||= self["FOREHEAD_GLABELLA"]
+              @forehead ||= self[:FOREHEAD_GLABELLA]
             end
 
             ##
@@ -468,7 +468,7 @@ module Google
             # @return [Lips]
             #
             def lips
-              @lips ||= Lips.new self["UPPER_LIP"], self["LOWER_LIP"]
+              @lips ||= Lips.new self[:UPPER_LIP], self[:LOWER_LIP]
             end
 
             ##
@@ -477,8 +477,8 @@ module Google
             # @return [Mouth]
             #
             def mouth
-              @mouth ||= Mouth.new self["MOUTH_LEFT"], self["MOUTH_CENTER"],
-                                   self["MOUTH_RIGHT"]
+              @mouth ||= Mouth.new self[:MOUTH_LEFT], self[:MOUTH_CENTER],
+                                   self[:MOUTH_RIGHT]
             end
 
             ##
@@ -487,10 +487,10 @@ module Google
             # @return [Nose]
             #
             def nose
-              @nose ||= Nose.new self["NOSE_BOTTOM_LEFT"],
-                                 self["NOSE_BOTTOM_CENTER"], self["NOSE_TIP"],
-                                 self["MIDPOINT_BETWEEN_EYES"],
-                                 self["NOSE_BOTTOM_RIGHT"]
+              @nose ||= Nose.new self[:NOSE_BOTTOM_LEFT],
+                                 self[:NOSE_BOTTOM_CENTER], self[:NOSE_TIP],
+                                 self[:MIDPOINT_BETWEEN_EYES],
+                                 self[:NOSE_BOTTOM_RIGHT]
             end
 
             ##
@@ -518,10 +518,10 @@ module Google
             end
 
             ##
-            # @private New Annotation::Face::Features from a Google API Client
+            # @private New Annotation::Face::Features from a GRPC
             # object.
-            def self.from_gapi gapi
-              new.tap { |f| f.instance_variable_set :@gapi, gapi }
+            def self.from_grpc grpc
+              new.tap { |f| f.instance_variable_set :@grpc, grpc }
             end
 
             ##
@@ -550,13 +550,13 @@ module Google
             #
             class Landmark
               ##
-              # @private The Landmark Google API Client object.
-              attr_accessor :gapi
+              # @private The Landmark GRPC object.
+              attr_accessor :grpc
 
               ##
               # @private Creates a new Landmark instance.
               def initialize
-                @gapi = {}
+                @grpc = nil
               end
 
               ##
@@ -578,7 +578,7 @@ module Google
               #   face.features.forehead.type #=> "FOREHEAD_GLABELLA"
               #
               def type
-                @gapi.type
+                @grpc.type
               end
 
               ##
@@ -587,8 +587,8 @@ module Google
               # @return [Float]
               #
               def x
-                return nil unless @gapi.position
-                @gapi.position.x
+                return nil unless @grpc.position
+                @grpc.position.x
               end
 
               ##
@@ -597,8 +597,8 @@ module Google
               # @return [Float]
               #
               def y
-                return nil unless @gapi.position
-                @gapi.position.y
+                return nil unless @grpc.position
+                @grpc.position.y
               end
 
               ##
@@ -607,8 +607,8 @@ module Google
               # @return [Float]
               #
               def z
-                return nil unless @gapi.position
-                @gapi.position.z
+                return nil unless @grpc.position
+                @grpc.position.z
               end
 
               ##
@@ -640,10 +640,10 @@ module Google
               end
 
               ##
-              # @private New Annotation::Face::Features from a Google API Client
+              # @private New Annotation::Face::Features from a GRPC
               # object.
-              def self.from_gapi gapi
-                new.tap { |f| f.instance_variable_set :@gapi, gapi }
+              def self.from_grpc grpc
+                new.tap { |f| f.instance_variable_set :@grpc, grpc }
               end
             end
 
@@ -1323,23 +1323,23 @@ module Google
           #   face.likelihood.sorrow #=> "VERY_UNLIKELY"
           #
           class Likelihood
-            POSITIVE_RATINGS = %w(POSSIBLE LIKELY VERY_LIKELY)
+            POSITIVE_RATINGS = %i(POSSIBLE LIKELY VERY_LIKELY)
 
             ##
-            # @private The FaceAnnotation Google API Client object.
-            attr_accessor :gapi
+            # @private The FaceAnnotation GRPC object.
+            attr_accessor :grpc
 
             ##
             # @private Creates a new Likelihood instance.
             def initialize
-              @gapi = {}
+              @grpc = nil
             end
 
             ##
             # Joy likelihood rating. Possible values are `VERY_UNLIKELY`,
             # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
             def joy
-              @gapi.joy_likelihood
+              @grpc.joy_likelihood
             end
 
             ##
@@ -1356,7 +1356,7 @@ module Google
             # Sorrow likelihood rating. Possible values are `VERY_UNLIKELY`,
             # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
             def sorrow
-              @gapi.sorrow_likelihood
+              @grpc.sorrow_likelihood
             end
 
             ##
@@ -1373,7 +1373,7 @@ module Google
             # Joy likelihood rating. Possible values are `VERY_UNLIKELY`,
             # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
             def anger
-              @gapi.anger_likelihood
+              @grpc.anger_likelihood
             end
 
             ##
@@ -1390,7 +1390,7 @@ module Google
             # Surprise likelihood rating. Possible values are `VERY_UNLIKELY`,
             # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
             def surprise
-              @gapi.surprise_likelihood
+              @grpc.surprise_likelihood
             end
 
             ##
@@ -1408,7 +1408,7 @@ module Google
             # `VERY_UNLIKELY`, `UNLIKELY`, `POSSIBLE`, `LIKELY`, and
             # `VERY_LIKELY`.
             def under_exposed
-              @gapi.under_exposed_likelihood
+              @grpc.under_exposed_likelihood
             end
 
             ##
@@ -1425,7 +1425,7 @@ module Google
             # Blurred likelihood rating. Possible values are `VERY_UNLIKELY`,
             # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
             def blurred
-              @gapi.blurred_likelihood
+              @grpc.blurred_likelihood
             end
 
             ##
@@ -1442,7 +1442,7 @@ module Google
             # Headwear likelihood rating. Possible values are `VERY_UNLIKELY`,
             # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
             def headwear
-              @gapi.headwear_likelihood
+              @grpc.headwear_likelihood
             end
 
             ##
@@ -1482,10 +1482,10 @@ module Google
             end
 
             ##
-            # @private New Annotation::Face::Likelihood from a Google API Client
+            # @private New Annotation::Face::Likelihood from a GRPC
             # object.
-            def self.from_gapi gapi
-              new.tap { |f| f.instance_variable_set :@gapi, gapi }
+            def self.from_grpc grpc
+              new.tap { |f| f.instance_variable_set :@grpc, grpc }
             end
           end
         end

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
@@ -37,13 +37,13 @@ module Google
         #
         class Properties
           ##
-          # @private The ImageProperties Google API Client object.
-          attr_accessor :gapi
+          # @private The ImageProperties GRPC object.
+          attr_accessor :grpc
 
           ##
           # @private Creates a new Properties instance.
           def initialize
-            @gapi = {}
+            @grpc = nil
           end
 
           ##
@@ -52,9 +52,9 @@ module Google
           # @return [Array<Color>] An array of the image's dominant colors.
           #
           def colors
-            return [] unless @gapi.dominant_colors
-            @colors ||= Array(@gapi.dominant_colors.colors).map do |c|
-              Color.from_gapi c
+            return [] unless @grpc.dominant_colors
+            @colors ||= Array(@grpc.dominant_colors.colors).map do |c|
+              Color.from_grpc c
             end
           end
 
@@ -87,9 +87,9 @@ module Google
           end
 
           ##
-          # @private New Annotation::Properties from a Google API Client object.
-          def self.from_gapi gapi
-            new.tap { |f| f.instance_variable_set :@gapi, gapi }
+          # @private New Annotation::Properties from a GRPC object.
+          def self.from_grpc grpc
+            new.tap { |f| f.instance_variable_set :@grpc, grpc }
           end
 
           ##
@@ -117,13 +117,13 @@ module Google
           #
           class Color
             ##
-            # @private The ColorInfo Google API Client object.
-            attr_accessor :gapi
+            # @private The ColorInfo GRPC object.
+            attr_accessor :grpc
 
             ##
             # @private Creates a new Color instance.
             def initialize
-              @gapi = {}
+              @grpc = nil
             end
 
             ##
@@ -132,7 +132,7 @@ module Google
             # @return [Float] A value in the interval [0, 255].
             #
             def red
-              @gapi.color.red
+              @grpc.color.red
             end
 
             ##
@@ -141,7 +141,7 @@ module Google
             # @return [Float] A value in the interval [0, 255].
             #
             def green
-              @gapi.color.green
+              @grpc.color.green
             end
 
             ##
@@ -150,7 +150,7 @@ module Google
             # @return [Float] A value in the interval [0, 255].
             #
             def blue
-              @gapi.color.blue
+              @grpc.color.blue
             end
 
             ##
@@ -161,7 +161,7 @@ module Google
             # @return [Float] A value in the range [0, 1].
             #
             def alpha
-              @gapi.color.alpha || 1.0
+              @grpc.color.alpha || 1.0
             end
 
             def rgb
@@ -176,7 +176,7 @@ module Google
             # @return [Float] A value in the range [0, 1].
             #
             def score
-              @gapi.score
+              @grpc.score
             end
 
             ##
@@ -185,7 +185,7 @@ module Google
             # @return [Float] A value in the range [0, 1].
             #
             def pixel_fraction
-              @gapi.pixel_fraction
+              @grpc.pixel_fraction
             end
 
             ##
@@ -207,10 +207,10 @@ module Google
             end
 
             ##
-            # @private New Annotation::Properties from a Google API Client
+            # @private New Annotation::Properties from a GRPC
             # object.
-            def self.from_gapi gapi
-              new.tap { |f| f.instance_variable_set :@gapi, gapi }
+            def self.from_grpc grpc
+              new.tap { |f| f.instance_variable_set :@grpc, grpc }
             end
           end
         end

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
@@ -38,23 +38,23 @@ module Google
         #   safe_search.spoof #=> "VERY_UNLIKELY"
         #
         class SafeSearch
-          POSITIVE_RATINGS = %w(POSSIBLE LIKELY VERY_LIKELY)
+          POSITIVE_RATINGS = %i(POSSIBLE LIKELY VERY_LIKELY)
 
           ##
-          # @private The SafeSearchAnnotation Google API Client object.
-          attr_accessor :gapi
+          # @private The SafeSearchAnnotation GRPC object.
+          attr_accessor :grpc
 
           ##
           # @private Creates a new SafeSearch instance.
           def initialize
-            @gapi = {}
+            @grpc = nil
           end
 
           ##
           # Adult likelihood rating. Possible values are `VERY_UNLIKELY`,
           # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
           def adult
-            @gapi.adult
+            @grpc.adult
           end
 
           ##
@@ -71,7 +71,7 @@ module Google
           # Spoof likelihood rating. Possible values are `VERY_UNLIKELY`,
           # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
           def spoof
-            @gapi.spoof
+            @grpc.spoof
           end
 
           ##
@@ -88,7 +88,7 @@ module Google
           # Medical likelihood rating. Possible values are `VERY_UNLIKELY`,
           # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
           def medical
-            @gapi.medical
+            @grpc.medical
           end
 
           ##
@@ -105,7 +105,7 @@ module Google
           # Violence likelihood rating. Possible values are `VERY_UNLIKELY`,
           # `UNLIKELY`, `POSSIBLE`, `LIKELY`, and `VERY_LIKELY`.
           def violence
-            @gapi.violence
+            @grpc.violence
           end
 
           ##
@@ -142,9 +142,9 @@ module Google
           end
 
           ##
-          # @private New Annotation::SafeSearch from a Google API Client object.
-          def self.from_gapi gapi
-            new.tap { |f| f.instance_variable_set :@gapi, gapi }
+          # @private New Annotation::SafeSearch from a GRPC object.
+          def self.from_grpc grpc
+            new.tap { |f| f.instance_variable_set :@grpc, grpc }
           end
         end
       end

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
@@ -39,13 +39,13 @@ module Google
         #
         class Text
           ##
-          # @private The EntityAnnotation Google API Client object.
-          attr_accessor :gapi
+          # @private The EntityAnnotation GRPC object.
+          attr_accessor :grpc
 
           ##
           # @private Creates a new Text instance.
           def initialize
-            @gapi = {}
+            @grpc = nil
             @words = []
           end
 
@@ -55,7 +55,7 @@ module Google
           # @return [String] The entire text including newline characters.
           #
           def text
-            @gapi.description
+            @grpc.description
           end
 
           ##
@@ -66,7 +66,7 @@ module Google
           #   language code.
           #
           def locale
-            @gapi.locale
+            @grpc.locale
           end
 
           ##
@@ -75,9 +75,9 @@ module Google
           # @return [Array<Vertex>]
           #
           def bounds
-            return [] unless @gapi.bounding_poly
-            @bounds ||= Array(@gapi.bounding_poly.vertices).map do |v|
-              Vertex.from_gapi v
+            return [] unless @grpc.bounding_poly
+            @bounds ||= Array(@grpc.bounding_poly.vertices).map do |v|
+              Vertex.from_grpc v
             end
           end
 
@@ -117,15 +117,15 @@ module Google
           end
 
           ##
-          # @private New Annotation::Text from an array of Google API Client
+          # @private New Annotation::Text from an array of GRPC
           # objects.
-          def self.from_gapi gapi_list
-            text, *words = Array gapi_list
+          def self.from_grpc grpc_list
+            text, *words = Array grpc_list
             return nil if text.nil?
             new.tap do |t|
-              t.instance_variable_set :@gapi, text
+              t.instance_variable_set :@grpc, text
               t.instance_variable_set :@words,
-                                      words.map { |w| Word.from_gapi w }
+                                      words.map { |w| Word.from_grpc w }
             end
           end
 
@@ -152,13 +152,13 @@ module Google
           #
           class Word
             ##
-            # @private The EntityAnnotation Google API Client object.
-            attr_accessor :gapi
+            # @private The EntityAnnotation GRPC object.
+            attr_accessor :grpc
 
             ##
             # @private Creates a new Word instance.
             def initialize
-              @gapi = {}
+              @grpc = nil
             end
 
             ##
@@ -167,7 +167,7 @@ module Google
             # @return [String]
             #
             def text
-              @gapi.description
+              @grpc.description
             end
 
             ##
@@ -176,9 +176,9 @@ module Google
             # @return [Array<Vertex>]
             #
             def bounds
-              return [] unless @gapi.bounding_poly
-              @bounds ||= Array(@gapi.bounding_poly.vertices).map do |v|
-                Vertex.from_gapi v
+              return [] unless @grpc.bounding_poly
+              @bounds ||= Array(@grpc.bounding_poly.vertices).map do |v|
+                Vertex.from_grpc v
               end
             end
 
@@ -207,10 +207,10 @@ module Google
             end
 
             ##
-            # @private New Annotation::Text::Word from a Google API Client
+            # @private New Annotation::Text::Word from a GRPC
             # object.
-            def self.from_gapi gapi
-              new.tap { |w| w.instance_variable_set :@gapi, gapi }
+            def self.from_grpc grpc
+              new.tap { |w| w.instance_variable_set :@grpc, grpc }
             end
           end
         end

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
@@ -81,8 +81,8 @@ module Google
           ##
           # @private New Annotation::Entity::Bounds::Vertex from a Google API
           # Client object.
-          def self.from_gapi gapi
-            new gapi.x, gapi.y
+          def self.from_grpc grpc
+            new grpc.x, grpc.y
           end
         end
       end

--- a/google-cloud-vision/lib/google/cloud/vision/image.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/image.rb
@@ -337,13 +337,15 @@ module Google
         end
 
         ##
-        # @private The Google API Client object for the Image.
-        def to_gapi
+        # @private The GRPC object for the Image.
+        def to_grpc
           if io?
             @io.rewind
-            Google::Apis::VisionV1::Image.new content: @io.read
+            Google::Cloud::Vision::V1::Image.new content: @io.read
           elsif url?
-            Google::Apis::VisionV1::Image.new source: { gcs_image_uri: @url }
+            Google::Cloud::Vision::V1::Image.new(
+              source: Google::Cloud::Vision::V1::ImageSource.new(
+                gcs_image_uri: @url))
           else
             fail ArgumentError, "Unable to use Image with Vision service."
           end
@@ -459,12 +461,13 @@ module Google
 
           ##
           # @private
-          def to_gapi
+          def to_grpc
             return nil if empty?
-            gapi = Google::Apis::VisionV1::ImageContext.new
-            gapi.lat_long_rect = area.to_gapi unless area.empty?
-            gapi.language_hints = languages unless languages.empty?
-            gapi
+
+            args = {}
+            args[:lat_long_rect] = area.to_grpc unless area.empty?
+            args[:language_hints] = languages unless languages.empty?
+            Google::Cloud::Vision::V1::ImageContext.new args
           end
 
           ##
@@ -553,11 +556,11 @@ module Google
               { min_lat_lng: min.to_h, max_lat_lng: max.to_h }
             end
 
-            def to_gapi
+            def to_grpc
               return nil if empty?
-              Google::Apis::VisionV1::LatLongRect.new(
-                min_lat_lng: min.to_gapi,
-                max_lat_lng: max.to_gapi
+              Google::Cloud::Vision::V1::LatLongRect.new(
+                min_lat_lng: min.to_grpc,
+                max_lat_lng: max.to_grpc
               )
             end
           end

--- a/google-cloud-vision/lib/google/cloud/vision/location.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/location.rb
@@ -79,18 +79,18 @@ module Google
         end
 
         ##
-        # @private New Google API Client LatLng object.
-        def to_gapi
-          Google::Apis::VisionV1::LatLng.new(
+        # @private New GRPC LatLng object.
+        def to_grpc
+          Google::Type::LatLng.new(
             latitude: latitude,
             longitude: longitude
           )
         end
 
         ##
-        # @private New Location from a Google API Client LatLng object.
-        def self.from_gapi gapi
-          new gapi.latitude, gapi.longitude
+        # @private New Location from a GRPC LatLng object.
+        def self.from_grpc grpc
+          new grpc.latitude, grpc.longitude
         end
       end
     end

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -254,10 +254,10 @@ module Google
 
           yield a if block_given?
 
-          gapi = service.annotate a.requests
-          annotations = Array(gapi.responses).map do |g|
+          grpc = service.annotate a.requests
+          annotations = Array(grpc.responses).map do |g|
             fail Error.from_error(g.error) if g.error
-            Annotation.from_gapi g
+            Annotation.from_grpc g
           end
           return annotations.first if annotations.count == 1
           annotations

--- a/google-cloud-vision/lib/google/cloud/vision/service.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/service.rb
@@ -39,11 +39,13 @@ module Google
         end
 
         def channel
+          require "grpc"
           GRPC::Core::Channel.new host, nil, chan_creds
         end
 
         def chan_creds
           return credentials if insecure?
+          require "grpc"
           GRPC::Core::ChannelCredentials.new.compose \
             GRPC::Core::CallCredentials.new credentials.client.updater_proc
         end

--- a/google-cloud-vision/lib/google/cloud/vision/service.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/service.rb
@@ -16,6 +16,7 @@
 require "google/cloud/errors"
 require "google/cloud/vision/version"
 require "google/cloud/vision/v1"
+require "google/gax/errors"
 
 module Google
   module Cloud
@@ -77,10 +78,7 @@ module Google
         protected
 
         def execute
-          require "grpc" # Ensure GRPC is loaded before rescuing exception
           yield
-        rescue GRPC::BadStatus => e
-          raise Google::Cloud::Error.from_error(e)
         rescue Google::Gax::GaxError => e
           # GaxError wraps BadStatus, but exposes it as #cause
           raise Google::Cloud::Error.from_error(e.cause)

--- a/google-cloud-vision/lib/google/cloud/vision/v1.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1.rb
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 require "google/cloud/vision/v1/image_annotator_api"
+# Require the protobufs so we can create objects before GRPC is loaded.
+require "google/cloud/vision/v1/image_annotator_pb"

--- a/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_api.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_api.rb
@@ -46,7 +46,7 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
-          CODE_GEN_NAME_VERSION = "grpcc/0.1.0".freeze
+          CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
 
           DEFAULT_TIMEOUT = 30
 

--- a/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_api.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_api.rb
@@ -46,7 +46,7 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
-          CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
+          CODE_GEN_NAME_VERSION = "grpcc/0.1.0".freeze
 
           DEFAULT_TIMEOUT = 30
 

--- a/google-cloud-vision/test/google/cloud/vision/annotation/face_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/face_test.rb
@@ -16,16 +16,17 @@ require "helper"
 
 describe Google::Cloud::Vision::Annotation::Face, :mock_vision do
   # Run through JSON to turn all keys to strings...
-  let(:gapi) { face_annotation_response }
-  let(:face) { Google::Cloud::Vision::Annotation::Face.from_gapi gapi }
+  let(:grpc) { face_annotation_response }
+  let(:face) { Google::Cloud::Vision::Annotation::Face.from_grpc grpc }
+
   it "knows the angles" do
     face.angles.wont_be :nil?
 
-    face.angles.roll.must_equal -0.050002542
-    face.angles.yaw.must_equal -0.081090336
-    face.angles.pan.must_equal -0.081090336
-    face.angles.pitch.must_equal 0.18012161
-    face.angles.tilt.must_equal 0.18012161
+    face.angles.roll.must_be_close_to -0.050002542
+    face.angles.yaw.must_be_close_to -0.081090336
+    face.angles.pan.must_be_close_to -0.081090336
+    face.angles.pitch.must_be_close_to 0.18012161
+    face.angles.tilt.must_be_close_to 0.18012161
   end
 
   it "knows the bounds" do
@@ -47,52 +48,52 @@ describe Google::Cloud::Vision::Annotation::Face, :mock_vision do
   it "knows the features" do
     face.features.wont_be :nil?
 
-    face.features.confidence.must_equal 34.489909
-    face.features.chin.center.to_a.must_equal [143.34183, 262.22998, -57.388493]
-    face.features.chin.left.to_a.must_equal   [63.102425, 248.99081, 44.207638]
-    face.features.chin.right.to_a.must_equal  [241.72728, 225.53488, 19.758242]
+    face.features.confidence.must_be_close_to 34.489909
+    face.features.chin.center.to_a.must_be_close_to_array [143.34183, 262.22998, -57.388493]
+    face.features.chin.left.to_a.must_be_close_to_array   [63.102425, 248.99081, 44.207638]
+    face.features.chin.right.to_a.must_be_close_to_array  [241.72728, 225.53488, 19.758242]
 
-    face.features.ears.left.to_a.must_equal  [54.872219, 207.23712, 97.030685]
-    face.features.ears.right.to_a.must_equal [252.67567, 180.43124, 70.15992]
+    face.features.ears.left.to_a.must_be_close_to_array  [54.872219, 207.23712, 97.030685]
+    face.features.ears.right.to_a.must_be_close_to_array [252.67567, 180.43124, 70.15992]
 
-    face.features.eyebrows.left.left.to_a.must_equal  [58.790176, 113.28249, 17.89735]
-    face.features.eyebrows.left.right.to_a.must_equal [106.14151, 98.593758, -13.116687]
-    face.features.eyebrows.left.top.to_a.must_equal   [80.248711, 94.04303, 0.21131183]
+    face.features.eyebrows.left.left.to_a.must_be_close_to_array  [58.790176, 113.28249, 17.89735]
+    face.features.eyebrows.left.right.to_a.must_be_close_to_array [106.14151, 98.593758, -13.116687]
+    face.features.eyebrows.left.top.to_a.must_be_close_to_array   [80.248711, 94.04303, 0.21131183]
 
-    face.features.eyebrows.right.left.to_a.must_equal  [148.61565, 92.294594, -18.804882]
-    face.features.eyebrows.right.right.to_a.must_equal [204.40808, 94.300117, -2.0009689]
-    face.features.eyebrows.right.top.to_a.must_equal   [174.70135, 81.580917, -12.702137]
+    face.features.eyebrows.right.left.to_a.must_be_close_to_array  [148.61565, 92.294594, -18.804882]
+    face.features.eyebrows.right.right.to_a.must_be_close_to_array [204.40808, 94.300117, -2.0009689]
+    face.features.eyebrows.right.top.to_a.must_be_close_to_array   [174.70135, 81.580917, -12.702137]
 
-    face.features.eyes.left.bottom.to_a.must_equal [84.883934, 134.59479, -2.8677137]
-    face.features.eyes.left.center.to_a.must_equal [83.707092, 128.34, -0.00013388535]
-    face.features.eyes.left.left.to_a.must_equal [72.213913, 132.04138, 9.6985674]
-    face.features.eyes.left.pupil.to_a.must_equal [86.531624, 126.49807, -2.2496929]
-    face.features.eyes.left.right.to_a.must_equal [105.28892, 125.57655, -2.51554]
-    face.features.eyes.left.top.to_a.must_equal [86.706947, 119.47144, -4.1606765]
+    face.features.eyes.left.bottom.to_a.must_be_close_to_array [84.883934, 134.59479, -2.8677137]
+    face.features.eyes.left.center.to_a.must_be_close_to_array [83.707092, 128.34, -0.00013388535]
+    face.features.eyes.left.left.to_a.must_be_close_to_array [72.213913, 132.04138, 9.6985674]
+    face.features.eyes.left.pupil.to_a.must_be_close_to_array [86.531624, 126.49807, -2.2496929]
+    face.features.eyes.left.right.to_a.must_be_close_to_array [105.28892, 125.57655, -2.51554]
+    face.features.eyes.left.top.to_a.must_be_close_to_array [86.706947, 119.47144, -4.1606765]
 
-    face.features.eyes.right.bottom.to_a.must_equal [179.30353, 121.03307, -14.843414]
-    face.features.eyes.right.center.to_a.must_equal [181.17694, 115.16437, -12.82961]
-    face.features.eyes.right.left.to_a.must_equal [158.2863, 118.491, -9.723031]
-    face.features.eyes.right.pupil.to_a.must_equal [175.99976, 114.64407, -14.53744]
-    face.features.eyes.right.right.to_a.must_equal [194.59413, 115.91954, -6.952745]
-    face.features.eyes.right.top.to_a.must_equal [173.99446, 107.94287, -16.050705]
+    face.features.eyes.right.bottom.to_a.must_be_close_to_array [179.30353, 121.03307, -14.843414]
+    face.features.eyes.right.center.to_a.must_be_close_to_array [181.17694, 115.16437, -12.82961]
+    face.features.eyes.right.left.to_a.must_be_close_to_array [158.2863, 118.491, -9.723031]
+    face.features.eyes.right.pupil.to_a.must_be_close_to_array [175.99976, 114.64407, -14.53744]
+    face.features.eyes.right.right.to_a.must_be_close_to_array [194.59413, 115.91954, -6.952745]
+    face.features.eyes.right.top.to_a.must_be_close_to_array [173.99446, 107.94287, -16.050705]
 
-    face.features.forehead.to_a.must_equal [126.53813, 93.812057, -18.863352]
+    face.features.forehead.to_a.must_be_close_to_array [126.53813, 93.812057, -18.863352]
 
-    face.features.lips.bottom.to_a.must_equal [137.28528, 219.23564, -56.663128]
-    face.features.lips.lower.to_a.must_equal [137.28528, 219.23564, -56.663128]
-    face.features.lips.top.to_a.must_equal [134.74164, 192.50438, -53.876408]
-    face.features.lips.upper.to_a.must_equal [134.74164, 192.50438, -53.876408]
+    face.features.lips.bottom.to_a.must_be_close_to_array [137.28528, 219.23564, -56.663128]
+    face.features.lips.lower.to_a.must_be_close_to_array [137.28528, 219.23564, -56.663128]
+    face.features.lips.top.to_a.must_be_close_to_array [134.74164, 192.50438, -53.876408]
+    face.features.lips.upper.to_a.must_be_close_to_array [134.74164, 192.50438, -53.876408]
 
-    face.features.mouth.center.to_a.must_equal [136.43481, 204.37952, -51.620205]
-    face.features.mouth.left.to_a.must_equal [104.53558, 214.05037, -30.056231]
-    face.features.mouth.right.to_a.must_equal [173.79134, 204.99333, -39.725758]
+    face.features.mouth.center.to_a.must_be_close_to_array [136.43481, 204.37952, -51.620205]
+    face.features.mouth.left.to_a.must_be_close_to_array [104.53558, 214.05037, -30.056231]
+    face.features.mouth.right.to_a.must_be_close_to_array [173.79134, 204.99333, -39.725758]
 
-    face.features.nose.bottom.to_a.must_equal [133.81947, 173.16437, -48.287724]
-    face.features.nose.left.to_a.must_equal [110.98372, 173.61331, -29.7784]
-    face.features.nose.right.to_a.must_equal [161.31354, 168.24527, -36.1628]
-    face.features.nose.tip.to_a.must_equal [128.14919, 153.68129, -63.198204]
-    face.features.nose.top.to_a.must_equal [127.83745, 110.17557, -22.650913]
+    face.features.nose.bottom.to_a.must_be_close_to_array [133.81947, 173.16437, -48.287724]
+    face.features.nose.left.to_a.must_be_close_to_array [110.98372, 173.61331, -29.7784]
+    face.features.nose.right.to_a.must_be_close_to_array [161.31354, 168.24527, -36.1628]
+    face.features.nose.tip.to_a.must_be_close_to_array [128.14919, 153.68129, -63.198204]
+    face.features.nose.top.to_a.must_be_close_to_array [127.83745, 110.17557, -22.650913]
   end
 
   it "knows the likelihood" do
@@ -105,17 +106,17 @@ describe Google::Cloud::Vision::Annotation::Face, :mock_vision do
     face.likelihood.blurred?.must_equal false
     face.likelihood.headwear?.must_equal false
 
-    face.likelihood.joy.must_equal "LIKELY"
-    face.likelihood.sorrow.must_equal "UNLIKELY"
-    face.likelihood.anger.must_equal "VERY_UNLIKELY"
-    face.likelihood.surprise.must_equal "UNLIKELY"
-    face.likelihood.under_exposed.must_equal "VERY_UNLIKELY"
-    face.likelihood.blurred.must_equal "VERY_UNLIKELY"
-    face.likelihood.headwear.must_equal "VERY_UNLIKELY"
+    face.likelihood.joy.must_equal :LIKELY
+    face.likelihood.sorrow.must_equal :UNLIKELY
+    face.likelihood.anger.must_equal :VERY_UNLIKELY
+    face.likelihood.surprise.must_equal :UNLIKELY
+    face.likelihood.under_exposed.must_equal :VERY_UNLIKELY
+    face.likelihood.blurred.must_equal :VERY_UNLIKELY
+    face.likelihood.headwear.must_equal :VERY_UNLIKELY
   end
 
   it "knows the confidence" do
-    face.confidence.must_equal 0.56748849
+    face.confidence.must_be_close_to 0.56748849
   end
 
   it "can convert to a hash" do
@@ -131,7 +132,7 @@ describe Google::Cloud::Vision::Annotation::Face, :mock_vision do
     face.to_s.must_equal "(angles, bounds, features, likelihood)"
     face.inspect.must_include face.to_s
 
-    face.angles.to_s.must_equal "(roll: -0.050002542, yaw: -0.081090336, pitch: 0.18012161)"
+    face.angles.to_s.must_equal "(roll: -0.05000254139304161, yaw: -0.08109033852815628, pitch: 0.18012161552906036)"
     face.angles.inspect.must_include face.angles.to_s
 
     face.bounds.inspect.must_include face.bounds.to_s

--- a/google-cloud-vision/test/google/cloud/vision/annotation/label_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/label_test.rb
@@ -16,16 +16,16 @@ require "helper"
 
 describe Google::Cloud::Vision::Annotation::Entity, :label, :mock_vision do
   # Run through JSON to turn all keys to strings...
-  let(:gapi) { label_annotation_response }
-  let(:label) { Google::Cloud::Vision::Annotation::Entity.from_gapi gapi }
+  let(:grpc) { label_annotation_response }
+  let(:label) { Google::Cloud::Vision::Annotation::Entity.from_grpc grpc }
 
   it "knows the given attributes" do
     label.mid.must_equal "/m/02wtjj"
-    label.locale.must_be :nil?
+    label.locale.must_be :empty?
     label.description.must_equal "stone carving"
-    label.score.must_equal 0.9859733
-    label.confidence.must_be :nil?
-    label.topicality.must_be :nil?
+    label.score.must_be_close_to 0.9859733
+    label.confidence.must_be :zero?
+    label.topicality.must_be :zero?
     label.bounds.must_be :empty?
     label.locations.must_be :empty?
     label.properties.must_be :empty?
@@ -35,18 +35,18 @@ describe Google::Cloud::Vision::Annotation::Entity, :label, :mock_vision do
     hash = label.to_h
     hash.must_be_kind_of Hash
     hash[:mid].must_equal "/m/02wtjj"
-    hash[:locale].must_equal nil
+    hash[:locale].must_equal ""
     hash[:description].must_equal "stone carving"
-    hash[:score].must_equal 0.9859733
-    hash[:confidence].must_equal nil
-    hash[:topicality].must_equal nil
+    hash[:score].must_be_close_to 0.9859733
+    hash[:confidence].must_equal 0.0
+    hash[:topicality].must_equal 0.0
     hash[:bounds].must_equal []
     hash[:locations].must_equal []
     hash[:properties].must_equal({})
   end
 
   it "can convert to a string" do
-    label.to_s.must_equal "mid: \"/m/02wtjj\", locale: nil, description: \"stone carving\", score: 0.9859733, confidence: nil, topicality: nil, bounds: 0, locations: 0, properties: {}"
+    label.to_s.must_equal "mid: \"/m/02wtjj\", locale: \"\", description: \"stone carving\", score: 0.9859732985496521, confidence: 0.0, topicality: 0.0, bounds: 0, locations: 0, properties: {}"
     label.inspect.must_include label.to_s
   end
 end

--- a/google-cloud-vision/test/google/cloud/vision/annotation/landmark_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/landmark_test.rb
@@ -16,23 +16,23 @@ require "helper"
 
 describe Google::Cloud::Vision::Annotation::Entity, :landmark, :mock_vision do
   # Run through JSON to turn all keys to strings...
-  let(:gapi) { landmark_annotation_response }
-  let(:landmark) { Google::Cloud::Vision::Annotation::Entity.from_gapi gapi }
+  let(:grpc) { landmark_annotation_response }
+  let(:landmark) { Google::Cloud::Vision::Annotation::Entity.from_grpc grpc }
 
   it "knows the given attributes" do
     landmark.mid.must_equal "/m/019dvv"
-    landmark.locale.must_be :nil?
+    landmark.locale.must_be :empty?
     landmark.description.must_equal "Mount Rushmore"
-    landmark.score.must_equal 0.91912264
-    landmark.confidence.must_be :nil?
-    landmark.topicality.must_be :nil?
+    landmark.score.must_be_close_to 0.91912264
+    landmark.confidence.must_be :zero?
+    landmark.topicality.must_be :zero?
     landmark.bounds[0].to_a.must_equal [1,  0]
     landmark.bounds[1].to_a.must_equal [295, 0]
     landmark.bounds[2].to_a.must_equal [295, 301]
     landmark.bounds[3].to_a.must_equal [1,  301]
-    landmark.locations[0].latitude.must_equal 43.878264
-    landmark.locations[0].longitude.must_equal -103.45700740814209
-    landmark.locations[0].to_a.must_equal [43.878264, -103.45700740814209]
+    landmark.locations[0].latitude.must_be_close_to 43.878264
+    landmark.locations[0].longitude.must_be_close_to -103.45700740814209
+    landmark.locations[0].to_a.must_be_close_to_array [43.878264, -103.45700740814209]
     landmark.properties.must_be :empty?
   end
 
@@ -40,11 +40,11 @@ describe Google::Cloud::Vision::Annotation::Entity, :landmark, :mock_vision do
     hash = landmark.to_h
     hash.must_be_kind_of Hash
     hash[:mid].must_equal "/m/019dvv"
-    hash[:locale].must_equal nil
+    hash[:locale].must_equal ""
     hash[:description].must_equal "Mount Rushmore"
-    hash[:score].must_equal 0.91912264
-    hash[:confidence].must_equal nil
-    hash[:topicality].must_equal nil
+    hash[:score].must_be_close_to 0.91912264
+    hash[:confidence].must_equal 0.0
+    hash[:topicality].must_equal 0.0
     hash[:bounds].must_be_kind_of Array
     hash[:bounds][0].must_equal({ x: 1,  y: 0 })
     hash[:bounds][1].must_equal({ x: 295, y: 0 })
@@ -56,7 +56,7 @@ describe Google::Cloud::Vision::Annotation::Entity, :landmark, :mock_vision do
   end
 
   it "can convert to a string" do
-    landmark.to_s.must_equal "mid: \"/m/019dvv\", locale: nil, description: \"Mount Rushmore\", score: 0.91912264, confidence: nil, topicality: nil, bounds: 4, locations: 1, properties: {}"
+    landmark.to_s.must_equal "mid: \"/m/019dvv\", locale: \"\", description: \"Mount Rushmore\", score: 0.9191226363182068, confidence: 0.0, topicality: 0.0, bounds: 4, locations: 1, properties: {}"
     landmark.inspect.must_include landmark.to_s
 
     landmark.locations.each do |location|

--- a/google-cloud-vision/test/google/cloud/vision/annotation/logo_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/logo_test.rb
@@ -16,16 +16,16 @@ require "helper"
 
 describe Google::Cloud::Vision::Annotation::Entity, :logo, :mock_vision do
   # Run through JSON to turn all keys to strings...
-  let(:gapi) { logo_annotation_response }
-  let(:logo) { Google::Cloud::Vision::Annotation::Entity.from_gapi gapi }
+  let(:grpc) { logo_annotation_response }
+  let(:logo) { Google::Cloud::Vision::Annotation::Entity.from_grpc grpc }
 
   it "knows the given attributes" do
     logo.mid.must_equal "/m/045c7b"
-    logo.locale.must_be :nil?
+    logo.locale.must_be :empty?
     logo.description.must_equal "Google"
-    logo.score.must_equal 0.6435439
-    logo.confidence.must_be :nil?
-    logo.topicality.must_be :nil?
+    logo.score.must_be_close_to 0.6435439
+    logo.confidence.must_be :zero?
+    logo.topicality.must_be :zero?
     logo.bounds[0].to_a.must_equal [1,  0]
     logo.bounds[1].to_a.must_equal [295, 0]
     logo.bounds[2].to_a.must_equal [295, 301]
@@ -38,11 +38,11 @@ describe Google::Cloud::Vision::Annotation::Entity, :logo, :mock_vision do
     hash = logo.to_h
     hash.must_be_kind_of Hash
     hash[:mid].must_equal "/m/045c7b"
-    hash[:locale].must_equal nil
+    hash[:locale].must_equal ""
     hash[:description].must_equal "Google"
-    hash[:score].must_equal 0.6435439
-    hash[:confidence].must_equal nil
-    hash[:topicality].must_equal nil
+    hash[:score].must_be_close_to 0.6435439
+    hash[:confidence].must_equal 0.0
+    hash[:topicality].must_equal 0.0
     hash[:bounds].must_be_kind_of Array
     hash[:bounds][0].must_equal({ x: 1,   y: 0 })
     hash[:bounds][1].must_equal({ x: 295, y: 0 })
@@ -53,7 +53,7 @@ describe Google::Cloud::Vision::Annotation::Entity, :logo, :mock_vision do
   end
 
   it "can convert to a string" do
-    logo.to_s.must_equal "mid: \"/m/045c7b\", locale: nil, description: \"Google\", score: 0.6435439, confidence: nil, topicality: nil, bounds: 4, locations: 0, properties: {}"
+    logo.to_s.must_equal "mid: \"/m/045c7b\", locale: \"\", description: \"Google\", score: 0.6435438990592957, confidence: 0.0, topicality: 0.0, bounds: 4, locations: 0, properties: {}"
     logo.inspect.must_include logo.to_s
   end
 end

--- a/google-cloud-vision/test/google/cloud/vision/annotation/properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/properties_test.rb
@@ -16,8 +16,8 @@ require "helper"
 
 describe Google::Cloud::Vision::Annotation::Properties, :mock_vision do
   # Run through JSON to turn all keys to strings...
-  let(:gapi) { properties_annotation_response }
-  let(:properties) { Google::Cloud::Vision::Annotation::Properties.from_gapi gapi }
+  let(:grpc) { properties_annotation_response }
+  let(:properties) { Google::Cloud::Vision::Annotation::Properties.from_grpc grpc }
 
   it "knows the given attributes" do
     properties.wont_be :nil?
@@ -30,40 +30,40 @@ describe Google::Cloud::Vision::Annotation::Properties, :mock_vision do
     properties.colors[0].blue.must_equal 254
     properties.colors[0].alpha.must_equal 1.0
     properties.colors[0].rgb.must_equal "91c1fe"
-    properties.colors[0].score.must_equal 0.65757853
-    properties.colors[0].pixel_fraction.must_equal 0.16903226
+    properties.colors[0].score.must_be_close_to 0.65757853
+    properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
     properties.colors[1].red.must_equal 0
     properties.colors[1].green.must_equal 0
     properties.colors[1].blue.must_equal 0
     properties.colors[1].alpha.must_equal 1.0
     properties.colors[1].rgb.must_equal "000000"
-    properties.colors[1].score.must_equal 0.09256918
-    properties.colors[1].pixel_fraction.must_equal 0.19258064
+    properties.colors[1].score.must_be_close_to 0.09256918
+    properties.colors[1].pixel_fraction.must_be_close_to 0.19258064
 
     properties.colors[2].red.must_equal 255
     properties.colors[2].green.must_equal 255
     properties.colors[2].blue.must_equal 255
     properties.colors[2].alpha.must_equal 1.0
     properties.colors[2].rgb.must_equal "ffffff"
-    properties.colors[2].score.must_equal 0.1002003
-    properties.colors[2].pixel_fraction.must_equal 0.022258064
+    properties.colors[2].score.must_be_close_to 0.1002003
+    properties.colors[2].pixel_fraction.must_be_close_to 0.022258064
 
     properties.colors[3].red.must_equal 3
     properties.colors[3].green.must_equal 4
     properties.colors[3].blue.must_equal 254
     properties.colors[3].alpha.must_equal 1.0
     properties.colors[3].rgb.must_equal "0304fe"
-    properties.colors[3].score.must_equal 0.089072376
-    properties.colors[3].pixel_fraction.must_equal 0.054516129
+    properties.colors[3].score.must_be_close_to 0.089072376
+    properties.colors[3].pixel_fraction.must_be_close_to 0.054516129
 
     properties.colors[9].red.must_equal 156
     properties.colors[9].green.must_equal 214
     properties.colors[9].blue.must_equal 255
     properties.colors[9].alpha.must_equal 1.0
     properties.colors[9].rgb.must_equal "9cd6ff"
-    properties.colors[9].score.must_equal 0.00096750073
-    properties.colors[9].pixel_fraction.must_equal 0.00064516132
+    properties.colors[9].score.must_be_close_to 0.00096750073
+    properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
   end
 
   it "can convert to a hash" do

--- a/google-cloud-vision/test/google/cloud/vision/annotation/safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/safe_search_test.rb
@@ -16,8 +16,8 @@ require "helper"
 
 describe Google::Cloud::Vision::Annotation::SafeSearch, :mock_vision do
   # Run through JSON to turn all keys to strings...
-  let(:gapi) { safe_search_annotation_response }
-  let(:safe_search) { Google::Cloud::Vision::Annotation::SafeSearch.from_gapi gapi }
+  let(:grpc) { safe_search_annotation_response }
+  let(:safe_search) { Google::Cloud::Vision::Annotation::SafeSearch.from_grpc grpc }
 
   it "knows the given attributes" do
     safe_search.wont_be :nil?
@@ -27,10 +27,10 @@ describe Google::Cloud::Vision::Annotation::SafeSearch, :mock_vision do
     safe_search.must_be :medical?
     safe_search.must_be :violence?
 
-    safe_search.adult.must_equal "VERY_UNLIKELY"
-    safe_search.spoof.must_equal "UNLIKELY"
-    safe_search.medical.must_equal "POSSIBLE"
-    safe_search.violence.must_equal "LIKELY"
+    safe_search.adult.must_equal :VERY_UNLIKELY
+    safe_search.spoof.must_equal :UNLIKELY
+    safe_search.medical.must_equal :POSSIBLE
+    safe_search.violence.must_equal :LIKELY
   end
 
   it "can convert to a hash" do

--- a/google-cloud-vision/test/google/cloud/vision/annotation/text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/text_test.rb
@@ -16,8 +16,8 @@ require "helper"
 
 describe Google::Cloud::Vision::Annotation::Text, :mock_vision do
   # Run through JSON to turn all keys to strings...
-  let(:gapi_list) { text_annotation_responses }
-  let(:text) { Google::Cloud::Vision::Annotation::Text.from_gapi gapi_list }
+  let(:grpc_list) { text_annotation_responses }
+  let(:text) { Google::Cloud::Vision::Annotation::Text.from_grpc grpc_list }
 
   it "knows the given attributes" do
     text.text.must_include "Google Cloud Client for Ruby"

--- a/google-cloud-vision/test/google/cloud/vision/image/context_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/context_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Vision::Image::Context, :mock_vision do
   it "is empty by default" do
     image.context.must_be :empty?
 
-    image.context.to_gapi.must_be :nil?
+    image.context.to_grpc.must_be :nil?
   end
 
   it "is can populate the location" do
@@ -32,9 +32,9 @@ describe Google::Cloud::Vision::Image::Context, :mock_vision do
     image.context.area.max.latitude = 37.4320041
     image.context.wont_be :empty?
 
-    image.context.to_gapi.wont_be :nil?
-    image.context.to_gapi.must_be_kind_of Google::Apis::VisionV1::ImageContext
-    lat_long_rect_must_equal image.context.to_gapi.lat_long_rect
+    image.context.to_grpc.wont_be :nil?
+    image.context.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::ImageContext
+    lat_long_rect_must_equal image.context.to_grpc.lat_long_rect
   end
 
   it "is can set the location object" do
@@ -42,9 +42,9 @@ describe Google::Cloud::Vision::Image::Context, :mock_vision do
     image.context.area.max = Google::Cloud::Vision::Location.new 37.4320041, -122.0762462
     image.context.wont_be :empty?
 
-    image.context.to_gapi.wont_be :nil?
-    image.context.to_gapi.must_be_kind_of Google::Apis::VisionV1::ImageContext
-    lat_long_rect_must_equal image.context.to_gapi.lat_long_rect
+    image.context.to_grpc.wont_be :nil?
+    image.context.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::ImageContext
+    lat_long_rect_must_equal image.context.to_grpc.lat_long_rect
   end
 
   it "is can set a location with a hash" do
@@ -52,9 +52,9 @@ describe Google::Cloud::Vision::Image::Context, :mock_vision do
     image.context.area.max = { longitude: -122.0762462, latitude: 37.4320041 }
     image.context.wont_be :empty?
 
-    image.context.to_gapi.wont_be :nil?
-    image.context.to_gapi.must_be_kind_of Google::Apis::VisionV1::ImageContext
-    lat_long_rect_must_equal image.context.to_gapi.lat_long_rect
+    image.context.to_grpc.wont_be :nil?
+    image.context.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::ImageContext
+    lat_long_rect_must_equal image.context.to_grpc.lat_long_rect
   end
 
   it "is can populate language hints" do
@@ -62,18 +62,18 @@ describe Google::Cloud::Vision::Image::Context, :mock_vision do
     image.context.languages << "es"
     image.context.wont_be :empty?
 
-    image.context.to_gapi.wont_be :nil?
-    image.context.to_gapi.must_be_kind_of Google::Apis::VisionV1::ImageContext
-    image.context.to_gapi.language_hints.must_equal language_hints
+    image.context.to_grpc.wont_be :nil?
+    image.context.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::ImageContext
+    image.context.to_grpc.language_hints.must_equal language_hints
   end
 
   it "is can set a language hints" do
     image.context.languages = ["en", "es"]
     image.context.wont_be :empty?
 
-    image.context.to_gapi.wont_be :nil?
-    image.context.to_gapi.must_be_kind_of Google::Apis::VisionV1::ImageContext
-    image.context.to_gapi.language_hints.must_equal language_hints
+    image.context.to_grpc.wont_be :nil?
+    image.context.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::ImageContext
+    image.context.to_grpc.language_hints.must_equal language_hints
   end
 
   it "is can set all the things" do
@@ -82,19 +82,19 @@ describe Google::Cloud::Vision::Image::Context, :mock_vision do
     image.context.languages = ["en", "es"]
     image.context.wont_be :empty?
 
-    image.context.to_gapi.wont_be :nil?
-    image.context.to_gapi.must_be_kind_of Google::Apis::VisionV1::ImageContext
-    lat_long_rect_must_equal image.context.to_gapi.lat_long_rect
-    image.context.to_gapi.language_hints.must_equal language_hints
+    image.context.to_grpc.wont_be :nil?
+    image.context.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::ImageContext
+    lat_long_rect_must_equal image.context.to_grpc.lat_long_rect
+    image.context.to_grpc.language_hints.must_equal language_hints
   end
 
-  def lat_long_rect_must_equal lat_long_rect_gapi
-    lat_long_rect_gapi.must_be_kind_of Google::Apis::VisionV1::LatLongRect
-    lat_long_rect_gapi.min_lat_lng.must_be_kind_of Google::Apis::VisionV1::LatLng
-    lat_long_rect_gapi.min_lat_lng.latitude.must_equal 37.4220041
-    lat_long_rect_gapi.min_lat_lng.longitude.must_equal -122.0862462
-    lat_long_rect_gapi.max_lat_lng.must_be_kind_of Google::Apis::VisionV1::LatLng
-    lat_long_rect_gapi.max_lat_lng.latitude.must_equal 37.4320041
-    lat_long_rect_gapi.max_lat_lng.longitude.must_equal -122.0762462
+  def lat_long_rect_must_equal lat_long_rect_grpc
+    lat_long_rect_grpc.must_be_kind_of Google::Cloud::Vision::V1::LatLongRect
+    lat_long_rect_grpc.min_lat_lng.must_be_kind_of Google::Type::LatLng
+    lat_long_rect_grpc.min_lat_lng.latitude.must_be_close_to 37.4220041
+    lat_long_rect_grpc.min_lat_lng.longitude.must_be_close_to -122.0862462
+    lat_long_rect_grpc.max_lat_lng.must_be_kind_of Google::Type::LatLng
+    lat_long_rect_grpc.max_lat_lng.latitude.must_be_close_to 37.4320041
+    lat_long_rect_grpc.max_lat_lng.longitude.must_be_close_to -122.0762462
   end
 end

--- a/google-cloud-vision/test/google/cloud/vision/image/faces_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/faces_test.rb
@@ -19,17 +19,15 @@ describe Google::Cloud::Vision::Image, :faces, :mock_vision do
   let(:image)    { vision.image filepath }
 
   it "detects multiple faces" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 10)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 10)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, faces_response_gapi, [req]
+    mock.expect :batch_annotate_images, faces_response_grpc, [req]
 
     vision.service.mocked_service = mock
     faces = image.faces 10
@@ -39,17 +37,15 @@ describe Google::Cloud::Vision::Image, :faces, :mock_vision do
   end
 
   it "detects multiple faces without specifying a count" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 100)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 100)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, faces_response_gapi, [req]
+    mock.expect :batch_annotate_images, faces_response_grpc, [req]
 
     vision.service.mocked_service = mock
     faces = image.faces
@@ -59,17 +55,15 @@ describe Google::Cloud::Vision::Image, :faces, :mock_vision do
   end
 
   it "detects a face" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, face_response_gapi, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req]
 
     vision.service.mocked_service = mock
     face = image.face
@@ -78,10 +72,10 @@ describe Google::Cloud::Vision::Image, :faces, :mock_vision do
     face.wont_be :nil?
   end
 
-  def face_response_gapi
-    Google::Apis::VisionV1::BatchAnnotateImagesResponse.new(
+  def face_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        Google::Apis::VisionV1::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           face_annotations: [
             face_annotation_response
           ]
@@ -90,10 +84,10 @@ describe Google::Cloud::Vision::Image, :faces, :mock_vision do
     )
   end
 
-  def faces_response_gapi
-    Google::Apis::VisionV1::BatchAnnotateImagesResponse.new(
+  def faces_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        Google::Apis::VisionV1::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           face_annotations: [
             face_annotation_response,
             face_annotation_response,

--- a/google-cloud-vision/test/google/cloud/vision/image/labels_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/labels_test.rb
@@ -20,17 +20,15 @@ describe Google::Cloud::Vision::Image, :labels, :mock_vision do
   let(:image)    { vision.image filepath }
 
   it "detects multiple labels" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: 10)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: 10)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, labels_response_gapi, [req]
+    mock.expect :batch_annotate_images, labels_response_grpc, [req]
 
     vision.service.mocked_service = mock
     labels = image.labels 10
@@ -40,17 +38,15 @@ describe Google::Cloud::Vision::Image, :labels, :mock_vision do
   end
 
   it "detects multiple labels without specifying a count" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: 100)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: 100)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, labels_response_gapi, [req]
+    mock.expect :batch_annotate_images, labels_response_grpc, [req]
 
     vision.service.mocked_service = mock
     labels = image.labels
@@ -60,17 +56,15 @@ describe Google::Cloud::Vision::Image, :labels, :mock_vision do
   end
 
   it "detects a label" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, label_response_gapi, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req]
 
     vision.service.mocked_service = mock
     label = image.label
@@ -79,10 +73,10 @@ describe Google::Cloud::Vision::Image, :labels, :mock_vision do
     label.wont_be :nil?
   end
 
-  def label_response_gapi
-    Google::Apis::VisionV1::BatchAnnotateImagesResponse.new(
+  def label_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        Google::Apis::VisionV1::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           label_annotations: [
             label_annotation_response
           ]
@@ -91,10 +85,10 @@ describe Google::Cloud::Vision::Image, :labels, :mock_vision do
     )
   end
 
-  def labels_response_gapi
-    Google::Apis::VisionV1::BatchAnnotateImagesResponse.new(
+  def labels_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        Google::Apis::VisionV1::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           label_annotations: [
             label_annotation_response,
             label_annotation_response,

--- a/google-cloud-vision/test/google/cloud/vision/image/landmarks_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/landmarks_test.rb
@@ -20,17 +20,15 @@ describe Google::Cloud::Vision::Image, :landmarks, :mock_vision do
   let(:image)    { vision.image filepath }
 
   it "detects multiple landmarks" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 10)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 10)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmarks_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmarks_response_grpc, [req]
 
     vision.service.mocked_service = mock
     landmarks = image.landmarks 10
@@ -40,17 +38,15 @@ describe Google::Cloud::Vision::Image, :landmarks, :mock_vision do
   end
 
   it "detects multiple landmarks without specifying a count" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 100)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 100)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmarks_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmarks_response_grpc, [req]
 
     vision.service.mocked_service = mock
     landmarks = image.landmarks
@@ -60,17 +56,15 @@ describe Google::Cloud::Vision::Image, :landmarks, :mock_vision do
   end
 
   it "detects a landmark" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmark_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
 
     vision.service.mocked_service = mock
     landmark = image.landmark
@@ -79,10 +73,10 @@ describe Google::Cloud::Vision::Image, :landmarks, :mock_vision do
     landmark.wont_be :nil?
   end
 
-  def landmark_response_gapi
-    Google::Apis::VisionV1::BatchAnnotateImagesResponse.new(
+  def landmark_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        Google::Apis::VisionV1::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           landmark_annotations: [
             landmark_annotation_response
           ]
@@ -91,10 +85,10 @@ describe Google::Cloud::Vision::Image, :landmarks, :mock_vision do
     )
   end
 
-  def landmarks_response_gapi
-    Google::Apis::VisionV1::BatchAnnotateImagesResponse.new(
+  def landmarks_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        Google::Apis::VisionV1::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           landmark_annotations: [
             landmark_annotation_response,
             landmark_annotation_response,

--- a/google-cloud-vision/test/google/cloud/vision/image/logos_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/logos_test.rb
@@ -20,17 +20,15 @@ describe Google::Cloud::Vision::Image, :logos, :mock_vision do
   let(:image)    { vision.image filepath }
 
   it "detects multiple logos" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: 10)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: 10)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logos_response_gapi, [req]
+    mock.expect :batch_annotate_images, logos_response_grpc, [req]
 
     vision.service.mocked_service = mock
     logos = image.logos 10
@@ -40,17 +38,15 @@ describe Google::Cloud::Vision::Image, :logos, :mock_vision do
   end
 
   it "detects multiple logos without specifying a count" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: 100)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: 100)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logos_response_gapi, [req]
+    mock.expect :batch_annotate_images, logos_response_grpc, [req]
 
     vision.service.mocked_service = mock
     logos = image.logos
@@ -60,17 +56,15 @@ describe Google::Cloud::Vision::Image, :logos, :mock_vision do
   end
 
   it "detects a logo" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logo_response_gapi, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req]
 
     vision.service.mocked_service = mock
     logo = image.logo
@@ -79,10 +73,10 @@ describe Google::Cloud::Vision::Image, :logos, :mock_vision do
     logo.wont_be :nil?
   end
 
-  def logo_response_gapi
-    Google::Apis::VisionV1::BatchAnnotateImagesResponse.new(
+  def logo_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        Google::Apis::VisionV1::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           logo_annotations: [
             logo_annotation_response
           ]
@@ -91,10 +85,10 @@ describe Google::Cloud::Vision::Image, :logos, :mock_vision do
     )
   end
 
-  def logos_response_gapi
-    Google::Apis::VisionV1::BatchAnnotateImagesResponse.new(
+  def logos_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        Google::Apis::VisionV1::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           logo_annotations: [
             logo_annotation_response,
             logo_annotation_response,

--- a/google-cloud-vision/test/google/cloud/vision/image/properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/properties_test.rb
@@ -20,17 +20,15 @@ describe Google::Cloud::Vision::Image, :properties, :mock_vision do
   let(:image)    { vision.image filepath }
 
   it "detects properties" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "IMAGE_PROPERTIES", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :IMAGE_PROPERTIES, max_results: 1)
+    req =[
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, properties_response_gapi, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req]
 
     vision.service.mocked_service = mock
     properties = image.properties
@@ -43,22 +41,22 @@ describe Google::Cloud::Vision::Image, :properties, :mock_vision do
     properties.colors[0].blue.must_equal 254
     properties.colors[0].alpha.must_equal 1.0
     properties.colors[0].rgb.must_equal "91c1fe"
-    properties.colors[0].score.must_equal 0.65757853
-    properties.colors[0].pixel_fraction.must_equal 0.16903226
+    properties.colors[0].score.must_be_close_to 0.65757853
+    properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
     properties.colors[9].red.must_equal 156
     properties.colors[9].green.must_equal 214
     properties.colors[9].blue.must_equal 255
     properties.colors[9].alpha.must_equal 1.0
     properties.colors[9].rgb.must_equal "9cd6ff"
-    properties.colors[9].score.must_equal 0.00096750073
-    properties.colors[9].pixel_fraction.must_equal 0.00064516132
+    properties.colors[9].score.must_be_close_to 0.00096750073
+    properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
   end
 
-  def properties_response_gapi
-    Google::Apis::VisionV1::BatchAnnotateImagesResponse.new(
+  def properties_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        Google::Apis::VisionV1::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           image_properties_annotation: properties_annotation_response
         )
       ]

--- a/google-cloud-vision/test/google/cloud/vision/image/safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/safe_search_test.rb
@@ -20,17 +20,15 @@ describe Google::Cloud::Vision::Image, :safe_search, :mock_vision do
   let(:image)    { vision.image filepath }
 
   it "detects safe_search" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "SAFE_SEARCH_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :SAFE_SEARCH_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, safe_search_response_gapi, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
 
     vision.service.mocked_service = mock
     safe_search = image.safe_search
@@ -43,10 +41,10 @@ describe Google::Cloud::Vision::Image, :safe_search, :mock_vision do
     safe_search.must_be :violence?
   end
 
-  def safe_search_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def safe_search_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           safe_search_annotation: safe_search_annotation_response
         )
       ]

--- a/google-cloud-vision/test/google/cloud/vision/image/text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/text_test.rb
@@ -20,17 +20,15 @@ describe Google::Cloud::Vision::Image, :text, :mock_vision do
   let(:image)    { vision.image filepath }
 
   it "detects text" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, text_response_gapi, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req]
 
     vision.service.mocked_service = mock
 
@@ -47,10 +45,10 @@ describe Google::Cloud::Vision::Image, :text, :mock_vision do
     text.words[27].bounds.map(&:to_a).must_equal [[304, 59], [351, 59], [351, 74], [304, 74]]
   end
 
-  def text_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def text_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           text_annotations: text_annotation_responses
         )
       ]

--- a/google-cloud-vision/test/google/cloud/vision/image_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.wont_be :url?
 
     image.inspect.must_be_kind_of String
-    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
+    image.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::Image
   end
 
   it "can create from a Pathname object" do
@@ -37,7 +37,7 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.wont_be :url?
 
     image.inspect.must_be_kind_of String
-    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
+    image.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::Image
   end
 
   it "can create from a File object" do
@@ -48,7 +48,7 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.wont_be :url?
 
     image.inspect.must_be_kind_of String
-    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
+    image.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::Image
   end
 
   it "can create from a StringIO object" do
@@ -59,7 +59,7 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.wont_be :url?
 
     image.inspect.must_be_kind_of String
-    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
+    image.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::Image
   end
 
   it "can create from a Tempfile object" do
@@ -75,7 +75,7 @@ describe Google::Cloud::Vision::Image, :mock_vision do
       image.wont_be :url?
 
       image.inspect.must_be_kind_of String
-      image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
+      image.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::Image
     end
   end
 
@@ -87,7 +87,7 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.must_be :url?
 
     image.inspect.must_be_kind_of String
-    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
+    image.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::Image
   end
 
   it "can create from a Storage::File object" do
@@ -99,7 +99,7 @@ describe Google::Cloud::Vision::Image, :mock_vision do
     image.must_be :url?
 
     image.inspect.must_be_kind_of String
-    image.to_gapi.must_be_kind_of Google::Apis::VisionV1::Image
+    image.to_grpc.must_be_kind_of Google::Cloud::Vision::V1::Image
   end
 
   it "raises when giving an object that is not IO or a Google Storage URL" do

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_faces_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_faces_test.rb
@@ -18,17 +18,15 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
   let(:filepath) { "acceptance/data/face.jpg" }
 
   it "detects face detection using mark alias" do
-    feature = MockVision::API::Feature.new(type: "FACE_DETECTION", max_results: 1)
-    req = MockVision::API::BatchAnnotateImagesRequest.new(
-      requests: [
-        MockVision::API::AnnotateImageRequest.new(
-          image: MockVision::API::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, face_response_gapi, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, faces: 1
@@ -39,17 +37,15 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
   end
 
   it "detects face detection using detect alias" do
-    feature = MockVision::API::Feature.new(type: "FACE_DETECTION", max_results: 1)
-    req = MockVision::API::BatchAnnotateImagesRequest.new(
-      requests: [
-        MockVision::API::AnnotateImageRequest.new(
-          image: MockVision::API::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, face_response_gapi, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, faces: 1
@@ -60,21 +56,19 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
   end
 
   it "detects face detection on multiple images" do
-    feature = MockVision::API::Feature.new(type: "FACE_DETECTION", max_results: 1)
-    req = MockVision::API::BatchAnnotateImagesRequest.new(
-      requests: [
-        MockVision::API::AnnotateImageRequest.new(
-          image: MockVision::API::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        ),
-        MockVision::API::AnnotateImageRequest.new(
-          image: MockVision::API::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, faces_response_gapi, [req]
+    mock.expect :batch_annotate_images, faces_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, faces: 1
@@ -86,17 +80,15 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
   end
 
   it "uses the default configuration" do
-    feature = MockVision::API::Feature.new(type: "FACE_DETECTION", max_results: Google::Cloud::Vision.default_max_faces)
-    req = MockVision::API::BatchAnnotateImagesRequest.new(
-      requests: [
-        MockVision::API::AnnotateImageRequest.new(
-          image: MockVision::API::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: Google::Cloud::Vision.default_max_faces)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, face_response_gapi, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, faces: true
@@ -106,17 +98,15 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
   end
 
   it "uses the default configuration when given a truthy value" do
-    feature = MockVision::API::Feature.new(type: "FACE_DETECTION", max_results: Google::Cloud::Vision.default_max_faces)
-    req = MockVision::API::BatchAnnotateImagesRequest.new(
-      requests: [
-        MockVision::API::AnnotateImageRequest.new(
-          image: MockVision::API::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: Google::Cloud::Vision.default_max_faces)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, face_response_gapi, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, faces: "9999"
@@ -126,17 +116,15 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
   end
 
   it "uses the updated configuration" do
-    feature = MockVision::API::Feature.new(type: "FACE_DETECTION", max_results: 25)
-    req = MockVision::API::BatchAnnotateImagesRequest.new(
-      requests: [
-        MockVision::API::AnnotateImageRequest.new(
-          image: MockVision::API::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 25)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, face_response_gapi, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req]
     vision.service.mocked_service = mock
 
     Google::Cloud::Vision.stub :default_max_faces, 25 do
@@ -146,10 +134,10 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
     mock.verify
   end
 
-  def face_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def face_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           face_annotations: [
             face_annotation_response
           ]
@@ -158,15 +146,15 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
     )
   end
 
-  def faces_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def faces_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           face_annotations: [
             face_annotation_response
           ]
         ),
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           face_annotations: [
             face_annotation_response
           ]

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_labels_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_labels_test.rb
@@ -18,17 +18,15 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
   let(:filepath) { "acceptance/data/landmark.jpg" }
 
   it "detects label detection" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, label_response_gapi, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, labels: 1
@@ -39,17 +37,15 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
   end
 
   it "detects label detection using mark alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, label_response_gapi, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, labels: 1
@@ -60,17 +56,15 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
   end
 
   it "detects label detection using detect alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, label_response_gapi, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, labels: 1
@@ -81,21 +75,19 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
   end
 
   it "detects label detection on multiple images" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        ),
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, labels_response_gapi, [req]
+    mock.expect :batch_annotate_images, labels_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, labels: 1
@@ -107,17 +99,15 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
   end
 
   it "uses the default configuration" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: Google::Cloud::Vision.default_max_labels)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: Google::Cloud::Vision.default_max_labels)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, label_response_gapi, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, labels: true
@@ -128,17 +118,15 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
   end
 
   it "uses the default configuration when given a truthy value" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: Google::Cloud::Vision.default_max_labels)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: Google::Cloud::Vision.default_max_labels)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, label_response_gapi, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, labels: "9999"
@@ -149,17 +137,15 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
   end
 
   it "uses the updated configuration" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: 25)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: 25)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, label_response_gapi, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req]
 
     vision.service.mocked_service = mock
     Google::Cloud::Vision.stub :default_max_labels, 25 do
@@ -170,10 +156,10 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
     mock.verify
   end
 
-  def label_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def label_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           label_annotations: [
             label_annotation_response
           ]
@@ -182,15 +168,15 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
     )
   end
 
-  def labels_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def labels_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           label_annotations: [
             label_annotation_response
           ]
         ),
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           label_annotations: [
             label_annotation_response
           ]

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_landmarks_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_landmarks_test.rb
@@ -18,17 +18,15 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
   let(:filepath) { "acceptance/data/landmark.jpg" }
 
   it "detects landmark detection" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmark_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, landmarks: 1
@@ -39,17 +37,15 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
   end
 
   it "detects landmark detection using mark alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmark_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, landmarks: 1
@@ -60,17 +56,15 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
   end
 
   it "detects landmark detection using detect alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmark_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, landmarks: 1
@@ -81,21 +75,19 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
   end
 
   it "detects landmark detection on multiple images" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        ),
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmarks_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmarks_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, landmarks: 1
@@ -107,17 +99,15 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
   end
 
   it "uses the default configuration" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: Google::Cloud::Vision.default_max_landmarks)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: Google::Cloud::Vision.default_max_landmarks)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmark_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, landmarks: true
@@ -128,17 +118,15 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
   end
 
   it "uses the default configuration when given a truthy value" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: Google::Cloud::Vision.default_max_landmarks)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: Google::Cloud::Vision.default_max_landmarks)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmark_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, landmarks: "9999"
@@ -149,17 +137,15 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
   end
 
   it "uses the updated configuration" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 25)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 25)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, landmark_response_gapi, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
 
     vision.service.mocked_service = mock
     Google::Cloud::Vision.stub :default_max_landmarks, 25 do
@@ -171,10 +157,10 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
     mock.verify
   end
 
-  def landmark_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def landmark_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           landmark_annotations: [
             landmark_annotation_response
           ]
@@ -183,15 +169,15 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
     )
   end
 
-  def landmarks_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def landmarks_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           landmark_annotations: [
             landmark_annotation_response
           ]
         ),
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           landmark_annotations: [
             landmark_annotation_response
           ]

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_logos_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_logos_test.rb
@@ -18,17 +18,15 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
   let(:filepath) { "acceptance/data/logo.jpg" }
 
   it "detects logo detection" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logo_response_gapi, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, logos: 1
@@ -39,17 +37,15 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
   end
 
   it "detects logo detection using mark alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logo_response_gapi, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, logos: 1
@@ -60,17 +56,15 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
   end
 
   it "detects logo detection using detect alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logo_response_gapi, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, logos: 1
@@ -81,21 +75,19 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
   end
 
   it "detects logo detection on multiple images" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        ),
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logos_response_gapi, [req]
+    mock.expect :batch_annotate_images, logos_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, logos: 1
@@ -107,17 +99,15 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
   end
 
   it "uses the default configuration" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: Google::Cloud::Vision.default_max_logos)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: Google::Cloud::Vision.default_max_logos)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logo_response_gapi, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, logos: true
@@ -128,17 +118,15 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
   end
 
   it "uses the default configuration when given a truthy value" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: Google::Cloud::Vision.default_max_logos)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: Google::Cloud::Vision.default_max_logos)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logo_response_gapi, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, logos: "9999"
@@ -149,17 +137,15 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
   end
 
   it "uses the updated configuration" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: 25)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: 25)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, logo_response_gapi, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req]
 
     vision.service.mocked_service = mock
     Google::Cloud::Vision.stub :default_max_logos, 25 do
@@ -170,10 +156,10 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
     mock.verify
   end
 
-  def logo_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def logo_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           logo_annotations: [
             logo_annotation_response
           ]
@@ -182,15 +168,15 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
     )
   end
 
-  def logos_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def logos_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           logo_annotations: [
             logo_annotation_response
           ]
         ),
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           logo_annotations: [
             logo_annotation_response
           ]

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_properties_test.rb
@@ -18,17 +18,15 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
   let(:filepath) { "acceptance/data/face.jpg" }
 
   it "detects properties detection" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "IMAGE_PROPERTIES", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :IMAGE_PROPERTIES, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, properties_response_gapi, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, properties: true
@@ -43,30 +41,28 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
     annotation.properties.colors[0].blue.must_equal 254
     annotation.properties.colors[0].alpha.must_equal 1.0
     annotation.properties.colors[0].rgb.must_equal "91c1fe"
-    annotation.properties.colors[0].score.must_equal 0.65757853
-    annotation.properties.colors[0].pixel_fraction.must_equal 0.16903226
+    annotation.properties.colors[0].score.must_be_close_to 0.65757853
+    annotation.properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
     annotation.properties.colors[9].red.must_equal 156
     annotation.properties.colors[9].green.must_equal 214
     annotation.properties.colors[9].blue.must_equal 255
     annotation.properties.colors[9].alpha.must_equal 1.0
     annotation.properties.colors[9].rgb.must_equal "9cd6ff"
-    annotation.properties.colors[9].score.must_equal 0.00096750073
-    annotation.properties.colors[9].pixel_fraction.must_equal 0.00064516132
+    annotation.properties.colors[9].score.must_be_close_to 0.00096750073
+    annotation.properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
   end
 
   it "detects properties detection using mark alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "IMAGE_PROPERTIES", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :IMAGE_PROPERTIES, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, properties_response_gapi, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, properties: true
@@ -81,30 +77,28 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
     annotation.properties.colors[0].blue.must_equal 254
     annotation.properties.colors[0].alpha.must_equal 1.0
     annotation.properties.colors[0].rgb.must_equal "91c1fe"
-    annotation.properties.colors[0].score.must_equal 0.65757853
-    annotation.properties.colors[0].pixel_fraction.must_equal 0.16903226
+    annotation.properties.colors[0].score.must_be_close_to 0.65757853
+    annotation.properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
     annotation.properties.colors[9].red.must_equal 156
     annotation.properties.colors[9].green.must_equal 214
     annotation.properties.colors[9].blue.must_equal 255
     annotation.properties.colors[9].alpha.must_equal 1.0
     annotation.properties.colors[9].rgb.must_equal "9cd6ff"
-    annotation.properties.colors[9].score.must_equal 0.00096750073
-    annotation.properties.colors[9].pixel_fraction.must_equal 0.00064516132
+    annotation.properties.colors[9].score.must_be_close_to 0.00096750073
+    annotation.properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
   end
 
   it "detects properties detection using detect alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "IMAGE_PROPERTIES", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :IMAGE_PROPERTIES, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, properties_response_gapi, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, properties: true
@@ -119,34 +113,32 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
     annotation.properties.colors[0].blue.must_equal 254
     annotation.properties.colors[0].alpha.must_equal 1.0
     annotation.properties.colors[0].rgb.must_equal "91c1fe"
-    annotation.properties.colors[0].score.must_equal 0.65757853
-    annotation.properties.colors[0].pixel_fraction.must_equal 0.16903226
+    annotation.properties.colors[0].score.must_be_close_to 0.65757853
+    annotation.properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
     annotation.properties.colors[9].red.must_equal 156
     annotation.properties.colors[9].green.must_equal 214
     annotation.properties.colors[9].blue.must_equal 255
     annotation.properties.colors[9].alpha.must_equal 1.0
     annotation.properties.colors[9].rgb.must_equal "9cd6ff"
-    annotation.properties.colors[9].score.must_equal 0.00096750073
-    annotation.properties.colors[9].pixel_fraction.must_equal 0.00064516132
+    annotation.properties.colors[9].score.must_be_close_to 0.00096750073
+    annotation.properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
   end
 
   it "detects properties detection on multiple images" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "IMAGE_PROPERTIES", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        ),
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :IMAGE_PROPERTIES, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, plural_properties_response_gapi, [req]
+    mock.expect :batch_annotate_images, plural_properties_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, properties: true
@@ -161,16 +153,16 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
     annotations[0].properties.colors[0].blue.must_equal 254
     annotations[0].properties.colors[0].alpha.must_equal 1.0
     annotations[0].properties.colors[0].rgb.must_equal "91c1fe"
-    annotations[0].properties.colors[0].score.must_equal 0.65757853
-    annotations[0].properties.colors[0].pixel_fraction.must_equal 0.16903226
+    annotations[0].properties.colors[0].score.must_be_close_to 0.65757853
+    annotations[0].properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
     annotations[0].properties.colors[9].red.must_equal 156
     annotations[0].properties.colors[9].green.must_equal 214
     annotations[0].properties.colors[9].blue.must_equal 255
     annotations[0].properties.colors[9].alpha.must_equal 1.0
     annotations[0].properties.colors[9].rgb.must_equal "9cd6ff"
-    annotations[0].properties.colors[9].score.must_equal 0.00096750073
-    annotations[0].properties.colors[9].pixel_fraction.must_equal 0.00064516132
+    annotations[0].properties.colors[9].score.must_be_close_to 0.00096750073
+    annotations[0].properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
 
     annotations[1].properties.colors.count.must_equal 10
 
@@ -179,30 +171,28 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
     annotations[1].properties.colors[0].blue.must_equal 254
     annotations[1].properties.colors[0].alpha.must_equal 1.0
     annotations[1].properties.colors[0].rgb.must_equal "91c1fe"
-    annotations[1].properties.colors[0].score.must_equal 0.65757853
-    annotations[1].properties.colors[0].pixel_fraction.must_equal 0.16903226
+    annotations[1].properties.colors[0].score.must_be_close_to 0.65757853
+    annotations[1].properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
     annotations[1].properties.colors[9].red.must_equal 156
     annotations[1].properties.colors[9].green.must_equal 214
     annotations[1].properties.colors[9].blue.must_equal 255
     annotations[1].properties.colors[9].alpha.must_equal 1.0
     annotations[1].properties.colors[9].rgb.must_equal "9cd6ff"
-    annotations[1].properties.colors[9].score.must_equal 0.00096750073
-    annotations[1].properties.colors[9].pixel_fraction.must_equal 0.00064516132
+    annotations[1].properties.colors[9].score.must_be_close_to 0.00096750073
+    annotations[1].properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
   end
 
   it "uses the default configuration when given a truthy value" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "IMAGE_PROPERTIES", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :IMAGE_PROPERTIES, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, properties_response_gapi, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, properties: "please"
@@ -217,35 +207,35 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
     annotation.properties.colors[0].blue.must_equal 254
     annotation.properties.colors[0].alpha.must_equal 1.0
     annotation.properties.colors[0].rgb.must_equal "91c1fe"
-    annotation.properties.colors[0].score.must_equal 0.65757853
-    annotation.properties.colors[0].pixel_fraction.must_equal 0.16903226
+    annotation.properties.colors[0].score.must_be_close_to 0.65757853
+    annotation.properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
     annotation.properties.colors[9].red.must_equal 156
     annotation.properties.colors[9].green.must_equal 214
     annotation.properties.colors[9].blue.must_equal 255
     annotation.properties.colors[9].alpha.must_equal 1.0
     annotation.properties.colors[9].rgb.must_equal "9cd6ff"
-    annotation.properties.colors[9].score.must_equal 0.00096750073
-    annotation.properties.colors[9].pixel_fraction.must_equal 0.00064516132
+    annotation.properties.colors[9].score.must_be_close_to 0.00096750073
+    annotation.properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
   end
 
-  def properties_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def properties_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           image_properties_annotation: properties_annotation_response
         )
       ]
     )
   end
 
-  def plural_properties_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def plural_properties_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           image_properties_annotation: properties_annotation_response
         ),
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           image_properties_annotation: properties_annotation_response
         )
       ]

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_safe_search_test.rb
@@ -18,17 +18,15 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
   let(:filepath) { "acceptance/data/face.jpg" }
 
   it "detects safe_search detection" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "SAFE_SEARCH_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :SAFE_SEARCH_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, safe_search_response_gapi, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, safe_search: true
@@ -44,17 +42,15 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
   end
 
   it "detects safe_search detection using mark alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "SAFE_SEARCH_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :SAFE_SEARCH_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, safe_search_response_gapi, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, safe_search: true
@@ -70,17 +66,15 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
   end
 
   it "detects safe_search detection using detect alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "SAFE_SEARCH_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :SAFE_SEARCH_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, safe_search_response_gapi, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, safe_search: true
@@ -96,21 +90,19 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
   end
 
   it "detects safe_search detection on multiple images" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "SAFE_SEARCH_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        ),
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :SAFE_SEARCH_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, safe_searches_response_gapi, [req]
+    mock.expect :batch_annotate_images, safe_searches_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, safe_search: true
@@ -132,17 +124,15 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
   end
 
   it "uses the default configuration when given a truthy value" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "SAFE_SEARCH_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :SAFE_SEARCH_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, safe_search_response_gapi, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, safe_search: "yep"
@@ -157,23 +147,23 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
     annotation.safe_search.must_be :violence?
   end
 
-  def safe_search_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def safe_search_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           safe_search_annotation: safe_search_annotation_response
         )
       ]
     )
   end
 
-  def safe_searches_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def safe_searches_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           safe_search_annotation: safe_search_annotation_response
         ),
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           safe_search_annotation: safe_search_annotation_response
         )
       ]

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_text_test.rb
@@ -18,17 +18,15 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
   let(:filepath) { "acceptance/data/text.png" }
 
   it "detects text detection" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, text_response_gapi, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, text: true
@@ -46,17 +44,15 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
   end
 
   it "detects text detection using mark alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, text_response_gapi, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, text: true
@@ -67,17 +63,15 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
   end
 
   it "detects text detection using detect alias" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, text_response_gapi, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, text: true
@@ -88,21 +82,19 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
   end
 
   it "detects text detection on multiple images" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        ),
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, texts_response_gapi, [req]
+    mock.expect :batch_annotate_images, texts_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, text: true
@@ -114,17 +106,15 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
   end
 
   it "uses the default configuration when given a truthy value" do
-    feature = Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [feature]
-        )
-      ]
-    )
+    feature = Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [feature]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, text_response_gapi, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, text: "totes"
@@ -141,25 +131,23 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
     annotation.text.words[27].bounds.map(&:to_a).must_equal [[304, 59], [351, 59], [351, 74], [304, 74]]
   end
 
-
-
-  def text_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def text_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           text_annotations: text_annotation_responses
         )
       ]
     )
   end
 
-  def texts_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def texts_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           text_annotations: text_annotation_responses
         ),
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           text_annotations: text_annotation_responses
         )
       ]

--- a/google-cloud-vision/test/google/cloud/vision/project_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project_test.rb
@@ -34,26 +34,24 @@ describe Google::Cloud::Vision::Project, :mock_vision do
   end
 
   it "allows different annotation options for different images" do
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [
-            Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 10),
-            Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-          ]
-        ),
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [
-            Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 20),
-            Google::Apis::VisionV1::Feature.new(type: "SAFE_SEARCH_DETECTION", max_results: 1)
-          ]
-        )
-      ]
-    )
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [
+          Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 10),
+          Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+        ]
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [
+          Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 20),
+          Google::Cloud::Vision::V1::Feature.new(type: :SAFE_SEARCH_DETECTION, max_results: 1)
+        ]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, faces_response_gapi, [req]
+    mock.expect :batch_annotate_images, faces_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate do |a|
@@ -68,24 +66,22 @@ describe Google::Cloud::Vision::Project, :mock_vision do
   end
 
   it "runs full annotation with empty options" do
-    req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-      requests: [
-        Google::Apis::VisionV1::AnnotateImageRequest.new(
-          image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-          features: [
-            Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 100),
-            Google::Apis::VisionV1::Feature.new(type: "LANDMARK_DETECTION", max_results: 100),
-            Google::Apis::VisionV1::Feature.new(type: "LOGO_DETECTION", max_results: 100),
-            Google::Apis::VisionV1::Feature.new(type: "LABEL_DETECTION", max_results: 100),
-            Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1),
-            Google::Apis::VisionV1::Feature.new(type: "SAFE_SEARCH_DETECTION", max_results: 1),
-            Google::Apis::VisionV1::Feature.new(type: "IMAGE_PROPERTIES", max_results: 1)
-          ]
-        )
-      ]
-    )
+    req = [
+      Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+        image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+        features: [
+          Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 100),
+          Google::Cloud::Vision::V1::Feature.new(type: :LANDMARK_DETECTION, max_results: 100),
+          Google::Cloud::Vision::V1::Feature.new(type: :LOGO_DETECTION, max_results: 100),
+          Google::Cloud::Vision::V1::Feature.new(type: :LABEL_DETECTION, max_results: 100),
+          Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1),
+          Google::Cloud::Vision::V1::Feature.new(type: :SAFE_SEARCH_DETECTION, max_results: 1),
+          Google::Cloud::Vision::V1::Feature.new(type: :IMAGE_PROPERTIES, max_results: 1)
+        ]
+      )
+    ]
     mock = Minitest::Mock.new
-    mock.expect :annotate_image, full_response_gapi, [req]
+    mock.expect :batch_annotate_images, full_response_grpc, [req]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath
@@ -130,33 +126,31 @@ describe Google::Cloud::Vision::Project, :mock_vision do
     annotation.properties.colors[0].blue.must_equal 254
     annotation.properties.colors[0].alpha.must_equal 1.0
     annotation.properties.colors[0].rgb.must_equal "91c1fe"
-    annotation.properties.colors[0].score.must_equal 0.65757853
-    annotation.properties.colors[0].pixel_fraction.must_equal 0.16903226
+    annotation.properties.colors[0].score.must_be_close_to 0.65757853
+    annotation.properties.colors[0].pixel_fraction.must_be_close_to 0.16903226
 
     annotation.properties.colors[9].red.must_equal 156
     annotation.properties.colors[9].green.must_equal 214
     annotation.properties.colors[9].blue.must_equal 255
-    annotation.properties.colors[9].alpha.must_equal 1.0
+    annotation.properties.colors[9].alpha.must_be_close_to 1.0
     annotation.properties.colors[9].rgb.must_equal "9cd6ff"
-    annotation.properties.colors[9].score.must_equal 0.00096750073
-    annotation.properties.colors[9].pixel_fraction.must_equal 0.00064516132
+    annotation.properties.colors[9].score.must_be_close_to 0.00096750073
+    annotation.properties.colors[9].pixel_fraction.must_be_close_to 0.00064516132
   end
 
   describe "ImageContext" do
     it "does not send when annotating file path" do
-      req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-        requests: [
-          Google::Apis::VisionV1::AnnotateImageRequest.new(
-            image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-            features: [
-              Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 10),
-              Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-            ]
-          )
-        ]
-      )
+      req = [
+        Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+          image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+          features: [
+            Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 10),
+            Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+          ]
+        )
+      ]
       mock = Minitest::Mock.new
-      mock.expect :annotate_image, context_response_gapi, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req]
 
       vision.service.mocked_service = mock
       annotation = vision.annotate filepath, faces: 10, text: true
@@ -168,19 +162,17 @@ describe Google::Cloud::Vision::Project, :mock_vision do
     end
 
     it "does not send when annotating an image without context" do
-      req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-        requests: [
-          Google::Apis::VisionV1::AnnotateImageRequest.new(
-            image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-            features: [
-              Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 10),
-              Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-            ]
-          )
-        ]
-      )
+      req = [
+        Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+          image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+          features: [
+            Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 10),
+            Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+          ]
+        )
+      ]
       mock = Minitest::Mock.new
-      mock.expect :annotate_image, context_response_gapi, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req]
 
       vision.service.mocked_service = mock
       image = vision.image filepath
@@ -193,19 +185,23 @@ describe Google::Cloud::Vision::Project, :mock_vision do
     end
 
     it "sends when annotating an image with location in context" do
-      req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-        requests: [
-          Google::Apis::VisionV1::AnnotateImageRequest.new(
-            image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-            features: [
-              Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 10),
-              Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-            ]
+      req = [
+        Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+          image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+          features: [
+            Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 10),
+            Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+          ],
+          image_context: Google::Cloud::Vision::V1::ImageContext.new(
+            lat_long_rect: Google::Cloud::Vision::V1::LatLongRect.new(
+              min_lat_lng: Google::Type::LatLng.new(latitude: 37.4220041, longitude: -122.0862462),
+              max_lat_lng: Google::Type::LatLng.new(latitude: 37.4320041, longitude: -122.0762462)
+            )
           )
-        ]
-      )
+        )
+      ]
       mock = Minitest::Mock.new
-      mock.expect :annotate_image, context_response_gapi, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req]
 
       vision.service.mocked_service = mock
       image = vision.image filepath
@@ -222,19 +218,23 @@ describe Google::Cloud::Vision::Project, :mock_vision do
     end
 
     it "sends when annotating an image with location hash in context" do
-      req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-        requests: [
-          Google::Apis::VisionV1::AnnotateImageRequest.new(
-            image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-            features: [
-              Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 10),
-              Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-            ]
+      req = [
+        Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+          image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+          features: [
+            Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 10),
+            Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+          ],
+          image_context: Google::Cloud::Vision::V1::ImageContext.new(
+            lat_long_rect: Google::Cloud::Vision::V1::LatLongRect.new(
+              min_lat_lng: Google::Type::LatLng.new(latitude: 37.4220041, longitude: -122.0862462),
+              max_lat_lng: Google::Type::LatLng.new(latitude: 37.4320041, longitude: -122.0762462)
+            )
           )
-        ]
-      )
+        )
+      ]
       mock = Minitest::Mock.new
-      mock.expect :annotate_image, context_response_gapi, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req]
 
       vision.service.mocked_service = mock
       image = vision.image filepath
@@ -249,19 +249,20 @@ describe Google::Cloud::Vision::Project, :mock_vision do
     end
 
     it "sends when annotating an image with language hints in context" do
-      req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-        requests: [
-          Google::Apis::VisionV1::AnnotateImageRequest.new(
-            image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-            features: [
-              Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 10),
-              Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-            ]
+      req = [
+        Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+          image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+          features: [
+            Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 10),
+            Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+          ],
+          image_context: Google::Cloud::Vision::V1::ImageContext.new(
+            language_hints: ["en", "es"]
           )
-        ]
-      )
+        )
+      ]
       mock = Minitest::Mock.new
-      mock.expect :annotate_image, context_response_gapi, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req]
 
       vision.service.mocked_service = mock
       image = vision.image filepath
@@ -275,19 +276,24 @@ describe Google::Cloud::Vision::Project, :mock_vision do
     end
 
     it "sends when annotating an image with location and language hints in context" do
-      req = Google::Apis::VisionV1::BatchAnnotateImagesRequest.new(
-        requests: [
-          Google::Apis::VisionV1::AnnotateImageRequest.new(
-            image: Google::Apis::VisionV1::Image.new(content: File.read(filepath, mode: "rb")),
-            features: [
-              Google::Apis::VisionV1::Feature.new(type: "FACE_DETECTION", max_results: 10),
-              Google::Apis::VisionV1::Feature.new(type: "TEXT_DETECTION", max_results: 1)
-            ]
+      req = [
+        Google::Cloud::Vision::V1::AnnotateImageRequest.new(
+          image: Google::Cloud::Vision::V1::Image.new(content: File.read(filepath, mode: "rb")),
+          features: [
+            Google::Cloud::Vision::V1::Feature.new(type: :FACE_DETECTION, max_results: 10),
+            Google::Cloud::Vision::V1::Feature.new(type: :TEXT_DETECTION, max_results: 1)
+          ],
+          image_context: Google::Cloud::Vision::V1::ImageContext.new(
+            lat_long_rect: Google::Cloud::Vision::V1::LatLongRect.new(
+              min_lat_lng: Google::Type::LatLng.new(latitude: 37.4220041, longitude: -122.0862462),
+              max_lat_lng: Google::Type::LatLng.new(latitude: 37.4320041, longitude: -122.0762462)
+            ),
+            language_hints: ["en", "es"]
           )
-        ]
-      )
+        )
+      ]
       mock = Minitest::Mock.new
-      mock.expect :annotate_image, context_response_gapi, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req]
 
       vision.service.mocked_service = mock
       image = vision.image filepath
@@ -303,15 +309,15 @@ describe Google::Cloud::Vision::Project, :mock_vision do
     end
   end
 
-  def faces_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def faces_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           face_annotations: [
             face_annotation_response
           ]
         ),
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           face_annotations: [
             face_annotation_response
           ]
@@ -320,10 +326,10 @@ describe Google::Cloud::Vision::Project, :mock_vision do
     )
   end
 
-  def full_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def full_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           face_annotations: [face_annotation_response],
           landmark_annotations: [landmark_annotation_response],
           logo_annotations: [logo_annotation_response],
@@ -336,10 +342,10 @@ describe Google::Cloud::Vision::Project, :mock_vision do
     )
   end
 
-  def context_response_gapi
-    MockVision::API::BatchAnnotateImagesResponse.new(
+  def context_response_grpc
+    Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
       responses: [
-        MockVision::API::AnnotateImageResponse.new(
+        Google::Cloud::Vision::V1::AnnotateImageResponse.new(
           face_annotations: [face_annotation_response],
           text_annotations: text_annotation_responses
         )

--- a/google-cloud-vision/test/google/cloud/vision_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision_test.rb
@@ -13,19 +13,17 @@
 # limitations under the License.
 
 require "helper"
-require "google/cloud/vision"
-require "google/cloud/core/gce"
 
 describe Google::Cloud do
   describe "#vision" do
     it "calls out to Google::Cloud.vision" do
       gcloud = Google::Cloud.new
-      stubbed_vision = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_vision = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal nil
         keyfile.must_equal nil
         scope.must_be :nil?
-        retries.must_be :nil?
         timeout.must_be :nil?
+        client_config.must_be :nil?
         "vision-project-object-empty"
       }
       Google::Cloud.stub :vision, stubbed_vision do
@@ -36,12 +34,12 @@ describe Google::Cloud do
 
     it "passes project and keyfile to Google::Cloud.vision" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_vision = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_vision = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_be :nil?
-        retries.must_be :nil?
         timeout.must_be :nil?
+        client_config.must_be :nil?
         "vision-project-object"
       }
       Google::Cloud.stub :vision, stubbed_vision do
@@ -52,16 +50,16 @@ describe Google::Cloud do
 
     it "passes project and keyfile and options to Google::Cloud.vision" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_vision = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
+      stubbed_vision = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
         scope.must_equal "http://example.com/scope"
-        retries.must_equal 5
         timeout.must_equal 60
+        client_config.must_equal({ "gax" => "options" })
         "vision-project-object-scoped"
       }
       Google::Cloud.stub :vision, stubbed_vision do
-        project = gcloud.vision scope: "http://example.com/scope", retries: 5, timeout: 60
+        project = gcloud.vision scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
         project.must_equal "vision-project-object-scoped"
       end
     end
@@ -92,11 +90,11 @@ describe Google::Cloud do
         scope.must_equal nil
         "vision-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "vision-credentials"
-        retries.must_equal nil
-        timeout.must_equal nil
+        timeout.must_be :nil?
+        client_config.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -143,11 +141,11 @@ describe Google::Cloud do
         scope.must_equal nil
         "vision-credentials"
       }
-      stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "vision-credentials"
-        retries.must_equal nil
-        timeout.must_equal nil
+        timeout.must_be :nil?
+        client_config.must_be :nil?
         OpenStruct.new project: project
       }
 

--- a/google-cloud-vision/test/helper.rb
+++ b/google-cloud-vision/test/helper.rb
@@ -21,22 +21,7 @@ require "json"
 require "base64"
 require "google/cloud/vision"
 
-##
-# Monkey-Patch Google API Client to support Mocks
-module Google::Apis::Core::Hashable
-  ##
-  # Minitest Mock depends on === to match same-value objects.
-  # By default, the Google API Client objects do not match with ===.
-  # Therefore, we must add this capability.
-  # This module seems like as good a place as any...
-  def === other
-    return(to_h === other.to_h) if other.respond_to? :to_h
-    super
-  end
-end
-
 class MockVision < Minitest::Spec
-  API = Google::Apis::VisionV1
   let(:project) { vision.service.project }
   let(:credentials) { vision.service.credentials }
   let(:vision) { Google::Cloud::Vision::Project.new(Google::Cloud::Vision::Service.new("test", OpenStruct.new)) }
@@ -46,95 +31,104 @@ class MockVision < Minitest::Spec
     addl.include? :mock_vision
   end
 
+  def assert_array_in_delta exp, act, msg = nil
+    assert_kind_of Array, exp
+    assert_kind_of Array, act
+    assert_equal exp.length, act.length, "Arrays being compared must be the same length"
+    exp.zip(act).each do |exp_val, act_val|
+      assert_in_delta exp_val, act_val
+    end
+  end
+
   def bounding_poly
-    API::BoundingPoly.new(
+    Google::Cloud::Vision::V1::BoundingPoly.new(
       vertices: [
-        API::Vertex.new(x: 1, y: 0),
-        API::Vertex.new(x: 295, y: 0),
-        API::Vertex.new(x: 295, y: 301),
-        API::Vertex.new(x: 1, y: 301)
+        Google::Cloud::Vision::V1::Vertex.new(x: 1, y: 0),
+        Google::Cloud::Vision::V1::Vertex.new(x: 295, y: 0),
+        Google::Cloud::Vision::V1::Vertex.new(x: 295, y: 301),
+        Google::Cloud::Vision::V1::Vertex.new(x: 1, y: 301)
       ]
     )
   end
 
   def face_annotation_response
-    API::FaceAnnotation.new(
+    Google::Cloud::Vision::V1::FaceAnnotation.new(
       bounding_poly: bounding_poly,
-      fd_bounding_poly: API::BoundingPoly.new(
+      fd_bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(
         vertices: [
-          API::Vertex.new(x: 28, y: 40),
-          API::Vertex.new(x: 250, y: 40),
-          API::Vertex.new(x: 250, y: 262),
-          API::Vertex.new(x: 28, y: 262)
+          Google::Cloud::Vision::V1::Vertex.new(x: 28, y: 40),
+          Google::Cloud::Vision::V1::Vertex.new(x: 250, y: 40),
+          Google::Cloud::Vision::V1::Vertex.new(x: 250, y: 262),
+          Google::Cloud::Vision::V1::Vertex.new(x: 28, y: 262)
         ]
       ),
       landmarks: [
-        API::Landmark.new(type: "LEFT_EYE", position: API::Position.new(x: 83.707092, y: 128.34, z: -0.00013388535)),
-        API::Landmark.new(type: "RIGHT_EYE", position: API::Position.new(x: 181.17694, y: 115.16437, z: -12.82961)),
-        API::Landmark.new(type: "LEFT_OF_LEFT_EYEBROW", position: API::Position.new(x: 58.790176, y: 113.28249, z: 17.89735)),
-        API::Landmark.new(type: "RIGHT_OF_LEFT_EYEBROW", position: API::Position.new(x: 106.14151, y: 98.593758, z: -13.116687)),
-        API::Landmark.new(type: 'LEFT_OF_RIGHT_EYEBROW', position: API::Position.new(x: 148.61565, y: 92.294594, z: -18.804882)),
-        API::Landmark.new(type: "RIGHT_OF_RIGHT_EYEBROW", position: API::Position.new(x: 204.40808, y: 94.300117, z: -2.0009689)),
-        API::Landmark.new(type: "MIDPOINT_BETWEEN_EYES", position: API::Position.new(x: 127.83745, y: 110.17557, z: -22.650913)),
-        API::Landmark.new(type: "NOSE_TIP", position: API::Position.new(x: 128.14919, y: 153.68129, z: -63.198204)),
-        API::Landmark.new(type: "UPPER_LIP", position: API::Position.new(x: 134.74164, y: 192.50438, z: -53.876408)),
-        API::Landmark.new(type: "LOWER_LIP", position: API::Position.new(x: 137.28528, y: 219.23564, z: -56.663128)),
-        API::Landmark.new(type: "MOUTH_LEFT", position: API::Position.new(x: 104.53558, y: 214.05037, z: -30.056231)),
-        API::Landmark.new(type: "MOUTH_RIGHT", position: API::Position.new(x: 173.79134, y: 204.99333, z: -39.725758)),
-        API::Landmark.new(type: "MOUTH_CENTER", position: API::Position.new(x: 136.43481, y: 204.37952, z: -51.620205)),
-        API::Landmark.new(type: "NOSE_BOTTOM_RIGHT", position: API::Position.new(x: 161.31354, y: 168.24527, z: -36.1628)),
-        API::Landmark.new(type: "NOSE_BOTTOM_LEFT", position: API::Position.new(x: 110.98372, y: 173.61331, z: -29.7784)),
-        API::Landmark.new(type: "NOSE_BOTTOM_CENTER", position: API::Position.new(x: 133.81947, y: 173.16437, z: -48.287724)),
-        API::Landmark.new(type: "LEFT_EYE_TOP_BOUNDARY", position: API::Position.new(x: 86.706947, y: 119.47144, z: -4.1606765)),
-        API::Landmark.new(type: "LEFT_EYE_RIGHT_CORNER", position: API::Position.new(x: 105.28892, y: 125.57655, z: -2.51554)),
-        API::Landmark.new(type: "LEFT_EYE_BOTTOM_BOUNDARY", position: API::Position.new(x: 84.883934, y: 134.59479, z: -2.8677137)),
-        API::Landmark.new(type: "LEFT_EYE_LEFT_CORNER", position: API::Position.new(x: 72.213913, y: 132.04138, z: 9.6985674)),
-        API::Landmark.new(type: "RIGHT_EYE_TOP_BOUNDARY", position: API::Position.new(x: 173.99446, y: 107.94287, z: -16.050705)),
-        API::Landmark.new(type: "RIGHT_EYE_RIGHT_CORNER", position: API::Position.new(x: 194.59413, y: 115.91954, z: -6.952745)),
-        API::Landmark.new(type: "RIGHT_EYE_BOTTOM_BOUNDARY", position: API::Position.new(x: 179.30353, y: 121.03307, z: -14.843414)),
-        API::Landmark.new(type: "RIGHT_EYE_LEFT_CORNER", position: API::Position.new(x: 158.2863, y: 118.491, z: -9.723031)),
-        API::Landmark.new(type: "LEFT_EYEBROW_UPPER_MIDPOINT", position: API::Position.new(x: 80.248711, y: 94.04303, z: 0.21131183)),
-        API::Landmark.new(type: "RIGHT_EYEBROW_UPPER_MIDPOINT", position: API::Position.new(x: 174.70135, y: 81.580917, z: -12.702137)),
-        API::Landmark.new(type: "LEFT_EAR_TRAGION", position: API::Position.new(x: 54.872219, y: 207.23712, z: 97.030685)),
-        API::Landmark.new(type: "RIGHT_EAR_TRAGION", position: API::Position.new(x: 252.67567, y: 180.43124, z: 70.15992)),
-        API::Landmark.new(type: "LEFT_EYE_PUPIL", position: API::Position.new(x: 86.531624, y: 126.49807, z: -2.2496929)),
-        API::Landmark.new(type: "RIGHT_EYE_PUPIL", position: API::Position.new(x: 175.99976, y: 114.64407, z: -14.53744)),
-        API::Landmark.new(type: "FOREHEAD_GLABELLA", position: API::Position.new(x: 126.53813, y: 93.812057, z: -18.863352)),
-        API::Landmark.new(type: "CHIN_GNATHION", position: API::Position.new(x: 143.34183, y: 262.22998, z: -57.388493)),
-        API::Landmark.new(type: "CHIN_LEFT_GONION", position: API::Position.new(x: 63.102425, y: 248.99081, z: 44.207638)),
-        API::Landmark.new(type: "CHIN_RIGHT_GONION", position: API::Position.new(x: 241.72728, y: 225.53488, z: 19.758242))
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_EYE, position: Google::Cloud::Vision::V1::Position.new(x: 83.707092, y: 128.34, z: -0.00013388535)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_EYE, position: Google::Cloud::Vision::V1::Position.new(x: 181.17694, y: 115.16437, z: -12.82961)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_OF_LEFT_EYEBROW, position: Google::Cloud::Vision::V1::Position.new(x: 58.790176, y: 113.28249, z: 17.89735)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_OF_LEFT_EYEBROW, position: Google::Cloud::Vision::V1::Position.new(x: 106.14151, y: 98.593758, z: -13.116687)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_OF_RIGHT_EYEBROW, position: Google::Cloud::Vision::V1::Position.new(x: 148.61565, y: 92.294594, z: -18.804882)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_OF_RIGHT_EYEBROW, position: Google::Cloud::Vision::V1::Position.new(x: 204.40808, y: 94.300117, z: -2.0009689)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :MIDPOINT_BETWEEN_EYES, position: Google::Cloud::Vision::V1::Position.new(x: 127.83745, y: 110.17557, z: -22.650913)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :NOSE_TIP, position: Google::Cloud::Vision::V1::Position.new(x: 128.14919, y: 153.68129, z: -63.198204)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :UPPER_LIP, position: Google::Cloud::Vision::V1::Position.new(x: 134.74164, y: 192.50438, z: -53.876408)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LOWER_LIP, position: Google::Cloud::Vision::V1::Position.new(x: 137.28528, y: 219.23564, z: -56.663128)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :MOUTH_LEFT, position: Google::Cloud::Vision::V1::Position.new(x: 104.53558, y: 214.05037, z: -30.056231)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :MOUTH_RIGHT, position: Google::Cloud::Vision::V1::Position.new(x: 173.79134, y: 204.99333, z: -39.725758)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :MOUTH_CENTER, position: Google::Cloud::Vision::V1::Position.new(x: 136.43481, y: 204.37952, z: -51.620205)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :NOSE_BOTTOM_RIGHT, position: Google::Cloud::Vision::V1::Position.new(x: 161.31354, y: 168.24527, z: -36.1628)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :NOSE_BOTTOM_LEFT, position: Google::Cloud::Vision::V1::Position.new(x: 110.98372, y: 173.61331, z: -29.7784)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :NOSE_BOTTOM_CENTER, position: Google::Cloud::Vision::V1::Position.new(x: 133.81947, y: 173.16437, z: -48.287724)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_EYE_TOP_BOUNDARY, position: Google::Cloud::Vision::V1::Position.new(x: 86.706947, y: 119.47144, z: -4.1606765)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_EYE_RIGHT_CORNER, position: Google::Cloud::Vision::V1::Position.new(x: 105.28892, y: 125.57655, z: -2.51554)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_EYE_BOTTOM_BOUNDARY, position: Google::Cloud::Vision::V1::Position.new(x: 84.883934, y: 134.59479, z: -2.8677137)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_EYE_LEFT_CORNER, position: Google::Cloud::Vision::V1::Position.new(x: 72.213913, y: 132.04138, z: 9.6985674)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_EYE_TOP_BOUNDARY, position: Google::Cloud::Vision::V1::Position.new(x: 173.99446, y: 107.94287, z: -16.050705)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_EYE_RIGHT_CORNER, position: Google::Cloud::Vision::V1::Position.new(x: 194.59413, y: 115.91954, z: -6.952745)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_EYE_BOTTOM_BOUNDARY, position: Google::Cloud::Vision::V1::Position.new(x: 179.30353, y: 121.03307, z: -14.843414)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_EYE_LEFT_CORNER, position: Google::Cloud::Vision::V1::Position.new(x: 158.2863, y: 118.491, z: -9.723031)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_EYEBROW_UPPER_MIDPOINT, position: Google::Cloud::Vision::V1::Position.new(x: 80.248711, y: 94.04303, z: 0.21131183)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_EYEBROW_UPPER_MIDPOINT, position: Google::Cloud::Vision::V1::Position.new(x: 174.70135, y: 81.580917, z: -12.702137)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_EAR_TRAGION, position: Google::Cloud::Vision::V1::Position.new(x: 54.872219, y: 207.23712, z: 97.030685)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_EAR_TRAGION, position: Google::Cloud::Vision::V1::Position.new(x: 252.67567, y: 180.43124, z: 70.15992)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_EYE_PUPIL, position: Google::Cloud::Vision::V1::Position.new(x: 86.531624, y: 126.49807, z: -2.2496929)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :RIGHT_EYE_PUPIL, position: Google::Cloud::Vision::V1::Position.new(x: 175.99976, y: 114.64407, z: -14.53744)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :FOREHEAD_GLABELLA, position: Google::Cloud::Vision::V1::Position.new(x: 126.53813, y: 93.812057, z: -18.863352)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :CHIN_GNATHION, position: Google::Cloud::Vision::V1::Position.new(x: 143.34183, y: 262.22998, z: -57.388493)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :CHIN_LEFT_GONION, position: Google::Cloud::Vision::V1::Position.new(x: 63.102425, y: 248.99081, z: 44.207638)),
+        Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :CHIN_RIGHT_GONION, position: Google::Cloud::Vision::V1::Position.new(x: 241.72728, y: 225.53488, z: 19.758242))
       ],
       roll_angle: -0.050002542,
       pan_angle: -0.081090336,
       tilt_angle: 0.18012161,
       detection_confidence: 0.56748849,
       landmarking_confidence: 34.489909,
-      joy_likelihood:          "LIKELY",
-      sorrow_likelihood:       "UNLIKELY",
-      anger_likelihood:        "VERY_UNLIKELY",
-      surprise_likelihood:     "UNLIKELY",
-      under_exposed_likelihood: "VERY_UNLIKELY",
-      blurred_likelihood:      "VERY_UNLIKELY",
-      headwear_likelihood:     "VERY_UNLIKELY",
+      joy_likelihood:           :LIKELY,
+      sorrow_likelihood:        :UNLIKELY,
+      anger_likelihood:         :VERY_UNLIKELY,
+      surprise_likelihood:      :UNLIKELY,
+      under_exposed_likelihood: :VERY_UNLIKELY,
+      blurred_likelihood:       :VERY_UNLIKELY,
+      headwear_likelihood:      :VERY_UNLIKELY,
     )
   end
 
   def landmark_annotation_response
-    API::EntityAnnotation.new(
+    Google::Cloud::Vision::V1::EntityAnnotation.new(
       mid: "/m/019dvv",
       description: "Mount Rushmore",
       score: 0.91912264,
       bounding_poly: bounding_poly,
       locations: [
-        API::LocationInfo.new(
-          lat_lng: API::LatLng.new(latitude: 43.878264, longitude: -103.45700740814209)
+        Google::Cloud::Vision::V1::LocationInfo.new(
+          lat_lng: Google::Type::LatLng.new(latitude: 43.878264, longitude: -103.45700740814209)
         )
      ]
     )
   end
 
   def logo_annotation_response
-    API::EntityAnnotation.new(
+    Google::Cloud::Vision::V1::EntityAnnotation.new(
       mid: "/m/045c7b",
       description: "Google",
       score: 0.6435439,
@@ -143,7 +137,7 @@ class MockVision < Minitest::Spec
   end
 
   def label_annotation_response
-    API::EntityAnnotation.new(
+    Google::Cloud::Vision::V1::EntityAnnotation.new(
       mid: "/m/02wtjj",
       description: "stone carving",
       score: 0.9859733
@@ -151,7 +145,7 @@ class MockVision < Minitest::Spec
   end
 
   def text_annotation_response
-    API::EntityAnnotation.new(
+    Google::Cloud::Vision::V1::EntityAnnotation.new(
       locale: "en",
       description: "Google Cloud Client for Ruby an idiomatic, intuitive, and\nnatural way for Ruby developers to integrate with Google Cloud\nPlatform services, like Cloud Datastore and Cloud Storage.\n",
       bounding_poly: bounding_poly
@@ -160,82 +154,86 @@ class MockVision < Minitest::Spec
 
   def text_annotation_responses
     [ text_annotation_response,
-      API::EntityAnnotation.new(description: "Google", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 13, y: 8), API::Vertex.new(x: 53, y: 8), API::Vertex.new(x: 53, y: 23), API::Vertex.new(x: 13, y: 23)])),
-      API::EntityAnnotation.new(description: "Cloud", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 59, y: 8), API::Vertex.new(x: 89, y: 8), API::Vertex.new(x: 89, y: 23), API::Vertex.new(x: 59, y: 23)])),
-      API::EntityAnnotation.new(description: "Client", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 96, y: 8), API::Vertex.new(x: 128, y: 8), API::Vertex.new(x: 128, y: 23), API::Vertex.new(x: 96, y: 23)])),
-      API::EntityAnnotation.new(description: "Library", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 132, y: 8), API::Vertex.new(x: 170, y: 8), API::Vertex.new(x: 170, y: 23), API::Vertex.new(x: 132, y: 23)])),
-      API::EntityAnnotation.new(description: "for", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 175, y: 8), API::Vertex.new(x: 191, y: 8), API::Vertex.new(x: 191, y: 23), API::Vertex.new(x: 175, y: 23)])),
-      API::EntityAnnotation.new(description: "Ruby", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 195, y: 8), API::Vertex.new(x: 221, y: 8), API::Vertex.new(x: 221, y: 23), API::Vertex.new(x: 195, y: 23)])),
-      API::EntityAnnotation.new(description: "an", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 236, y: 8), API::Vertex.new(x: 245, y: 8), API::Vertex.new(x: 245, y: 23), API::Vertex.new(x: 236, y: 23)])),
-      API::EntityAnnotation.new(description: "idiomatic,", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 250, y: 8), API::Vertex.new(x: 307, y: 8), API::Vertex.new(x: 307, y: 23), API::Vertex.new(x: 250, y: 23)])),
-      API::EntityAnnotation.new(description: "intuitive,", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 311, y: 8), API::Vertex.new(x: 360, y: 8), API::Vertex.new(x: 360, y: 23), API::Vertex.new(x: 311, y: 23)])),
-      API::EntityAnnotation.new(description: "and", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 363, y: 8), API::Vertex.new(x: 385, y: 8), API::Vertex.new(x: 385, y: 23), API::Vertex.new(x: 363, y: 23)])),
-      API::EntityAnnotation.new(description: "natural", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 13, y: 33), API::Vertex.new(x: 52, y: 33), API::Vertex.new(x: 52, y: 49), API::Vertex.new(x: 13, y: 49)])),
-      API::EntityAnnotation.new(description: "way", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 56, y: 33), API::Vertex.new(x: 77, y: 33), API::Vertex.new(x: 77, y: 49), API::Vertex.new(x: 56, y: 49)])),
-      API::EntityAnnotation.new(description: "for", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 82, y: 33), API::Vertex.new(x: 98, y: 33), API::Vertex.new(x: 98, y: 49), API::Vertex.new(x: 82, y: 49)])),
-      API::EntityAnnotation.new(description: "Ruby", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 102, y: 33), API::Vertex.new(x: 130, y: 33), API::Vertex.new(x: 130, y: 49), API::Vertex.new(x: 102, y: 49)])),
-      API::EntityAnnotation.new(description: "developers", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 135, y: 33), API::Vertex.new(x: 196, y: 33), API::Vertex.new(x: 196, y: 49), API::Vertex.new(x: 135, y: 49)])),
-      API::EntityAnnotation.new(description: "to", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 201, y: 33), API::Vertex.new(x: 212, y: 33), API::Vertex.new(x: 212, y: 49), API::Vertex.new(x: 201, y: 49)])),
-      API::EntityAnnotation.new(description: "integrate", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 215, y: 33), API::Vertex.new(x: 265, y: 33), API::Vertex.new(x: 265, y: 49), API::Vertex.new(x: 215, y: 49)])),
-      API::EntityAnnotation.new(description: "with", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 270, y: 33), API::Vertex.new(x: 293, y: 33), API::Vertex.new(x: 293, y: 49), API::Vertex.new(x: 270, y: 49)])),
-      API::EntityAnnotation.new(description: "Google", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 299, y: 33), API::Vertex.new(x: 339, y: 33), API::Vertex.new(x: 339, y: 49), API::Vertex.new(x: 299, y: 49)])),
-      API::EntityAnnotation.new(description: "Cloud", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 345, y: 33), API::Vertex.new(x: 376, y: 33), API::Vertex.new(x: 376, y: 49), API::Vertex.new(x: 345, y: 49)])),
-      API::EntityAnnotation.new(description: "Platform", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 13, y: 59), API::Vertex.new(x: 59, y: 59), API::Vertex.new(x: 59, y: 74), API::Vertex.new(x: 13, y: 74)])),
-      API::EntityAnnotation.new(description: "services,", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 67, y: 59), API::Vertex.new(x: 117, y: 59), API::Vertex.new(x: 117, y: 74), API::Vertex.new(x: 67, y: 74)])),
-      API::EntityAnnotation.new(description: "like", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 121, y: 59), API::Vertex.new(x: 138, y: 59), API::Vertex.new(x: 138, y: 74), API::Vertex.new(x: 121, y: 74)])),
-      API::EntityAnnotation.new(description: "Cloud", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 145, y: 59), API::Vertex.new(x: 177, y: 59), API::Vertex.new(x: 177, y: 74), API::Vertex.new(x: 145, y: 74)])),
-      API::EntityAnnotation.new(description: "Datastore", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 181, y: 59), API::Vertex.new(x: 236, y: 59), API::Vertex.new(x: 236, y: 74), API::Vertex.new(x: 181, y: 74)])),
-      API::EntityAnnotation.new(description: "and", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 242, y: 59), API::Vertex.new(x: 260, y: 59), API::Vertex.new(x: 260, y: 74), API::Vertex.new(x: 242, y: 74)])),
-      API::EntityAnnotation.new(description: "Cloud", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 267, y: 59), API::Vertex.new(x: 298, y: 59), API::Vertex.new(x: 298, y: 74), API::Vertex.new(x: 267, y: 74)])),
-      API::EntityAnnotation.new(description: "Storage.", bounding_poly: API::BoundingPoly.new(vertices: [API::Vertex.new(x: 304, y: 59), API::Vertex.new(x: 351, y: 59), API::Vertex.new(x: 351, y: 74), API::Vertex.new(x: 304, y: 74)]))
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Google", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 53, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 53, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Cloud", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 59, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 89, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 89, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 59, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Client", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 96, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 128, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 128, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 96, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Library", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 132, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 170, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 170, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 132, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "for", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 175, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 191, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 191, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 175, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Ruby", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 195, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 221, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 221, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 195, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "an", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 236, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 245, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 245, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 236, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "idiomatic,", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 250, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 307, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 307, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 250, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "intuitive,", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 311, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 360, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 360, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 311, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "and", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 363, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 385, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 385, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 363, y: 23)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "natural", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 52, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 52, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "way", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 56, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 77, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 77, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 56, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "for", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 82, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 98, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 98, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 82, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Ruby", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 102, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 130, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 130, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 102, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "developers", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 135, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 196, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 196, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 135, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "to", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 201, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 212, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 212, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 201, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "integrate", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 215, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 265, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 265, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 215, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "with", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 270, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 293, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 293, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 270, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Google", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 299, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 339, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 339, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 299, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Cloud", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 345, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 376, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 376, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 345, y: 49)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Platform", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 59, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 59, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 74)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "services,", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 67, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 117, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 117, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 67, y: 74)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "like", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 121, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 138, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 138, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 121, y: 74)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Cloud", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 145, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 177, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 177, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 145, y: 74)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Datastore", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 181, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 236, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 236, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 181, y: 74)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "and", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 242, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 260, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 260, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 242, y: 74)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Cloud", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 267, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 298, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 298, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 267, y: 74)])),
+      Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Storage.", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 304, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 351, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 351, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 304, y: 74)]))
     ]
   end
 
   def safe_search_annotation_response
-    API::SafeSearchAnnotation.new(
-      adult:    "VERY_UNLIKELY",
-      spoof:    "UNLIKELY",
-      medical:  "POSSIBLE",
-      violence: "LIKELY"
+    Google::Cloud::Vision::V1::SafeSearchAnnotation.new(
+      adult:    :VERY_UNLIKELY,
+      spoof:    :UNLIKELY,
+      medical:  :POSSIBLE,
+      violence: :LIKELY
     )
   end
 
   def properties_annotation_response
-    API::ImageProperties.new(
-      dominant_colors: API::DominantColorsAnnotation.new(
+    Google::Cloud::Vision::V1::ImageProperties.new(
+      dominant_colors: Google::Cloud::Vision::V1::DominantColorsAnnotation.new(
         colors: [
-          API::ColorInfo.new(color: API::Color.new(red: 145, green: 193, blue: 254),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 145, green: 193, blue: 254),
                              score: 0.65757853,
                              pixel_fraction: 0.16903226),
-          API::ColorInfo.new(color: API::Color.new(red: 0, green: 0, blue: 0),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 0, green: 0, blue: 0),
                              score: 0.09256918,
                              pixel_fraction: 0.19258064),
-          API::ColorInfo.new(color: API::Color.new(red: 255, green: 255, blue: 255),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 255, green: 255, blue: 255),
                              score: 0.1002003,
                              pixel_fraction: 0.022258064),
-          API::ColorInfo.new(color: API::Color.new(red: 3, green: 4, blue: 254),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 3, green: 4, blue: 254),
                              score: 0.089072376,
                              pixel_fraction: 0.054516129),
-          API::ColorInfo.new(color: API::Color.new(red: 168, green: 215, blue: 255),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 168, green: 215, blue: 255),
                              score: 0.019252902,
                              pixel_fraction: 0.0070967744),
-          API::ColorInfo.new(color: API::Color.new(red: 127, green: 177, blue: 255),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 127, green: 177, blue: 255),
                              score: 0.017626688,
                              pixel_fraction: 0.0045161289),
-          API::ColorInfo.new(color: API::Color.new(red: 178, green: 223, blue: 255),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 178, green: 223, blue: 255),
                              score: 0.015010362,
                              pixel_fraction: 0.0022580645),
-          API::ColorInfo.new(color: API::Color.new(red: 172, green: 224, blue: 255),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 172, green: 224, blue: 255),
                              score: 0.0049617039,
                              pixel_fraction: 0.0012903226),
-          API::ColorInfo.new(color: API::Color.new(red: 160, green: 218, blue: 255),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 160, green: 218, blue: 255),
                              score: 0.0027604031,
                              pixel_fraction: 0.0022580645),
-          API::ColorInfo.new(color: API::Color.new(red: 156, green: 214, blue: 255),
+          Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 156, green: 214, blue: 255),
                              score: 0.00096750073,
                              pixel_fraction: 0.00064516132)
         ]
       )
     )
   end
+end
+
+module MiniTest::Expectations
+  infect_an_assertion :assert_array_in_delta, :must_be_close_to_array
 end


### PR DESCRIPTION
Move Vision from the JSON API to the gRPC API, using GAPIC as provided by GAX.