### PR TITLE
Revert Pub/Sub List implementations

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -200,7 +200,7 @@ module Google
           ensure_service!
           options = { token: token, max: max }
           grpc = service.list_topics options
-          Topic::List.from_grpc grpc, service
+          Topic::List.from_grpc grpc, service, max
         end
         alias_method :find_topics, :topics
         alias_method :list_topics, :topics
@@ -434,7 +434,7 @@ module Google
           ensure_service!
           options = { token: token, max: max }
           grpc = service.list_subscriptions options
-          Subscription::List.from_grpc grpc, service
+          Subscription::List.from_grpc grpc, service, max
         end
         alias_method :find_subscriptions, :subscriptions
         alias_method :list_subscriptions, :subscriptions

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -99,9 +99,11 @@ module Google
             call_options = Google::Gax::CallOptions.new page_token: token
           end
           execute do
-            publisher.list_topics project_path(options),
-                                  page_size: options[:max],
-                                  options: call_options
+            paged_enum = publisher.list_topics project_path(options),
+                                               page_size: options[:max],
+                                               options: call_options
+
+            paged_enum.page.response
           end
         end
 
@@ -148,9 +150,12 @@ module Google
             call_options = Google::Gax::CallOptions.new page_token: token
           end
           execute do
-            publisher.list_topic_subscriptions topic_path(topic, options),
-                                               page_size: options[:max],
-                                               options: call_options
+            paged_enum = publisher.list_topic_subscriptions \
+              topic_path(topic, options),
+              page_size: options[:max],
+              options: call_options
+
+            paged_enum.page.response
           end
         end
 
@@ -161,9 +166,11 @@ module Google
             call_options = Google::Gax::CallOptions.new page_token: token
           end
           execute do
-            subscriber.list_subscriptions project_path(options),
-                                          page_size: options[:max],
-                                          options: call_options
+            paged_enum = subscriber.list_subscriptions project_path(options),
+                                                       page_size: options[:max],
+                                                       options: call_options
+
+            paged_enum.page.response
           end
         end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
@@ -26,10 +26,7 @@ module Google
           # If not empty, indicates that there are more subscriptions
           # that match the request and this value should be passed to
           # the next {Google::Cloud::Pubsub::Topic#subscriptions} to continue.
-          def token
-            page_token = @paged_enum.page_token
-            page_token if page_token && page_token != ""
-          end
+          attr_accessor :token
 
           ##
           # @private Create a new Subscription::List with an array of values.
@@ -57,8 +54,7 @@ module Google
           #   end
           #
           def next?
-            ensure_paged_enum!
-            @paged_enum.next_page?
+            !token.nil?
           end
 
           ##
@@ -78,11 +74,11 @@ module Google
           #
           def next
             return nil unless next?
-            @paged_enum.next_page
+            ensure_service!
             if @topic
-              self.class.from_topic_grpc @paged_enum, @service, @topic
+              next_topic_subscriptions
             else
-              self.class.from_grpc @paged_enum, @service
+              next_subscriptions
             end
           end
 
@@ -154,27 +150,31 @@ module Google
           ##
           # @private New Subscriptions::List from a
           # Google::Pubsub::V1::ListSubscriptionsRequest object.
-          def self.from_grpc paged_enum, service
-            subs = new
-            paged_enum.page.each do |topic_grpc|
-              subs << Subscription.from_grpc(topic_grpc, service)
-            end
-            subs.instance_variable_set "@paged_enum", paged_enum
+          def self.from_grpc grpc_list, service, max = nil
+            subs = new(Array(grpc_list.subscriptions).map do |grpc|
+              Subscription.from_grpc grpc, service
+            end)
+            token = grpc_list.next_page_token
+            token = nil if token == ""
+            subs.instance_variable_set "@token",   token
             subs.instance_variable_set "@service", service
+            subs.instance_variable_set "@max",     max
             subs
           end
 
           ##
           # @private New Subscriptions::List from a
           # Google::Pubsub::V1::ListTopicSubscriptionsResponse object.
