### PR TITLE
Add Speech Streaming

### DIFF
--- a/google-cloud-speech/acceptance/speech/stream_test.rb
+++ b/google-cloud-speech/acceptance/speech/stream_test.rb
@@ -1,0 +1,272 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "speech_helper"
+
+describe "Streaming Recognition", :speech do
+  let(:filepath) { "acceptance/data/audio.raw" }
+
+  it "default params" do
+    counters = Hash.new { |h, k| h[k] = 0 }
+
+    stream = speech.stream encoding: :raw, sample_rate: 16000
+
+    stream.on_interim      { counters[:interim] += 1 }
+    stream.on_result        { counters[:result] += 1 }
+    stream.on_speech_start { counters[:speech_start] += 1 }
+    stream.on_speech_end   { counters[:speech_end] += 1 }
+    stream.on_complete     { counters[:complete] += 1 }
+    stream.on_utterance    { counters[:utterance] += 1 }
+
+    stream.send File.read(filepath, mode: "rb")
+
+    stream.stop
+
+    while counters[:complete] == 0 do
+      sleep 1
+    end
+    sleep 3 # give more callbacks time to finish
+
+    results = stream.results
+
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+
+    counters[:interim].must_be :zero?
+    counters[:result].must_equal 1
+    counters[:speech_start].must_equal 1
+    counters[:speech_end].must_be :>=, 0
+    counters[:complete].must_equal 1
+    counters[:utterance].must_be :zero?
+  end
+
+  it "sends multiple times" do
+    counters = Hash.new { |h, k| h[k] = 0 }
+
+    stream = speech.stream encoding: :raw, sample_rate: 16000
+
+    stream.on_interim      { counters[:interim] += 1 }
+    stream.on_result        { counters[:result] += 1 }
+    stream.on_speech_start { counters[:speech_start] += 1 }
+    stream.on_speech_end   { counters[:speech_end] += 1 }
+    stream.on_complete     { counters[:complete] += 1 }
+    stream.on_utterance    { counters[:utterance] += 1 }
+
+    file = File.open filepath, "rb"
+
+    # simulate a live stream, by sending a second at a time
+    until file.eof?
+      stream.send file.read(32000) # about a seconds worth of data
+      sleep 1
+    end
+
+    stream.stop
+
+    while counters[:complete] == 0 do
+      sleep 1
+    end
+    sleep 3 # give more callbacks time to finish
+
+    results = stream.results
+
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+
+    counters[:interim].must_be :zero?
+    counters[:result].must_equal 1
+    counters[:speech_start].must_equal 1
+    counters[:speech_end].must_be :>=, 0
+    counters[:complete].must_equal 1
+    counters[:utterance].must_be :zero?
+  end
+
+  describe "interim" do
+    it "default params" do
+      counters = Hash.new { |h, k| h[k] = 0 }
+
+      stream = speech.stream encoding: :raw, sample_rate: 16000, interim: true
+
+      stream.on_interim      { counters[:interim] += 1 }
+      stream.on_result        { counters[:result] += 1 }
+      stream.on_speech_start { counters[:speech_start] += 1 }
+      stream.on_speech_end   { counters[:speech_end] += 1 }
+      stream.on_complete     { counters[:complete] += 1 }
+      stream.on_utterance    { counters[:utterance] += 1 }
+
+      stream.send File.read(filepath, mode: "rb")
+
+      stream.stop
+
+      while counters[:complete] == 0 do
+        sleep 1
+      end
+      sleep 3 # give more callbacks time to finish
+
+      results = stream.results
+
+      results.count.must_equal 1
+      results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+      results.first.confidence.must_be_close_to 0.98267895
+      results.first.alternatives.must_be :empty?
+
+      counters[:interim].must_be :>, 0
+      counters[:result].must_equal 1
+      counters[:speech_start].must_equal 1
+      counters[:speech_end].must_be :>=, 0
+      counters[:complete].must_equal 1
+      counters[:utterance].must_be :zero?
+    end
+
+    it "sends multiple times" do
+      counters = Hash.new { |h, k| h[k] = 0 }
+
+      stream = speech.stream encoding: :raw, sample_rate: 16000, interim: true
+
+      stream.on_interim      { counters[:interim] += 1 }
+      stream.on_result        { counters[:result] += 1 }
+      stream.on_speech_start { counters[:speech_start] += 1 }
+      stream.on_speech_end   { counters[:speech_end] += 1 }
+      stream.on_complete     { counters[:complete] += 1 }
+      stream.on_utterance    { counters[:utterance] += 1 }
+
+      file = File.open filepath, "rb"
+
+      # simulate a live stream, by sending a second at a time
+      until file.eof?
+        stream.send file.read(32000) # about a seconds worth of data
+        sleep 1
+      end
+
+      stream.stop
+
+      while counters[:complete] == 0 do
+        sleep 1
+      end
+      sleep 3 # give more callbacks time to finish
+
+      results = stream.results
+
+      results.count.must_equal 1
+      results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+      results.first.confidence.must_be_close_to 0.98267895
+      results.first.alternatives.must_be :empty?
+
+      counters[:interim].must_be :>, 0
+      counters[:result].must_equal 1
+      counters[:speech_start].must_equal 1
+      counters[:speech_end].must_be :>=, 0
+      counters[:complete].must_equal 1
+      counters[:utterance].must_be :zero?
+    end
+  end
+
+  describe "utterance" do
+    it "default params" do
+      counters = Hash.new { |h, k| h[k] = 0 }
+
+      stream = speech.stream encoding: :raw, sample_rate: 16000, utterance: true
+
+      stream.on_interim      { counters[:interim] += 1 }
+      stream.on_result        { counters[:result] += 1 }
+      stream.on_speech_start { counters[:speech_start] += 1 }
+      stream.on_speech_end   { counters[:speech_end] += 1 }
+      stream.on_complete     { counters[:complete] += 1 }
+      stream.on_utterance    { counters[:utterance] += 1 }
+
+      stream.send File.read(filepath, mode: "rb")
+
+      # send 5 seconds of silence to kick off the utterance callback
+      silent_frame = Array(0).pack("s<").encode("ASCII-8BIT")
+      silent_second = silent_frame * 1600
+      5.times do
+        stream.send silent_second
+        sleep 1
+      end
+
+      stream.stop
+
+      while counters[:complete] == 0 do
+        sleep 1
+      end
+      sleep 3 # give more callbacks time to finish
+
+      results = stream.results
+
+      results.count.must_equal 1
+      results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+      results.first.confidence.must_be_close_to 0.98267895
+      results.first.alternatives.must_be :empty?
+
+      counters[:interim].must_equal 0
+      counters[:result].must_equal 1
+      counters[:speech_start].must_equal 1
+      counters[:speech_end].must_be :>=, 0
+      counters[:complete].must_equal 1
+      counters[:utterance].must_equal 1
+    end
+
+    it "sends multiple times" do
+      counters = Hash.new { |h, k| h[k] = 0 }
+
+      stream = speech.stream encoding: :raw, sample_rate: 16000, utterance: true
+
+      stream.on_interim      { counters[:interim] += 1 }
+      stream.on_result        { counters[:result] += 1 }
+      stream.on_speech_start { counters[:speech_start] += 1 }
+      stream.on_speech_end   { counters[:speech_end] += 1 }
+      stream.on_complete     { counters[:complete] += 1 }
+      stream.on_utterance    { counters[:utterance] += 1 }
+
+      file = File.open filepath, "rb"
+
+      # simulate a live stream, by sending a second at a time
+      until file.eof?
+        stream.send file.read(32000) # about a seconds worth of data
+        sleep 1
+      end
+      # send 5 seconds of silence to kick off the utterance callback
+      silent_frame = Array(0).pack("s<").encode("ASCII-8BIT")
+      silent_second = silent_frame * 1600
+      5.times do
+        stream.send silent_second
+        sleep 1
+      end
+
+      stream.stop
+
+      while counters[:complete] == 0 do
+        sleep 1
+      end
+      sleep 3 # give more callbacks time to finish
+
+      results = stream.results
+
+      results.count.must_equal 1
+      results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+      results.first.confidence.must_be_close_to 0.98267895
+      results.first.alternatives.must_be :empty?
+
+      counters[:interim].must_equal 0
+      counters[:result].must_equal 1
+      counters[:speech_start].must_equal 1
+      counters[:speech_end].must_be :>=, 0
+      counters[:complete].must_equal 1
+      counters[:utterance].must_equal 1
+    end
+  end
+end

