### PR TITLE
Add yard-doctest example testing to Speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ results = audio.recognize
 
 result = results.first
 result.transcript #=> "how old is the Brooklyn Bridge"
-result.confidence #=> 88.15
+result.confidence #=> 0.9826789498329163
 ```
 
 ### Storage

--- a/google-cloud-speech/.rubocop.yml
+++ b/google-cloud-speech/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - "acceptance/**/*"
     - "google-cloud-speech.gemspec"
     - "Rakefile"
+    - "support/**/*"
     - "test/**/*"
     - "lib/google/cloud/speech/v1beta1/*"
 

--- a/google-cloud-speech/README.md
+++ b/google-cloud-speech/README.md
@@ -31,7 +31,7 @@ results = audio.recognize
 
 result = results.first
 result.transcript #=> "how old is the Brooklyn Bridge"
-result.confidence #=> 88.15
+result.confidence #=> 0.9826789498329163
 ```
 
 ## Supported Ruby Versions

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -67,6 +67,7 @@ end
 
 desc "Runs yard-doctest example tests."
 task :doctest do
+  sh "bundle exec yard doctest"
 end
 
 desc "Start an interactive shell."

--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -110,7 +110,7 @@ module Google
     #
     # result = results.first
     # result.transcript #=> "how old is the Brooklyn Bridge"
-    # result.confidence #=> 88.15
+    # result.confidence #=> 0.9826789498329163
     # ```
     #
     # Use {Speech::Audio#recognize_job} for asynchronous speech recognition,
@@ -134,7 +134,7 @@ module Google
     #
     # result = results.first
     # result.transcript #=> "how old is the Brooklyn Bridge"
-    # result.confidence #=> 88.15
+    # result.confidence #=> 0.9826789498329163
     # ```
     #
     # Use {Speech::Project#speech} for streaming audio data for speech
@@ -147,13 +147,15 @@ module Google
     #
     # speech = Google::Cloud::Speech.new
     #
+    # audio = speech.audio "path/to/audio.raw"
+    #
     # stream = audio.stream encoding: :raw, sample_rate: 16000
     #
     # # register callback for when a result is returned
     # stream.on_result do |results|
     #   result = results.first
     #   result.transcript #=> "how old is the Brooklyn Bridge"
-    #   result.confidence #=> 0.8099
+    #   result.confidence #=> 0.9826789498329163
     # end
     #
     # # Stream 5 seconds of audio from the microhone

--- a/google-cloud-speech/lib/google/cloud/speech/audio.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/audio.rb
@@ -44,7 +44,7 @@ module Google
       #
       #   result = results.first
       #   result.transcript #=> "how old is the Brooklyn Bridge"
-      #   result.confidence #=> 88.15
+      #   result.confidence #=> 0.9826789498329163
       #
       class Audio
         # @private The V1beta1::RecognitionAudio object.
@@ -182,7 +182,7 @@ module Google
         #
         #   result = results.first
         #   result.transcript #=> "how old is the Brooklyn Bridge"
-        #   result.confidence #=> 88.15
+        #   result.confidence #=> 0.9826789498329163
         #
         def recognize max_alternatives: nil, profanity_filter: nil, phrases: nil
           ensure_speech!

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -467,8 +467,8 @@ module Google
         #   # register callback for when a result is returned
         #   stream.on_result do |results|
         #     result = results.first
-        #     result.transcript #=> "how old is the Brooklyn Bridge"
-        #     result.confidence #=> 0.8099
+        #     puts result.transcript # "how old is the Brooklyn Bridge"
+        #     puts result.confidence # 0.9826789498329163
         #   end
         #
         #   # Stream 5 seconds of audio from the microhone

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -49,7 +49,7 @@ module Google
       #
       #   result = results.first
       #   result.transcript #=> "how old is the Brooklyn Bridge"
-      #   result.confidence #=> 88.15
+      #   result.confidence #=> 0.9826789498329163
       #
       class Project
         ##

--- a/google-cloud-speech/lib/google/cloud/speech/result.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/result.rb
@@ -37,7 +37,8 @@ module Google
       #   confidence was not set.
       # @attr_reader [Array<Result::Alternative>] alternatives Additional
       #   recognition hypotheses (up to the value specified in
-      #   `max_alternatives`).
+      #   `max_alternatives`). The server may return fewer than
+      #   `max_alternatives`.
       #
       # @example
       #   require "google/cloud/speech"
@@ -50,7 +51,7 @@ module Google
       #
       #   result = results.first
       #   result.transcript #=> "how old is the Brooklyn Bridge"
-      #   result.confidence #=> 0.8099
+      #   result.confidence #=> 0.9826789498329163
       #
       class Result
         attr_reader :transcript, :confidence, :alternatives

