### PR TITLE
Allow custom Logging MonitoredResource being defined in Rails

### DIFF
--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -46,7 +46,9 @@ logging.write_entries entry
 
 ## Rails Integration
 
-This library also provides a built in Railtie for Ruby on Rails integration. To do this, simply add this line to config/application.rb:
+This library also provides a built in Railtie for Ruby on Rails integration. When enabled, it substitutes default Rails logger with an instance of Google::Cloud::Logging::logger. Then all consequent log entries will be submitted to Stackdriver Logging service. 
+
+To do this, simply add this line to config/application.rb:
 ```ruby
 require "google/cloud/logging/rails"
 ```
@@ -64,8 +66,12 @@ config.google_cloud.use_logging = true
  
 # Set Stackdriver Logging log name
 config.google_cloud.logging.log_name = "my-app-log"
+ 
+# Override default monitored resource if needed. E.g. used on AWS
+config.google_cloud.logging.monitored_resource.type = "aws_ec2_instance"
+config.google_cloud.logging.monitored_resource.labels.instance_id = "ec2-instance-id"
+config.google_cloud.logging.monitored_resource.labels.aws_account = "AWS account number"
 ```
-
 Alternatively, check out [stackdriver](../stackdriver) gem, which includes this Railtie by default.
 
 ## Rack Integration
@@ -75,7 +81,7 @@ Other Rack base framework can also directly leverage the built-in Middleware.
 require "google/cloud/logging"
 
 logging = Google::Cloud::Logging.new
-resource = Google::Cloud::Logging::Middleware.build_monitoring_resource
+resource = Google::Cloud::Logging::Middleware.build_monitored_resource
 logger = logging.logger "my-log-name",
                         resource
 use Google::Cloud::Logging::Middleware, logger: logger

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -46,7 +46,7 @@ logging.write_entries entry
 
 ## Rails Integration
 
-This library also provides a built in Railtie for Ruby on Rails integration. When enabled, it substitutes default Rails logger with an instance of Google::Cloud::Logging::logger. Then all consequent log entries will be submitted to Stackdriver Logging service. 
+This library also provides a built in Railtie for Ruby on Rails integration. When enabled, it sets an instance of Google::Cloud::Logging::Logger as the default Rails logger. Then all consequent log entries will be submitted to the Stackdriver Logging service. 
 
 To do this, simply add this line to config/application.rb:
 ```ruby

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -77,30 +77,39 @@ module Google
         # both are provided. Otherwise, construct a default monitored resource
         # based on the current environment.
         #
-        # If not given both type and label:
-        #   If running from GAE, return resource:
-        #   {
-        #     type: "gae_app", {
+        # @example
+        #   # If both type and labels are provided, it returns resource:
+        #   <Google::Cloud::Logging::Resource
+        #     @type=[given type],
+        #     @labels=[given labels] >
+        #
+        #   # Otherwise, if running from GAE, returns resource:
+        #   <Google::Cloud::Logging::Resource
+        #     @type="gae_app",
+        #     @labels={
         #       module_id: [GAE module name],
-        #       version_id: [GAE module version]
-        #     }
-        #   }
-        #   If running from GKE, return resource:
-        #   {
-        #     type: "container", {
+        #       version_id: [GAE module version] }>
+        #
+        #   # If running from GKE, returns resource:
+        #   <Google::Cloud::Logging::Resource
+        #     @type="container",
+        #     @labels={
         #       cluster_name: [GKE cluster name],
-        #       namespace_id: [GKE namespace_id]
-        #     }
-        #   }
-        #   If running from GCE, return resource:
-        #   {
-        #     type: "gce_instance", {
+        #       namespace_id: [GKE namespace_id] }>
+        #
+        #   # If running from GCE, return resource:
+        #   <Google::Cloud::Logging::Resource
+        #     @type="gce_instance",
+        #     @labels={
         #       instance_id: [GCE VM instance id],