--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -94,10 +94,10 @@ module Google
     # recognition operation.
     #
     # Use {Speech::Audio#recognize} for synchronous speech recognition that
-    # returns {Result} objects only after all audio has been processed. This
-    # method is limited to audio data of 1 minute or less in duration, and will
-    # take roughly the same amount of time to process as the duration of the
-    # supplied audio data.
+    # returns {Speech::Result} objects only after all audio has been processed.
+    # This method is limited to audio data of 1 minute or less in duration, and
+    # will take roughly the same amount of time to process as the duration of
+    # the supplied audio data.
     #
     # ```ruby
     # require "google/cloud/speech"
@@ -114,8 +114,8 @@ module Google
     # ```
     #
     # Use {Speech::Audio#recognize_job} for asynchronous speech recognition,
-    # in which a {Job} is returned immediately after the audio data has
-    # been sent. The job can be refreshed to retrieve {Result} objects
+    # in which a {Speech::Job} is returned immediately after the audio data has
+    # been sent. The job can be refreshed to retrieve {Speech::Result} objects
     # once the audio data has been processed.
     #
     # ```ruby
@@ -136,6 +136,37 @@ module Google
     # result.transcript #=> "how old is the Brooklyn Bridge"
     # result.confidence #=> 88.15
     # ```