--- a/google-cloud-speech/lib/google/cloud/speech/result.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/result.rb
@@ -99,10 +99,10 @@ module Google
         #
         #   result = results.first
         #   result.transcript #=> "how old is the Brooklyn Bridge"
-        #   result.confidence #=> 0.8099
+        #   result.confidence #=> 0.9826789498329163
         #   alternative = result.alternatives.first
         #   alternative.transcript #=> "how old is the Brooklyn brim"
-        #   alternative.confidence #=> 0.2203
+        #   alternative.confidence #=> 0.22030000388622284
         #
         class Alternative
           attr_reader :transcript, :confidence
@@ -155,9 +155,9 @@ module Google
       #   # register callback for when an interim result is returned
       #   stream.on_interim do |final_results, interim_results|
       #     interim_result = interim_results.first
-      #     interim_result.transcript #=> "how old is the Brooklyn Bridge"
-      #     interim_result.confidence #=> 0.8099
-      #     interim_result.stability #=> 0.8999
+      #     puts interim_result.transcript # "how old is the Brooklyn Bridge"
+      #     puts interim_result.confidence # 0.9826789498329163
+      #     puts interim_result.stability # 0.8999
       #   end
       #
       #   # Stream 5 seconds of audio from the microhone

--- a/google-cloud-speech/lib/google/cloud/speech/stream.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/stream.rb
@@ -35,8 +35,8 @@ module Google
       #   # register callback for when a result is returned
       #   stream.on_result do |results|
       #     result = results.first
-      #     result.transcript #=> "how old is the Brooklyn Bridge"
-      #     result.confidence #=> 0.8099
+      #     puts result.transcript # "how old is the Brooklyn Bridge"
+      #     puts result.confidence # 0.9826789498329163
       #   end
       #
       #   # Stream 5 seconds of audio from the microhone
@@ -137,13 +137,13 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = audio.stream encoding: :raw, sample_rate: 16000
+        #   stream = speech.stream encoding: :raw, sample_rate: 16000
         #
         #   # register callback for when a result is returned
         #   stream.on_result do |results|
         #     result = results.first
-        #     result.transcript #=> "how old is the Brooklyn Bridge"
-        #     result.confidence #=> 0.8099
+        #     puts result.transcript # "how old is the Brooklyn Bridge"
+        #     puts result.confidence # 0.9826789498329163
         #   end
         #
         #   # Stream 5 seconds of audio from the microhone
@@ -207,8 +207,8 @@ module Google
         #
         #   results = stream.results
         #   result = results.first
-        #   result.transcript #=> "how old is the Brooklyn Bridge"
-        #   result.confidence #=> 0.8099
+        #   puts result.transcript # "how old is the Brooklyn Bridge"
+        #   puts result.confidence # 0.9826789498329163
         #
         def results
           Mutex.new.synchronize do
@@ -233,9 +233,9 @@ module Google
         #   # register callback for when an interim result is returned
         #   stream.on_interim do |final_results, interim_results|
         #     interim_result = interim_results.first
-        #     interim_result.transcript #=> "how old is the Brooklyn Bridge"
-        #     interim_result.confidence #=> 0.8099
-        #     interim_result.stability #=> 0.8999
+        #     puts interim_result.transcript # "how old is the Brooklyn Bridge"
+        #     puts interim_result.confidence # 0.9826789498329163
+        #     puts interim_result.stability # 0.8999
         #   end
         #
         #   # Stream 5 seconds of audio from the microhone
@@ -272,8 +272,8 @@ module Google
         #   # register callback for when an interim result is returned
         #   stream.on_result do |results|
         #     result = results.first
-        #     result.transcript #=> "how old is the Brooklyn Bridge"
-        #     result.confidence #=> 0.8099
+        #     puts result.transcript # "how old is the Brooklyn Bridge"
+        #     puts result.confidence # 0.9826789498329163
         #   end
         #
         #   # Stream 5 seconds of audio from the microhone

