### PR TITLE
Fix jsondoc for instrumentation libraries

### DIFF
--- a/google-cloud-error_reporting/docs/toc.json
+++ b/google-cloud-error_reporting/docs/toc.json
@@ -19,7 +19,7 @@
     },
     {
       "title": "Railtie",
-      "type": "google/cloud/errorreporting/rails"
+      "type": "google/cloud/errorreporting/railtie"
     }
   ]
 }

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -47,7 +47,8 @@ module Google
         # @param [Array<Class>] ignore_classes A single or an array of Exception
         #   classes to ignore
         #
-        # @return A new instance of Middleware
+        # @return [Google::Cloud::ErrorReporting::Middleware] A new instance of
+        #   Middleware
         #
         def initialize app, error_reporting: nil, project_id: nil,
                        service_name: nil, service_version: nil,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -126,9 +126,10 @@ module Google
         # config.google_cloud.use_error_reporting is explicitly true. Otherwise
         # false.
         #
-        # @param config The Rails.application.config
+        # @param [Rails::Railtie::Configuration] config The
+        #   Rails.application.config
         #
-        # @return true or false
+        # @return [Boolean] Whether to use Stackdriver Error Reporting
         #
         def self.use_error_reporting? config
           gcp_config = config.google_cloud

--- a/google-cloud-logging/docs/toc.json
+++ b/google-cloud-logging/docs/toc.json
@@ -51,7 +51,7 @@
         },
         {
           "title": "Railtie",
-          "type": "google/cloud/logging/rails"
+          "type": "google/cloud/logging/railtie"
         }
       ]
     }

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -24,8 +24,7 @@ module Google
         ##
         # Create a new AppEngine logging Middleware.
         #
-        # @param app Rack application
-        #
+        # @param [Rack Application] app Rack application
         # @param [Google::Cloud::Logging::Logger] logger A logger to be used by
         #   this middleware. The middleware will be interacting with the logger
         #   to track Stackdriver request trace ID. It also properly sets
@@ -48,7 +47,7 @@ module Google
         #
         # @param [Hash] env Rack environment hash
         #
-        # @return The response from downstream Rack app
+        # @return [Rack::Response] The response from downstream Rack app
         #
         def call env
           env["rack.logger"] = logger

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -81,9 +81,10 @@ module Google
         # able to authenticate. Also either Rails needs to be in "production"
         # environment or config.stackdriver.use_logging is explicitly true.
         #
-        # @param config The Rails.application.config
+        # @param [Rails::Railtie::Configuration] config The
+        #   Rails.application.config
         #
-        # @return [Boolean]
+        # @return [Boolean] Whether to use Stackdriver Logging
         #
         def self.use_logging? config
           gcp_config = config.google_cloud

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -117,7 +117,7 @@
         },
         {
           "title": "Railtie",
-          "type": "google/cloud/errorreporting/rails"
+          "type": "google/cloud/errorreporting/railtie"
         }
       ]
     },
@@ -143,7 +143,7 @@
         },
         {
           "title": "Railtie",
-          "type": "google/cloud/logging/rails"
+          "type": "google/cloud/logging/railtie"
         }
       ]
     },

--- a/stackdriver/docs/toc.json
+++ b/stackdriver/docs/toc.json
@@ -27,7 +27,7 @@
         },
         {
           "title": "Railtie",
-          "type": "google/cloud/errorreporting/rails"
+          "type": "google/cloud/errorreporting/railtie"
         }
       ]
     },
@@ -53,7 +53,7 @@
         },
         {
           "title": "Railtie",
-          "type": "google/cloud/logging/rails"
+          "type": "google/cloud/logging/railtie"
         }
       ]
     },


### PR DESCRIPTION
Fix the jsondoc for middleware.rb and rails.rb in both google-cloud-logging and google-cloud-error_reporting.