+    #
+    # Use {Speech::Project#speech} for streaming audio data for speech
+    # recognition, in which a {Speech::Stream} is returned. The stream object
+    # can receive results while sending audio by performing bidirectional
+    # streaming speech-recognition.
+    #
+    # ```ruby
+    # require "google/cloud/speech"
+    #
+    # speech = Google::Cloud::Speech.new
+    #
+    # stream = audio.stream encoding: :raw, sample_rate: 16000
+    #
+    # # register callback for when a result is returned
+    # stream.on_result do |results|
+    #   result = results.first
+    #   result.transcript #=> "how old is the Brooklyn Bridge"
+    #   result.confidence #=> 0.8099
+    # end
+    #
+    # # Stream 5 seconds of audio from the microhone
+    # # Actual implementation of microphone input varies by platform
+    # 5.times.do
+    #   stream.send MicrophoneInput.read(32000)
+    # end
+    #
+    # stream.stop
+    # ```
+    #
+    # Obtaining audio data from input sources such as a Microphone is outside
+    # the scope of this document.
     #
     module Speech
       ##

--- a/google-cloud-speech/lib/google/cloud/speech/service.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/service.rb
@@ -39,10 +39,12 @@ module Google
         end
 
         def channel
+          require "grpc"
           GRPC::Core::Channel.new host, nil, chan_creds
         end
 
         def chan_creds
+          require "grpc"
           return credentials if insecure?
           GRPC::Core::ChannelCredentials.new.compose \
             GRPC::Core::CallCredentials.new credentials.client.updater_proc
@@ -82,6 +84,10 @@ module Google
 
         def recognize_async audio, config
           execute { service.async_recognize config, audio }
+        end
+
+        def recognize_stream request_enum
+          service.speech_stub.streaming_recognize request_enum
         end
 
         def get_op name