-          def self.from_topic_grpc paged_enum, service, topic
-            subs = new
-            paged_enum.page.each do |subscription_name|
-              subs << Subscription.new_lazy(subscription_name, service)
-            end
-            subs.instance_variable_set "@paged_enum", paged_enum
+          def self.from_topic_grpc grpc_list, service, topic, max = nil
+            subs = new(Array(grpc_list.subscriptions).map do |grpc|
+              Subscription.new_lazy grpc, service
+            end)
+            token = grpc_list.next_page_token
+            token = nil if token == ""
+            subs.instance_variable_set "@token",   token
             subs.instance_variable_set "@service", service
-            subs.instance_variable_set "@topic", topic
+            subs.instance_variable_set "@topic",   topic
+            subs.instance_variable_set "@max",     max
             subs
           end
 
@@ -183,8 +183,20 @@ module Google
           ##
           # @private Raise an error unless an active connection to the service
           # is available.
-          def ensure_paged_enum!
-            fail "Must have active connection to service" unless @paged_enum
+          def ensure_service!
+            fail "Must have active connection to service" unless @service
+          end
+
+          def next_subscriptions
+            options = { prefix: @prefix, token: @token, max: @max }
+            grpc = @service.list_subscriptions options
+            self.class.from_grpc grpc, @service, @max
+          end
+
+          def next_topic_subscriptions
+            options = { token: @token, max: @max }
+            grpc = @service.list_topics_subscriptions @topic, options
+            self.class.from_topic_grpc grpc, @service, @topic, @max
           end
         end
       end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -219,7 +219,7 @@ module Google
           ensure_service!
           options = { token: token, max: max }
           grpc = service.list_topics_subscriptions name, options
-          Subscription::List.from_topic_grpc grpc, service, name
+          Subscription::List.from_topic_grpc grpc, service, name, max
         end
         alias_method :find_subscriptions, :subscriptions
         alias_method :list_subscriptions, :subscriptions

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -15,61 +15,29 @@
 require "helper"
 
 describe Google::Cloud::Pubsub::Project, :mock_pubsub do
-  let(:mock_topics_with_token) do
-    first_get_res = Google::Pubsub::V1::ListTopicsResponse.decode_json topics_json(3, "next_page_token")
-    page = Google::Gax::PagedEnumerable::Page.new first_get_res, "next_page_token", "topics"
-    mock = Minitest::Mock.new
-    mock.expect :page, page, []
-    mock
+  let(:topics_with_token) do
+    response = Google::Pubsub::V1::ListTopicsResponse.decode_json topics_json(3, "next_page_token")
+    paged_enum_struct response
   end
-  let(:mock_topics_without_token) do
-    second_get_res = Google::Pubsub::V1::ListTopicsResponse.decode_json topics_json(2)
-    page = Google::Gax::PagedEnumerable::Page.new second_get_res, "next_page_token", "topics"
-    mock = Minitest::Mock.new
-    mock.expect :page, page, []
-    mock.expect :page_token, nil, []
-    mock
+  let(:topics_without_token) do
+    response = Google::Pubsub::V1::ListTopicsResponse.decode_json topics_json(2)
+    paged_enum_struct response
   end
-  let(:mock_topics_both_pages) do
-    first_get_res = Google::Pubsub::V1::ListTopicsResponse.decode_json topics_json(3, "next_page_token")
-    page = Google::Gax::PagedEnumerable::Page.new first_get_res, "next_page_token", "topics"
-    second_get_res = Google::Pubsub::V1::ListTopicsResponse.decode_json topics_json(2)
-    page_2 = Google::Gax::PagedEnumerable::Page.new second_get_res, "next_page_token", "topics"
-    mock = Minitest::Mock.new
-    mock.expect :page, page, []
-    mock.expect :next_page?, true, []
-    mock.expect :next_page, page_2, []
-    mock.expect :page, page_2, []
-    mock.expect :next_page?, true, []
-    mock
+  let(:topics_with_token_2) do
+    response = Google::Pubsub::V1::ListTopicsResponse.decode_json topics_json(3, "second_page_token")
+    paged_enum_struct response
   end
-  let(:mock_subscriptions_with_token) do
-    first_get_res = Google::Pubsub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 3, "next_page_token")
-    page = Google::Gax::PagedEnumerable::Page.new first_get_res, "next_page_token", "subscriptions"
-    mock = Minitest::Mock.new
-    mock.expect :page, page, []
-    mock
+  let(:subscriptions_with_token) do
+    response = Google::Pubsub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 3, "next_page_token")
+    paged_enum_struct response
   end
