### PR TITLE
Add stackdriver gem

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -45,6 +45,14 @@
       ]
     },
     {
+      "id": "stackdriver",
+      "name": "stackdriver",
+      "defaultService": "stackdriver",
+      "versions": [
+        "master"
+      ]
+    },
+    {
       "id": "google-cloud-bigquery",
       "name": "google-cloud-bigquery",
       "defaultService": "google/cloud/bigquery",

--- a/google-cloud-error_reporting/docs/toc.json
+++ b/google-cloud-error_reporting/docs/toc.json
@@ -12,6 +12,14 @@
     {
       "title": "ErrorGroupServiceApi",
       "type": "google/cloud/errorreporting/v1beta1/errorgroupserviceapi"
+    },
+    {
+      "title": "Middleware",
+      "type": "google/cloud/errorreporting/middleware"
+    },
+    {
+      "title": "Railtie",
+      "type": "google/cloud/errorreporting/rails"
     }
   ]
 }

--- a/google-cloud-logging/docs/toc.json
+++ b/google-cloud-logging/docs/toc.json
@@ -44,6 +44,14 @@
         {
           "title": "Resource",
           "type": "google/cloud/logging/resource"
+        },
+        {
+          "title": "Middleware",
+          "type": "google/cloud/logging/middleware"
+        },
+        {
+          "title": "Railtie",
+          "type": "google/cloud/logging/rails"
         }
       ]
     }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -110,6 +110,14 @@
         {
           "title": "ErrorGroupServiceApi",
           "type": "google/cloud/errorreporting/v1beta1/errorgroupserviceapi"
+        },
+        {
+          "title": "Middleware",
+          "type": "google/cloud/errorreporting/middleware"
+        },
+        {
+          "title": "Railtie",
+          "type": "google/cloud/errorreporting/rails"
         }
       ]
     },
@@ -128,6 +136,14 @@
         {
           "title": "Resource",
           "type": "google/cloud/logging/resource"
+        },
+        {
+          "title": "Middleware",
+          "type": "google/cloud/logging/middleware"
+        },
+        {
+          "title": "Railtie",
+          "type": "google/cloud/logging/rails"
         }
       ]
     },

--- a/stackdriver/.gitignore
+++ b/stackdriver/.gitignore
@@ -1,0 +1,9 @@
+Gemfile.lock
+coverage/*
+doc/*
+pkg/*
+html/*
+jsondoc/*
+
+# Ignore YARD stuffs
+.yardoc

--- a/stackdriver/.rubocop.yml
+++ b/stackdriver/.rubocop.yml
@@ -1,0 +1,40 @@
+AllCops:
+  Exclude:
+    - "*.gemspec"
+    - "Rakefile"
+    - "lib/legacy_stackdriver.rb"
+    - "test/**/*"
+
+Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/MethodDefParentheses:
+  EnforcedStyle: require_no_parentheses
+Style/NumericLiterals:
+  Enabled: false
+Style/SpaceAroundOperators:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Style/EmptyLines:
+  Enabled: false
+Style/EmptyElse:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Max: 10
+Metrics/PerceivedComplexity:
+  Max: 10
+Metrics/AbcSize:
+  Max: 25
+Metrics/MethodLength:
+  Max: 20
+Metrics/ParameterLists:
+  Enabled: false
+Style/RescueModifier:
+  Enabled: false
+Style/ClassVars:
+  Enabled: false
+Style/TrivialAccessors:
+  Enabled: false

--- a/stackdriver/.yardopts
+++ b/stackdriver/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--title=Stackdriver
+--markup markdown
+
+./lib/**/*.rb
+-
+README.md

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -1,0 +1,12 @@
+source "http://rubygems.org"
+
+gemspec
+
+gem "rake"
+gem "google-cloud-error_reporting", path: "../google-cloud-error_reporting"
+gem "google-cloud-logging", path: "../google-cloud-logging"
+gem "google-cloud-monitoring", path: "../google-cloud-monitoring"
+
+gem "gcloud-jsondoc",
+    git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
+    branch: "gcloud-jsondoc"

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -1,6 +1,8 @@
 # stackdriver
 
-This gem is a convenience package for loading all Stackdriver gems in the google-cloud-ruby project. 
+This gem instruments a Ruby web application for Stackdriver diagnostics. When loaded, it integrates with Rails, Sinatra, or other Rack-based web frameworks to collect application diagnostic and monitoring information for your application.
+
+Specifically, this gem is a convenience package that loads and automatically activates the instrumentation features of the following gems:
 - [google-cloud-logging](../google-cloud-logging)
 - [google-cloud-error_reporting](../google-cloud-error_reporting)
 - [google-cloud-monitoring](../google-cloud-monitoring)
