### PR TITLE
Add Datastore resource-prefix header

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -71,7 +71,10 @@ module Google
         # Allocate IDs for incomplete keys.
         # (This is useful for referencing an entity before it is inserted.)
         def allocate_ids *incomplete_keys
-          execute { service.allocate_ids project, incomplete_keys }
+          execute do
+            service.allocate_ids project, incomplete_keys,
+                                 options: default_options
+          end
         end
 
         ##
@@ -79,7 +82,9 @@ module Google
         def lookup *keys, consistency: nil, transaction: nil
           read_options = generate_read_options consistency, transaction
 
-          execute { service.lookup project, read_options, keys }
+          execute do
+            service.lookup project, read_options, keys, options: default_options
+          end
         end
 
         # Query for entities.
@@ -98,7 +103,8 @@ module Google
                               partition_id,
                               read_options,
                               query: query,
-                              gql_query: gql_query
+                              gql_query: gql_query,
+                              options: default_options
           end
         end
 
@@ -114,14 +120,17 @@ module Google
         def commit mutations, transaction: nil
           mode =  transaction.nil? ? :NON_TRANSACTIONAL : :TRANSACTIONAL
           execute do
-            service.commit project, mode, mutations, transaction: transaction
+            service.commit project, mode, mutations, transaction: transaction,
+                                                     options: default_options
           end
         end
 
         ##
         # Roll back a transaction.
         def rollback transaction
-          execute { service.rollback project, transaction }
+          execute do
+            service.rollback project, transaction, options: default_options
+          end
         end
 
         def inspect
@@ -142,6 +151,14 @@ module Google
               transaction: transaction)
           end
           nil
+        end
+
+        def default_headers
+          { "google-cloud-resource-prefix" => "projects/#{@project}" }
+        end
+
+        def default_options
+          Google::Gax::CallOptions.new kwargs: default_headers
         end
 
         def execute

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -14,10 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Dataset do
-  let(:project) { "my-todo-project" }
-  let(:credentials) { OpenStruct.new }
-  let(:dataset) { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
+describe Google::Cloud::Datastore::Dataset, :mock_datastore do
   let(:query) { Google::Cloud::Datastore::Query.new.kind("User") }
   let(:gql_query_grpc) { Google::Datastore::V1::GqlQuery.new(query_string: "SELECT * FROM Task") }
   let(:run_query_res) do
@@ -86,7 +83,7 @@ describe Google::Cloud::Datastore::Dataset do
     allocate_res = Google::Datastore::V1::AllocateIdsResponse.new(
       keys: [Google::Cloud::Datastore::Key.new("ds-test", 1234).to_grpc]
     )
-    dataset.service.mocked_service.expect :allocate_ids, allocate_res, [project, keys]
+    dataset.service.mocked_service.expect :allocate_ids, allocate_res, [project, keys, options: default_options]
 
     incomplete_key = Google::Cloud::Datastore::Key.new "ds-test"
     incomplete_key.must_be :incomplete?
@@ -114,7 +111,7 @@ describe Google::Cloud::Datastore::Dataset do
       end.to_grpc)
     mode = :NON_TRANSACTIONAL
     mutations = [mutation]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -137,7 +134,7 @@ describe Google::Cloud::Datastore::Dataset do
 
     mode = :NON_TRANSACTIONAL
     mutations = [mutation]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -161,7 +158,7 @@ describe Google::Cloud::Datastore::Dataset do
 
     mode = :NON_TRANSACTIONAL
     mutations = [mutation]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -183,7 +180,7 @@ describe Google::Cloud::Datastore::Dataset do
 
     mode = :NON_TRANSACTIONAL
     mutations = [mutation]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -210,7 +207,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -241,7 +238,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -269,7 +266,7 @@ describe Google::Cloud::Datastore::Dataset do
 
     mode = :NON_TRANSACTIONAL
     mutations = [mutation]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -291,7 +288,7 @@ describe Google::Cloud::Datastore::Dataset do
 
     mode = :NON_TRANSACTIONAL
     mutations = [mutation]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -319,7 +316,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -351,7 +348,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -378,7 +375,7 @@ describe Google::Cloud::Datastore::Dataset do
       end.to_grpc)
     mode = :NON_TRANSACTIONAL
     mutations = [mutation]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -407,7 +404,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -440,7 +437,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -459,7 +456,7 @@ describe Google::Cloud::Datastore::Dataset do
 
   it "find can take a kind and id" do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", 123).to_grpc]
-    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys, options: default_options]
 
     entity = dataset.find "ds-test", 123
     entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -467,7 +464,7 @@ describe Google::Cloud::Datastore::Dataset do
 
   it "find can take a kind and name" do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc]
-    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys, options: default_options]
 
     entity = dataset.find "ds-test", "thingie"
     entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -475,7 +472,7 @@ describe Google::Cloud::Datastore::Dataset do
 
   it "find can take a key" do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc]
-    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys, options: default_options]
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     entity = dataset.find key
@@ -484,7 +481,7 @@ describe Google::Cloud::Datastore::Dataset do
 
   it "find is aliased to get" do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", 123).to_grpc]
-    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys, options: default_options]
 
     entity = dataset.get "ds-test", 123
     entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -493,7 +490,7 @@ describe Google::Cloud::Datastore::Dataset do
   it "find can specify consistency" do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", 123).to_grpc]
     read_options = Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
-    dataset.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys, options: default_options]
 
     entity = dataset.find "ds-test", 123, consistency: :eventual
     entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -509,7 +506,7 @@ describe Google::Cloud::Datastore::Dataset do
   it "find_all takes several keys" do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
             Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
-    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys, options: default_options]
 
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -525,7 +522,7 @@ describe Google::Cloud::Datastore::Dataset do
   it "find_all is aliased to lookup" do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
             Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
-    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [project, nil, keys, options: default_options]
 
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -542,7 +539,7 @@ describe Google::Cloud::Datastore::Dataset do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
             Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
     read_options = Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
-    dataset.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys]
+    dataset.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys, options: default_options]
 
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -588,7 +585,7 @@ describe Google::Cloud::Datastore::Dataset do
     it "contains deferred entities" do
       keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
               Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
-      dataset.service.mocked_service.expect :lookup, lookup_res_deferred, [project, nil, keys]
+      dataset.service.mocked_service.expect :lookup, lookup_res_deferred, [project, nil, keys, options: default_options]
 
       key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
       key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -607,7 +604,7 @@ describe Google::Cloud::Datastore::Dataset do
     it "contains missing entities" do
       keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
               Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
-      dataset.service.mocked_service.expect :lookup, lookup_res_missing, [project, nil, keys]
+      dataset.service.mocked_service.expect :lookup, lookup_res_missing, [project, nil, keys, options: default_options]
 
       key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
       key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -630,7 +627,7 @@ describe Google::Cloud::Datastore::Dataset do
     )
     mode = :NON_TRANSACTIONAL
     mutations = [mutation]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -647,7 +644,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -668,7 +665,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -687,7 +684,7 @@ describe Google::Cloud::Datastore::Dataset do
     )
     mode = :NON_TRANSACTIONAL
     mutations = [mutation]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     dataset.delete key
@@ -701,7 +698,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -722,7 +719,7 @@ describe Google::Cloud::Datastore::Dataset do
     mode = :NON_TRANSACTIONAL
     mutations = [mutation1, mutation2]
 
-    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, multiple_commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity1 = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -736,7 +733,7 @@ describe Google::Cloud::Datastore::Dataset do
   end
 
   it "run will fulfill a query" do
-    dataset.service.mocked_service.expect :run_query, run_query_res, [project, nil, nil, query: query.to_grpc, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [project, nil, nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
     entities.count.must_equal 2
@@ -774,7 +771,7 @@ describe Google::Cloud::Datastore::Dataset do
                    end.to_grpc), Google::Datastore::V1::Mutation.new(
                                  delete: Google::Cloud::Datastore::Key.new("ds-test", "to-be-deleted").to_grpc)
     ]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: nil, options: default_options]
 
     entity_to_be_saved = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "to-be-saved"
@@ -794,7 +791,7 @@ describe Google::Cloud::Datastore::Dataset do
   end
 
   it "run_query will fulfill a query" do
-    dataset.service.mocked_service.expect :run_query, run_query_res, [project, nil, nil, query: query.to_grpc, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [project, nil, nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run_query query
     entities.count.must_equal 2
@@ -824,7 +821,7 @@ describe Google::Cloud::Datastore::Dataset do
 
   it "run_query will fulfill a query with a namespace" do
     partition_id = Google::Datastore::V1::PartitionId.new(namespace_id: "foobar")
-    dataset.service.mocked_service.expect :run_query, run_query_res, [project, partition_id, nil, query: query.to_grpc, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [project, partition_id, nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run_query query, namespace: "foobar"
     entities.count.must_equal 2
@@ -853,7 +850,7 @@ describe Google::Cloud::Datastore::Dataset do
   end
 
   it "run will fulfill a gql query" do
-    dataset.service.mocked_service.expect :run_query, run_query_res, [project, nil, nil, query: nil, gql_query: gql_query_grpc]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [project, nil, nil, query: nil, gql_query: gql_query_grpc, options: default_options]
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run gql
@@ -885,7 +882,7 @@ describe Google::Cloud::Datastore::Dataset do
 
   it "run will fulfill a gql query with a namespace" do
     partition_id = Google::Datastore::V1::PartitionId.new(namespace_id: "foobar")
-    dataset.service.mocked_service.expect :run_query, run_query_res, [project, partition_id, nil, query: nil, gql_query: gql_query_grpc]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [project, partition_id, nil, query: nil, gql_query: gql_query_grpc, options: default_options]
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run gql, namespace: "foobar"
@@ -916,7 +913,7 @@ describe Google::Cloud::Datastore::Dataset do
   end
 
   it "run_query will fulfill a gql query" do
-    dataset.service.mocked_service.expect :run_query, run_query_res, [project, nil, nil, query: nil, gql_query: gql_query_grpc]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [project, nil, nil, query: nil, gql_query: gql_query_grpc, options: default_options]
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run_query gql
@@ -948,7 +945,7 @@ describe Google::Cloud::Datastore::Dataset do
 
   it "run_query will fulfill a gql query with a namespace" do
     partition_id = Google::Datastore::V1::PartitionId.new(namespace_id: "foobar")
-    dataset.service.mocked_service.expect :run_query, run_query_res, [project, partition_id, nil, query: nil, gql_query: gql_query_grpc]
+    dataset.service.mocked_service.expect :run_query, run_query_res, [project, partition_id, nil, query: nil, gql_query: gql_query_grpc, options: default_options]
 
     gql = dataset.gql "SELECT * FROM Task"
     entities = dataset.run_query gql, namespace: "foobar"
@@ -1143,7 +1140,7 @@ describe Google::Cloud::Datastore::Dataset do
         e["name"] = "thingamajig"
       end.to_grpc)
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [mutation], transaction: tx_id]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [mutation], transaction: tx_id, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -1159,7 +1156,7 @@ describe Google::Cloud::Datastore::Dataset do
     begin_tx_res = Google::Datastore::V1::BeginTransactionResponse.new(transaction: tx_id)
     rollback_res = Google::Datastore::V1::RollbackResponse.new
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project]
-    dataset.service.mocked_service.expect :rollback, rollback_res, [project, tx_id]
+    dataset.service.mocked_service.expect :rollback, rollback_res, [project, tx_id, options: default_options]
 
     error = assert_raises Google::Cloud::Datastore::TransactionError do
       dataset.transaction do |tx|

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Entity, :exclude_from_indexes do
+describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastore do
 
   let(:entity) do
     Google::Cloud::Datastore::Entity.new.tap do |ent|

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Entity do
+describe Google::Cloud::Datastore::Entity, :mock_datastore do
 
   let(:entity) do
     Google::Cloud::Datastore::Entity.new.tap do |ent|

--- a/google-cloud-datastore/test/google/cloud/datastore/gql_query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/gql_query_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::GqlQuery do
+describe Google::Cloud::Datastore::GqlQuery, :mock_datastore do
   it "can set named_bindings" do
     gql = Google::Cloud::Datastore::GqlQuery.new
     gql.query_string = "SELECT * FROM Task WHERE completed = @completed"

--- a/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Key do
+describe Google::Cloud::Datastore::Key, :mock_datastore do
 
   it "behaves correctly when empty" do
     key = Google::Cloud::Datastore::Key.new

--- a/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
@@ -14,10 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Dataset, :find_all do
-  let(:project)     { "my-todo-project" }
-  let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
+describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
   # let(:query_cursor) { Google::Cloud::Datastore::Cursor.new "c3VwZXJhd2Vzb21lIQ==" }
 
   let(:key1) { Google::Cloud::Datastore::Key.new "ds-test", "thingie1" }
@@ -75,8 +72,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
   end
 
   it "paginates" do
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys, options: default_options]
 
     first_entities = dataset.find_all keys
     first_entities.count.must_equal 2