-  let(:mock_subscriptions_without_token) do
-    second_get_res = Google::Pubsub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 2)
-    page = Google::Gax::PagedEnumerable::Page.new second_get_res, "next_page_token", "subscriptions"
-    mock = Minitest::Mock.new
-    mock.expect :page, page, []
-    mock.expect :page_token, nil, []
-    mock
+  let(:subscriptions_without_token) do
+    response = Google::Pubsub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 2)
+    paged_enum_struct response
   end
-  let(:mock_subscriptions_both_pages) do
-    first_get_res = Google::Pubsub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 3, "next_page_token")
-    page = Google::Gax::PagedEnumerable::Page.new first_get_res, "next_page_token", "subscriptions"
-    second_get_res = Google::Pubsub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 2)
-    page_2 = Google::Gax::PagedEnumerable::Page.new second_get_res, "next_page_token", "subscriptions"
-    mock = Minitest::Mock.new
-    mock.expect :page, page, []
-    mock.expect :next_page?, true, []
-    mock.expect :next_page, page_2, []
-    mock.expect :page, page_2, []
-    mock.expect :next_page?, true, []
-    mock
+  let(:subscriptions_with_token_2) do
+    response = Google::Pubsub::V1::ListSubscriptionsResponse.decode_json subscriptions_json("fake-topic", 3, "second_page_token")
+    paged_enum_struct response
   end
 
   it "knows the project identifier" do
@@ -189,56 +157,51 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "lists topics" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics
 
-    topics.size.must_equal 3
-
     mock.verify
-    mock_topics_with_token.verify
+
+    topics.size.must_equal 3
   end
 
   it "lists topics with find_topics alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.find_topics
 
-    topics.size.must_equal 3
-
     mock.verify
-    mock_topics_with_token.verify
+
+    topics.size.must_equal 3
   end
 
   it "lists topics with list_topics alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.list_topics
 
-    topics.size.must_equal 3
-
     mock.verify
-    mock_topics_with_token.verify
+
+    topics.size.must_equal 3
   end
 
   it "paginates topics" do
-    mock_topics_with_token.expect :page_token, "next_page_token", []
-    mock_topics_with_token.expect :page_token, "next_page_token", []
-
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")} # TODO: use this instead of Hash, below
-    mock.expect :list_topics, mock_topics_without_token, ["projects/#{project}", Hash]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
     first_topics = pubsub.topics
     second_topics = pubsub.topics token: first_topics.token
 
+    mock.verify
 
     first_topics.size.must_equal 3
     token = first_topics.token
@@ -247,139 +210,130 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     second_topics.size.must_equal 2
     second_topics.token.must_be :nil?
-
-    mock.verify
-    mock_topics_with_token.verify
-    mock_topics_without_token.verify
   end
 
   it "paginates topics with max set" do
-    mock_topics_with_token.expect :page_token, "next_page_token", []
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_with_token, ["projects/#{project}", page_size: 3, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: 3, options: nil]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics max: 3
+
+    mock.verify
 
     topics.size.must_equal 3
     token = topics.token
     token.wont_be :nil?
     token.must_equal "next_page_token"
-
-    mock.verify
-    mock_topics_with_token.verify
   end
 
   it "paginates topics with next? and next" do
-    mock_topics_both_pages.expect :next_page?, false, []
-
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_both_pages, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
     first_topics = pubsub.topics
     second_topics = first_topics.next
 
+    mock.verify
+
     first_topics.size.must_equal 3
     first_topics.next?.must_equal true
 
     second_topics.size.must_equal 2
     second_topics.next?.must_equal false
-
-    mock.verify
-    mock_topics_both_pages.verify
   end
 
   it "paginates topics with next? and next and max set" do
-    mock_topics_both_pages.expect :next_page?, false, []
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_both_pages, ["projects/#{project}", page_size: 3, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: 3, options: nil]
+    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
     first_topics = pubsub.topics max: 3
     second_topics = first_topics.next
 
+    mock.verify
+
     first_topics.size.must_equal 3
     first_topics.next?.must_equal true
 
     second_topics.size.must_equal 2
     second_topics.next?.must_equal false