--- a/google-cloud-speech/lib/google/cloud/speech/stream.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/stream.rb
@@ -1,0 +1,476 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/speech/v1beta1"
+require "google/cloud/speech/result"
+require "forwardable"
+
+module Google
+  module Cloud
+    module Speech
+      ##
+      # # Stream
+      #
+      # A resource that represents the streaming requests and responses.
+      #
+      # @example
+      #   require "google/cloud/speech"
+      #
+      #   speech = Google::Cloud::Speech.new
+      #
+      #   stream = audio.stream encoding: :raw, sample_rate: 16000
+      #
+      #   # register callback for when a result is returned
+      #   stream.on_result do |results|
+      #     result = results.first
+      #     result.transcript #=> "how old is the Brooklyn Bridge"
+      #     result.confidence #=> 0.8099
+      #   end
+      #
+      #   # Stream 5 seconds of audio from the microhone
+      #   # Actual implementation of microphone input varies by platform
+      #   5.times.do
+      #     stream.send MicrophoneInput.read(32000)
+      #   end
+      #
+      #   stream.stop
+      #
+      class Stream
+        ##
+        # @private Creates a new Speech Stream instance.
+        # This must always be private, since it may change as the implementation
+        # changes over time.
+        def initialize service, streaming_recognize_request
+          @service = service
+          @streaming_recognize_request = streaming_recognize_request
+          @results = []
+          @callbacks = Hash.new { |h, k| h[k] = [] }
+        end
+
+        # rubocop:disable all
+        # Disabled rubocop because start is complex and all the logic needs to
+        # happen on the thread. Please refactor this to make it nicer.
+
+        ##
+        # Starts the stream. The stream will be started in the first #send call.
+        def start
+          return if @request_queue
+          @request_queue = EnumeratorQueue.new(self)
+          @request_queue.push @streaming_recognize_request
+
+          Thread.new do
+            @response_enum = @service.recognize_stream @request_queue.each_item
+            @response_enum.each do |response|
+              unless response.is_a? V1beta1::StreamingRecognizeResponse
+                fail ArgumentError, "Unable to handle #{response.class}"
+              end
+
+              # results are StreamingRecognitionResult
+              final_grpc, interim_grpcs = *response.results
+              if final_grpc && final_grpc.is_final
+                Mutex.new.synchronize do
+                  @results[response.result_index] = Result.from_grpc final_grpc
+                end
+                # callback for final result received
+                result!
+              else
+                # all results are interim
+                interim_grpcs = response.results
+              end
+
+              # convert to Speech object from GRPC object
+              interim_results = interim_grpcs.map do |grpc|
+                InterimResult.from_grpc grpc
+              end
+              # callback for interim results received
+              interim! interim_results if interim_results.any?
+
+              # Handle the endpointer by raising events
+              if response.endpointer_type == :START_OF_SPEECH
+                speech_start!
+              elsif response.endpointer_type == :END_OF_SPEECH
+                speech_end!
+              elsif response.endpointer_type == :END_OF_AUDIO
+                # TODO: do we automatically call stop here?
+                complete!
+              elsif response.endpointer_type == :END_OF_UTTERANCE
+                # TODO: do we automatically call stop here?
+                utterance!
+              end
+            end
+            Thread.pass
+          end
+        end
+
+        # rubocop:enable all
+
+        ##
+        # Checks if the stream has been started.
+        #
+        # @return [boolean] `true` when started, `false` otherwise.
+        def started?
+          Mutex.new.synchronize do
+            !(!@request_queue)
+          end
+        end
+
+        ##
+        # Sends audio content to the server.
+        #
+        # @param [String] bytes A string of binary audio data to be recognized.
+        #   The data should be encoded as `ASCII-8BIT`.
+        #
+        # @example
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
+        #
+        #   stream = audio.stream encoding: :raw, sample_rate: 16000
+        #
+        #   # register callback for when a result is returned
+        #   stream.on_result do |results|
+        #     result = results.first
+        #     result.transcript #=> "how old is the Brooklyn Bridge"
+        #     result.confidence #=> 0.8099
+        #   end
+        #
+        #   # Stream 5 seconds of audio from the microhone
+        #   # Actual implementation of microphone input varies by platform
+        #   5.times.do
+        #     stream.send MicrophoneInput.read(32000)
+        #   end
+        #
+        #   stream.stop
+        #
+        def send bytes
+          start # lazily call start if the stream wasn't started yet
+          # TODO: do not send if stopped?
+          Mutex.new.synchronize do
+            req = V1beta1::StreamingRecognizeRequest.new(
+              audio_content: bytes.encode("ASCII-8BIT"))
+            @request_queue.push req
+          end
+        end
+
+        ##
+        # Stops the stream. Signals to the server that no more data will be
+        # sent.
+        def stop
+          Mutex.new.synchronize do
+            return if @request_queue.nil?
+            @request_queue.push self
+            @stopped = true
+          end
+        end
+
+        ##
+        # Checks if the stream has been stopped.
+        #
+        # @return [boolean] `true` when stopped, `false` otherwise.
+        def stopped?
+          Mutex.new.synchronize do
+            @stopped
+          end
+        end
+
+        ##
+        # The speech recognition results for the audio.
+        #
+        # @return [Array<Result>] The transcribed text of audio recognized.
+        #
+        # @example
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
+        #
+        #   stream = audio.stream encoding: :raw, sample_rate: 16000
+        #
+        #   # Stream 5 seconds of audio from the microhone
+        #   # Actual implementation of microphone input varies by platform
+        #   5.times.do
+        #     stream.send MicrophoneInput.read(32000)
+        #   end
+        #
+        #   stream.stop
+        #
+        #   results = stream.results
+        #   result = results.first
+        #   result.transcript #=> "how old is the Brooklyn Bridge"
+        #   result.confidence #=> 0.8099
+        #
+        def results
+          Mutex.new.synchronize do
+            @results
+          end
+        end
+
+        ##
+        # Register to be notified on the reception of an interim result.
+        #
+        # @yield [callback] The block for accessing final and interim results.
+        # @yieldparam [Array<Result>] final_results The final results.
+        # @yieldparam [Array<Result>] interim_results The interim results.
+        #
+        # @example
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
+        #
+        #   stream = audio.stream encoding: :raw, sample_rate: 16000
+        #
+        #   # register callback for when an interim result is returned
+        #   stream.on_interim do |final_results, interim_results|
+        #     interim_result = interim_results.first
+        #     interim_result.transcript #=> "how old is the Brooklyn Bridge"
+        #     interim_result.confidence #=> 0.8099
+        #     interim_result.stability #=> 0.8999
+        #   end
+        #
+        #   # Stream 5 seconds of audio from the microhone
+        #   # Actual implementation of microphone input varies by platform
+        #   5.times.do
+        #     stream.send MicrophoneInput.read(32000)
+        #   end
+        #
+        #   stream.stop
+        #
+        def on_interim &block
+          @callbacks[:interim] << block
+        end
+
+        # @private yields two arguments, all final results and the
+        # non-final/incomplete result
+        def interim! interim_results
+          @callbacks[:interim].each { |c| c.call results, interim_results }
+        end
+
+        ##
+        # Register to be notified on the reception of a final result.
+        #
+        # @yield [callback] The block for accessing final results.
+        # @yieldparam [Array<Result>] results The final results.
+        #
+        # @example
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
+        #
+        #   stream = audio.stream encoding: :raw, sample_rate: 16000
+        #
+        #   # register callback for when an interim result is returned
+        #   stream.on_result do |results|
+        #     result = results.first
+        #     result.transcript #=> "how old is the Brooklyn Bridge"
+        #     result.confidence #=> 0.8099
+        #   end
+        #
+        #   # Stream 5 seconds of audio from the microhone
+        #   # Actual implementation of microphone input varies by platform
+        #   5.times.do
+        #     stream.send MicrophoneInput.read(32000)
+        #   end
+        #
+        #   stream.stop
+        #
+        def on_result &block
+          @callbacks[:result] << block
+        end
+
+        # @private yields each final results as they are recieved
+        def result!
+          @callbacks[:result].each { |c| c.call results }
+        end
+
+        ##
+        # Register to be notified when speech has been detected in the audio
+        # stream.
+        #
+        # @yield [callback] The block to be called when speech has been detected
+        #   in the audio stream.
+        #
+        # @example
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
+        #
+        #   stream = audio.stream encoding: :raw, sample_rate: 16000
+        #
+        #   # register callback for when speech has started.
+        #   stream.on_speech_start do
+        #     puts "Speech has started."
+        #   end
+        #
+        #   # Stream 5 seconds of audio from the microhone
+        #   # Actual implementation of microphone input varies by platform
+        #   5.times.do
+        #     stream.send MicrophoneInput.read(32000)
+        #   end
+        #
+        #   stream.stop
+        #
+        def on_speech_start &block
+          @callbacks[:speech_start] << block
+        end
+
+        # @private returns single final result once :END_OF_UTTERANCE is
+        # recieved.
+        def speech_start!
+          @callbacks[:speech_start].each(&:call)
+        end
+
+        ##
+        # Register to be notified when speech has ceased to be detected in the
+        # audio stream.
+        #
+        # @yield [callback] The block to be called when speech has ceased to be
+        #   detected in the audio stream.
+        #
+        # @example
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
+        #
+        #   stream = audio.stream encoding: :raw, sample_rate: 16000
+        #
+        #   # register callback for when speech has ended.
+        #   stream.on_speech_end do
+        #     puts "Speech has ended."
+        #   end
+        #
+        #   # Stream 5 seconds of audio from the microhone
+        #   # Actual implementation of microphone input varies by platform
+        #   5.times.do
+        #     stream.send MicrophoneInput.read(32000)
+        #   end
+        #
+        #   stream.stop
+        #
+        def on_speech_end &block
+          @callbacks[:speech_end] << block
+        end
+
+        # @private yields single final result once :END_OF_UTTERANCE is
+        # recieved.
+        def speech_end!
+          @callbacks[:speech_end].each(&:call)
+        end
+
+        ##
+        # Register to be notified when the end of the audio stream has been
+        # reached.
+        #
+        # @yield [callback] The block to be called when the end of the audio
+        #   stream has been reached.
+        #
+        # @example
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
+        #
+        #   stream = audio.stream encoding: :raw, sample_rate: 16000
+        #
+        #   # register callback for when audio has ended.
+        #   stream.on_complete do
+        #     puts "Audio has ended."
+        #   end
+        #
+        #   # Stream 5 seconds of audio from the microhone
+        #   # Actual implementation of microphone input varies by platform
+        #   5.times.do
+        #     stream.send MicrophoneInput.read(32000)
+        #   end
+        #
+        #   stream.stop
+        #
+        def on_complete &block
+          @callbacks[:complete] << block
+        end
+
+        # @private yields all final results once the recognition is completed
+        # depending on how the Stream is configured, this can be on the
+        # reception of :END_OF_AUDIO or :END_OF_UTTERANCE.
+        def complete!
+          @callbacks[:complete].each(&:call)
+        end
+
+        ##
+        # Register to be notified when the server has detected the end of the
+        # user's speech utterance and expects no additional speech. Therefore,
+        # the server will not process additional audio. The client should stop
+        # sending additional audio data. This event only occurs when `utterance`
+        # is `true`.
+        #
+        # @yield [callback] The block to be called when the end of the audio
+        #   stream has been reached.
+        #
+        # @example
+        #   require "google/cloud/speech"
+        #
+        #   speech = Google::Cloud::Speech.new
+        #
+        #   stream = audio.stream encoding: :raw,
+        #                         sample_rate: 16000,
+        #                         utterance: true
+        #
+        #   # register callback for when utterance has occurred.
+        #   stream.on_utterance do
+        #     puts "Utterance has occurred."
+        #     stream.stop
+        #   end
+        #
+        #   # Stream 5 seconds of audio from the microhone
+        #   # Actual implementation of microphone input varies by platform
+        #   5.times.do
+        #     stream.send MicrophoneInput.read(32000)
+        #   end
+        #
+        #   stream.stop unless stream.stopped?
+        #
+        def on_utterance &block
+          @callbacks[:utterance] << block
+        end
+
+        # @private returns single final result once :END_OF_UTTERANCE is
+        # recieved.
+        def utterance!
+          @callbacks[:utterance].each(&:call)
+        end
+
+        # @private
+        class EnumeratorQueue
+          extend Forwardable
+          def_delegators :@q, :push
+
+          # @private
+          def initialize sentinel
+            @q = Queue.new
+            @sentinel = sentinel
+          end
+
+          # @private
+          def each_item
+            return enum_for(:each_item) unless block_given?
+            loop do
+              r = @q.pop
+              break if r.equal? @sentinel
+              fail r if r.is_a? Exception
+              yield r
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-speech/test/google/cloud/speech/interim_result_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/interim_result_test.rb
@@ -1,0 +1,36 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Speech::InterimResult, :mock_speech do
+  let(:results_json) { "{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" the Brooklyn Bridge\"}],\"stability\":0.0099999998}]}" }
+  let(:results_grpc) { Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json results_json }
+  let(:results) { results_grpc.results.map { |result_grpc| Google::Cloud::Speech::InterimResult.from_grpc result_grpc } }
+
+  it "knows itself" do
+    results.count.must_equal 2
+    results.each { |r| r.must_be_kind_of Google::Cloud::Speech::InterimResult }
+
+    results.first.transcript.must_equal "how old is"
+    results.first.confidence.must_be :zero?
+    results.first.alternatives.must_be :empty?
+    results.first.stability.must_be_close_to 0.89999998
+
+    results.last.transcript.must_equal " the Brooklyn Bridge"
+    results.last.confidence.must_be :zero?
+    results.last.alternatives.must_be :empty?
+    results.last.stability.must_be_close_to 0.0099999998
+  end
+end

