### PR TITLE
Remove outdated Vision requires

### DIFF
--- a/google-cloud-vision/lib/google/cloud/vision/annotate.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotate.rb
@@ -14,7 +14,6 @@
 
 
 require "google/cloud/vision/image"
-require "google/apis/vision_v1"
 
 module Google
   module Cloud

--- a/google-cloud-vision/lib/google/cloud/vision/image.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/image.rb
@@ -14,7 +14,6 @@
 
 
 require "google/cloud/vision/location"
-require "google/apis/vision_v1"
 require "stringio"
 require "base64"
 


### PR DESCRIPTION
Vision has switched from Google API Client to GAPIC/GRPC.
These old requires should have been removed.

[fixes #997]