-
-    mock.verify
-    mock_topics_both_pages.verify
   end
 
   it "paginates topics with all" do
-    mock_topics_both_pages.expect :next_page?, false, []
-
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_both_pages, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics.all.to_a
 
-    topics.size.must_equal 5
-
     mock.verify
-    mock_topics_both_pages.verify
+
+    topics.size.must_equal 5
   end
 
   it "paginates topics with all and max set" do
-    mock_topics_both_pages.expect :next_page?, false, []
-
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_both_pages, ["projects/#{project}", page_size: 3, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: 3, options: nil]
+    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics(max: 3).all.to_a
 
-    topics.size.must_equal 5
-
     mock.verify
-    mock_topics_both_pages.verify
+
+    topics.size.must_equal 5
   end
 
   it "iterates topics with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_both_pages, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_with_token_2, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics.all.take(5)
 
-    topics.size.must_equal 5
-
     mock.verify
-    mock_topics_both_pages.verify
+
+    topics.size.must_equal 5
   end
 
   it "iterates topics with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_both_pages, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_with_token_2, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics.all(request_limit: 1).to_a
 
-    topics.size.must_equal 5
-
     mock.verify
-    mock_topics_both_pages.verify
+
+    topics.size.must_equal 6
   end
 
   it "paginates topics without max set" do
-    mock_topics_with_token.expect :page_token, "next_page_token", []
     mock = Minitest::Mock.new
-    mock.expect :list_topics, mock_topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics
+
+    mock.verify
 
     topics.size.must_equal 3
     token = topics.token
     token.wont_be :nil?
     token.must_equal "next_page_token"
-
-    mock.verify
-    mock_topics_with_token.verify
   end
 
   it "gets a subscription" do
@@ -475,64 +429,60 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "lists subscriptions" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.subscriptions
 
+    mock.verify
+
     subs.count.must_equal 3
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
     end
-
-    mock.verify
-    mock_subscriptions_with_token.verify
   end
 
   it "lists subscriptions with find_subscriptions alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.find_subscriptions
 
+    mock.verify
+
     subs.count.must_equal 3
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
     end
-
-    mock.verify
-    mock_subscriptions_with_token.verify
   end
 
   it "lists subscriptions with list_subscriptions alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.list_subscriptions
+
+    mock.verify
 
     subs.count.must_equal 3
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
     end
-
-    mock.verify
-    mock_subscriptions_with_token.verify
   end
 
   it "paginates subscriptions" do
-    mock_subscriptions_with_token.expect :page_token, "next_page_token", []
-    mock_subscriptions_with_token.expect :page_token, "next_page_token", []
-
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")} # TODO: use this instead of Hash, below
-    mock.expect :list_subscriptions, mock_subscriptions_without_token, ["projects/#{project}", Hash]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
     first_subs = pubsub.subscriptions
     second_subs = pubsub.subscriptions token: first_subs.token
+
+    mock.verify
 
     first_subs.count.must_equal 3
     token = first_subs.token
@@ -541,39 +491,35 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     second_subs.count.must_equal 2
     second_subs.token.must_be :nil?
-
-    mock.verify
-    mock_subscriptions_with_token.verify
-    mock_subscriptions_without_token.verify
   end
 
   it "paginates subscriptions with max set" do
-    mock_subscriptions_with_token.expect :page_token, "next_page_token", []
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_with_token, ["projects/#{project}", page_size: 3, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: 3, options: nil]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.subscriptions max: 3
+
+    mock.verify
 
     subs.count.must_equal 3
     token = subs.token
     token.wont_be :nil?
     token.must_equal "next_page_token"
-
-    mock.verify
-    mock_subscriptions_with_token.verify
   end
 
   it "paginates subscriptions with next? and next" do
-    mock_subscriptions_both_pages.expect :next_page?, false, []
-
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_both_pages, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
     first_subs = pubsub.subscriptions
     second_subs = first_subs.next
 
+    mock.verify
+
     first_subs.count.must_equal 3
     first_subs.next?.must_equal true
     first_subs.each do |sub|
@@ -587,21 +533,20 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
       sub.wont_be :lazy?
     end
-
-    mock.verify
-    mock_subscriptions_both_pages.verify
   end
 
   it "paginates subscriptions with next? and next and max set" do