@@ -103,8 +100,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
 
   it "paginates with consistency" do
     read_options = Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys, options: default_options]
 
     first_entities = dataset.find_all keys, consistency: :eventual
     first_entities.count.must_equal 2
@@ -138,10 +135,10 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       # )]
     )
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [], transaction: tx_id]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [], transaction: tx_id, options: default_options]
     read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys, options: default_options]
 
     dataset.transaction do |tx|
       first_entities = tx.find_all keys
@@ -169,8 +166,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
   end
 
   it "paginates with next? and next" do
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys, options: default_options]
 
     first_entities = dataset.find_all keys
     first_entities.next?.must_equal true
@@ -199,8 +196,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
 
   it "paginates with next? and next and consistency" do
     read_options = Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys, options: default_options]
 
     first_entities = dataset.find_all keys, consistency: :eventual
     first_entities.next?.must_equal true
@@ -236,10 +233,10 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       # )]
     )
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [], transaction: tx_id]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [], transaction: tx_id, options: default_options]
     read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys, options: default_options]
 
     dataset.transaction do |tx|
       first_entities = tx.find_all keys
@@ -269,8 +266,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
   end
 
   it "paginates with all" do
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys, options: default_options]
 
     entities = dataset.find_all(keys).all.to_a
     entities.count.must_equal 4
@@ -281,8 +278,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
 
   it "paginates with all and consistency" do
     read_options = Google::Datastore::V1::ReadOptions.new(read_consistency: :EVENTUAL)
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys, options: default_options]
 
     entities = dataset.find_all(keys, consistency: :eventual).all.to_a
     entities.count.must_equal 4
@@ -300,10 +297,10 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
       # )]
     )
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project]
-    dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [], transaction: tx_id]
+    dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [], transaction: tx_id, options: default_options]
     read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, read_options, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, read_options, second_keys, options: default_options]
 
     dataset.transaction do |tx|
       entities = tx.find_all(keys).all.to_a
@@ -315,8 +312,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
   end
 
   it "iterates with all using Enumerator" do
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys, options: default_options]
 
     entities = dataset.find_all(keys).all.take(3)
     entities.count.must_equal 3
@@ -326,8 +323,8 @@ describe Google::Cloud::Datastore::Dataset, :find_all do
   end
 
   it "iterates with all and request_limit set" do
-    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys]
-    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys]
+    dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, nil, first_keys, options: default_options]
+    dataset.service.mocked_service.expect :lookup, second_lookup_res, [project, nil, second_keys, options: default_options]
 
     # This test is a bit handwavy, as there aren't more results to lookup.
     # But if you reduce the limit it will not make additional call.

--- a/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "stringio"
 require "tempfile"
 
-describe Google::Cloud::Datastore::Properties do
+describe Google::Cloud::Datastore::Properties, :mock_datastore do
   let(:time_obj) { Time.new(2014, 1, 1, 0, 0, 0, 0) }
   let(:time_grpc) { Google::Protobuf::Timestamp.new(seconds: time_obj.to_i, nanos: time_obj.nsec) }
 

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
@@ -14,10 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Dataset, :all do
-  let(:project)     { "my-todo-project" }
-  let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
+describe Google::Cloud::Datastore::Dataset, :all, :mock_datastore do
   let(:first_run_query) { Google::Cloud::Datastore::Query.new.kind("Task").to_grpc }
   let(:first_run_query_res) do
     run_query_res_entities = 25.times.map do |i|
@@ -62,8 +59,8 @@ describe Google::Cloud::Datastore::Dataset, :all do
 
   before do
     dataset.service.mocked_service = Minitest::Mock.new
-    dataset.service.mocked_service.expect :run_query, first_run_query_res, [project, nil, nil, query: first_run_query, gql_query: nil]
-    dataset.service.mocked_service.expect :run_query, next_run_query_res, [project, nil, nil, query: next_run_query, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, first_run_query_res, [project, nil, nil, query: first_run_query, gql_query: nil, options: default_options]
+    dataset.service.mocked_service.expect :run_query, next_run_query_res, [project, nil, nil, query: next_run_query, gql_query: nil, options: default_options]
   end
 
   after do

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
@@ -14,10 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Dataset, :all_with_more do
-  let(:project)     { "my-todo-project" }
-  let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
+describe Google::Cloud::Datastore::Dataset, :all_with_more, :mock_datastore do
   let(:first_run_query) { Google::Cloud::Datastore::Query.new.kind("Task").to_grpc }
   let(:first_run_query_res) do
     run_query_res_entities = 25.times.map do |i|
@@ -63,8 +60,8 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more do
 
   before do
     dataset.service.mocked_service = Minitest::Mock.new
-    dataset.service.mocked_service.expect :run_query, first_run_query_res, [project, nil, nil, query: first_run_query, gql_query: nil]
-    dataset.service.mocked_service.expect :run_query, next_run_query_res, [project, nil, nil, query: next_run_query, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, first_run_query_res, [project, nil, nil, query: first_run_query, gql_query: nil, options: default_options]
+    dataset.service.mocked_service.expect :run_query, next_run_query_res, [project, nil, nil, query: next_run_query, gql_query: nil, options: default_options]
   end
 
   after do

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Dataset::QueryResults do
+describe Google::Cloud::Datastore::Dataset::QueryResults, :mock_datastore do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
   let(:dataset)     { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
@@ -68,7 +68,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
 
   it "has more_results not_finished" do
     query = Google::Cloud::Datastore::Query.new.kind("User")
-    dataset.service.mocked_service.expect :run_query, run_query_res_not_finished, [project, nil, nil, query: query.to_grpc, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, run_query_res_not_finished, [project, nil, nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
     entities.count.must_equal 2
@@ -97,7 +97,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
   end
 
   it "has more_results more_after_limit" do
-    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_limit, [project, nil, nil, query: query.to_grpc, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_limit, [project, nil, nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
     entities.count.must_equal 2
@@ -126,7 +126,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
   end
 
   it "has more_results more_after_cursor" do
-    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_cursor, [project, nil, nil, query: query.to_grpc, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, run_query_res_more_after_cursor, [project, nil, nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
     entities.count.must_equal 2
@@ -155,7 +155,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults do
   end
 
   it "has more_results no_more" do
-    dataset.service.mocked_service.expect :run_query, run_query_res_no_more, [project, nil, nil, query: query.to_grpc, gql_query: nil]
+    dataset.service.mocked_service.expect :run_query, run_query_res_no_more, [project, nil, nil, query: query.to_grpc, gql_query: nil, options: default_options]
 
     entities = dataset.run query
     entities.count.must_equal 2

--- a/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Query do
+describe Google::Cloud::Datastore::Query, :mock_datastore do
   let(:query) { Google::Cloud::Datastore::Query.new }
   it "can query on kind" do
     query.kind "Task"

--- a/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
@@ -14,10 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Transaction do
-  let(:project)     { "my-todo-project" }
-  let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
+describe Google::Cloud::Datastore::Transaction, :mock_datastore do
   let(:service) do
     s = dataset.service
     s.mocked_service = Minitest::Mock.new
@@ -308,7 +305,7 @@ describe Google::Cloud::Datastore::Transaction do
       Google::Datastore::V1::Mutation.new(
         delete: Google::Cloud::Datastore::Key.new("ds-test", "to-be-deleted").to_grpc)
     ]
-    transaction.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: tx_id]
+    transaction.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: tx_id, options: default_options]
 
     entity_to_be_saved = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "to-be-saved"
@@ -340,7 +337,7 @@ describe Google::Cloud::Datastore::Transaction do
   it "find can take a key" do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc]
     read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
-    transaction.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys]
+    transaction.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys, options: default_options]
 
     key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
     entity = transaction.find key
@@ -351,7 +348,7 @@ describe Google::Cloud::Datastore::Transaction do
     keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
              Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
     read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
-    transaction.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys]
+    transaction.service.mocked_service.expect :lookup, lookup_res, [project, read_options, keys, options: default_options]
 
     key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
     key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
@@ -367,7 +364,7 @@ describe Google::Cloud::Datastore::Transaction do
   it "run will fulfill a query" do
     query_grpc = Google::Cloud::Datastore::Query.new.kind("User").to_grpc
     read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
-    transaction.service.mocked_service.expect :run_query, run_query_res, [project, nil, read_options, query: query_grpc, gql_query: nil]
+    transaction.service.mocked_service.expect :run_query, run_query_res, [project, nil, read_options, query: query_grpc, gql_query: nil, options: default_options]
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
     entities = transaction.run query
@@ -396,7 +393,7 @@ describe Google::Cloud::Datastore::Transaction do
           e["name"] = "thingamajig"
         end.to_grpc)
     ]
-    transaction.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: tx_id]
+    transaction.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: tx_id, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
@@ -425,7 +422,7 @@ describe Google::Cloud::Datastore::Transaction do
           e["name"] = "thingamajig"
         end.to_grpc)
     ]
-    transaction.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: tx_id]
+    transaction.service.mocked_service.expect :commit, commit_res, [project, mode, mutations, transaction: tx_id, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test"
@@ -441,7 +438,7 @@ describe Google::Cloud::Datastore::Transaction do
 
   it "rollback does not persist entities" do
     rollback_res = Google::Datastore::V1::RollbackResponse.new
-    transaction.service.mocked_service.expect :rollback, rollback_res, [project, tx_id]
+    transaction.service.mocked_service.expect :rollback, rollback_res, [project, tx_id, options: default_options]
 
     entity = Google::Cloud::Datastore::Entity.new.tap do |e|
       e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"

--- a/google-cloud-datastore/test/helper.rb
+++ b/google-cloud-datastore/test/helper.rb
@@ -17,3 +17,38 @@ require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"
 require "google/cloud/datastore"
+
+##
+# Monkey-Patch CallOptions to support Mocks
+class Google::Gax::CallOptions
+  ##
+  # Minitest Mock depends on === to match same-value objects.
+  # By default, CallOptions objects do not match with ===.
+  # Therefore, we must add this capability.
+  def === other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout === other.timeout &&
+      retry_options === other.retry_options &&
+      page_token === other.page_token &&
+      kwargs === other.kwargs
+  end
+  def == other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout == other.timeout &&
+      retry_options == other.retry_options &&
+      page_token == other.page_token &&
+      kwargs == other.kwargs
+  end
+end
+
+class MockDatastore < Minitest::Spec
+  let(:project) { "my-todo-project" }
+  let(:default_options) { Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" }) }
+  let(:credentials) { OpenStruct.new }
+  let(:dataset) { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project, credentials)) }
+
+  # Register this spec type for when :dns is used.
+  register_spec_type(self) do |desc, *addl|
+    addl.include? :mock_datastore
+  end
+end

--- a/google-cloud-language/lib/google/cloud/language/service.rb
+++ b/google-cloud-language/lib/google/cloud/language/service.rb
@@ -78,16 +78,24 @@ module Google
             extract_syntax: syntax, extract_entities: entities,
             extract_document_sentiment: sentiment)
           encoding = verify_encoding! encoding
-          execute { service.annotate_text doc_grpc, features, encoding }
+          execute do
+            service.annotate_text doc_grpc, features, encoding,
+                                  options: default_options
+          end
         end
 
         def entities doc_grpc, encoding: nil
           encoding = verify_encoding! encoding
-          execute { service.analyze_entities doc_grpc, encoding }
+          execute do
+            service.analyze_entities doc_grpc, encoding,
+                                     options: default_options
+          end
         end
 
         def sentiment doc_grpc
-          execute { service.analyze_sentiment doc_grpc }
+          execute do
+            service.analyze_sentiment doc_grpc, options: default_options
+          end
         end
 
         def inspect
@@ -100,6 +108,14 @@ module Google
           # TODO: verify encoding against V1beta1::EncodingType
           return :UTF8 if encoding.nil?
           encoding
+        end
+
+        def default_headers
+          { "google-cloud-resource-prefix" => "projects/#{@project}" }
+        end
+
+        def default_options
+          Google::Gax::CallOptions.new kwargs: default_headers
         end
 
         def execute

--- a/google-cloud-language/test/google/cloud/language/document/full_html_annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/document/full_html_annotation_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Language::Document, :full_html_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
     doc.service.mocked_service = mock
     annotation = doc.annotate