--- a/google-cloud-speech/support/doctest_helper.rb
+++ b/google-cloud-speech/support/doctest_helper.rb
@@ -1,0 +1,163 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/storage"
+require "google/cloud/speech"
+
+class File
+  def self.file? f
+    true
+  end
+  def self.readable? f
+    true
+  end
+  def self.read f, opts
+    "fake file data"
+  end
+end
+
+module Google
+  module Cloud
+    module Speech
+      def self.stub_new
+        define_singleton_method :new do |*args|
+          yield *args
+        end
+      end
+    end
+  end
+end
+
+def mock_speech
+  Google::Cloud::Speech.stub_new do |*args|
+    credentials = OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {}))
+    speech = Google::Cloud::Speech::Project.new(Google::Cloud::Speech::Service.new("my-project-id", credentials))
+
+    speech.service.mocked_service = Minitest::Mock.new
+    speech.service.mocked_ops = Minitest::Mock.new
+    yield speech.service.mocked_service, speech.service.mocked_ops
+    speech
+  end
+end
+
+module Google
+  module Cloud
+    module Storage
+      def self.stub_new
+        define_singleton_method :new do |*args|
+          yield *args
+        end
+      end
+    end
+  end
+end
+
+def mock_storage
+  Google::Cloud::Storage.stub_new do |*args|
+    credentials = OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {}))
+    storage = Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new("my-project-id", credentials))
+
+    storage.service.mocked_service = Minitest::Mock.new
+    yield storage.service.mocked_service
+    storage
+  end
+end
+
+YARD::Doctest.configure do |doctest|
+  doctest.before "Google::Cloud#speech" do
+    mock_speech
+  end
+
+  doctest.before "Google::Cloud::Speech::Project" do
+    mock_speech do |mock|
+      mock.expect :sync_recognize, sync_recognize_response, recognize_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Speech::Project#recognize_job" do
+    mock_speech do |mock|
+      mock.expect :async_recognize, op_done_false, recognize_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Speech::Project#recognize_job@With a Google Cloud Storage File object:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket,  OpenStruct.new(name: "bucket-name"), ["bucket-name"]
+      mock.expect :get_object,  OpenStruct.new(name: "bucket-name"), ["bucket-name", "path/to/audio.raw", {:generation=>nil, :options=>{}}]
+    end
+    mock_speech do |mock|
+      mock.expect :async_recognize, op_done_false, recognize_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Speech::Audio" do
+    mock_speech do |mock|
+      mock.expect :sync_recognize, sync_recognize_response, recognize_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Speech::Audio#recognize_job" do
+    mock_speech do |mock_service, mock_ops|
+      mock_service.expect :async_recognize, op_done_false, recognize_args
+      mock_ops.expect :get_operation, op_done_true, [op_req]
+    end
+  end
+
+  doctest.before "Google::Cloud::Speech::Job" do
+    mock_speech do |mock_service, mock_ops|
+      mock_service.expect :async_recognize, op_done_false, recognize_args
+      mock_ops.expect :get_operation, op_done_true, [op_req]
+    end
+  end
+
+  doctest.before "Google::Cloud::Speech::Job#results" do
+    mock_speech do |mock_service|
+      mock_service.expect :async_recognize, op_done_true, recognize_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Speech::Result" do
+    mock_speech do |mock|
+      mock.expect :sync_recognize, sync_recognize_response, recognize_args
+    end
+  end
+end
+
+# Fixture helpers
+
+# TODO: Match argument values, not just types
+def recognize_args
+  [Google::Cloud::Speech::V1beta1::RecognitionConfig, Google::Cloud::Speech::V1beta1::RecognitionAudio]
+end
+
+def sync_recognize_response
+  results_json = "{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.9826789498329163}]}]}"
+  Google::Cloud::Speech::V1beta1::SyncRecognizeResponse.decode_json results_json
+end
+
+def op_req
+  Google::Longrunning::GetOperationRequest.new name: "1234567890"
+end
+
+def op_done_false
+  job_json = "{\"name\":\"1234567890\",\"metadata\":{\"typeUrl\":\"type.googleapis.com/google.cloud.speech.v1beta1.AsyncRecognizeMetadata\",\"value\":\"CFQSDAi6jKS/BRCwkLafARoMCIeZpL8FEKjRqswC\"}}"
+  Google::Longrunning::Operation.decode_json job_json
+end
+
+def op_done_true
+  results_json = "{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.98267895}]}]}"
+  results_grpc = Google::Cloud::Speech::V1beta1::AsyncRecognizeResponse.decode_json results_json
+  complete_json = "{\"name\":\"1234567890\",\"metadata\":{\"typeUrl\":\"type.googleapis.com/google.cloud.speech.v1beta1.AsyncRecognizeMetadata\",\"value\":\"CFQSDAi6jKS/BRCwkLafARoMCIeZpL8FEKjRqswC\"}, \"done\": true, \"response\": {\"typeUrl\":\"type.googleapis.com/google.cloud.speech.v1beta1.AsyncRecognizeResponse\",\"value\":\"#{Base64.strict_encode64(results_grpc.to_proto)}\"}"
+  Google::Longrunning::Operation.decode_json complete_json
+end


### PR DESCRIPTION
This PR adds testing for google-cloud-speech examples, running the example code whenever at least one expectation is provided by return-value comment (`#=>`). Examples without at least one expectation are not executed at this time by [yard-doctest](https://github.com/p0deje/yard-doctest).

There are currently 24 assertions in the Speech code examples:

```sh
$ bundle exec rake doctest
bundle exec yard doctest
Run options: --seed 34816

# Running:

.................................

Finished in 5.148561s, 6.4096 runs/s, 4.6615 assertions/s.

33 runs, 24 assertions, 0 failures, 0 errors, 0 skips

```

[refs #226]