-    mock_subscriptions_both_pages.expect :next_page?, false, []
-
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_both_pages, ["projects/#{project}", page_size: 3, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: 3, options: nil]
+    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
     first_subs = pubsub.subscriptions max: 3
     second_subs = first_subs.next
 
+    mock.verify
+
     first_subs.count.must_equal 3
     first_subs.next?.must_equal true
     first_subs.each do |sub|
@@ -615,80 +560,77 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
       sub.wont_be :lazy?
     end
-
-    mock.verify
-    mock_subscriptions_both_pages.verify
   end
 
   it "paginates subscriptions with all" do
-    mock_subscriptions_both_pages.expect :next_page?, false, []
-
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_both_pages, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.subscriptions.all.to_a
 
+    mock.verify
+
     subs.count.must_equal 5
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
       sub.wont_be :lazy?
     end
-
-    mock.verify
-    mock_subscriptions_both_pages.verify
   end
 
   it "paginates subscriptions with all and max set" do
-    mock_subscriptions_both_pages.expect :next_page?, false, []
-
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_both_pages, ["projects/#{project}", page_size: 3, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: 3, options: nil]
+    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.subscriptions(max: 3).all.to_a
 
+    mock.verify
+
     subs.count.must_equal 5
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
       sub.wont_be :lazy?
     end
-
-    mock.verify
-    mock_subscriptions_both_pages.verify
   end
 
   it "iterates subscriptions with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_both_pages, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_with_token_2, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.subscriptions.all.take(5)
 
+    mock.verify
+
     subs.count.must_equal 5
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
       sub.wont_be :lazy?
     end
-
-    mock.verify
-    mock_subscriptions_both_pages.verify
   end
 
   it "iterates subscriptions with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, mock_subscriptions_both_pages, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_with_token_2, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.subscriptions.all(request_limit: 1).to_a
 
-    subs.count.must_equal 5
+    mock.verify
+
+    subs.count.must_equal 6
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
       sub.wont_be :lazy?
     end
-
-    mock.verify
-    mock_subscriptions_both_pages.verify
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
@@ -18,28 +18,24 @@ describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
                                                 pubsub.service }
-  let(:mock_subscriptions_with_token) do
-    first_get_res = Google::Pubsub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, "next_page_token")
-    page = Google::Gax::PagedEnumerable::Page.new first_get_res, "next_page_token", "subscriptions"
-    mock = Minitest::Mock.new
-    mock.expect :page, page, []
-    mock
+  let(:subscriptions_with_token) do
+    response = Google::Pubsub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, "next_page_token")
+    paged_enum_struct response
   end
   it "lists subscriptions" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, mock_subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
     topic.service.mocked_publisher = mock
 
     subs = topic.subscriptions
+
+    mock.verify
 
     subs.count.must_equal 3
     subs.each do |sub|
       sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
       sub.must_be :lazy?
     end
-
-    mock.verify
-    mock_subscriptions_with_token.verify
   end
 
   describe "lazy topic that exists" do
@@ -50,19 +46,18 @@ describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
 
       it "lists subscriptions" do
         mock = Minitest::Mock.new
-        mock.expect :list_topic_subscriptions, mock_subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
+        mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
         topic.service.mocked_publisher = mock
 
         subs = topic.subscriptions
+
+        mock.verify
 
         subs.count.must_equal 3
         subs.each do |sub|
           sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
           sub.must_be :lazy?
         end
-
-        mock.verify
-        mock_subscriptions_with_token.verify
       end
     end
 
@@ -73,19 +68,18 @@ describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
 
       it "lists subscriptions" do
         mock = Minitest::Mock.new
-        mock.expect :list_topic_subscriptions, mock_subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
+        mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
         topic.service.mocked_publisher = mock
 
         subs = topic.subscriptions
+
+        mock.verify
 
         subs.count.must_equal 3
         subs.each do |sub|
           sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
           sub.must_be :lazy?
         end
-
-        mock.verify
-        mock_subscriptions_with_token.verify
       end
     end
   end


### PR DESCRIPTION
Restore previous pagination design, using `response` from GAX `PagedEnumerable`. This approach was developed by @blowmage for #963.

I restored all unit test fixtures and expectations to original values as well.