@@ -42,7 +42,7 @@ describe Google::Cloud::Language::Document, :full_html_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
     doc.service.mocked_service = mock
     doc.language = "en"

--- a/google-cloud-language/test/google/cloud/language/document/full_text_annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/document/full_text_annotation_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Language::Document, :full_text_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
     doc.service.mocked_service = mock
     annotation = doc.annotate
@@ -42,7 +42,7 @@ describe Google::Cloud::Language::Document, :full_text_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
     doc.service.mocked_service = mock
     doc.text!
@@ -60,7 +60,7 @@ describe Google::Cloud::Language::Document, :full_text_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
     doc.service.mocked_service = mock
     doc.text!
@@ -79,7 +79,7 @@ describe Google::Cloud::Language::Document, :full_text_annotation, :mock_languag
     grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
     mock = Minitest::Mock.new
-    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
     doc.service.mocked_service = mock
     doc.language = :en

--- a/google-cloud-language/test/google/cloud/language/project/full_html_annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/project/full_html_annotation_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate html_content, format: :html
@@ -41,7 +41,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate html_content, format: :html, language: :en
@@ -60,7 +60,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document html_content, format: :html
@@ -78,7 +78,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document html_content, format: :html, language: :en
@@ -97,7 +97,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         doc = language.html html_content
@@ -115,7 +115,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         doc = language.html html_content, language: :en
@@ -136,7 +136,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", format: :html
@@ -153,7 +153,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", format: :html, language: :en
@@ -170,7 +170,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.html"
@@ -189,7 +189,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", format: :html
@@ -207,7 +207,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", format: :html, language: :en
@@ -225,7 +225,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.html"
@@ -244,7 +244,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         doc = language.html "gs://bucket/path.ext"
@@ -262,7 +262,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         doc = language.html "gs://bucket/path.ext", language: :en
@@ -283,7 +283,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -301,7 +301,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -319,7 +319,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.html"
@@ -339,7 +339,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -358,7 +358,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -377,7 +377,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.html"
@@ -397,7 +397,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -416,7 +416,7 @@ describe Google::Cloud::Language::Project, :full_html_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json html_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"

--- a/google-cloud-language/test/google/cloud/language/project/full_text_annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/project/full_text_annotation_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate text_content
@@ -41,7 +41,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate text_content, format: :text
@@ -58,7 +58,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate text_content, format: :text, language: :en
@@ -75,7 +75,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate text_content, language: :en
@@ -94,7 +94,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document text_content
@@ -112,7 +112,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document text_content, format: :text
@@ -130,7 +130,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document text_content, format: :text, language: :en
@@ -148,7 +148,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document text_content, language: :en
@@ -167,7 +167,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         doc = language.text text_content
@@ -185,7 +185,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         doc = language.text text_content, language: :en
@@ -206,7 +206,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext"
@@ -223,7 +223,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", format: :text
@@ -240,7 +240,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", format: :text, language: :en
@@ -257,7 +257,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       annotation = language.annotate "gs://bucket/path.ext", language: :en
@@ -276,7 +276,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext"
@@ -294,7 +294,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", format: :text
@@ -312,7 +312,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", format: :text, language: :en
@@ -330,7 +330,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document "gs://bucket/path.ext", language: :en
@@ -349,7 +349,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         doc = language.text "gs://bucket/path.ext"
@@ -367,7 +367,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         doc = language.text "gs://bucket/path.ext", language: :en
@@ -388,7 +388,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -406,7 +406,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -424,7 +424,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -442,7 +442,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -462,7 +462,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -481,7 +481,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -500,7 +500,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -519,7 +519,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -539,7 +539,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
@@ -558,7 +558,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         grpc_resp = Google::Cloud::Language::V1beta1::AnnotateTextResponse.decode_json text_json
 
         mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8]
+        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
         language.service.mocked_service = mock
         gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"

--- a/google-cloud-language/test/helper.rb
+++ b/google-cloud-language/test/helper.rb
@@ -21,8 +21,32 @@ require "json"
 require "base64"
 require "google/cloud/language"
 
+##
+# Monkey-Patch CallOptions to support Mocks
+class Google::Gax::CallOptions
+  ##
+  # Minitest Mock depends on === to match same-value objects.
+  # By default, CallOptions objects do not match with ===.
+  # Therefore, we must add this capability.
+  def === other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout === other.timeout &&
+      retry_options === other.retry_options &&
+      page_token === other.page_token &&
+      kwargs === other.kwargs
+  end
+  def == other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout == other.timeout &&
+      retry_options == other.retry_options &&
+      page_token == other.page_token &&
+      kwargs == other.kwargs
+  end
+end
+
 class MockLanguage < Minitest::Spec
   let(:project) { "test" }
+  let(:default_options) { Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" }) }
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
   let(:language) { Google::Cloud::Language::Project.new(Google::Cloud::Language::Service.new(project, credentials)) }
 

--- a/google-cloud-logging/lib/google/cloud/logging/service.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/service.rb
@@ -96,7 +96,11 @@ module Google
                          max: nil
 
           project_ids = Array(projects || @project)
-          call_opts = Google::Gax::CallOptions.new(page_token: token) if token
+          call_opts = default_options
+          if token
+            call_opts = Google::Gax::CallOptions.new(kwargs: default_headers,
+                                                     page_token: token)
+          end
 
           execute do
             paged_enum = logging.list_log_entries project_ids,
@@ -119,16 +123,23 @@ module Google
           execute do
             logging.write_log_entries entries,
                                       log_name: log_path(log_name),
-                                      resource: resource, labels: labels
+                                      resource: resource, labels: labels,
+                                      options: default_options
           end
         end
 
         def delete_log name
-          execute { logging.delete_log log_path(name) }
+          execute do
+            logging.delete_log log_path(name), options: default_options
+          end
         end
 
         def list_resource_descriptors token: nil, max: nil
-          call_opts = Google::Gax::CallOptions.new(page_token: token) if token
+          call_opts = default_options
+          if token
+            call_opts = Google::Gax::CallOptions.new(kwargs: default_headers,
+                                                     page_token: token)
+          end
 
           execute do
             logging.list_monitored_resource_descriptors \
@@ -137,7 +148,11 @@ module Google
         end
 
         def list_sinks token: nil, max: nil
-          call_opts = Google::Gax::CallOptions.new(page_token: token) if token
+          call_opts = default_options
+          if token
+            call_opts = Google::Gax::CallOptions.new(kwargs: default_headers,
+                                                     page_token: token)
+          end
 
           execute do
             paged_enum = sinks.list_sinks \
@@ -151,11 +166,13 @@ module Google
             name: name, destination: destination, filter: filter,
             output_version_format: version }.delete_if { |_, v| v.nil? })
 
-          execute { sinks.create_sink project_path, sink }
+          execute do
+            sinks.create_sink project_path, sink, options: default_options
+          end
         end
 
         def get_sink name
-          execute { sinks.get_sink sink_path(name) }
+          execute { sinks.get_sink sink_path(name), options: default_options }
         end
 
         def update_sink name, destination, filter, version
@@ -163,15 +180,23 @@ module Google
             name: name, destination: destination, filter: filter,
             output_version_format: version }.delete_if { |_, v| v.nil? })
 
-          execute { sinks.update_sink sink_path(name), sink }
+          execute do
+            sinks.update_sink sink_path(name), sink, options: default_options
+          end
         end
 
         def delete_sink name
-          execute { sinks.delete_sink sink_path(name) }
+          execute do
+            sinks.delete_sink sink_path(name), options: default_options
+          end
         end
 
         def list_metrics token: nil, max: nil
-          call_opts = Google::Gax::CallOptions.new(page_token: token) if token
+          call_opts = default_options
+          if token
+            call_opts = Google::Gax::CallOptions.new(kwargs: default_headers,
+                                                     page_token: token)
+          end
 
           execute do
             paged_enum = metrics.list_log_metrics \
@@ -185,11 +210,16 @@ module Google
             name: name, description: description,
             filter: filter }.delete_if { |_, v| v.nil? })
 
-          execute { metrics.create_log_metric project_path, metric }
+          execute do
+            metrics.create_log_metric project_path, metric,
+                                      options: default_options
+          end
         end
 
         def get_metric name
-          execute { metrics.get_log_metric metric_path(name) }
+          execute do
+            metrics.get_log_metric metric_path(name), options: default_options
+          end
         end
 
         def update_metric name, description, filter
@@ -197,11 +227,17 @@ module Google
             name: name, description: description,
             filter: filter }.delete_if { |_, v| v.nil? })
 
-          execute { metrics.update_log_metric metric_path(name), metric }
+          execute do
+            metrics.update_log_metric metric_path(name), metric,
+                                      options: default_options
+          end
         end
 
         def delete_metric name
-          execute { metrics.delete_log_metric metric_path(name) }
+          execute do
+            metrics.delete_log_metric metric_path(name),
+                                      options: default_options
+          end
         end
 
         def inspect
@@ -229,6 +265,14 @@ module Google
         def metric_path metric_name
           return metric_name if metric_name.to_s.include? "/"
           "#{project_path}/metrics/#{metric_name}"
+        end
+
+        def default_headers
+          { "google-cloud-resource-prefix" => "projects/#{@project}" }
+        end
+
+        def default_options
+          Google::Gax::CallOptions.new kwargs: default_headers
         end
 
         def execute

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -52,7 +52,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
         labels: labels
       )
     end
-    [entries, log_name: full_log_name, resource: resource.to_grpc, labels: labels]
+    [entries, log_name: full_log_name, resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
   it "writes a single entry" do

--- a/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
 
   def write_req_args
     entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
-    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels]
+    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
   before do

--- a/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   def write_req_args severity
     entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
-    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels]
+    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
   before do

--- a/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
 
   def write_req_args severity
     entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
-    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels]
+    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
   before do

--- a/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
 
   def write_req_args severity
     entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
-    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels]
+    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
   before do

--- a/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   def write_req_args severity
     entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
-    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels]
+    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
   before do

--- a/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Logging::Logger, :unknown, :mock_logging do
 
   def write_req_args severity
     entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
-    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels]
+    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
   before do

--- a/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
 
   def write_req_args severity
     entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
-    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels]
+    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
   before do

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   def write_req_args severity
     entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
-    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels]
+    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
   it "creates a DEBUG log entry with #debug" do

--- a/google-cloud-logging/test/google/cloud/logging/metric_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/metric_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Logging::Metric, :mock_logging do
       filter: new_metric_filter
     )
     mock = Minitest::Mock.new
-    mock.expect :update_log_metric, metric_grpc, ["projects/test/metrics/#{metric.name}", new_metric]
+    mock.expect :update_log_metric, metric_grpc, ["projects/test/metrics/#{metric.name}", new_metric, options: default_options]
     metric.service.mocked_metrics = mock
 
     metric.description = new_metric_description
@@ -51,7 +51,7 @@ describe Google::Cloud::Logging::Metric, :mock_logging do
 
   it "can refresh itself" do
     mock = Minitest::Mock.new
-    mock.expect :get_log_metric, metric_grpc, ["projects/test/metrics/#{metric.name}"]
+    mock.expect :get_log_metric, metric_grpc, ["projects/test/metrics/#{metric.name}", options: default_options]
     metric.service.mocked_metrics = mock
 
     metric.refresh!
@@ -61,7 +61,7 @@ describe Google::Cloud::Logging::Metric, :mock_logging do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_log_metric, metric_grpc, ["projects/test/metrics/#{metric.name}"]
+    mock.expect :delete_log_metric, metric_grpc, ["projects/test/metrics/#{metric.name}", options: default_options]
     metric.service.mocked_metrics = mock
 
     metric.delete

--- a/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(num_entries))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: nil]
+    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     entries = logging.entries
@@ -38,7 +38,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(num_entries))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: nil]
+    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     entries = logging.find_entries
@@ -54,8 +54,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: nil]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries
@@ -78,8 +78,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: nil]
-    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries projects: ["project1", "project2", "project3"],
@@ -107,8 +107,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: nil]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries
@@ -130,8 +130,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: nil]
-    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries projects: ["project1", "project2", "project3"],
@@ -155,8 +155,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: nil]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries.all.to_a
@@ -172,8 +172,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: nil]
-    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries(projects: ["project1", "project2", "project3"],
@@ -191,8 +191,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: nil]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries.all.take(5)
@@ -208,8 +208,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: nil]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries.all(request_limit: 1).to_a
@@ -224,7 +224,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [["project1"], filter: nil, order_by: nil, page_size: nil, options: nil]
+    mock.expect :list_log_entries, list_res, [["project1"], filter: nil, order_by: nil, page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     entries = logging.entries projects: "project1"
@@ -241,7 +241,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [["project1", "project2", "project3"], filter: nil, order_by: nil, page_size: nil, options: nil]
+    mock.expect :list_log_entries, list_res, [["project1", "project2", "project3"], filter: nil, order_by: nil, page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     entries = logging.entries projects: ["project1", "project2", "project3"]
@@ -260,7 +260,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: adv_logs_filter, order_by: nil, page_size: nil, options: nil]
+    mock.expect :list_log_entries, list_res, [[project], filter: adv_logs_filter, order_by: nil, page_size: nil, options: default_options]
 
     logging.service.mocked_logging = mock
 
@@ -278,7 +278,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: "timestamp", page_size: nil, options: nil]
+    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: "timestamp", page_size: nil, options: default_options]
 
     logging.service.mocked_logging = mock
 