-        #       zone: [GCE vm group zone]
-        #     }
-        #   }
-        #   Otherwise default to { type: "global" }, which means not associated
-        #   with GCP.
+        #       zone: [GCE vm group zone] }>
+        #
+        #   # Otherwise default to "global" type, which means not
+        #   # associated with GCP:
+        #   <Google::Cloud::Logging::Resource
+        #     @type="global",
+        #     @labels={}>
+        #
         #
         # Reference https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource
         # for a full list of monitoring resources
@@ -126,29 +135,33 @@ module Google
         # @private Extract information from current environment and construct
         # the correct monitoring resource types and labels.
         #
-        # If running from GAE, return resource:
-        # {
-        #   type: "gae_app", {
-        #     module_id: [GAE module name],
-        #     version_id: [GAE module version]
-        #   }
-        # }
-        # If running from GKE, return resource:
-        # {
-        #   type: "container", {
-        #     cluster_name: [GKE cluster name],
-        #     namespace_id: [GKE namespace_id]
-        #   }
-        # }
-        # If running from GCE, return resource:
-        # {
-        #   type: "gce_instance", {
-        #     instance_id: [GCE VM instance id],
-        #     zone: [GCE vm group zone]
-        #   }
-        # }
-        # Otherwise default to { type: "global" }, which means not associated
-        # with GCP.
+        # @example
+        #   # If running from GAE, returns resource:
+        #   <Google::Cloud::Logging::Resource
+        #     @type="gae_app",
+        #     @labels={
+        #       module_id: [GAE module name],
+        #       version_id: [GAE module version] }>
+        #
+        #   # If running from GKE, returns resource:
+        #   <Google::Cloud::Logging::Resource
+        #     @type="container",
+        #     @labels={
+        #       cluster_name: [GKE cluster name],
+        #       namespace_id: [GKE namespace_id] }>
+        #
+        #   # If running from GCE, return resource:
+        #   <Google::Cloud::Logging::Resource
+        #     @type="gce_instance",
+        #     @labels={
+        #       instance_id: [GCE VM instance id],
+        #       zone: [GCE vm group zone] }>
+        #
+        #   # Otherwise default to "global" type, which means not
+        #   # associated with GCP:
+        #   <Google::Cloud::Logging::Resource
+        #     @type="global",
+        #     @labels={}>
         #
         # Reference https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource
         # for a full list of monitoring resources

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -77,39 +77,35 @@ module Google
         # both are provided. Otherwise, construct a default monitored resource
         # based on the current environment.
         #
-        # @example
-        #   # If both type and labels are provided, it returns resource:
-        #   <Google::Cloud::Logging::Resource
-        #     @type=[given type],
-        #     @labels=[given labels] >
+        # @example If both type and labels are provided, it returns resource:
+        #   rc = Middleware.build_monitored_resource "aws_ec2_instance",
+        #                                            { instance_id: "ec2-id",
+        #                                              aws_account: "aws-id" }
+        #   rc.type   #=> "aws_ec2_instance"
+        #   rc.labels #=> { instance_id: "ec2-id", aws_account: "aws-id" }
         #
-        #   # Otherwise, if running from GAE, returns resource:
-        #   <Google::Cloud::Logging::Resource
-        #     @type="gae_app",
-        #     @labels={
-        #       module_id: [GAE module name],
-        #       version_id: [GAE module version] }>
+        # @example If running from GAE, returns default resource:
+        #   rc = Middleware.build_monitored_resource
+        #   rc.type   #=> "gae_app"
+        #   rc.labels #=> { module_id: [GAE module name],
+        #             #     version_id: [GAE module version] }
         #
-        #   # If running from GKE, returns resource:
-        #   <Google::Cloud::Logging::Resource
-        #     @type="container",
-        #     @labels={
-        #       cluster_name: [GKE cluster name],
-        #       namespace_id: [GKE namespace_id] }>
+        # @example If running from GKE, returns default resource:
+        #   rc = Middleware.build_monitored_resource
+        #   rc.type   #=> "container"
+        #   rc.labels #=> { cluster_name: [GKE cluster name],
+        #             #     namespace_id: [GKE namespace_id] }
         #
