### PR TITLE
Refactor Google::Cloud::Core::GCE to Google::Cloud::Core::Environment

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-require "google/cloud/core/gce"
+require "google/cloud/core/environment"
 require "google/cloud/errors"
 require "google/cloud/bigquery/service"
 require "google/cloud/bigquery/credentials"
@@ -88,7 +88,7 @@ module Google
           ENV["BIGQUERY_PROJECT"] ||
             ENV["GOOGLE_CLOUD_PROJECT"] ||
             ENV["GCLOUD_PROJECT"] ||
-            Google::Cloud::Core::GCE.project_id
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Bigquery::Credentials.stub :default, default_credentials do
             bigquery = Google::Cloud.bigquery
             bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
@@ -125,7 +125,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Bigquery::Credentials.stub :default, default_credentials do
             bigquery = Google::Cloud::Bigquery.new
             bigquery.must_be_kind_of Google::Cloud::Bigquery::Project

--- a/google-cloud-core/lib/google/cloud/core/environment.rb
+++ b/google-cloud-core/lib/google/cloud/core/environment.rb
@@ -20,10 +20,11 @@ module Google
     module Core
       ##
       # @private
-      # Represents the Google Compute Engine environment.
-      module GCE
+      # Represents the Google Cloud Platform environments.
+      module Environment
         CHECK_URI = "http://169.254.169.254"
         PROJECT_URI = "#{CHECK_URI}/computeMetadata/v1/project/project-id"
+        INSTANCE_METADATA_URI = "#{CHECK_URI}/computeMetadata/v1/instance"
 
         def self.gce? options = {}
           conn = options[:connection] || Faraday.default_connection

--- a/google-cloud-core/lib/google/cloud/core/environment.rb
+++ b/google-cloud-core/lib/google/cloud/core/environment.rb
@@ -23,10 +23,13 @@ module Google
       # Represents the Google Cloud Platform environments.
       module Environment
         CHECK_URI = "http://169.254.169.254"
-        PROJECT_URI = "#{CHECK_URI}/computeMetadata/v1/project/project-id"
+        PROJECT_URI = "#{CHECK_URI}/computeMetadata/v1/project"
         INSTANCE_METADATA_URI = "#{CHECK_URI}/computeMetadata/v1/instance"
 
-        def self.gce? options = {}
+        ##
+        # Check if running from a gce vm, which actually hosts GCE, GKE, and
+        # GAE environments.
+        def self.gce_vm? options = {}
           conn = options[:connection] || Faraday.default_connection
           resp = conn.get CHECK_URI do |req|
             req.options.timeout = 0.1
@@ -38,22 +41,99 @@ module Google
           return false
         end
 
-        def self.project_id options = {}
-          @gce ||= {}
-          return @gce[:project_id] if @gce.key? :project_id
-          conn = options[:connection] || Faraday.default_connection
+        ##
+        # Check if running from Google Compute Engine, and not using GAE or GKE
+        #
+        # @return [Boolean] True iff running from GCE and not GAE or GKE
+        def self.gce?
+          gce_vm? && !gae? && !gke?
+        end
+
+        ##
+        # Check if running from Google Container Engine by querying for
+        # GKE cluster name and VM instance_zone
+        #
+        # @return [Boolean] True iff self.gke_cluster_name() and
+        # self.instance_zone() both return true values
+        def self.gke?
+          gke_cluster_name && instance_zone
+        end
+
+        ##
+        # Check if running from Google App Engine by checking existance of
+        # GAE_VM, GAE_MODULE_NAME, GAE_MODULE_VERSION environment variables.
+        #
+        # @return [Boolean] True if all three GAE environment variables are
+        #   defined
+        def self.gae?
+          ENV["GAE_VM"] && gae_module_id && gae_module_version
+        end
+
+        def self.project_id
+          uri = "#{PROJECT_URI}/project-id"
+          get_metadata_attribute uri, :project_id
+        end
+
+        ##
+        # Retrieve GAE module name
+        def self.gae_module_id
+          ENV["GAE_MODULE_NAME"]
+        end
+
+        ##
+        # Retrieve GAE module version
+        def self.gae_module_version
+          ENV["GAE_MODULE_VERSION"]
+        end
+
+        ##
+        # Retrieve GKE cluster name
+        def self.gke_cluster_name
+          uri = "#{INSTANCE_METADATA_URI}/attributes/cluster-name"
+          get_metadata_attribute uri, :cluster_name
+        end
+
+        ##
+        # Retrieve GKE namespace id
+        def self.gke_namespace_id
+          ENV["GKE_NAMESPACE_ID"]
+        end
+
+        ##
+        # Retrieve GCE VM zone
+        def self.instance_zone
+          uri = "#{INSTANCE_METADATA_URI}/zone"
+          full_zone = get_metadata_attribute uri, :zone
+          full_zone.nil? ? nil : full_zone.split(%r{/}).last
+        end
+
+        ##
+        # Retrieve GCE VM instance_id
+        def self.instance_id
+          uri = "#{INSTANCE_METADATA_URI}/id"
+          get_metadata_attribute uri, :instance_id
+        end
+
+        ##
+        # Helper method to send HTTP request to GCP metadata service and
+        # retrieve environment information
+        def self.get_metadata_attribute uri, attr_name, connection: nil
+          @metadata ||= {}
+          return @metadata[attr_name] if @metadata.key? attr_name
+
+          conn = connection || Faraday.default_connection
+
+          puts conn.get uri
+
           conn.headers = { "Metadata-Flavor" => "Google" }