@@ -296,7 +296,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: "timestamp desc", page_size: nil, options: nil]
+    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: "timestamp desc", page_size: nil, options: default_options]
 
     logging.service.mocked_logging = mock
 
@@ -314,7 +314,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: 3, options: nil]
+    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: 3, options: default_options]
 
     logging.service.mocked_logging = mock
 
@@ -332,7 +332,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: nil]
+    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
 
     logging.service.mocked_logging = mock
 

--- a/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, [project_path, page_size: nil, options: nil]
+    mock.expect :list_log_metrics, list_res, [project_path, page_size: nil, options: default_options]
     logging.service.mocked_metrics = mock
 
     metrics = logging.metrics
@@ -36,7 +36,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, [project_path, page_size: nil, options: nil]
+    mock.expect :list_log_metrics, list_res, [project_path, page_size: nil, options: default_options]
     logging.service.mocked_metrics = mock
 
     metrics = logging.find_metrics
@@ -52,8 +52,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_metrics = mock
 
     first_metrics = logging.metrics
@@ -76,8 +76,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_metrics = mock
 
     first_metrics = logging.metrics
@@ -99,8 +99,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: 3, options: nil]
-    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: 3, options: default_options]
+    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: 3, options: token_options("next_page_token")]
     logging.service.mocked_metrics = mock
 
     first_metrics = logging.metrics max: 3
@@ -122,8 +122,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_metrics = mock
 
     all_metrics = logging.metrics.all.to_a
@@ -139,8 +139,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: 3, options: nil]
-    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: 3, options: default_options]
+    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: 3, options: token_options("next_page_token")]
     logging.service.mocked_metrics = mock
 
     all_metrics = logging.metrics(max: 3).all.to_a
@@ -156,8 +156,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_metrics = mock
 
     all_metrics = logging.metrics.all.take(5)
@@ -173,8 +173,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_log_metrics, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_log_metrics, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_metrics = mock
 
     all_metrics = logging.metrics.all(request_limit: 1).to_a
@@ -189,7 +189,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, [project_path, page_size: 3, options: nil]
+    mock.expect :list_log_metrics, list_res, [project_path, page_size: 3, options: default_options]
     logging.service.mocked_metrics = mock
 
     metrics = logging.metrics max: 3
@@ -206,7 +206,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, [project_path, page_size: nil, options: nil]
+    mock.expect :list_log_metrics, list_res, [project_path, page_size: nil, options: default_options]
     logging.service.mocked_metrics = mock
 
     metrics = logging.metrics
@@ -230,7 +230,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
                                                                                     "filter" => new_metric_filter).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_log_metric, create_res, ["projects/test", new_metric]
+    mock.expect :create_log_metric, create_res, ["projects/test", new_metric, options: default_options]
     logging.service.mocked_metrics = mock
 
     metric = logging.create_metric new_metric_name, new_metric_filter
@@ -258,7 +258,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
                                                                                     "filter" => new_metric_filter).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_log_metric, create_res, ["projects/test", new_metric]
+    mock.expect :create_log_metric, create_res, ["projects/test", new_metric, options: default_options]
     logging.service.mocked_metrics = mock
 
     metric = logging.create_metric new_metric_name, new_metric_filter, description: new_metric_description
@@ -275,7 +275,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     get_res = Google::Logging::V2::LogMetric.decode_json(random_metric_hash.merge("name" => metric_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :get_log_metric, get_res, ["projects/test/metrics/#{metric_name}"]
+    mock.expect :get_log_metric, get_res, ["projects/test/metrics/#{metric_name}", options: default_options]
     logging.service.mocked_metrics = mock
 
     metric = logging.metric metric_name

--- a/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, options: nil]
+    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     resource_descriptors = logging.resource_descriptors
@@ -36,7 +36,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, options: nil]
+    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     resource_descriptors = logging.find_resource_descriptors
@@ -52,8 +52,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
+    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     first_descriptors = logging.resource_descriptors
@@ -76,8 +76,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
+    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: token_options("next_page_token")]
 
     logging.service.mocked_logging = mock
 
@@ -100,8 +100,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: 3, options: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: 3, options: default_options]
+    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: 3, options: token_options("next_page_token")]
 
     logging.service.mocked_logging = mock
 
@@ -124,8 +124,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
+    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: token_options("next_page_token")]
 
     logging.service.mocked_logging = mock
 
@@ -142,8 +142,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: 3, options: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: 3, options: default_options]
+    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: 3, options: token_options("next_page_token")]
 
     logging.service.mocked_logging = mock
 
@@ -160,8 +160,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "second_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
+    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: token_options("next_page_token")]
 
     logging.service.mocked_logging = mock
 
@@ -178,8 +178,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "second_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, options: default_options]
+    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, options: token_options("next_page_token")]
 
     logging.service.mocked_logging = mock
 
@@ -195,7 +195,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: 3, options: nil]
+    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: 3, options: default_options]
     logging.service.mocked_logging = mock
 
     resource_descriptors = logging.resource_descriptors max: 3
@@ -212,7 +212,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, options: nil]
+    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     resource_descriptors = logging.resource_descriptors

--- a/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, [project_path, page_size: nil, options: nil]
+    mock.expect :list_sinks, list_res, [project_path, page_size: nil, options: default_options]
     logging.service.mocked_sinks = mock
 
     sinks = logging.sinks
@@ -36,7 +36,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, [project_path, page_size: nil, options: nil]
+    mock.expect :list_sinks, list_res, [project_path, page_size: nil, options: default_options]
     logging.service.mocked_sinks = mock
 
     sinks = logging.find_sinks
@@ -52,8 +52,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_sinks = mock
 
     first_sinks = logging.sinks
@@ -76,8 +76,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_sinks = mock
 
     first_sinks = logging.sinks
@@ -99,8 +99,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [project_path, page_size: 3, options: nil]
-    mock.expect :list_sinks, second_list_res, [project_path, page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_sinks, first_list_res, [project_path, page_size: 3, options: default_options]
+    mock.expect :list_sinks, second_list_res, [project_path, page_size: 3, options: token_options("next_page_token")]
     logging.service.mocked_sinks = mock
 
     first_sinks = logging.sinks max: 3
@@ -122,8 +122,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_sinks = mock
 
     all_sinks = logging.sinks.all.to_a
@@ -139,8 +139,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [project_path, page_size: 3, options: nil]
-    mock.expect :list_sinks, second_list_res, [project_path, page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_sinks, first_list_res, [project_path, page_size: 3, options: default_options]
+    mock.expect :list_sinks, second_list_res, [project_path, page_size: 3, options: token_options("next_page_token")]
     logging.service.mocked_sinks = mock
 
     all_sinks = logging.sinks(max: 3).all.to_a
@@ -156,8 +156,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_sinks = mock
 
     all_sinks = logging.sinks.all.take(5)
@@ -173,8 +173,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: nil]
-    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")]
+    mock.expect :list_sinks, first_list_res, [project_path, page_size: nil, options: default_options]
+    mock.expect :list_sinks, second_list_res, [project_path, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_sinks = mock
 
     all_sinks = logging.sinks.all(request_limit: 1).to_a
@@ -190,7 +190,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, [project_path, page_size: 3, options: nil]
+    mock.expect :list_sinks, list_res, [project_path, page_size: 3, options: default_options]
     logging.service.mocked_sinks = mock
 
     sinks = logging.sinks max: 3
@@ -208,7 +208,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, [project_path, page_size: nil, options: nil]
+    mock.expect :list_sinks, list_res, [project_path, page_size: nil, options: default_options]
     logging.service.mocked_sinks = mock
 
     sinks = logging.sinks
@@ -230,7 +230,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
                                                                                 "destination" => new_sink_destination).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_sink, create_res, ["projects/test", new_sink]
+    mock.expect :create_sink, create_res, ["projects/test", new_sink, options: default_options]
     logging.service.mocked_sinks = mock
 
     sink = logging.create_sink new_sink_name, new_sink_destination
@@ -261,7 +261,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
                                                           "output_version_format" => "V2").to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_sink, create_res, ["projects/test", new_sink]
+    mock.expect :create_sink, create_res, ["projects/test", new_sink, options: default_options]
     logging.service.mocked_sinks = mock
 
     sink = logging.create_sink new_sink_name,