@@ -14,24 +16,10 @@ $ gem install stackdriver
 ```
 
 ## Overview
-Stackdriver offers several services. Users can use the client libraries for these services directly in applications.
-```ruby
-require "google/cloud/logging"
-require "google/cloud/error_reporting/v1beta1"
-require "google/cloud/monitoring/v3"
-...
-```
-Rails applications can further benefit from the Railties from the Stackdriver libraries by explicitly requiring corresponding modules.
-```ruby
-require "google/cloud/logging/rails"
-require "google/cloud/error_reporting/rails"
-...
-```
-But instead of requiring multiple gems and explicitly load the built-in Railtie classes, now users can manage all of above through this single **stackdriver** umbrella gem.
+Instead of requiring multiple Stackdriver client library gems and explicitly load each built-in Railtie classes, now users can achieve all these through requiring this single **stackdriver** umbrella gem.
 ```ruby
 require "stackdriver"
 ```
-
 
 ## Supported Ruby Versions
 

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -1,0 +1,61 @@
+# stackdriver
+
+This gem is a convenience package for loading all Stackdriver gems in the google-cloud-ruby project. 
+- [google-cloud-logging](../google-cloud-logging)
+- [google-cloud-error_reporting](../google-cloud-error_reporting)
+- [google-cloud-monitoring](../google-cloud-monitoring)
+
+Please see the top-level project [README](../README.md) for more information about the individual Stackdriver google-cloud-ruby gems.
+
+## Quick Start
+
+```sh
+$ gem install stackdriver
+```
+
+## Overview
+Stackdriver offers several services. Users can use the client libraries for these services directly in applications.
+```ruby
+require "google/cloud/logging"
+require "google/cloud/error_reporting/v1beta1"
+require "google/cloud/monitoring/v3"
+...
+```
+Rails applications can further benefit from the Railties from the Stackdriver libraries by explicitly requiring corresponding modules.
+```ruby
+require "google/cloud/logging/rails"
+require "google/cloud/error_reporting/rails"
+...
+```
+But instead of requiring multiple gems and explicitly load the built-in Railtie classes, now users can manage all of above through this single **stackdriver** umbrella gem.
+```ruby
+require "stackdriver"
+```
+
+
+## Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+## Versioning
+
+This library follows [Semantic Versioning](http://semver.org/).
+
+It is currently in major version zero (0.y.z), which means that anything may change at any time and the public API should not be considered stable.
+
+## Contributing
+
+Contributions to this library are always welcome and highly encouraged.
+
+See the [Contributing Guide](https://googlecloudplatform.github.io/stackdriver-ruby/#/docs/guides/contributing) for more information on how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. See [Code of Conduct](../CODE_OF_CONDUCT.md) for more information.
+
+## License
+
+This library is licensed under Apache 2.0. Full license text is available in [LICENSE](../LICENSE).
+
+## Support
+
+Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -1,0 +1,87 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "bundler/setup"
+require "bundler/gem_tasks"
+
+require "rubocop/rake_task"
+RuboCop::RakeTask.new
+
+task :test do
+  $LOAD_PATH.unshift "lib", "test"
+  Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
+end
+
+namespace :test do
+  desc "Runs tests with coverage."
+  task :coverage do
+    require "simplecov"
+    SimpleCov.start do
+      command_name "stackdriver"
+      track_files "lib/**/*.rb"
+      add_filter "test/"
+    end
+
+    Rake::Task["test"].invoke
+  end
+end
+
+desc "Runs acceptance tests."
+task :acceptance do
+end
+
+namespace :acceptance do
+  desc "Runs acceptance cleanup."
+  task :cleanup do
+  end
+end
+
+desc "Runs yard-doctest example tests."
+task :doctest do
+  sh "bundle exec yard doctest"
+end
+
+desc "Start an interactive shell."
+task :console do
+  require "irb"
+  require "irb/completion"
+  require "pp"
+
+  $LOAD_PATH.unshift "lib"
+
+  require "google/cloud"
+  Bundler.require # load all the gems defined in the Gemfile
+  def gcloud; @gcloud ||= Google::Cloud.new; end
+
+  ARGV.clear
+  IRB.start
+end
+
+desc "Generates JSON output from stackdriver .yardoc"
+task :jsondoc => :yard do
+  require "rubygems"
+  require "gcloud/jsondoc"
+
+  registry = YARD::Registry.load! ".yardoc"
+  generator = Gcloud::Jsondoc::Generator.new registry, "stackdriver"
+  generator.write_to "jsondoc"
+  cp ["docs/toc.json"], "jsondoc", verbose: true
+end
+
+require "yard"
+require "yard/rake/yardoc_task"
+YARD::Rake::YardocTask.new
+
+task :default => :test

--- a/stackdriver/docs/toc.json
+++ b/stackdriver/docs/toc.json
@@ -1,0 +1,75 @@
+{
+  "guides": [],
+  "services": [
+    {
+      "title": "stackdriver",
+      "type": "stackdriver"
+    },
+    {
+      "title": "Error Reporting",
+      "type": "google/cloud/errorreporting/v1beta1",
+      "nav": [
+        {
+          "title": "ReportErrorsServiceApi",
+          "type": "google/cloud/errorreporting/v1beta1/reporterrorsserviceapi"
+        },
+        {
+          "title": "ErrorStatsServiceApi",
+          "type": "google/cloud/errorreporting/v1beta1/errorstatsserviceapi"
+        },
+        {
+          "title": "ErrorGroupServiceApi",
+          "type": "google/cloud/errorreporting/v1beta1/errorgroupserviceapi"
+        },
+        {
+          "title": "Middleware",
+          "type": "google/cloud/errorreporting/middleware"
+        },
+        {
+          "title": "Railtie",
+          "type": "google/cloud/errorreporting/rails"
+        }
+      ]
+    },
+    {
+      "title": "Logging",
+      "type": "google/cloud/logging",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/logging/project"
+        },
+        {
+          "title": "Entry",
+          "type": "google/cloud/logging/entry"
+        },
+        {
+          "title": "Resource",
+          "type": "google/cloud/logging/resource"
+        },
+        {
+          "title": "Middleware",
+          "type": "google/cloud/logging/middleware"
+        },
+        {
+          "title": "Railtie",
+          "type": "google/cloud/logging/rails"
+        }
+      ]
+    },
+    {
+      "title": "Monitoring",
+      "type": "google/cloud/monitoring/v3",
+      "nav": [
+        {
+          "title": "GroupServiceApi",
+          "type": "google/cloud/monitoring/v3/groupserviceapi"
+        },
+        {
+          "title": "MetricServiceApi",
+          "type": "google/cloud/monitoring/v3/metricserviceapi"
+        }
+      ]
+    }
+  ]
+}

--- a/stackdriver/lib/legacy_stackdriver.rb
+++ b/stackdriver/lib/legacy_stackdriver.rb
@@ -1,0 +1,105 @@
+# Copyright (c) 2013 Grant T. Olson
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#   * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#
+#     * Neither the name of the Grant T. Olson nor the names of
+#       additional contributors may be used to endorse or promote
+#       products derived from this software without specific prior
+#       written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+#
+# This file provides backward compatibility with legacy stackdriver v0.2.2 gem.
+# Original code can be found at https://github.com/sammarx/stackdriver-ruby
+#
+require 'multi_json'
+
+module StackDriver
+  POST_URI = "https://custom-gateway.stackdriver.com/v1/custom"
+  DELETE_URI = "https://custom-gateway.stackdriver.com/v1/delete_custom"
+
+  def self.init *args
+    # Deprecation message
+    puts "This API has been deprecated by Stackdriver. For new version of " \
+      "API, please visit " \
+      " https://googlecloudplatform.github.io/google-cloud-ruby/#/"
+
+    if args.count > 1
+      puts "Customer ID is no longer needed, and will be deprecated"
+      args.shift
+    end
+    @api_key = args[0]
+  end
+
+  def self.send_metric name, value, time, instance=''
+    msg = build_message name, value, time, instance
+    post MultiJson.dump(msg), StackDriver::POST_URI
+  end
+
+  def self.send_multi_metrics data
+    msg = build_multi_message data
+    post MultiJson.dump(msg), StackDriver::POST_URI
+  end
+
+  def self.delete_metric name, time
+    msg = build_message name, nil, time
+    post MultiJson.dump(msg), StackDriver::DELETE_URI
+  end
+
+  private
+
+  def self.post msg, uri
+    headers = {'content-type' => 'application/json',
+               'x-stackdriver-apikey' => @api_key}
+
+    uri = URI(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    http.start do |http|
+      response = http.post(uri.path, msg, headers)
+      if response.code != "201"
+        raise RuntimeError, "#{response.code} - #{response.body}"
+      end
+    end
+  end
+
+  def self.build_message name, value, time, instance=''
+    data_point = {'name' => name, 'value' => value, 'collected_at' => time}
+    data_point.merge!('value' => value) unless value.nil?
+    data_point.merge!('instance' => instance) unless instance.empty?
+    {'timestamp' => Time.now.to_i, 'proto_version' => '1', 'data' => data_point}
+  end
+
+  def self.build_multi_message data
+    data_point = data
+    {
+      'timestamp' => Time.now.to_i,
+      'proto_version' => '1',
+      'data' => data_point
+    }
+  end
+end

--- a/stackdriver/lib/legacy_stackdriver.rb
+++ b/stackdriver/lib/legacy_stackdriver.rb
@@ -43,9 +43,10 @@ module StackDriver
 
   def self.init *args
     # Deprecation message
-    puts "This API has been deprecated by Stackdriver. For new version of " \
-      "API, please visit " \
-      " https://googlecloudplatform.github.io/google-cloud-ruby/#/"
+    puts "This usage is specific to the legacy Stackdriver service. It is " \
+      "deprecated and will be removed at some point in the future. Please " \
+      "migrate to the Google Stackdriver API documented at " \
+      "https://googlecloudplatform.github.io/google-cloud-ruby/"
 
     if args.count > 1
       puts "Customer ID is no longer needed, and will be deprecated"

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -1,0 +1,30 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+gem "google-cloud-error_reporting"
+gem "google-cloud-logging"
+gem "google-cloud-monitoring"
+
+require "google/cloud/error_reporting/v1beta1"
+require "google/cloud/logging"
+require "google/cloud/monitoring/v3"
+
+if defined? ::Rails::Railtie
+  require "google/cloud/error_reporting/rails"
+  require "google/cloud/logging/rails"
+end
+
+# Backward compatibility with legacy stackdriver gem
+require "legacy_stackdriver"

--- a/stackdriver/lib/stackdriver/version.rb
+++ b/stackdriver/lib/stackdriver/version.rb
@@ -1,0 +1,18 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Stackdriver
+  VERSION = "0.21.0".freeze
+end

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -1,0 +1,35 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path("../lib/stackdriver/version", __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.name          = "stackdriver"
+  gem.version       = Stackdriver::VERSION
+
+  gem.authors       = ["Heng Xiong"]
+  gem.email         = ["hxiong388@gmail.com"]
+  gem.description   = "stackdriver is the official library for Google Stackdriver APIs."
+  gem.summary       = "API Client library for Google Stackdriver"
+  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.license       = "Apache-2.0"
+
+  gem.files         = `git ls-files -- lib/*`.split("\n")
+  gem.require_paths = ["lib"]
+
+  gem.required_ruby_version = ">= 2.0.0"
+
+  gem.add_runtime_dependency "google-cloud-error_reporting"
+  gem.add_runtime_dependency "google-cloud-logging"
+  gem.add_runtime_dependency "google-cloud-monitoring"
+
+  gem.add_development_dependency "minitest", "~> 5.9"
+  gem.add_development_dependency "minitest-autotest", "~> 1.0"
+  gem.add_development_dependency "minitest-focus", "~> 1.1"
+  gem.add_development_dependency "minitest-rg", "~> 5.2"
+  gem.add_development_dependency "autotest-suffix", "~> 1.1"
+  gem.add_development_dependency "rubocop", "~> 0.43"
+  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "railties", ">= 3.2"
+  gem.add_development_dependency "actionpack", "~> 4.0"
+  gem.add_development_dependency "rack", ">= 0.1"
+end

--- a/stackdriver/test/helper.rb
+++ b/stackdriver/test/helper.rb
@@ -1,0 +1,20 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gem "minitest"
+require "minitest/autorun"
+require "minitest/focus"
+require "minitest/rg"
+require "rails/railtie"
+require "stackdriver"

--- a/stackdriver/test/stackdriver/version_test.rb
+++ b/stackdriver/test/stackdriver/version_test.rb
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "stackdriver/version"
+
+describe Stackdriver do
+  it "has a version" do
+    Stackdriver::VERSION.wont_be :nil?
+  end
+end

--- a/stackdriver/test/stackdriver_test.rb
+++ b/stackdriver/test/stackdriver_test.rb
@@ -1,0 +1,38 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Stackdriver do
+  it "requires google-cloud-error_reporting" do
+    defined?(Google::Cloud::ErrorReporting).wont_be :nil?
+  end
+
+  it "requires google-cloud-logging" do
+    defined?(Google::Cloud::Logging).wont_be :nil?
+  end
+
+  it "requires google-cloud-monitoring" do
+    defined?(Google::Cloud::Monitoring).wont_be :nil?
+  end
+
+  it "requires google-cloud-error_reporting rails module" do
+    defined?(Google::Cloud::ErrorReporting::Railtie).wont_be :nil?
+  end
+
+  it "requires google-cloud-logging rails module" do
+    defined?(Google::Cloud::Logging::Railtie).wont_be :nil?
+  end
+end


### PR DESCRIPTION
Created the stackdriver umbrella gem that includes all the Stackdriver gem and automatically enables their instrumentation functionalities.

Since there's an existing [stackdriver gem](https://github.com/sammarx/stackdriver-ruby), we're also providing backward compatibility for one release.

I've also added as much of the jsondoc functionalities by referencing existing google-cloud gem. But I didn't find a way to actually preview the generated jsondocs without pushing it to Github. Please let me know if there's anything else I'm missing on the docs stuff.