-        #   # If running from GCE, return resource:
-        #   <Google::Cloud::Logging::Resource
-        #     @type="gce_instance",
-        #     @labels={
-        #       instance_id: [GCE VM instance id],
-        #       zone: [GCE vm group zone] }>
+        # @example If running from GCE, return default resource:
+        #   rc = Middleware.build_monitored_resource
+        #   rc.type   #=> "gce_instance"
+        #   rc.labels #=> { instance_id: [GCE VM instance id],
+        #             #     zone: [GCE vm group zone] }
         #
-        #   # Otherwise default to "global" type, which means not
-        #   # associated with GCP:
-        #   <Google::Cloud::Logging::Resource
-        #     @type="global",
-        #     @labels={}>
-        #
+        # @example Otherwise default to generic "global" type:
+        #   rc = Middleware.build_monitored_resource
+        #   rc.type   #=> "global"
+        #   rc.labels #=> {}
         #
         # Reference https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource
         # for a full list of monitoring resources
@@ -135,33 +131,28 @@ module Google
         # @private Extract information from current environment and construct
         # the correct monitoring resource types and labels.
         #
-        # @example
-        #   # If running from GAE, returns resource:
-        #   <Google::Cloud::Logging::Resource
-        #     @type="gae_app",
-        #     @labels={
-        #       module_id: [GAE module name],
-        #       version_id: [GAE module version] }>
+        # @example If running from GAE, returns default resource:
+        #   rc = Middleware.build_monitored_resource
+        #   rc.type   #=> "gae_app"
+        #   rc.labels #=> { module_id: [GAE module name],
+        #             #     version_id: [GAE module version] }
         #
-        #   # If running from GKE, returns resource:
-        #   <Google::Cloud::Logging::Resource
-        #     @type="container",
-        #     @labels={
-        #       cluster_name: [GKE cluster name],
-        #       namespace_id: [GKE namespace_id] }>
+        # @example If running from GKE, returns default resource:
+        #   rc = Middleware.build_monitored_resource
+        #   rc.type   #=> "container"
+        #   rc.labels #=> { cluster_name: [GKE cluster name],
+        #             #     namespace_id: [GKE namespace_id] }
         #
-        #   # If running from GCE, return resource:
-        #   <Google::Cloud::Logging::Resource
-        #     @type="gce_instance",
-        #     @labels={
-        #       instance_id: [GCE VM instance id],
-        #       zone: [GCE vm group zone] }>
+        # @example If running from GCE, return default resource:
+        #   rc = Middleware.build_monitored_resource
+        #   rc.type   #=> "gce_instance"
+        #   rc.labels #=> { instance_id: [GCE VM instance id],
+        #             #     zone: [GCE vm group zone] }
         #
-        #   # Otherwise default to "global" type, which means not
-        #   # associated with GCP:
-        #   <Google::Cloud::Logging::Resource
-        #     @type="global",
-        #     @labels={}>
+        # @example Otherwise default to generic "global" type:
+        #   rc = Middleware.build_monitored_resource
+        #   rc.type   #=> "global"
+        #   rc.labels #=> {}
         #
         # Reference https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource
         # for a full list of monitoring resources

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -73,9 +73,9 @@ module Google
         end
 
         ##
-        # Construct monitoring resource based on given type and label (both are
-        # present). Otherwise construct a default monitoring resource based on
-        # current environment.
+        # Construct a monitored resource based on the given type and label if
+        # both are provided. Otherwise, construct a default monitored resource
+        # based on the current environment.
         #
         # If not given both type and label:
         #   If running from GAE, return resource:

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -50,6 +50,10 @@ module Google
         config.google_cloud = ::ActiveSupport::OrderedOptions.new unless
           config.respond_to? :google_cloud
         config.google_cloud.logging = ::ActiveSupport::OrderedOptions.new
+        config.google_cloud.logging.monitored_resource =
+          ::ActiveSupport::OrderedOptions.new
+        config.google_cloud.logging.monitored_resource.labels =
+          ::ActiveSupport::OrderedOptions.new
 
         initializer "Stackdriver.Logging", before: :initialize_logger do |app|
           if self.class.use_logging? app.config