@@ -283,7 +283,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     get_res = Google::Logging::V2::LogSink.decode_json(random_sink_hash.merge("name" => sink_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :get_sink, get_res, ["projects/test/sinks/#{sink_name}"]
+    mock.expect :get_sink, get_res, ["projects/test/sinks/#{sink_name}", options: default_options]
     logging.service.mocked_sinks = mock
 
     sink = logging.sink sink_name

--- a/google-cloud-logging/test/google/cloud/logging/project/write_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/write_entries_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [[entry.to_grpc], log_name: nil, resource: nil, labels: nil]
+    mock.expect :write_log_entries, write_res, [[entry.to_grpc], log_name: nil, resource: nil, labels: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     logging.write_entries entry
@@ -42,7 +42,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [[entry1.to_grpc, entry2.to_grpc], log_name: nil, resource: nil, labels: nil]
+    mock.expect :write_log_entries, write_res, [[entry1.to_grpc, entry2.to_grpc], log_name: nil, resource: nil, labels: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     logging.write_entries [entry1, entry2]
@@ -58,7 +58,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [[entry.to_grpc], log_name: "projects/test/logs/testlog", resource: nil, labels: nil]
+    mock.expect :write_log_entries, write_res, [[entry.to_grpc], log_name: "projects/test/logs/testlog", resource: nil, labels: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     logging.write_entries entry, log_name: "testlog"
@@ -77,7 +77,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [[entry.to_grpc], log_name: nil, resource: resource.to_grpc, labels: nil]
+    mock.expect :write_log_entries, write_res, [[entry.to_grpc], log_name: nil, resource: resource.to_grpc, labels: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     logging.write_entries entry, resource: resource
@@ -93,7 +93,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [[entry.to_grpc], log_name: nil, resource: nil, labels: { "env" => "production" }]
+    mock.expect :write_log_entries, write_res, [[entry.to_grpc], log_name: nil, resource: nil, labels: { "env" => "production" }, options: default_options]
     logging.service.mocked_logging = mock
 
     logging.write_entries entry, labels: {env: :production}

--- a/google-cloud-logging/test/google/cloud/logging/project_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project_test.rb
@@ -69,7 +69,7 @@ describe Google::Cloud::Logging::Project, :mock_logging do
     log_name = "syslog"
 
     mock = Minitest::Mock.new
-    mock.expect :delete_log, Google::Protobuf::Empty.new, ["projects/#{project}/logs/#{log_name}"]
+    mock.expect :delete_log, Google::Protobuf::Empty.new, ["projects/#{project}/logs/#{log_name}", options: default_options]
     logging.service.mocked_logging = mock
 
     success = logging.delete_log log_name
@@ -83,7 +83,7 @@ describe Google::Cloud::Logging::Project, :mock_logging do
     log_name = "projects/#{project}/logs/syslog"
 
     mock = Minitest::Mock.new
-    mock.expect :delete_log, Google::Protobuf::Empty.new, [log_name]
+    mock.expect :delete_log, Google::Protobuf::Empty.new, [log_name, options: default_options]
     logging.service.mocked_logging = mock
 
     success = logging.delete_log log_name

--- a/google-cloud-logging/test/google/cloud/logging/sink_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/sink_test.rb
@@ -52,7 +52,7 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
       output_version_format: :V1
     )
     mock = Minitest::Mock.new
-    mock.expect :update_sink, sink_grpc, ["projects/test/sinks/#{sink.name}", new_sink]
+    mock.expect :update_sink, sink_grpc, ["projects/test/sinks/#{sink.name}", new_sink, options: default_options]
     sink.service.mocked_sinks = mock
 
     sink.destination = new_sink_destination
@@ -70,7 +70,7 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
 
   it "can refresh itself" do
     mock = Minitest::Mock.new
-    mock.expect :get_sink, sink_grpc, ["projects/test/sinks/#{sink.name}"]
+    mock.expect :get_sink, sink_grpc, ["projects/test/sinks/#{sink.name}", options: default_options]
     sink.service.mocked_sinks = mock
 
     sink.refresh!
@@ -80,7 +80,7 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_sink, sink_grpc, ["projects/test/sinks/#{sink.name}"]
+    mock.expect :delete_sink, sink_grpc, ["projects/test/sinks/#{sink.name}", options: default_options]
     sink.service.mocked_sinks = mock
 
     sink.delete

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -31,24 +31,34 @@ class Google::Gax::CallOptions
   # Therefore, we must add this capability.
   def === other
     return false unless other.is_a? Google::Gax::CallOptions
-    # Logging only uses page_token, so this is sufficent
-    page_token === other.page_token
+    timeout === other.timeout &&
+      retry_options === other.retry_options &&
+      page_token === other.page_token &&
+      kwargs === other.kwargs
   end
   def == other
     return false unless other.is_a? Google::Gax::CallOptions
-    # Logging only uses page_token, so this is sufficent
-    page_token == other.page_token
+    timeout == other.timeout &&
+      retry_options == other.retry_options &&
+      page_token == other.page_token &&
+      kwargs == other.kwargs
   end
 end
 
 class MockLogging < Minitest::Spec
   let(:project) { "test" }
+  let(:default_options) { Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" }) }
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
   let(:logging) { Google::Cloud::Logging::Project.new(Google::Cloud::Logging::Service.new(project, credentials)) }
 
   # Register this spec type for when :mock_logging is used.
   register_spec_type(self) do |desc, *addl|
     addl.include? :mock_logging
+  end
+
+  def token_options token
+    Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" },
+                                 page_token: token)
   end
 
   def random_entry_hash

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project/publish_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project/publish_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Pubsub::Project, :publish, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     msg = pubsub.publish topic_name, message1
@@ -46,7 +46,7 @@ describe Google::Cloud::Pubsub::Project, :publish, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     msg = pubsub.publish topic_name, message1, format: :text
@@ -66,7 +66,7 @@ describe Google::Cloud::Pubsub::Project, :publish, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     msgs = pubsub.publish topic_name do |batch|
@@ -90,7 +90,7 @@ describe Google::Cloud::Pubsub::Project, :publish, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     msg = pubsub.publish topic_name, message1, autocreate: true

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project/subscribe_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Pubsub::Project, :subscribe, :mock_pubsub do
   it "creates a subscription when calling subscribe" do
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     sub = pubsub.subscribe topic_name, new_sub_name
@@ -66,7 +66,7 @@ describe Google::Cloud::Pubsub::Project, :subscribe, :mock_pubsub do
   it "creates a subscription but not topic even when called with autocreate" do
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     sub = pubsub.subscribe topic_name, new_sub_name, autocreate: true
@@ -85,7 +85,7 @@ describe Google::Cloud::Pubsub::Project, :subscribe, :mock_pubsub do
     it "creates a subscription when calling subscribe" do
       create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
       mock = Minitest::Mock.new
-      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil]
+      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, options: default_options]
       pubsub.service.mocked_subscriber = mock
 
       sub = pubsub.subscribe topic_name, new_sub_name

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -49,7 +49,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     create_res = Google::Pubsub::V1::Topic.decode_json topic_json(new_topic_name)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name)]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.create_topic new_topic_name
@@ -64,7 +64,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     create_res = Google::Pubsub::V1::Topic.decode_json topic_json(new_topic_name)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name)]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.new_topic new_topic_name
@@ -79,7 +79,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
     mock = Minitest::Mock.new
-    mock.expect :get_topic, get_res, [topic_path(topic_name)]
+    mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.topic topic_name
@@ -95,7 +95,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
     mock = Minitest::Mock.new
-    mock.expect :get_topic, get_res, [topic_path(topic_name)]
+    mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.get_topic topic_name
@@ -111,7 +111,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
     mock = Minitest::Mock.new
-    mock.expect :get_topic, get_res, [topic_path(topic_name)]
+    mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.find_topic topic_name
@@ -157,7 +157,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "lists topics" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics
@@ -169,7 +169,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "lists topics with find_topics alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.find_topics
@@ -181,7 +181,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "lists topics with list_topics alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.list_topics
@@ -193,8 +193,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates topics" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
@@ -214,7 +214,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates topics with max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: 3, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: 3, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics max: 3
@@ -229,8 +229,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates topics with next? and next" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
@@ -248,8 +248,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates topics with next? and next and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: 3, options: nil]
-    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: 3, options: default_options]
+    opts = {page_size: 3, options: token_options("next_page_token")}
     mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
@@ -267,8 +267,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates topics with all" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
@@ -281,8 +281,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates topics with all and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: 3, options: nil]
-    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: 3, options: default_options]
+    opts = {page_size: 3, options: token_options("next_page_token")}
     mock.expect :list_topics, topics_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
@@ -295,8 +295,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "iterates topics with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topics, topics_with_token_2, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
@@ -309,8 +309,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "iterates topics with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topics, topics_with_token_2, ["projects/#{project}", opts]
     pubsub.service.mocked_publisher = mock
 
@@ -323,7 +323,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates topics without max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_topics, topics_with_token, ["projects/#{project}", page_size: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topics = pubsub.topics
@@ -341,7 +341,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json("random-topic", sub_name)
     mock = Minitest::Mock.new
-    mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+    mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     sub = pubsub.subscription sub_name
@@ -359,7 +359,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json("random-topic", sub_name)
     mock = Minitest::Mock.new
-    mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+    mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     sub = pubsub.get_subscription sub_name
@@ -377,7 +377,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json("random-topic", sub_name)
     mock = Minitest::Mock.new
-    mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+    mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     sub = pubsub.find_subscription sub_name
@@ -429,7 +429,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "lists subscriptions" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.subscriptions
@@ -444,7 +444,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "lists subscriptions with find_subscriptions alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.find_subscriptions
@@ -459,7 +459,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "lists subscriptions with list_subscriptions alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.list_subscriptions
@@ -474,8 +474,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates subscriptions" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
@@ -495,7 +495,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates subscriptions with max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: 3, options: nil]
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: 3, options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     subs = pubsub.subscriptions max: 3
@@ -510,8 +510,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates subscriptions with next? and next" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
@@ -537,8 +537,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates subscriptions with next? and next and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: 3, options: nil]
-    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: 3, options: default_options]
+    opts = {page_size: 3, options: token_options("next_page_token")}
     mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
@@ -564,8 +564,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates subscriptions with all" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
@@ -582,8 +582,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "paginates subscriptions with all and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: 3, options: nil]
-    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: 3, options: default_options]
+    opts = {page_size: 3, options: token_options("next_page_token")}
     mock.expect :list_subscriptions, subscriptions_without_token, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
@@ -600,8 +600,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "iterates subscriptions with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_subscriptions, subscriptions_with_token_2, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 
@@ -618,8 +618,8 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
   it "iterates subscriptions with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_subscriptions, subscriptions_with_token, ["projects/#{project}", page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_subscriptions, subscriptions_with_token_2, ["projects/#{project}", opts]
     pubsub.service.mocked_subscriber = mock
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -62,7 +62,7 @@ describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
   it "can acknowledge" do
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), [rec_message.ack_id]]
+    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), [rec_message.ack_id], options: default_options]
     subscription.service.mocked_subscriber = mock
 
     rec_message.acknowledge!
@@ -73,7 +73,7 @@ describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
   it "can ack" do
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), [rec_message.ack_id]]
+    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), [rec_message.ack_id], options: default_options]
     subscription.service.mocked_subscriber = mock
 
     rec_message.ack!
@@ -85,7 +85,7 @@ describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
     new_deadline = 42
     mad_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :modify_ack_deadline, mad_res, [subscription_path(subscription_name), [rec_message.ack_id], new_deadline]
+    mock.expect :modify_ack_deadline, mad_res, [subscription_path(subscription_name), [rec_message.ack_id], new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     rec_message.delay! new_deadline

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     ack_id = rec_message1.ack_id
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [ack_id]]
+    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [ack_id], options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.acknowledge ack_id
@@ -47,7 +47,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids]
+    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.acknowledge(*ack_ids)
@@ -59,7 +59,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids]
+    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.acknowledge ack_ids
@@ -70,7 +70,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
   it "can acknowledge a message" do
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [rec_message1.ack_id]]
+    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [rec_message1.ack_id], options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.acknowledge rec_message1
@@ -83,7 +83,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     ack_ids = rec_messages.map(&:ack_id)
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids]
+    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.acknowledge(*rec_messages)
@@ -96,7 +96,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     ack_ids = rec_messages.map(&:ack_id)
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids]
+    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.acknowledge rec_messages
@@ -114,7 +114,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
       ack_id = rec_message1.ack_id
       ack_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [ack_id]]
+      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [ack_id], options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.acknowledge ack_id
@@ -126,7 +126,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       ack_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids]
+      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.acknowledge(*ack_ids)
@@ -138,7 +138,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       ack_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids]
+      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.acknowledge ack_ids
@@ -149,7 +149,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     it "can acknowledge a message" do
       ack_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [rec_message1.ack_id]]
+      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [rec_message1.ack_id], options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.acknowledge rec_message1
@@ -162,7 +162,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
       ack_ids = rec_messages.map(&:ack_id)
       ack_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids]
+      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.acknowledge(*rec_messages)
@@ -175,7 +175,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
       ack_ids = rec_messages.map(&:ack_id)
       ack_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids]
+      mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.acknowledge rec_messages

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -44,7 +44,7 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     push_config = Google::Pubsub::V1::PushConfig.new(push_endpoint: new_push_endpoint)
     mpc_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :modify_push_config, mpc_res, [subscription_path(sub_name), push_config]
+    mock.expect :modify_push_config, mpc_res, [subscription_path(sub_name), push_config, options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     subscription.endpoint = new_push_endpoint
@@ -61,7 +61,7 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     it "makes an HTTP API call to retrieve topic" do
       get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
       mock = Minitest::Mock.new
-      mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+      mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.topic.must_be_kind_of Google::Cloud::Pubsub::Topic
@@ -75,7 +75,7 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     it "makes an HTTP API call to retrieve deadline" do
       get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
       mock = Minitest::Mock.new
-      mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+      mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.deadline.must_equal sub_deadline
@@ -86,7 +86,7 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     it "makes an HTTP API call to retrieve endpoint" do
       get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
       mock = Minitest::Mock.new
-      mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+      mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.endpoint.must_equal sub_endpoint
@@ -99,7 +99,7 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
       push_config = Google::Pubsub::V1::PushConfig.new(push_endpoint: new_push_endpoint)
       mpc_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :modify_push_config, mpc_res, [subscription_path(sub_name), push_config]
+      mock.expect :modify_push_config, mpc_res, [subscription_path(sub_name), push_config, options: default_options]
       pubsub.service.mocked_subscriber = mock
 
       subscription.endpoint = new_push_endpoint

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delay_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     new_deadline = 42
     mad_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [ack_id], new_deadline]
+    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [ack_id], new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.delay new_deadline, ack_id
@@ -46,7 +46,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     new_deadline = 42
     mad_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline]
+    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.delay new_deadline, *ack_ids
@@ -59,7 +59,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     new_deadline = 42
     mad_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline]
+    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.delay new_deadline, ack_ids
@@ -71,7 +71,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     new_deadline = 42
     mad_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [rec_message1.ack_id], new_deadline]
+    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [rec_message1.ack_id], new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.delay new_deadline, rec_message1
@@ -84,7 +84,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     new_deadline = 42
     mad_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline]
+    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.delay new_deadline, *rec_messages
@@ -97,7 +97,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     new_deadline = 42
     mad_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline]
+    mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.delay new_deadline, rec_messages
@@ -116,7 +116,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       new_deadline = 42
       mad_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [ack_id], new_deadline]
+      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [ack_id], new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.delay new_deadline, ack_id
@@ -129,7 +129,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       new_deadline = 42
       mad_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline]
+      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.delay new_deadline, *ack_ids
@@ -142,7 +142,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       new_deadline = 42
       mad_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline]
+      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.delay new_deadline, ack_ids
@@ -154,7 +154,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       new_deadline = 42
       mad_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [rec_message1.ack_id], new_deadline]
+      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [rec_message1.ack_id], new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.delay new_deadline, rec_message1
@@ -167,7 +167,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       new_deadline = 42
       mad_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline]