--- a/google-cloud-speech/test/google/cloud/speech/project/stream_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/stream_test.rb
@@ -1,0 +1,268 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+class StreamingServiceStub
+  attr_reader :request_enum, :responses
+
+  def initialize responses
+    @responses = responses
+  end
+
+  def streaming_recognize request_enum
+    @request_enum = request_enum
+    # return response enumerator
+    @responses.each
+  end
+end
+
+describe Google::Cloud::Speech::Project, :stream, :mock_speech do
+  it "streams audio" do
+    stream = speech.stream encoding: :raw, sample_rate: 16000
+    stream.must_be_kind_of Google::Cloud::Speech::Stream
+    stream.wont_be :started?
+    stream.wont_be :stopped?
+
+    counters = Hash.new { |h, k| h[k] = 0 }
+
+    stream.on_interim      { counters[:interim] += 1 }
+    stream.on_result       { counters[:result] += 1 }
+    stream.on_speech_start { counters[:speech_start] += 1 }
+    stream.on_speech_end   { counters[:speech_end] += 1 }
+    stream.on_complete     { counters[:complete] += 1 }
+    stream.on_utterance    { counters[:utterance] += 1 }
+
+    config_grpc = Google::Cloud::Speech::V1beta1::RecognitionConfig.new(encoding: :LINEAR16, sample_rate: 16000)
+    streaming_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognitionConfig.new(config: config_grpc)
+    init_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(streaming_config: streaming_grpc)
+    audio_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(audio_content: File.read("acceptance/data/audio.raw", mode: "rb"))
+
+    responses = [
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"START_OF_SPEECH\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"END_OF_SPEECH\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"END_OF_AUDIO\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.98267895}],\"isFinal\":true}]}")
+    ]
+
+    stub = StreamingServiceStub.new(responses)
+    speech.service.mocked_service = OpenStruct.new(speech_stub: stub)
+
+    stream.send File.read("acceptance/data/audio.raw", mode: "rb")
+
+    stream.stop
+
+    sleep 0.1 # give callbacks time to fire
+
+    stub.request_enum.to_a.must_equal [init_grpc, audio_grpc]
+
+    results = stream.results
+
+    results.wont_be :empty?
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+
+    counters[:interim].must_equal 0
+    counters[:result].must_equal 1
+    counters[:speech_start].must_equal 1
+    counters[:speech_end].must_equal 1
+    counters[:complete].must_equal 1
+    counters[:utterance].must_equal 0
+  end
+
+  it "streams audio over several sends" do
+    stream = speech.stream encoding: :raw, sample_rate: 16000
+    stream.must_be_kind_of Google::Cloud::Speech::Stream
+    stream.wont_be :started?
+    stream.wont_be :stopped?
+
+    counters = Hash.new { |h, k| h[k] = 0 }
+
+    stream.on_interim      { counters[:interim] += 1 }
+    stream.on_result       { counters[:result] += 1 }
+    stream.on_speech_start { counters[:speech_start] += 1 }
+    stream.on_speech_end   { counters[:speech_end] += 1 }
+    stream.on_complete     { counters[:complete] += 1 }
+    stream.on_utterance    { counters[:utterance] += 1 }
+
+    file = File.open "acceptance/data/audio.raw", "rb"
+
+    config_grpc = Google::Cloud::Speech::V1beta1::RecognitionConfig.new(encoding: :LINEAR16, sample_rate: 16000)
+    streaming_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognitionConfig.new(config: config_grpc)
+    init_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(streaming_config: streaming_grpc)
+    audio_grpc1 = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(audio_content: file.read(16000))
+    audio_grpc2 = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(audio_content: file.read(16000))
+    audio_grpc3 = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(audio_content: file.read(16000))
+
+    responses = [
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"START_OF_SPEECH\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"END_OF_SPEECH\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"END_OF_AUDIO\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.98267895}],\"isFinal\":true}]}")
+    ]
+
+    stub = StreamingServiceStub.new(responses)
+    speech.service.mocked_service = OpenStruct.new(speech_stub: stub)
+
+    file.rewind
+    stream.send file.read(16000)
+    stream.send file.read(16000)
+    stream.send file.read(16000)
+
+    stream.stop
+
+    sleep 0.1 # give callbacks time to fire
+
+    stub.request_enum.to_a.must_equal [init_grpc, audio_grpc1, audio_grpc2, audio_grpc3]
+
+    results = stream.results
+
+    results.wont_be :empty?
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+
+    counters[:interim].must_equal 0
+    counters[:result].must_equal 1
+    counters[:speech_start].must_equal 1
+    counters[:speech_end].must_equal 1
+    counters[:complete].must_equal 1
+    counters[:utterance].must_equal 0
+  end
+
+  it "streams audio with alternatives and interum results" do
+    stream = speech.stream encoding: :raw, sample_rate: 16000, max_alternatives: 10, interim: true
+    stream.must_be_kind_of Google::Cloud::Speech::Stream
+    stream.wont_be :started?
+    stream.wont_be :stopped?
+
+    counters = Hash.new { |h, k| h[k] = 0 }
+
+    stream.on_interim      { counters[:interim] += 1 }
+    stream.on_result       { counters[:result] += 1 }
+    stream.on_speech_start { counters[:speech_start] += 1 }
+    stream.on_speech_end   { counters[:speech_end] += 1 }
+    stream.on_complete     { counters[:complete] += 1 }
+    stream.on_utterance    { counters[:utterance] += 1 }
+
+    config_grpc = Google::Cloud::Speech::V1beta1::RecognitionConfig.new(encoding: :LINEAR16, sample_rate: 16000, max_alternatives: 10)
+    streaming_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognitionConfig.new(config: config_grpc, interim_results: true)
+    init_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(streaming_config: streaming_grpc)
+    audio_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(audio_content: File.read("acceptance/data/audio.raw", mode: "rb"))
+
+    responses = [
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"START_OF_SPEECH\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" old is\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" old is the\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" is the\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" is Sarah\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" is the book\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" is the brook\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" is the Brooklyn\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" the Brooklyn\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" the Brooklyn Bridge\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn\"}],\"stability\":0.89999998},{\"alternatives\":[{\"transcript\":\" Bridge\"}],\"stability\":0.0099999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\"}],\"stability\":0.89999998}]}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"END_OF_SPEECH\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"END_OF_AUDIO\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.98267895}],\"isFinal\":true}]}")
+    ]
+
+    stub = StreamingServiceStub.new(responses)
+    speech.service.mocked_service = OpenStruct.new(speech_stub: stub)
+
+    stream.send File.read("acceptance/data/audio.raw", mode: "rb")
+
+    stream.stop
+
+    sleep 0.1 # give callbacks time to fire
+
+    stub.request_enum.to_a.must_equal [init_grpc, audio_grpc]
+
+    results = stream.results
+
+    results.wont_be :empty?
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+
+    counters[:interim].must_equal 14
+    counters[:result].must_equal 1
+    counters[:speech_start].must_equal 1
+    counters[:speech_end].must_equal 1
+    counters[:complete].must_equal 1
+    counters[:utterance].must_equal 0
+  end
+
+  it "streams for a single utterance" do
+    stream = speech.stream encoding: :raw, sample_rate: 16000, max_alternatives: 10, interim: true
+    stream.must_be_kind_of Google::Cloud::Speech::Stream
+    stream.wont_be :started?
+    stream.wont_be :stopped?
+
+    counters = Hash.new { |h, k| h[k] = 0 }
+
+    stream.on_interim      { counters[:interim] += 1 }
+    stream.on_result       { counters[:result] += 1 }
+    stream.on_speech_start { counters[:speech_start] += 1 }
+    stream.on_speech_end   { counters[:speech_end] += 1 }
+    stream.on_complete     { counters[:complete] += 1 }
+    stream.on_utterance    { counters[:utterance] += 1 }
+
+    config_grpc = Google::Cloud::Speech::V1beta1::RecognitionConfig.new(encoding: :LINEAR16, sample_rate: 16000, max_alternatives: 10)
+    streaming_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognitionConfig.new(config: config_grpc, interim_results: true)
+    init_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(streaming_config: streaming_grpc)
+    audio_grpc = Google::Cloud::Speech::V1beta1::StreamingRecognizeRequest.new(audio_content: File.read("acceptance/data/audio.raw", mode: "rb"))
+
+    responses = [
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"START_OF_SPEECH\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"END_OF_UTTERANCE\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[],\"endpointerType\":\"END_OF_AUDIO\"}"),
+      Google::Cloud::Speech::V1beta1::StreamingRecognizeResponse.decode_json("{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.98267895}],\"isFinal\":true}]}")
+    ]
+
+    stub = StreamingServiceStub.new(responses)
+    speech.service.mocked_service = OpenStruct.new(speech_stub: stub)
+
+    stream.send File.read("acceptance/data/audio.raw", mode: "rb")
+
+    stream.stop
+
+    sleep 0.1 # give callbacks time to fire
+
+    stub.request_enum.to_a.must_equal [init_grpc, audio_grpc]
+
+    results = stream.results
+
+    results.wont_be :empty?
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+
+    counters[:interim].must_equal 0
+    counters[:result].must_equal 1
+    counters[:speech_start].must_equal 1
+    counters[:speech_end].must_equal 0
+    counters[:complete].must_equal 1
+    counters[:utterance].must_equal 1
+  end
+end

--- a/google-cloud-speech/test/google/cloud/speech/stream_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/stream_test.rb
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Speech::Stream, :mock_speech do
+  it "knows itself" do
+    stream = speech.stream encoding: :raw, sample_rate: 16000
+    stream.must_be_kind_of Google::Cloud::Speech::Stream
+    stream.wont_be :started?
+    stream.wont_be :stopped?
+  end
+end


### PR DESCRIPTION
This PR is an implementation of Speech's Streaming support.

A stream object represents the bi-directional requests and responses. Users will not need to create IO objects or pipes or Enumerators, but can simply call `Stream#send` and receive notifications using blocks. The intention here is to lower the barrier to using the streaming API.

```ruby
require "google/cloud/speech"

speech = Google::Cloud::Speech.new

stream = audio.stream encoding: :raw, sample_rate: 16000

# register callback for when a result is returned
stream.on_result do |results|
  result = results.first
  result.transcript #=> "how old is the Brooklyn Bridge"
  result.confidence #=> 0.8099
end

# Stream 5 seconds of audio from the microhone
# Actual implementation of microphone input varies by platform
5.times.do
  stream.send MicrophoneInput.read(32000)
end

stream.stop
```