-          resp = conn.get PROJECT_URI do |req|
+          resp = conn.get uri do |req|
             req.options.timeout = 0.1
           end
-          if resp.status == 200
-            @gce[:project_id] = resp.body
-          else
-            @gce[:project_id] = nil
-          end
+
+          @metadata[attr_name] = resp.status == 200 ? resp.body : nil
         rescue Faraday::TimeoutError, Faraday::ConnectionFailed
-          @gce ||= {}
-          @gce[:project_id] = nil
+          @metadata ||= {}
+          @metadata[attr_name] = nil
         end
       end
     end

--- a/google-cloud-core/test/google/cloud/core/environment_test.rb
+++ b/google-cloud-core/test/google/cloud/core/environment_test.rb
@@ -1,0 +1,55 @@
+require "helper"
+require "google/cloud/core/environment"
+
+describe Google::Cloud::Core::Environment do
+  describe ".gce?" do
+    it "returns false if .gke? is true" do
+      ENV.stub :[], nil do
+        Google::Cloud::Core::Environment.stub :gke?, true do
+          Google::Cloud::Core::Environment.stub :gce_vm?, true do
+            Google::Cloud::Core::Environment.gce?.must_equal false
+          end
+        end
+      end
+    end
+
+    it "returns false if .gae? is true" do
+      ENV.stub :[], nil do
+        Google::Cloud::Core::Environment.stub :gae?, true do
+          Google::Cloud::Core::Environment.stub :gce_vm?, true do
+            Google::Cloud::Core::Environment.gce?.must_equal false
+          end
+        end
+      end
+    end
+  end
+
+  describe ".get_metadata_attribute" do
+    let(:succ_response) { OpenStruct.new status: 200, body: "Success!" }
+    let(:fail_response) { OpenStruct.new status: 500, body: "Failed!" }
+
+    after do
+      Google::Cloud::Core::Environment.instance_variable_set "@metadata", {}
+    end
+
+    it "returns attr if request made successfully" do
+      request_mock = Minitest::Mock.new
+      request_mock.expect :options, OpenStruct.new
+
+      Faraday.default_connection.stub :get, succ_response, request_mock do
+        attr = Google::Cloud::Core::Environment.get_metadata_attribute "uri", :attr
+        attr.must_equal succ_response.body
+      end
+    end
+
+    it "returns nil if request failed" do
+      request_mock = Minitest::Mock.new
+      request_mock.expect :options, OpenStruct.new
+
+      Faraday.default_connection.stub :get, fail_response, request_mock do
+        attr = Google::Cloud::Core::Environment.get_metadata_attribute "uri", :attr
+        attr.must_be :nil?
+      end
+    end
+  end
+end

--- a/google-cloud-core/test/google/cloud/core/environment_test.rb
+++ b/google-cloud-core/test/google/cloud/core/environment_test.rb
@@ -1,3 +1,18 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 require "helper"
 require "google/cloud/core/environment"
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-require "google/cloud/core/gce"
+require "google/cloud/core/environment"
 require "google/cloud/datastore/grpc_utils"
 require "google/cloud/datastore/credentials"
 require "google/cloud/datastore/service"
@@ -89,7 +89,7 @@ module Google
             ENV["DATASTORE_PROJECT"] ||
             ENV["GOOGLE_CLOUD_PROJECT"] ||
             ENV["GCLOUD_PROJECT"] ||
