### PR TITLE
Rake jsondoc

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,16 +1,18 @@
 # Releasing google-cloud-ruby
 
-The google-cloud-ruby library uses [semantic versioning](http://semver.org). Replace the `<prev_version>` and `<version>` placeholders shown in the examples below with the appropriate numbers, e.g. `0.1.0` and `0.2.0`.
+These instructions apply to every gem within the google-cloud-ruby project. Each gem should be released separately.
 
-After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ruby/pulls) for a release have been merged and all [Travis CI builds](https://travis-ci.org/GoogleCloudPlatform/google-cloud-ruby) are green, you may create a release as follows:
+The google-cloud-ruby project uses [semantic versioning](http://semver.org). Replace the `<prev_version>` and `<version>` placeholders shown in the examples below with the appropriate numbers, e.g. `0.1.0` and `0.2.0`. Replace the `<gem>` placeholder with the appropriate full name of the package, e.g. `google-cloud-datastore`.
 
-1. Build the google-cloud-ruby gem locally.
+After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ruby/pulls) for a release have been merged and all [Travis CI builds](https://travis-ci.org/GoogleCloudPlatform/google-cloud-ruby) and [Appveyor CI builds](https://ci.appveyor.com/project/GoogleCloudPlatform/google-cloud-ruby) are green, you may create a release as follows:
+
+1. Build the gem locally.
 
   ```sh
   $ rake build
   ```
 
-1. Install the google-cloud-ruby gem locally.
+1. Install the gem locally.
 
   ```sh
   $ rake install
@@ -24,7 +26,7 @@ After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ru
   open https://github.com/GoogleCloudPlatform/google-cloud-ruby/compare/v<prev_version>...master
   ```
 
-1. Review the commits in the GitHub compare view, making notes of significant changes. (For examples of what a significant change is, browse the changes in the [CHANGELOG.md](CHANGELOG.md).
+1. Review the commits in the GitHub compare view, making notes of significant changes. (For examples of what a significant change is, browse the changes in the gem's `CHANGELOG.md`
 
 1. If you haven't already, switch to the master branch, ensure that you have no changes, and pull from origin.
 
@@ -34,14 +36,14 @@ After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ru
   $ git pull --rebase
   ```
 
-1. Edit [CHANGELOG.md](CHANGELOG.md). Using your notes from the previous step, write bullet-point lists of the major and minor changes. You can also add examples, fixes, thank yous, and anything else helpful or relevant. See gcloud-node [v0.18.0](https://github.com/GoogleCloudPlatform/gcloud-node/releases/tag/v0.18.0) for an example with all the bells and whistles.
+1. Edit the gem's `CHANGELOG.md`. Using your notes from the previous step, write bullet-point lists of the major and minor changes. You can also add examples, fixes, thank yous, and anything else helpful or relevant. See google-cloud-node [v0.18.0](https://github.com/GoogleCloudPlatform/google-cloud-node/releases/tag/v0.18.0) for an example with all the bells and whistles.
 
-1. Edit [lib/gcloud/version.rb](lib/gcloud/version.rb), changing the value of `VERSION` to your new version number.
+1. Edit the gem's `version.rb`, changing the value of `VERSION` to your new version number.
 
 1. Commit your changes. Copy and paste the significant points from your `CHANGELOG.md` edit as the description in your commit message.
 
   ```sh
-  $ git commit -am "Bump for version <version> ... "
+  $ git commit -am "Release <gem> <version> ..."
   ```
 
 1. Ensure again that you have every commit from `origin master`.
@@ -53,7 +55,7 @@ After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ru
 1. Tag the version.
 
   ```sh
-  $ git tag -m 'v<version>' v<version>
+  $ git tag -m '<gem>/v<version>' <gem>/v<version>
   ```
 
 1. Push your commit.
@@ -68,14 +70,16 @@ After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ru
   $ git push --tags
   ```
 
-1. On the [google-cloud-ruby releases page](https://github.com/GoogleCloudPlatform/google-cloud-ruby/releases), click [Draft a new release](https://github.com/GoogleCloudPlatform/google-cloud-ruby/releases/new). Complete the form. Include the bullet-point lists of the major and minor changes from [CHANGELOG.md](CHANGELOG.md). You can also add examples, fixes, thank yous, and anything else helpful or relevant. See gcloud-node [v0.18.0](https://github.com/GoogleCloudPlatform/gcloud-node/releases/tag/v0.18.0) for an example with all the bells and whistles.
+1. On the [google-cloud-ruby releases page](https://github.com/GoogleCloudPlatform/google-cloud-ruby/releases), click [Draft a new release](https://github.com/GoogleCloudPlatform/google-cloud-ruby/releases/new). Complete the form. Include the bullet-point lists of the major and minor changes from the gem's `CHANGELOG.md`. You can also add examples, fixes, thank yous, and anything else helpful or relevant. See google-cloud-node [v0.18.0](https://github.com/GoogleCloudPlatform/google-cloud-node/releases/tag/v0.18.0) for an example with all the bells and whistles.
 
 1. Click `Publish release`.
 
 1. Check that the [Travis CI build](https://travis-ci.org/GoogleCloudPlatform/google-cloud-ruby) has passed for the version commit.
 
-1. Confirm that the gem for the new version is available on [RubyGems.org](https://rubygems.org/gems/gcloud).
+1. Confirm that the gem for the new version is available on [RubyGems.org](https://rubygems.org/gems/google-cloud).
 
 1. Confirm that the new version is displayed after "Latest release" on the [google-cloud-ruby gh-pages site](http://googlecloudplatform.github.io/google-cloud-ruby/).
+
+1. Confirm that the new version is displayed in the packages pulldown and the version switcher on the [google-cloud-ruby docs site](https://googlecloudplatform.github.io/google-cloud-ruby/#/). Verify that the new docs version contains the public API changes in the release.
 
 High fives all around!

--- a/gcloud/docs/toc.json
+++ b/gcloud/docs/toc.json
@@ -28,16 +28,5 @@
       "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
     }
   ],
-  "services": [
-    {
-      "title": "BigQuery",
-      "type": "google/cloud/bigquery",
-      "nav": [
-        {
-          "title": "Project",
-          "type": "Gcloud"
-        }
-      ]
-    }
-  ]
+  "services": []
 }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -56,6 +56,16 @@
       ]
     },
     {
+      "title": "Core",
+      "type": "google/cloud/errors",
+      "nav": [
+        {
+          "title": "Errors",
+          "type": "google/cloud/errors"
+        }
+      ]
+    },
+    {
       "title": "Datastore",
       "type": "google/cloud/datastore",
       "nav": [


### PR DESCRIPTION
The goal of this PR is to fully automate the generation and deployment of JSON docs. It provides the following:
1. New `jsondoc:package` task that accepts accepts a tag with the format `<gem>/<version>`, generates the
   JSON docs for the given package and version, then assembles the complete `google-cloud` JSON docs from the previously built JSON docs for all gems, using the latest versions in `gh-pages`. Finally, it publishes the changes in the cloned `gh-pages` repo. This task also supports tags for the `google-cloud` package, which will be released after tags for other new gems.
2. Updated `jsondoc:master` task does the same, but generates fresh JSON docs for all gems.
3. Support for the new `stackdriver` package has been added, but is disabled pending release (see `TODO`s in `Rakefile`.)
4. Update `RELEASING.md` to support individual gems.

Not included in this PR (to be added in a future PR): 
1. Instead of assuming that the current branch (`master`) for the execution context holds the correct content for generating JSON docs for a tag, `git clone` a new repo and execute `jsondoc` in the correct tag (branch) passed to `jsondoc:package`.
2. Instead of resolving the dependencies of a `google-cloud` version with the latests versions of gems in `manifest.json`, better reproduce the dependency resolution of Rubygems.