+      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.delay new_deadline, *rec_messages
@@ -180,7 +180,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
       new_deadline = 42
       mad_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline]
+      mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.delay new_deadline, rec_messages

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Pubsub::Subscription, :delete, :mock_pubsub do
   it "can delete itself" do
     del_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :delete_subscription, del_res, [subscription_path(sub_name)]
+    mock.expect :delete_subscription, del_res, [subscription_path(sub_name), options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     subscription.delete
@@ -42,7 +42,7 @@ describe Google::Cloud::Pubsub::Subscription, :delete, :mock_pubsub do
     it "can delete itself" do
       del_res = Google::Protobuf::Empty.new
       mock = Minitest::Mock.new
-      mock.expect :delete_subscription, del_res, [subscription_path(sub_name)]
+      mock.expect :delete_subscription, del_res, [subscription_path(sub_name), options: default_options]
       pubsub.service.mocked_subscriber = mock
 
       subscription.delete

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
@@ -38,7 +38,7 @@ describe Google::Cloud::Pubsub::Subscription, :exists, :mock_pubsub do
     it "checks if the subscription exists by making an HTTP call" do
       get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
       mock = Minitest::Mock.new
-      mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+      mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
       subscription.must_be :exists?

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Pubsub::Subscription, :policy, :mock_pubsub do
     }.to_json
     get_res = Google::Iam::V1::Policy.decode_json policy_json
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [subscription_path(sub_name)]
+    mock.expect :get_iam_policy, get_res, [subscription_path(sub_name), options: default_options]
     subscription.service.mocked_subscriber = mock
 
     policy = subscription.policy
@@ -101,7 +101,7 @@ describe Google::Cloud::Pubsub::Subscription, :policy, :mock_pubsub do
     }.to_json
     get_res = Google::Iam::V1::Policy.decode_json policy_json
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [subscription_path(sub_name)]
+    mock.expect :get_iam_policy, get_res, [subscription_path(sub_name), options: default_options]
     subscription.service.mocked_subscriber = mock
 
     existing_policy = Google::Cloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
@@ -142,7 +142,7 @@ describe Google::Cloud::Pubsub::Subscription, :policy, :mock_pubsub do
     }.to_json
     get_res = Google::Iam::V1::Policy.decode_json policy_json
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [subscription_path(sub_name)]
+    mock.expect :get_iam_policy, get_res, [subscription_path(sub_name), options: default_options]
 
     new_policy = {
       "etag"=>"CAE=",
@@ -157,7 +157,7 @@ describe Google::Cloud::Pubsub::Subscription, :policy, :mock_pubsub do
 
     policy = Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
-    mock.expect :set_iam_policy, set_res, [subscription_path(sub_name), policy]
+    mock.expect :set_iam_policy, set_res, [subscription_path(sub_name), policy, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     policy = subscription.policy
@@ -194,7 +194,7 @@ describe Google::Cloud::Pubsub::Subscription, :policy, :mock_pubsub do
     }.to_json
     get_res = Google::Iam::V1::Policy.decode_json policy_json
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [subscription_path(sub_name)]
+    mock.expect :get_iam_policy, get_res, [subscription_path(sub_name), options: default_options]
 
     new_policy = {
       "etag"=>"CAE=",
@@ -209,7 +209,7 @@ describe Google::Cloud::Pubsub::Subscription, :policy, :mock_pubsub do
 
     policy = Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
-    mock.expect :set_iam_policy, set_res, [subscription_path(sub_name), policy]
+    mock.expect :set_iam_policy, set_res, [subscription_path(sub_name), policy, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     policy = subscription.policy do |p|
@@ -235,7 +235,7 @@ describe Google::Cloud::Pubsub::Subscription, :policy, :mock_pubsub do
       permissions: ["pubsub.subscriptions.get"]
     )
     mock = Minitest::Mock.new
-    mock.expect :test_iam_permissions, test_res, [subscription_path(sub_name), permissions]
+    mock.expect :test_iam_permissions, test_res, [subscription_path(sub_name), permissions, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     permissions = subscription.test_permissions "pubsub.subscriptions.get",

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_autoack_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_autoack_test.rb
@@ -50,8 +50,8 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :autoack, :mock_pubsub do
     ack_res = Google::Protobuf::Empty.new
     pull_res = Google::Pubsub::V1::PullResponse.decode_json rec_msgs_json
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids]
-    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true]
+    mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
+    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     rec_messages = subscription.pull autoack: true
@@ -64,7 +64,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :autoack, :mock_pubsub do
   it "does not auto acknowledge when pulling messages and getting 0 results" do
     pull_res = Google::Pubsub::V1::PullResponse.decode_json empty_rec_msgs_json
     mock = Minitest::Mock.new
-    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true]
+    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     rec_messages = subscription.pull autoack: true

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     rec_message_msg = "pulled-message"
     pull_res = Google::Pubsub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
     mock = Minitest::Mock.new
-    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true]
+    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     rec_messages = subscription.pull
@@ -47,7 +47,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
       rec_message_msg = "pulled-message"
       pull_res = Google::Pubsub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
       mock = Minitest::Mock.new
-      mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true]
+      mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: true, options: default_options]
       subscription.service.mocked_subscriber = mock
 
       rec_messages = subscription.pull

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :wait, :mock_pubsub do
     rec_message_msg = "pulled-message"
     pull_res = Google::Pubsub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
     mock = Minitest::Mock.new
-    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: false]
+    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: false, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     rec_messages = subscription.pull immediate: false
@@ -41,7 +41,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :wait, :mock_pubsub do
     rec_message_msg = "pulled-message"
     pull_res = Google::Pubsub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
     mock = Minitest::Mock.new
-    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: false]
+    mock.expect :pull, pull_res, [subscription_path(sub_name), 100, return_immediately: false, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     rec_messages = subscription.wait_for_messages

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
@@ -43,7 +43,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
     push_config = Google::Pubsub::V1::PushConfig.new(push_endpoint: new_push_endpoint)
     mpc_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :modify_push_config, mpc_res, [subscription_path(subscription_name), push_config]
+    mock.expect :modify_push_config, mpc_res, [subscription_path(subscription_name), push_config, options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     subscription.endpoint = new_push_endpoint
@@ -54,7 +54,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
   it "can delete itself" do
     del_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :delete_subscription, del_res, [subscription_path(subscription_name)]
+    mock.expect :delete_subscription, del_res, [subscription_path(subscription_name), options: default_options]
     pubsub.service.mocked_subscriber = mock
 
     subscription.delete
@@ -66,7 +66,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
     rec_message_msg = "pulled-message"
     pull_res = Google::Pubsub::V1::PullResponse.decode_json rec_messages_json(rec_message_msg)
     mock = Minitest::Mock.new
-    mock.expect :pull, pull_res, [subscription_path(subscription_name), 100, return_immediately: true]
+    mock.expect :pull, pull_res, [subscription_path(subscription_name), 100, return_immediately: true, options: default_options]
     subscription.service.mocked_subscriber = mock
 
     rec_messages = subscription.pull
@@ -80,7 +80,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
   it "can acknowledge one message" do
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), ["ack-id-1"]]
+    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), ["ack-id-1"], options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.acknowledge "ack-id-1"
@@ -91,7 +91,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
   it "can acknowledge many messages" do
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), ["ack-id-1", "ack-id-2", "ack-id-3"]]
+    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), ["ack-id-1", "ack-id-2", "ack-id-3"], options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.acknowledge "ack-id-1", "ack-id-2", "ack-id-3"
@@ -102,7 +102,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
   it "can acknowledge with ack" do
     ack_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), ["ack-id-1"]]
+    mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), ["ack-id-1"], options: default_options]
     subscription.service.mocked_subscriber = mock
 
     subscription.ack "ack-id-1"

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Pubsub::Topic, :exists, :mock_pubsub do
       it "checks if the topic exists by making an HTTP call" do
         get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
         mock = Minitest::Mock.new
-        mock.expect :get_topic, get_res, [topic_path(topic_name)]
+        mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
         topic.service.mocked_publisher = mock
 
         topic.must_be :exists?
@@ -54,7 +54,7 @@ describe Google::Cloud::Pubsub::Topic, :exists, :mock_pubsub do
       it "checks if the topic exists by making an HTTP call" do
         get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
         mock = Minitest::Mock.new
-        mock.expect :get_topic, get_res, [topic_path(topic_name)]
+        mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
         topic.service.mocked_publisher = mock
 
         topic.must_be :exists?
@@ -73,7 +73,7 @@ describe Google::Cloud::Pubsub::Topic, :exists, :mock_pubsub do
       it "checks if the topic exists by making an HTTP call" do
         get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
         mock = Minitest::Mock.new
-        mock.expect :get_topic, get_res, [topic_path(topic_name)]
+        mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
         topic.service.mocked_publisher = mock
 
         topic.must_be :exists?

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     }.to_json
     get_res = Google::Iam::V1::Policy.decode_json policy_json
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [topic_path(topic_name)]
+    mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
     topic.service.mocked_publisher = mock
 
     policy = topic.policy
@@ -98,7 +98,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     }.to_json
     get_res = Google::Iam::V1::Policy.decode_json policy_json
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [topic_path(topic_name)]
+    mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
     topic.service.mocked_publisher = mock
 
     existing_policy = Google::Cloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
@@ -139,7 +139,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     }.to_json
     get_res = Google::Iam::V1::Policy.decode_json policy_json
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [topic_path(topic_name)]
+    mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
 
     new_policy = {
       "etag"=>"CAE=",
@@ -154,7 +154,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
 
     policy = Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
-    mock.expect :set_iam_policy, set_res, [topic_path(topic_name), policy]
+    mock.expect :set_iam_policy, set_res, [topic_path(topic_name), policy, options: default_options]
     topic.service.mocked_publisher = mock
 
     policy = topic.policy
@@ -191,7 +191,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     }.to_json
     get_res = Google::Iam::V1::Policy.decode_json policy_json
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [topic_path(topic_name)]
+    mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
 
     new_policy = {
       "etag"=>"CAE=",
@@ -206,7 +206,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
 
     policy = Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
-    mock.expect :set_iam_policy, set_res, [topic_path(topic_name), policy]
+    mock.expect :set_iam_policy, set_res, [topic_path(topic_name), policy, options: default_options]
     topic.service.mocked_publisher = mock
 
     policy = topic.policy do |p|
@@ -232,7 +232,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
       permissions: ["pubsub.topics.get"]
     )
     mock = Minitest::Mock.new
-    mock.expect :test_iam_permissions, test_res, [topic_path(topic_name), permissions]
+    mock.expect :test_iam_permissions, test_res, [topic_path(topic_name), permissions, options: default_options]
     topic.service.mocked_publisher = mock
 
     permissions = topic.test_permissions "pubsub.topics.get",

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
 
     msg = topic.publish message1
@@ -48,7 +48,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
 
     msg = topic.publish "あ"
@@ -66,7 +66,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
 
     msg = nil
@@ -90,7 +90,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
 
     msg = topic.publish message1, format: :text
@@ -110,7 +110,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
 
     msgs = topic.publish do |batch|
@@ -139,7 +139,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
       ]
       publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
       mock = Minitest::Mock.new
-      mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+      mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
       topic.service.mocked_publisher = mock
 
       msg = topic.publish message1
@@ -156,7 +156,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
       ]
       publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
       mock = Minitest::Mock.new
-      mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+      mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
       topic.service.mocked_publisher = mock
 
       msg = topic.publish message1, format: :text
@@ -176,7 +176,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
       ]
       publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
       mock = Minitest::Mock.new
-      mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+      mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
       topic.service.mocked_publisher = mock
 
       msgs = topic.publish do |batch|

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
   it "creates a subscription when calling subscribe" do
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name
@@ -42,7 +42,7 @@ describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
     it "creates a subscription when calling subscribe" do
       create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
       mock = Minitest::Mock.new
-      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil]
+      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, options: default_options]
       topic.service.mocked_subscriber = mock
 
       sub = topic.subscribe new_sub_name

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
   it "gets an existing subscription" do
     get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, found_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :get_subscription, get_res, [subscription_path(found_sub_name)]