@@ -58,11 +62,14 @@ module Google
 
             project_id = log_config.project_id || gcp_config.project_id
             keyfile = log_config.keyfile || gcp_config.keyfile
+            resource_type = log_config.monitored_resource.type
+            resource_labels = log_config.monitored_resource.labels
 
             logging = Google::Cloud::Logging.new project: project_id,
                                                  keyfile: keyfile
             resource =
-              Google::Cloud::Logging::Middleware.build_monitoring_resource
+              Logging::Middleware.build_monitored_resource resource_type,
+                                                           resource_labels
             log_name = log_config.log_name || DEFAULT_LOG_NAME
 
             app.config.logger = Google::Cloud::Logging::Logger.new logging,

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -87,12 +87,40 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
     end
   end
 
-  describe ".build_monitoring_resource" do
+  describe ".build_monitored_resource" do
+    let(:custom_type) { "custom-monitored-resource-type" }
+    let(:custom_labels) { {label_one: 1, label_two: 2} }
+    let(:default_rc) { "Default-monitored-resource" }
+
+    it "returns resource of right type if given parameters" do
+      Google::Cloud::Logging::Middleware.stub :default_monitored_resource, default_rc do
+        rc = Google::Cloud::Logging::Middleware.build_monitored_resource custom_type, custom_labels
+        rc.type.must_equal custom_type
+        rc.labels.must_equal custom_labels
+      end
+    end
+
+    it "returns default monitored resource if only given type" do
+      Google::Cloud::Logging::Middleware.stub :default_monitored_resource, default_rc do
+        rc = Google::Cloud::Logging::Middleware.build_monitored_resource custom_type
+        rc.must_equal default_rc
+      end
+    end
+
+    it "returns default monitored resource if only given labels" do
+      Google::Cloud::Logging::Middleware.stub :default_monitored_resource, default_rc do
+        rc = Google::Cloud::Logging::Middleware.build_monitored_resource nil, custom_labels
+        rc.must_equal default_rc
+      end
+    end
+  end
+
+  describe ".default_monitored_resource" do
     it "returns resource of type gae_app if gae? is true" do
       Google::Cloud::Core::Environment.stub :gae?, true do
         Google::Cloud::Core::Environment.stub :gke?, false do
           Google::Cloud::Core::Environment.stub :gce?, false do
-            rc = Google::Cloud::Logging::Middleware.build_monitoring_resource
+            rc = Google::Cloud::Logging::Middleware.build_monitored_resource
             rc.type.must_equal "gae_app"
           end
         end
@@ -103,7 +131,7 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
       Google::Cloud::Core::Environment.stub :gae?, false do
         Google::Cloud::Core::Environment.stub :gke?, true do
           Google::Cloud::Core::Environment.stub :gce?, false do
-            rc = Google::Cloud::Logging::Middleware.build_monitoring_resource
+            rc = Google::Cloud::Logging::Middleware.build_monitored_resource
             rc.type.must_equal "container"
           end
         end
@@ -114,7 +142,7 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
       Google::Cloud::Core::Environment.stub :gae?, false do
         Google::Cloud::Core::Environment.stub :gke?, false do
           Google::Cloud::Core::Environment.stub :gce?, true do
-            rc = Google::Cloud::Logging::Middleware.build_monitoring_resource
+            rc = Google::Cloud::Logging::Middleware.build_monitored_resource
             rc.type.must_equal "gce_instance"
           end
         end
@@ -125,7 +153,7 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
       Google::Cloud::Core::Environment.stub :gae?, false do
         Google::Cloud::Core::Environment.stub :gke?, false do
           Google::Cloud::Core::Environment.stub :gce?, false do
-            rc = Google::Cloud::Logging::Middleware.build_monitoring_resource
+            rc = Google::Cloud::Logging::Middleware.build_monitored_resource
             rc.type.must_equal "global"
           end
         end


### PR DESCRIPTION
Allow users to override default Logging MonitoredResource when using google-cloud-logging instrumentation library in their Rails apps.

Also renamed Google::Cloud::Logging::Middleware.build_monitoring_resource to build monitored_resource to be more consistent with GCP documentations.