-            Google::Cloud::Core::GCE.project_id
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##

--- a/google-cloud-datastore/test/google/cloud/datastore_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Datastore::Credentials.stub :default, default_credentials do
             datastore = Google::Cloud.datastore
             datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
@@ -125,7 +125,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Datastore::Credentials.stub :default, default_credentials do
             datastore = Google::Cloud::Datastore.new
             datastore.must_be_kind_of Google::Cloud::Datastore::Dataset

--- a/google-cloud-dns/lib/google/cloud/dns/project.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/project.rb
@@ -14,7 +14,7 @@
 
 
 require "google/cloud/errors"
-require "google/cloud/core/gce"
+require "google/cloud/core/environment"
 require "google/cloud/dns/service"
 require "google/cloud/dns/credentials"
 require "google/cloud/dns/zone"
@@ -130,7 +130,7 @@ module Google
           ENV["DNS_PROJECT"] ||
             ENV["GOOGLE_CLOUD_PROJECT"] ||
             ENV["GCLOUD_PROJECT"] ||
-            Google::Cloud::Core::GCE.project_id
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##

--- a/google-cloud-dns/test/google/cloud/dns_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Dns::Credentials.stub :default, default_credentials do
             dns = Google::Cloud.dns
             dns.must_be_kind_of Google::Cloud::Dns::Project
@@ -125,7 +125,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Dns::Credentials.stub :default, default_credentials do
             dns = Google::Cloud::Dns.new
             dns.must_be_kind_of Google::Cloud::Dns::Project

--- a/google-cloud-language/lib/google/cloud/language/project.rb
+++ b/google-cloud-language/lib/google/cloud/language/project.rb
@@ -14,7 +14,7 @@
 
 
 require "google/cloud/errors"
-require "google/cloud/core/gce"
+require "google/cloud/core/environment"
 require "google/cloud/language/service"
 require "google/cloud/language/document"
 require "google/cloud/language/annotation"
@@ -79,7 +79,7 @@ module Google
           ENV["LANGUAGE_PROJECT"] ||
             ENV["GOOGLE_CLOUD_PROJECT"] ||
             ENV["GCLOUD_PROJECT"] ||
-            Google::Cloud::Core::GCE.project_id
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##

--- a/google-cloud-language/test/google/cloud/language_test.rb
+++ b/google-cloud-language/test/google/cloud/language_test.rb
@@ -73,7 +73,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Language::Credentials.stub :default, default_credentials do
             language = Google::Cloud.language
             language.must_be_kind_of Google::Cloud::Language::Project
@@ -124,7 +124,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Language::Credentials.stub :default, default_credentials do
             language = Google::Cloud::Language.new
             language.must_be_kind_of Google::Cloud::Language::Project

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -14,7 +14,7 @@
 
 
 require "google/cloud/errors"
-require "google/cloud/core/gce"
+require "google/cloud/core/environment"
 require "google/cloud/logging/service"
 require "google/cloud/logging/credentials"
 require "google/cloud/logging/entry"
@@ -80,7 +80,7 @@ module Google
           ENV["LOGGING_PROJECT"] ||
             ENV["GOOGLE_CLOUD_PROJECT"] ||
             ENV["GCLOUD_PROJECT"] ||
-            Google::Cloud::Core::GCE.project_id
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##

--- a/google-cloud-logging/test/google/cloud/logging_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging_test.rb
@@ -73,7 +73,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Logging::Credentials.stub :default, default_credentials do
             logging = Google::Cloud.logging
             logging.must_be_kind_of Google::Cloud::Logging::Project
@@ -124,7 +124,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Logging::Credentials.stub :default, default_credentials do
             logging = Google::Cloud::Logging.new
             logging.must_be_kind_of Google::Cloud::Logging::Project

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -14,7 +14,7 @@
 
 
 require "google/cloud/errors"
-require "google/cloud/core/gce"
+require "google/cloud/core/environment"
 require "google/cloud/pubsub/service"
 require "google/cloud/pubsub/credentials"
 require "google/cloud/pubsub/topic"
@@ -76,7 +76,7 @@ module Google
           ENV["PUBSUB_PROJECT"] ||
             ENV["GOOGLE_CLOUD_PROJECT"] ||
             ENV["GCLOUD_PROJECT"] ||