+    mock.expect :get_subscription, get_res, [subscription_path(found_sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscription found_sub_name
@@ -38,7 +38,7 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
   it "gets an existing subscription with get_subscription alias" do
     get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, found_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :get_subscription, get_res, [subscription_path(found_sub_name)]
+    mock.expect :get_subscription, get_res, [subscription_path(found_sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.get_subscription found_sub_name
@@ -52,7 +52,7 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
   it "gets an existing subscription with find_subscription alias" do
     get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, found_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :get_subscription, get_res, [subscription_path(found_sub_name)]
+    mock.expect :get_subscription, get_res, [subscription_path(found_sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.find_subscription found_sub_name
@@ -91,7 +91,7 @@ describe Google::Cloud::Pubsub::Topic, :subscription, :mock_pubsub do
     it "gets an existing subscription" do
       get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, found_sub_name)
       mock = Minitest::Mock.new
-      mock.expect :get_subscription, get_res, [subscription_path(found_sub_name)]
+      mock.expect :get_subscription, get_res, [subscription_path(found_sub_name), options: default_options]
       topic.service.mocked_subscriber = mock
 
       sub = topic.subscription found_sub_name

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
@@ -22,9 +22,10 @@ describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
     response = Google::Pubsub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, "next_page_token")
     paged_enum_struct response
   end
+
   it "lists subscriptions" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
     topic.service.mocked_publisher = mock
 
     subs = topic.subscriptions
@@ -46,7 +47,7 @@ describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
 
       it "lists subscriptions" do
         mock = Minitest::Mock.new
-        mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
+        mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
         topic.service.mocked_publisher = mock
 
         subs = topic.subscriptions
@@ -68,7 +69,7 @@ describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
 
       it "lists subscriptions" do
         mock = Minitest::Mock.new
-        mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
+        mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
         topic.service.mocked_publisher = mock
 
         subs = topic.subscriptions

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -38,7 +38,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
   it "can delete itself" do
     get_res = Google::Protobuf::Empty.new
     mock = Minitest::Mock.new
-    mock.expect :delete_topic, get_res, [topic_path(topic_name)]
+    mock.expect :delete_topic, get_res, [topic_path(topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic.delete
@@ -50,7 +50,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name
@@ -65,7 +65,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.create_subscription new_sub_name
@@ -80,7 +80,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.new_subscription new_sub_name
@@ -96,7 +96,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     deadline = 42
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: 42]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: 42, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, deadline: deadline
@@ -113,7 +113,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     push_config = Google::Pubsub::V1::PushConfig.new(push_endpoint: endpoint)
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: push_config, ack_deadline_seconds: nil]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: push_config, ack_deadline_seconds: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, endpoint: endpoint
@@ -162,7 +162,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
     get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
     mock = Minitest::Mock.new
-    mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+    mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscription sub_name
@@ -179,7 +179,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
     get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
     mock = Minitest::Mock.new
-    mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+    mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.get_subscription sub_name
@@ -196,7 +196,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
     get_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, sub_name)
     mock = Minitest::Mock.new
-    mock.expect :get_subscription, get_res, [subscription_path(sub_name)]
+    mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.find_subscription sub_name
@@ -210,7 +210,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "lists subscriptions" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
     topic.service.mocked_publisher = mock
 
     subs = topic.subscriptions
@@ -226,7 +226,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "lists subscriptions with find_subscriptions alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
     topic.service.mocked_publisher = mock
 
     subs = topic.find_subscriptions
@@ -240,7 +240,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "lists subscriptions with list_subscriptions alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
     topic.service.mocked_publisher = mock
 
     subs = topic.list_subscriptions
@@ -256,8 +256,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "paginates subscriptions" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topic_subscriptions, subscriptions_without_token, [topic_path(topic_name), opts]
     topic.service.mocked_publisher = mock
 
@@ -285,7 +285,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "paginates subscriptions with max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: 3, options: nil]
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: 3, options: default_options]
     topic.service.mocked_publisher = mock
 
     subs = topic.subscriptions max: 3
@@ -304,8 +304,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "paginates subscriptions with next? and next" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topic_subscriptions, subscriptions_without_token, [topic_path(topic_name), opts]
     topic.service.mocked_publisher = mock
 
@@ -331,8 +331,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "paginates subscriptions with with next? and next and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: 3, options: nil]
-    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: 3, options: default_options]
+    opts = {page_size: 3, options: token_options("next_page_token")}
     mock.expect :list_topic_subscriptions, subscriptions_without_token, [topic_path(topic_name), opts]
     topic.service.mocked_publisher = mock
 
@@ -358,8 +358,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "paginates subscriptions with all" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topic_subscriptions, subscriptions_without_token, [topic_path(topic_name), opts]
     topic.service.mocked_publisher = mock
 
@@ -376,8 +376,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "paginates subscriptions with with all and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: 3, options: nil]
-    opts = {page_size: 3, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: 3, options: default_options]
+    opts = {page_size: 3, options: token_options("next_page_token")}
     mock.expect :list_topic_subscriptions, subscriptions_without_token, [topic_path(topic_name), opts]
     topic.service.mocked_publisher = mock
 
@@ -394,8 +394,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "iterates subscriptions with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topic_subscriptions, subscriptions_with_token_2, [topic_path(topic_name), opts]
     topic.service.mocked_publisher = mock
 
@@ -412,8 +412,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "iterates subscriptions with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: nil]
-    opts = {page_size: nil, options: Google::Gax::CallOptions.new(page_token: "next_page_token")}
+    mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
+    opts = {page_size: nil, options: token_options("next_page_token")}
     mock.expect :list_topic_subscriptions, subscriptions_with_token_2, [topic_path(topic_name), opts]
     topic.service.mocked_publisher = mock
 
@@ -436,7 +436,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
 
     msg = topic.publish message
@@ -455,7 +455,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
 
     msg = topic.publish message, format: :text
@@ -478,7 +478,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2"] }.to_json)
     mock = Minitest::Mock.new
-    mock.expect :publish, publish_res, [topic_path(topic_name), messages]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
     topic.service.mocked_publisher = mock
 
     msgs = topic.publish do |batch|

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -31,20 +31,30 @@ class Google::Gax::CallOptions
   # Therefore, we must add this capability.
   def === other
     return false unless other.is_a? Google::Gax::CallOptions
-    # only use is page_token, so this is sufficient
-    page_token === other.page_token
+    timeout === other.timeout &&
+      retry_options === other.retry_options &&
+      page_token === other.page_token &&
+      kwargs === other.kwargs
   end
   def == other
     return false unless other.is_a? Google::Gax::CallOptions
-    # only use is page_token, so this is sufficient
-    page_token == other.page_token
+    timeout == other.timeout &&
+      retry_options == other.retry_options &&
+      page_token == other.page_token &&
+      kwargs == other.kwargs
   end
 end
 
 class MockPubsub < Minitest::Spec
   let(:project) { "test" }
+  let(:default_options) { Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" }) }
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
   let(:pubsub) { Google::Cloud::Pubsub::Project.new(Google::Cloud::Pubsub::Service.new(project, credentials)) }
+
+  def token_options token
+    Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" },
+                                 page_token: token)
+  end
 
   def topics_json num_topics, token = ""
     topics = num_topics.times.map do

--- a/google-cloud-speech/lib/google/cloud/speech/service.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/service.rb
@@ -77,11 +77,15 @@ module Google
         end
 
         def recognize_sync audio, config
-          execute { service.sync_recognize config, audio }
+          execute do
+            service.sync_recognize config, audio, options: default_options
+          end
         end
 
         def recognize_async audio, config
-          execute { service.async_recognize config, audio }
+          execute do
+            service.async_recognize config, audio, options: default_options
+          end
         end
 
         def get_op name
@@ -94,6 +98,14 @@ module Google
         end
 
         protected
+
+        def default_headers
+          { "google-cloud-resource-prefix" => "projects/#{@project}" }
+        end
+
+        def default_options
+          Google::Gax::CallOptions.new kwargs: default_headers
+        end
 
         def execute
           require "grpc" # Ensure GRPC is loaded before rescuing exception

--- a/google-cloud-speech/test/google/cloud/speech/audio/recognize_job_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/recognize_job_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Speech::Audio, :recognize_job, :mock_speech do
     config_grpc = Google::Cloud::Speech::V1beta1::RecognitionConfig.new(encoding: :LINEAR16, sample_rate: 16000, language_code: "en")
 
     mock = Minitest::Mock.new
-    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc]
+    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc, options: default_options]
 
     audio.encoding = :raw
     audio.sample_rate = 16000

--- a/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Speech::Audio, :recognize, :mock_speech do
     config_grpc = Google::Cloud::Speech::V1beta1::RecognitionConfig.new(encoding: :LINEAR16, sample_rate: 16000, language_code: "en")
 
     mock = Minitest::Mock.new
-    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc]
+    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     audio.encoding = :raw
     audio.sample_rate = 16000

--- a/google-cloud-speech/test/google/cloud/speech/project/recognize_job_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/recognize_job_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Speech::Project, :recognize_job, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(content: File.read("acceptance/data/audio.raw", mode: "rb"))
 
     mock = Minitest::Mock.new
-    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc]
+    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     job = speech.recognize_job "acceptance/data/audio.raw", encoding: :raw, sample_rate: 16000
@@ -38,7 +38,7 @@ describe Google::Cloud::Speech::Project, :recognize_job, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(content: File.read("acceptance/data/audio.raw", mode: "rb"))
 
     mock = Minitest::Mock.new
-    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc]
+    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     job = speech.recognize_job File.open("acceptance/data/audio.raw", "rb"), encoding: :raw, sample_rate: 16000
@@ -53,7 +53,7 @@ describe Google::Cloud::Speech::Project, :recognize_job, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(uri: "gs://some_bucket/audio.raw")
 
     mock = Minitest::Mock.new
-    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc]
+    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     job = speech.recognize_job "gs://some_bucket/audio.raw", encoding: :raw, sample_rate: 16000
@@ -68,7 +68,7 @@ describe Google::Cloud::Speech::Project, :recognize_job, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(uri: "gs://some_bucket/audio.raw")
 
     mock = Minitest::Mock.new
-    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc]
+    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     gcs_fake = OpenStruct.new to_gs_url: "gs://some_bucket/audio.raw"
@@ -84,7 +84,7 @@ describe Google::Cloud::Speech::Project, :recognize_job, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(uri: "gs://some_bucket/audio.raw")
 
     mock = Minitest::Mock.new
-    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc]
+    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     audio = speech.audio "gs://some_bucket/audio.raw"
@@ -100,7 +100,7 @@ describe Google::Cloud::Speech::Project, :recognize_job, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(uri: "gs://some_bucket/audio.raw")
 
     mock = Minitest::Mock.new
-    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc]
+    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     audio = speech.audio "gs://some_bucket/audio.raw", encoding: :raw, sample_rate: 16000, language: "en"
@@ -116,7 +116,7 @@ describe Google::Cloud::Speech::Project, :recognize_job, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(uri: "gs://some_bucket/audio.raw")
 
     mock = Minitest::Mock.new
-    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc]
+    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     audio = speech.audio "gs://some_bucket/audio.raw", encoding: :flac, sample_rate: 48000, language: "en"

--- a/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(content: File.read(filepath, mode: "rb"))
 
     mock = Minitest::Mock.new
-    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc]
+    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     results = speech.recognize filepath, encoding: :raw, sample_rate: 16000
@@ -42,7 +42,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(content: File.read(filepath, mode: "rb"))
 
     mock = Minitest::Mock.new
-    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc]
+    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     results = speech.recognize File.open(filepath, "rb"), encoding: :raw, sample_rate: 16000
@@ -59,7 +59,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(uri: "gs://some_bucket/audio.raw")
 
     mock = Minitest::Mock.new
-    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc]
+    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     results = speech.recognize "gs://some_bucket/audio.raw", encoding: :raw, sample_rate: 16000
@@ -76,7 +76,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(uri: "gs://some_bucket/audio.raw")
 
     mock = Minitest::Mock.new
-    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc]
+    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     gcs_fake = OpenStruct.new to_gs_url: "gs://some_bucket/audio.raw"
@@ -94,7 +94,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(content: File.read(filepath, mode: "rb"))
 
     mock = Minitest::Mock.new
-    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc]
+    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     audio = speech.audio filepath, encoding: :raw, sample_rate: 16000, language: "en"
@@ -112,7 +112,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(content: File.read(filepath, mode: "rb"))
 
     mock = Minitest::Mock.new
-    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc]
+    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     audio = speech.audio filepath
@@ -130,7 +130,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     audio_grpc = Google::Cloud::Speech::V1beta1::RecognitionAudio.new(content: File.read(filepath, mode: "rb"))
 
     mock = Minitest::Mock.new
-    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc]
+    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
     audio = speech.audio filepath, encoding: :flac, sample_rate: 48000, language: "en"

--- a/google-cloud-speech/test/helper.rb
+++ b/google-cloud-speech/test/helper.rb
@@ -21,8 +21,32 @@ require "json"
 require "base64"
 require "google/cloud/speech"
 
