### PR TITLE
Wrong Example...

### DIFF
--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -23,7 +23,7 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ```ruby
 require "google/cloud/logging"
 
-logging = Google::Cloud::Logging.new
+logging = Google::Cloud.new.logging
 
 # List all log entries
 logging.entries.each do |e|


### PR DESCRIPTION
```
irb(main):001:0> require "google/cloud/logging"
=> true
irb(main):002:0>
irb(main):003:0* logging = Google::Cloud::Logging.new
NoMethodError: undefined method `new' for Google::Cloud::Logging:Module
	from (irb):3
	from /usr/local/bin/irb:11:in `<main>'```