-            Google::Cloud::Core::GCE.project_id
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Pubsub::Credentials.stub :default, default_credentials do
             pubsub = Google::Cloud.pubsub
             pubsub.must_be_kind_of Google::Cloud::Pubsub::Project
@@ -125,7 +125,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Pubsub::Credentials.stub :default, default_credentials do
             pubsub = Google::Cloud::Pubsub.new
             pubsub.must_be_kind_of Google::Cloud::Pubsub::Project

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -14,7 +14,7 @@
 
 
 require "google/cloud/errors"
-require "google/cloud/core/gce"
+require "google/cloud/core/environment"
 require "google/cloud/speech/service"
 require "google/cloud/speech/audio"
 require "google/cloud/speech/result"
@@ -83,7 +83,7 @@ module Google
           ENV["SPEECH_PROJECT"] ||
             ENV["GOOGLE_CLOUD_PROJECT"] ||
             ENV["GCLOUD_PROJECT"] ||
-            Google::Cloud::Core::GCE.project_id
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##

--- a/google-cloud-speech/test/google/cloud/speech_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech_test.rb
@@ -73,7 +73,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Speech::Credentials.stub :default, default_credentials do
             speech = Google::Cloud.speech
             speech.must_be_kind_of Google::Cloud::Speech::Project
@@ -124,7 +124,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Speech::Credentials.stub :default, default_credentials do
             speech = Google::Cloud::Speech.new
             speech.must_be_kind_of Google::Cloud::Speech::Project

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-require "google/cloud/core/gce"
+require "google/cloud/core/environment"
 require "google/cloud/storage/errors"
 require "google/cloud/storage/service"
 require "google/cloud/storage/credentials"
@@ -82,7 +82,7 @@ module Google
           ENV["STORAGE_PROJECT"] ||
             ENV["GOOGLE_CLOUD_PROJECT"] ||
             ENV["GCLOUD_PROJECT"] ||
-            Google::Cloud::Core::GCE.project_id
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##

--- a/google-cloud-storage/test/google/cloud/storage_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Storage::Credentials.stub :default, default_credentials do
             storage = Google::Cloud.storage
             storage.must_be_kind_of Google::Cloud::Storage::Project
@@ -125,7 +125,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Storage::Credentials.stub :default, default_credentials do
             storage = Google::Cloud::Storage.new
             storage.must_be_kind_of Google::Cloud::Storage::Project

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -14,7 +14,7 @@
 
 
 require "google/cloud/errors"
-require "google/cloud/core/gce"
+require "google/cloud/core/environment"
 require "google/cloud/vision/service"
 require "google/cloud/vision/credentials"
 require "google/cloud/vision/annotate"
@@ -79,7 +79,7 @@ module Google
           ENV["VISION_PROJECT"] ||
             ENV["GOOGLE_CLOUD_PROJECT"] ||
             ENV["GCLOUD_PROJECT"] ||
-            Google::Cloud::Core::GCE.project_id
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##

--- a/google-cloud-vision/test/google/cloud/vision_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision_test.rb
@@ -73,7 +73,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Vision::Credentials.stub :default, default_credentials do
             vision = Google::Cloud.vision
             vision.must_be_kind_of Google::Cloud::Vision::Project
@@ -124,7 +124,7 @@ describe Google::Cloud do
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
-        Google::Cloud::Core::GCE.stub :project_id, "project-id" do
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
           Google::Cloud::Vision::Credentials.stub :default, default_credentials do
             vision = Google::Cloud::Vision.new
             vision.must_be_kind_of Google::Cloud::Vision::Project


### PR DESCRIPTION
Hi Mike, Chris,

For all the instrumentation libraries I'm going to add soon, they require utility functions to check which environment code is running from and retrieve metadata. The existing Google::Cloud::Core::GCE module already does something like this, but only for GCE VM environment and queries GCP project_id. I think it makes sense to re-purpose and expand this module to support all metadata management for various GCP environments.

In this PR, I'm renaming Google::Cloud::Core::GCE to Google::Cloud::Core::Environment. I'm also adding several utility functions: 
* original "gce?" function renamed to "gce_vm?", because this function is essentially checking if environment is on a GCE VM.
* "gae?" funcion checks if running in GAE environment
* "gke?" function checks if running in GKE environment
* new "gce?" function checks if running on GCE deployed environment and make sure it's not GAE or GKE
* Finally, various other metadata retrieving functions that gets information from environment variables or internal metadata service

I'm adding more elaborate integration tests in later PR.

Please let me know what you think.

Thanks,
heng Xiong