+##
+# Monkey-Patch CallOptions to support Mocks
+class Google::Gax::CallOptions
+  ##
+  # Minitest Mock depends on === to match same-value objects.
+  # By default, CallOptions objects do not match with ===.
+  # Therefore, we must add this capability.
+  def === other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout === other.timeout &&
+      retry_options === other.retry_options &&
+      page_token === other.page_token &&
+      kwargs === other.kwargs
+  end
+  def == other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout == other.timeout &&
+      retry_options == other.retry_options &&
+      page_token == other.page_token &&
+      kwargs == other.kwargs
+  end
+end
+
 class MockSpeech < Minitest::Spec
   let(:project) { "test" }
+  let(:default_options) { Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" }) }
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
   let(:speech) { Google::Cloud::Speech::Project.new(Google::Cloud::Speech::Service.new(project, credentials)) }
 

--- a/google-cloud-vision/lib/google/cloud/vision/service.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/service.rb
@@ -70,7 +70,9 @@ module Google
         ##
         # Returns API::BatchAnnotateImagesResponse
         def annotate requests
-          execute { service.batch_annotate_images requests }
+          execute do
+            service.batch_annotate_images requests, options: default_options
+          end
         end
 
         def inspect
@@ -78,6 +80,14 @@ module Google
         end
 
         protected
+
+        def default_headers
+          { "google-cloud-resource-prefix" => "projects/#{@project}" }
+        end
+
+        def default_options
+          Google::Gax::CallOptions.new kwargs: default_headers
+        end
 
         def execute
           yield

--- a/google-cloud-vision/test/google/cloud/vision/image/faces_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/faces_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Vision::Image, :faces, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, faces_response_grpc, [req]
+    mock.expect :batch_annotate_images, faces_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     faces = image.faces 10
@@ -45,7 +45,7 @@ describe Google::Cloud::Vision::Image, :faces, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, faces_response_grpc, [req]
+    mock.expect :batch_annotate_images, faces_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     faces = image.faces
@@ -63,7 +63,7 @@ describe Google::Cloud::Vision::Image, :faces, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, face_response_grpc, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     face = image.face

--- a/google-cloud-vision/test/google/cloud/vision/image/labels_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/labels_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Vision::Image, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, labels_response_grpc, [req]
+    mock.expect :batch_annotate_images, labels_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     labels = image.labels 10
@@ -46,7 +46,7 @@ describe Google::Cloud::Vision::Image, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, labels_response_grpc, [req]
+    mock.expect :batch_annotate_images, labels_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     labels = image.labels
@@ -64,7 +64,7 @@ describe Google::Cloud::Vision::Image, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, label_response_grpc, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     label = image.label

--- a/google-cloud-vision/test/google/cloud/vision/image/landmarks_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/landmarks_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Vision::Image, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmarks_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmarks_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     landmarks = image.landmarks 10
@@ -46,7 +46,7 @@ describe Google::Cloud::Vision::Image, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmarks_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmarks_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     landmarks = image.landmarks
@@ -64,7 +64,7 @@ describe Google::Cloud::Vision::Image, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     landmark = image.landmark

--- a/google-cloud-vision/test/google/cloud/vision/image/logos_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/logos_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Vision::Image, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logos_response_grpc, [req]
+    mock.expect :batch_annotate_images, logos_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     logos = image.logos 10
@@ -46,7 +46,7 @@ describe Google::Cloud::Vision::Image, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logos_response_grpc, [req]
+    mock.expect :batch_annotate_images, logos_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     logos = image.logos
@@ -64,7 +64,7 @@ describe Google::Cloud::Vision::Image, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logo_response_grpc, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     logo = image.logo

--- a/google-cloud-vision/test/google/cloud/vision/image/properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/properties_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Vision::Image, :properties, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, properties_response_grpc, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     properties = image.properties

--- a/google-cloud-vision/test/google/cloud/vision/image/safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/safe_search_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Vision::Image, :safe_search, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     safe_search = image.safe_search

--- a/google-cloud-vision/test/google/cloud/vision/image/text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/text_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Vision::Image, :text, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, text_response_grpc, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
 

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_faces_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_faces_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, face_response_grpc, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, faces: 1
@@ -45,7 +45,7 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, face_response_grpc, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, faces: 1
@@ -68,7 +68,7 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, faces_response_grpc, [req]
+    mock.expect :batch_annotate_images, faces_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, faces: 1
@@ -88,7 +88,7 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, face_response_grpc, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, faces: true
@@ -106,7 +106,7 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, face_response_grpc, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, faces: "9999"
@@ -124,7 +124,7 @@ describe Google::Cloud::Vision::Project, :annotate, :faces, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, face_response_grpc, [req]
+    mock.expect :batch_annotate_images, face_response_grpc, [req, options: default_options]
     vision.service.mocked_service = mock
 
     Google::Cloud::Vision.stub :default_max_faces, 25 do

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_labels_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_labels_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, label_response_grpc, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, labels: 1
@@ -45,7 +45,7 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, label_response_grpc, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, labels: 1
@@ -64,7 +64,7 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, label_response_grpc, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, labels: 1
@@ -87,7 +87,7 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, labels_response_grpc, [req]
+    mock.expect :batch_annotate_images, labels_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, labels: 1
@@ -107,7 +107,7 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, label_response_grpc, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, labels: true
@@ -126,7 +126,7 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, label_response_grpc, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, labels: "9999"
@@ -145,7 +145,7 @@ describe Google::Cloud::Vision::Project, :annotate, :labels, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, label_response_grpc, [req]
+    mock.expect :batch_annotate_images, label_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     Google::Cloud::Vision.stub :default_max_labels, 25 do

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_landmarks_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_landmarks_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, landmarks: 1
@@ -45,7 +45,7 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, landmarks: 1
@@ -64,7 +64,7 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, landmarks: 1
@@ -87,7 +87,7 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmarks_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmarks_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, landmarks: 1
@@ -107,7 +107,7 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, landmarks: true
@@ -126,7 +126,7 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, landmarks: "9999"
@@ -145,7 +145,7 @@ describe Google::Cloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, landmark_response_grpc, [req]
+    mock.expect :batch_annotate_images, landmark_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     Google::Cloud::Vision.stub :default_max_landmarks, 25 do

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_logos_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_logos_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logo_response_grpc, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, logos: 1
@@ -45,7 +45,7 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logo_response_grpc, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, logos: 1
@@ -64,7 +64,7 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logo_response_grpc, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, logos: 1
@@ -87,7 +87,7 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logos_response_grpc, [req]
+    mock.expect :batch_annotate_images, logos_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, logos: 1
@@ -107,7 +107,7 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logo_response_grpc, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, logos: true
@@ -126,7 +126,7 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logo_response_grpc, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, logos: "9999"
@@ -145,7 +145,7 @@ describe Google::Cloud::Vision::Project, :annotate, :logos, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, logo_response_grpc, [req]
+    mock.expect :batch_annotate_images, logo_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     Google::Cloud::Vision.stub :default_max_logos, 25 do

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_properties_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, properties_response_grpc, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, properties: true
@@ -62,7 +62,7 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, properties_response_grpc, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, properties: true
@@ -98,7 +98,7 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, properties_response_grpc, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, properties: true
@@ -138,7 +138,7 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, plural_properties_response_grpc, [req]
+    mock.expect :batch_annotate_images, plural_properties_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, properties: true
@@ -192,7 +192,7 @@ describe Google::Cloud::Vision::Project, :annotate, :properties, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, properties_response_grpc, [req]
+    mock.expect :batch_annotate_images, properties_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, properties: "please"

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_safe_search_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, safe_search: true
@@ -50,7 +50,7 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, safe_search: true
@@ -74,7 +74,7 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, safe_search: true
@@ -102,7 +102,7 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, safe_searches_response_grpc, [req]
+    mock.expect :batch_annotate_images, safe_searches_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, safe_search: true
@@ -132,7 +132,7 @@ describe Google::Cloud::Vision::Project, :annotate, :safe_search, :mock_vision d
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, safe_search_response_grpc, [req]
+    mock.expect :batch_annotate_images, safe_search_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, safe_search: "yep"

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_text_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, text_response_grpc, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, text: true
@@ -52,7 +52,7 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, text_response_grpc, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.mark filepath, text: true
@@ -71,7 +71,7 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, text_response_grpc, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.detect filepath, text: true
@@ -94,7 +94,7 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, texts_response_grpc, [req]
+    mock.expect :batch_annotate_images, texts_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate filepath, filepath, text: true
@@ -114,7 +114,7 @@ describe Google::Cloud::Vision::Project, :annotate, :text, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, text_response_grpc, [req]
+    mock.expect :batch_annotate_images, text_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath, text: "totes"

--- a/google-cloud-vision/test/google/cloud/vision/project_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project_test.rb
@@ -51,7 +51,7 @@ describe Google::Cloud::Vision::Project, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, faces_response_grpc, [req]
+    mock.expect :batch_annotate_images, faces_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotations = vision.annotate do |a|
@@ -81,7 +81,7 @@ describe Google::Cloud::Vision::Project, :mock_vision do
       )
     ]
     mock = Minitest::Mock.new
-    mock.expect :batch_annotate_images, full_response_grpc, [req]
+    mock.expect :batch_annotate_images, full_response_grpc, [req, options: default_options]
 
     vision.service.mocked_service = mock
     annotation = vision.annotate filepath
@@ -150,7 +150,7 @@ describe Google::Cloud::Vision::Project, :mock_vision do
         )
       ]
       mock = Minitest::Mock.new
-      mock.expect :batch_annotate_images, context_response_grpc, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req, options: default_options]
 
       vision.service.mocked_service = mock
       annotation = vision.annotate filepath, faces: 10, text: true
@@ -172,7 +172,7 @@ describe Google::Cloud::Vision::Project, :mock_vision do
         )
       ]
       mock = Minitest::Mock.new
-      mock.expect :batch_annotate_images, context_response_grpc, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req, options: default_options]
 
       vision.service.mocked_service = mock
       image = vision.image filepath
@@ -201,7 +201,7 @@ describe Google::Cloud::Vision::Project, :mock_vision do
         )
       ]
       mock = Minitest::Mock.new
-      mock.expect :batch_annotate_images, context_response_grpc, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req, options: default_options]
 
       vision.service.mocked_service = mock
       image = vision.image filepath
@@ -234,7 +234,7 @@ describe Google::Cloud::Vision::Project, :mock_vision do
         )
       ]
       mock = Minitest::Mock.new
-      mock.expect :batch_annotate_images, context_response_grpc, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req, options: default_options]
 
       vision.service.mocked_service = mock
       image = vision.image filepath
@@ -262,7 +262,7 @@ describe Google::Cloud::Vision::Project, :mock_vision do
         )
       ]
       mock = Minitest::Mock.new
-      mock.expect :batch_annotate_images, context_response_grpc, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req, options: default_options]
 
       vision.service.mocked_service = mock
       image = vision.image filepath
@@ -293,7 +293,7 @@ describe Google::Cloud::Vision::Project, :mock_vision do
         )
       ]
       mock = Minitest::Mock.new
-      mock.expect :batch_annotate_images, context_response_grpc, [req]
+      mock.expect :batch_annotate_images, context_response_grpc, [req, options: default_options]
 
       vision.service.mocked_service = mock
       image = vision.image filepath

--- a/google-cloud-vision/test/helper.rb
+++ b/google-cloud-vision/test/helper.rb
@@ -21,8 +21,32 @@ require "json"
 require "base64"
 require "google/cloud/vision"
 
+##
+# Monkey-Patch CallOptions to support Mocks
+class Google::Gax::CallOptions
+  ##
+  # Minitest Mock depends on === to match same-value objects.
+  # By default, CallOptions objects do not match with ===.
+  # Therefore, we must add this capability.
+  def === other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout === other.timeout &&
+      retry_options === other.retry_options &&
+      page_token === other.page_token &&
+      kwargs === other.kwargs
+  end
+  def == other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout == other.timeout &&
+      retry_options == other.retry_options &&
+      page_token == other.page_token &&
+      kwargs == other.kwargs
+  end
+end
+
 class MockVision < Minitest::Spec
   let(:project) { vision.service.project }
+  let(:default_options) { Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" }) }
   let(:credentials) { vision.service.credentials }
   let(:vision) { Google::Cloud::Vision::Project.new(Google::Cloud::Vision::Service.new("test", OpenStruct.new)) }
 


### PR DESCRIPTION
Add `google-cloud-resource-prefix` header to GRPC requests.

- [x] Datastore
- [x] Language
- [x] Logging
- [x] Pub/Sub
- [x] Speech
- [x] Vision
