### PR TITLE
Customize jsondoc for stackdriver gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -221,9 +221,6 @@ namespace :jsondoc do
     end
     puts "git clone --quiet --branch=gh-pages --single-branch #{git_repo} #{gh_pages} > /dev/null"
     puts `git clone --quiet --branch=gh-pages --single-branch #{git_repo} #{gh_pages} > /dev/null`
-
-    # Create <gh_pages>/json/stackdriver/master/google/cloud/ directory
-    mkdir_p gh_pages + "json/stackdriver/master/google/cloud/"
   end
 
   desc "Copies a gem's jsondoc to gh-pages repo in temp dir."
@@ -303,10 +300,10 @@ namespace :jsondoc do
       all_google_cloud_methods << JSON.parse(File.read("#{src}/google/cloud.json"))["methods"]
     end
 
-    header "Merging each gem types.json into #{gh_pages}/json/google-cloud/jsondoc/types.json"
+    header "Merging each gem types.json into #{gh_pages}/json/google-cloud/#{version}/types.json"
     File.write gh_pages + "json/google-cloud/#{version}/types.json", all_types.flatten.to_json
 
-    header "Merging methods from each google/cloud.json into #{gh_pages}/json/google-cloud/jsondoc/google/cloud.json"
+    header "Merging methods from each google/cloud.json into #{gh_pages}/json/google-cloud/#{version}/google/cloud.json"
     all_google_cloud_methods.each {|x| x.each {|y| puts y["id"]}}
     google_cloud_json["methods"] = all_google_cloud_methods.flatten
     File.write gh_pages + "json/google-cloud/#{version}/google/cloud.json", google_cloud_json.to_json
@@ -317,12 +314,16 @@ namespace :jsondoc do
     version, gh_pages_dir = extract_args args, :version, :gh_pages_dir
     gh_pages = gh_pages_path gh_pages_dir
 
-    stackdriver_types = []
+    stackdriver_types = JSON.parse File.read("stackdriver/jsondoc/types.json")
     stackdriver_json = JSON.parse File.read("stackdriver/jsondoc/stackdriver.json")
 
     stackdriver_google_cloud_methods = [stackdriver_json["methods"]]
 
     header "Copying all jsondoc from gh-pages to stackdriver package in gh-pages"
+
+    unless Dir.exist? gh_pages + "json/stackdriver/#{version}/google/cloud"
+      mkdir_p gh_pages + "json/stackdriver/#{version}/google/cloud", verbose: true
+    end
 
     stackdriver_gems = ["google-cloud-logging", "google-cloud-error_reporting", "google-cloud-monitoring"]
     gems.each do |gem|
@@ -345,6 +346,10 @@ namespace :jsondoc do
       cp_r "#{src}/google/cloud/#{gem_shortname}",
            gh_pages + "json/stackdriver/#{version}/google/cloud/#{gem_shortname}",
            verbose: true
+      # Copy all the .md files too
+      cp Dir.glob("#{src}/*.md"),
+         gh_pages + "json/stackdriver/#{version}/google/cloud/#{gem_shortname}",
+         verbose: true
 
       # Copy the contents of google/cloud/ for the gem.
       cp Dir["#{src}/google/cloud/*.json"], gh_pages + "json/stackdriver/#{version}/google/cloud/", verbose: true
@@ -352,13 +357,13 @@ namespace :jsondoc do
       stackdriver_google_cloud_methods << JSON.parse(File.read("#{src}/google/cloud.json"))["methods"]
     end
 
-    header "Merging each Stackdriver gem types.json into #{gh_pages}/json/stackdriver/jsondoc/types.json"
-    File.write gh_pages + "json/stackdriver/master/types.json", stackdriver_types.flatten.to_json
+    header "Merging each Stackdriver gem types.json into #{gh_pages}/json/stackdriver/#{version}/types.json"
+    File.write gh_pages + "json/stackdriver/#{version}/types.json", stackdriver_types.flatten.to_json
 
-    header "Merging methods from each Stackdriver google/cloud.json into #{gh_pages}/json/stackdriver/jsondoc/google/cloud.json"
+    header "Merging methods from each Stackdriver google/cloud.json into #{gh_pages}/json/stackdriver/#{version}/google/cloud.json"
     stackdriver_google_cloud_methods.each {|x| x.each {|y| puts y["id"]}}
     stackdriver_json["methods"] = stackdriver_google_cloud_methods.flatten
-    File.write gh_pages + "json/stackdriver/master/google/cloud.json", stackdriver_json.to_json
+    File.write gh_pages + "json/stackdriver/#{version}/google/cloud.json", stackdriver_json.to_json
   end
 
   desc "Publishes the jsondoc changes in the tmp dir cloned repo, gh-pages"
@@ -408,8 +413,7 @@ namespace :jsondoc do
       Rake::Task["jsondoc:toc"].invoke(gem, "master", gh_pages_dir)
     end
     Rake::Task["jsondoc:google_cloud"].invoke("master", gh_pages_dir)
-    # TODO: Uncomment following line when ready to release stackdriver gem
-    # Rake::Task["jsondoc:stackdriver"].invoke("master", gh_pages_dir)
+    Rake::Task["jsondoc:stackdriver"].invoke("master", gh_pages_dir)
     Rake::Task["jsondoc:publish"].invoke("master", gh_pages_dir)
   end
 
@@ -446,14 +450,13 @@ namespace :jsondoc do
       Rake::Task["jsondoc:google_cloud"].invoke(google_cloud_version, gh_pages_dir)
     end
 
-    # TODO: Uncomment following lines when ready to release stackdriver gem
-    # stackdriver_gems = ["stackdriver", "google-cloud-logging", "google-cloud-error_reporting", "google-cloud-monitoring"]
-    # if stackdriver_gems.include? gem
-    #   stackdriver_version = manifest_versions["stackdriver"]
-    #   header "Assembling jsondoc for stackdriver package"
-    #   puts "Latest stackdriver package version is '#{stackdriver_version}' (from docs/manifest.json)"
-    #   Rake::Task["jsondoc:stackdriver"].invoke(stackdriver_version, gh_pages_dir)
-    # end
+    stackdriver_gems = ["stackdriver", "google-cloud-logging", "google-cloud-error_reporting", "google-cloud-monitoring"]
+    if stackdriver_gems.include? gem
+      stackdriver_version = manifest_versions["stackdriver"]
+      header "Assembling jsondoc for stackdriver package"
+      puts "Latest stackdriver package version is '#{stackdriver_version}' (from docs/manifest.json)"
+      Rake::Task["jsondoc:stackdriver"].invoke(stackdriver_version, gh_pages_dir)
+    end
 
     Rake::Task["jsondoc:publish"].invoke(tag, gh_pages_dir)
   end

--- a/Rakefile
+++ b/Rakefile
@@ -411,6 +411,8 @@ namespace :jsondoc do
     Rake::Task["jsondoc:clone_gh_pages"].invoke(gh_pages_dir)
     gems.each do |gem|
       Rake::Task["jsondoc:toc"].invoke(gem, "master", gh_pages_dir)
+      Rake::Task["jsondoc:toc"].reenable
+      Rake::Task["jsondoc:copy"].reenable
     end
     Rake::Task["jsondoc:google_cloud"].invoke("master", gh_pages_dir)
     Rake::Task["jsondoc:stackdriver"].invoke("master", gh_pages_dir)

--- a/Rakefile
+++ b/Rakefile
@@ -314,12 +314,7 @@ namespace :jsondoc do
     version, gh_pages_dir = extract_args args, :version, :gh_pages_dir
     gh_pages = gh_pages_path gh_pages_dir
 
-    stackdriver_types = JSON.parse File.read("stackdriver/jsondoc/types.json")
-    stackdriver_json = JSON.parse File.read("stackdriver/jsondoc/stackdriver.json")
-
-    stackdriver_google_cloud_methods = [stackdriver_json["methods"]]
-
-    header "Copying all jsondoc from gh-pages to stackdriver package in gh-pages"
+    header "Copying reference docs from gh-pages to stackdriver package in gh-pages"
 
     unless Dir.exist? gh_pages + "json/stackdriver/#{version}/google/cloud"
       mkdir_p gh_pages + "json/stackdriver/#{version}/google/cloud", verbose: true
@@ -341,29 +336,13 @@ namespace :jsondoc do
 
       gem_shortname = gem[/\Agoogle-cloud-(.+)/, 1]
       gem_shortname = gem_shortname.gsub "_", "" # "resource_manager" -> "resourcemanager"
-      # Copy the contents of subdir for the gem namespace.
+      # Copy all the .md files from each gem
       rm_rf gh_pages + "json/stackdriver/#{version}/google/cloud/#{gem_shortname}", verbose: true
-      cp_r "#{src}/google/cloud/#{gem_shortname}",
-           gh_pages + "json/stackdriver/#{version}/google/cloud/#{gem_shortname}",
-           verbose: true
-      # Copy all the .md files too
+      mkdir_p gh_pages + "json/stackdriver/#{version}/google/cloud/#{gem_shortname}", verbose: true
       cp Dir.glob("#{src}/*.md"),
          gh_pages + "json/stackdriver/#{version}/google/cloud/#{gem_shortname}",
          verbose: true
-
-      # Copy the contents of google/cloud/ for the gem.
-      cp Dir["#{src}/google/cloud/*.json"], gh_pages + "json/stackdriver/#{version}/google/cloud/", verbose: true
-      stackdriver_types << JSON.parse(File.read("#{src}/types.json"))
-      stackdriver_google_cloud_methods << JSON.parse(File.read("#{src}/google/cloud.json"))["methods"]
     end
-
-    header "Merging each Stackdriver gem types.json into #{gh_pages}/json/stackdriver/#{version}/types.json"
-    File.write gh_pages + "json/stackdriver/#{version}/types.json", stackdriver_types.flatten.to_json
-
-    header "Merging methods from each Stackdriver google/cloud.json into #{gh_pages}/json/stackdriver/#{version}/google/cloud.json"
-    stackdriver_google_cloud_methods.each {|x| x.each {|y| puts y["id"]}}
-    stackdriver_json["methods"] = stackdriver_google_cloud_methods.flatten
-    File.write gh_pages + "json/stackdriver/#{version}/google/cloud.json", stackdriver_json.to_json
   end
 
   desc "Publishes the jsondoc changes in the tmp dir cloned repo, gh-pages"

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -49,6 +49,7 @@
       "name": "stackdriver",
       "defaultService": "stackdriver",
       "versions": [
+        "v0.3.0",
         "master"
       ]
     },

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -85,7 +85,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-error_reporting"
   generator.write_to "jsondoc"
-  cp ["docs/toc.json"], "jsondoc", verbose: true
+  cp ["docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-error_reporting/docs/instrumentation.md
+++ b/google-cloud-error_reporting/docs/instrumentation.md
@@ -1,0 +1,39 @@
+# Stackdriver Error Reporting Instrumentation
+
+Then google-cloud-error_reporting gem provides a Rack Middleware class that can easily integrate with Rack based application frameworks, such as Rails and Sinatra. When enabled, it automatically gathers application exceptions from requests and submit the information to the Stackdriver Error Reporting service.  
+
+On top of that, the google-cloud-error_reporting also implements a Railtie class that automatically enables the Rack Middleware in Rails applications when used.
+
+## Rails Integration
+
+To use the Stackdriver Error Reporting Railtie for Ruby on Rails applications, simply add this line to config/application.rb:
+```ruby
+require "google/cloud/error_reporting/rails"
+```
+Then the library can be configured through this set of Rails parameters in config/environments/*.rb:
+```ruby
+# Sharing authentication parameters
+config.google_cloud.project_id = "gcp-project-id"
+config.google_cloud.keyfile = "/path/to/gcp/secret.json"
+# Or more specificly for ErrorReporting
+config.google_cloud.error_reporting.project_id = "gcp-project-id"
+config.google_cloud.error_reporting.keyfile = "/path/to/gcp/sercret.json"
+ 
+# Explicitly enable or disable ErrorReporting
+config.google_cloud.use_error_reporting = true
+ 
+# Set Stackdriver Error Reporting service context
+config.google_cloud.error_reporting.service_name = "my-app-name"
+config.google_cloud.error_reporting.service_version = "my-app-version"
+```
+
+Alternatively, check out [stackdriver](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver) gem, which enables this Railtie by default.
+
+## Rack Integration
+
+Other Rack base framework can also directly leverage the built-in Middleware:
+```ruby
+require "google/cloud/error_reporting/v1beta1"
+ 
+use Google::Cloud::ErrorReporting::Middleware
+```

--- a/google-cloud-error_reporting/docs/toc.json
+++ b/google-cloud-error_reporting/docs/toc.json
@@ -1,5 +1,11 @@
 {
-  "guides": [],
+  "guides": [
+    {
+      "title": "Instrumentation",
+      "id": "instrumentation",
+      "contents": "instrumentation.md"
+    }
+  ],
   "services": [
     {
       "title": "ReportErrorsServiceApi",

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -146,7 +146,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-logging"
   generator.write_to "jsondoc"
-  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
+  cp ["docs/authentication.md", "docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-logging/docs/instrumentation.md
+++ b/google-cloud-logging/docs/instrumentation.md
@@ -1,0 +1,46 @@
+# Stackdriver Logging Instrumentation
+
+Then google-cloud-logging gem provides a Rack Middleware class that can easily integrate with Rack based application frameworks, such as Rails and Sinatra. When enabled, it sets an instance of Google::Cloud::Logging::Logger as the default Rack or Rails logger. Then all consequent log entries will be submitted to the Stackdriver Logging service. 
+
+On top of that, the google-cloud-logging also implements a Railtie class that automatically enables the Rack Middleware in Rails applications when used.
+
+## Rails Integration
+
+To use the Stackdriver Logging Railtie for Ruby on Rails applications, simply add this line to config/application.rb:
+```ruby
+require "google/cloud/logging/rails"
+```
+Then the library can be configured through this set of Rails parameters in config/environments/*.rb:
+```ruby
+# Sharing authentication parameters
+config.google_cloud.project_id = "gcp-project-id"
+config.google_cloud.keyfile = "/path/to/gcp/secret.json"
+# Or more specificly for Logging
+config.google_cloud.logging.project_id = "gcp-project-id"
+config.google_cloud.logging.keyfile = "/path/to/gcp/sercret.json"
+ 
+# Explicitly enable or disable Logging
+config.google_cloud.use_logging = true
+ 
+# Set Stackdriver Logging log name
+config.google_cloud.logging.log_name = "my-app-log"
+ 
+# Override default monitored resource if needed. E.g. used on AWS
+config.google_cloud.logging.monitored_resource.type = "aws_ec2_instance"
+config.google_cloud.logging.monitored_resource.labels.instance_id = "ec2-instance-id"
+config.google_cloud.logging.monitored_resource.labels.aws_account = "AWS account number"
+```
+Alternatively, check out [stackdriver](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver) gem, which enables this Railtie by default.
+
+## Rack Integration
+
+Other Rack base framework can also directly leverage the built-in Middleware.
+```ruby
+require "google/cloud/logging"
+ 
+logging = Google::Cloud::Logging.new
+resource = Google::Cloud::Logging::Middleware.build_monitored_resource
+logger = logging.logger "my-log-name",
+                        resource
+use Google::Cloud::Logging::Middleware, logger: logger
+```

--- a/google-cloud-logging/docs/toc.json
+++ b/google-cloud-logging/docs/toc.json
@@ -10,6 +10,11 @@
       ]
     },
     {
+      "title": "Instrumentation",
+      "id": "instrumentation",
+      "contents": "instrumentation.md"
+    },
+    {
       "title": "FAQ",
       "id": "faq",
       "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -45,7 +45,9 @@ module Google
     # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
     #
     # If you just want to write your application's logs to the Stackdriver
-    # Logging service, you may find it easiest to use the [Ruby Logger
+    # Logging service, you may find it easiest to use the [Stackdriver Logging
+    # Instrumentation](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/instrumentation)
+    # or the [Ruby Logger
     # implementation](#creating-a-ruby-logger-implementation) provided by this
     # library. Otherwise, read on to learn more about the Logging API.
     #

--- a/stackdriver/.yardopts
+++ b/stackdriver/.yardopts
@@ -1,6 +1,7 @@
 --no-private
 --title=Stackdriver
 --markup markdown
+--exclude ./lib/legacy_stackdriver.rb
 
 ./lib/**/*.rb
 -

--- a/stackdriver/docs/toc.json
+++ b/stackdriver/docs/toc.json
@@ -1,75 +1,20 @@
 {
-  "guides": [],
+  "guides": [
+    {
+      "title": "Error Reporting Instrumentation",
+      "id": "error_reporting_instrumentation",
+      "contents": "google/cloud/errorreporting/instrumentation.md"
+    },
+    {
+      "title": "Logging Instrumentation",
+      "id": "logging_instrumentation",
+      "contents": "google/cloud/logging/instrumentation.md"
+    }
+  ],
   "services": [
     {
-      "title": "stackdriver",
+      "title": "Stackdriver",
       "type": "stackdriver"
-    },
-    {
-      "title": "Error Reporting",
-      "type": "google/cloud/errorreporting/v1beta1",
-      "nav": [
-        {
-          "title": "ReportErrorsServiceApi",
-          "type": "google/cloud/errorreporting/v1beta1/reporterrorsserviceapi"
-        },
-        {
-          "title": "ErrorStatsServiceApi",
-          "type": "google/cloud/errorreporting/v1beta1/errorstatsserviceapi"
-        },
-        {
-          "title": "ErrorGroupServiceApi",
-          "type": "google/cloud/errorreporting/v1beta1/errorgroupserviceapi"
-        },
-        {
-          "title": "Middleware",
-          "type": "google/cloud/errorreporting/middleware"
-        },
-        {
-          "title": "Railtie",
-          "type": "google/cloud/errorreporting/railtie"
-        }
-      ]
-    },
-    {
-      "title": "Logging",
-      "type": "google/cloud/logging",
-      "nav": [
-        {
-          "title": "Project",
-          "type": "google/cloud/logging/project"
-        },
-        {
-          "title": "Entry",
-          "type": "google/cloud/logging/entry"
-        },
-        {
-          "title": "Resource",
-          "type": "google/cloud/logging/resource"
-        },
-        {
-          "title": "Middleware",
-          "type": "google/cloud/logging/middleware"
-        },
-        {
-          "title": "Railtie",
-          "type": "google/cloud/logging/railtie"
-        }
-      ]
-    },
-    {
-      "title": "Monitoring",
-      "type": "google/cloud/monitoring/v3",
-      "nav": [
-        {
-          "title": "GroupServiceApi",
-          "type": "google/cloud/monitoring/v3/groupserviceapi"
-        },
-        {
-          "title": "MetricServiceApi",
-          "type": "google/cloud/monitoring/v3/metricserviceapi"
-        }
-      ]
     }
   ]
 }

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -28,3 +28,32 @@ end
 
 # Backward compatibility with legacy stackdriver gem
 require "legacy_stackdriver"
+
+##
+# # Stackdriver
+#
+# The stackdriver gem instruments a Ruby web application for Stackdriver
+# diagnostics. When loaded, it integrates with Rails, Sinatra, or other
+# Rack-based web frameworks to collect application diagnostic and monitoring
+# information for your application.
+#
+# Specifically, this gem is a convenience package that loads the following gems:
+# - [google-cloud-logging](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging)
+# - [google-cloud-error_reporting](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-error_reporting)
+# - [google-cloud-monitoring](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-monitoring)
+#
+# On top of that, stackdriver gem automatically activates the following
+# instrumentation features:
+# - [google-cloud-logging instrumentation](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/logging_instrumentation)
+# - [google-cloud-error_reporting instrumentation](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/error_reporting_instrumentation)
+#
+#
+# ## Usage
+#
+# Instead of requiring multiple Stackdriver client library gems and explicitly
+# load each built-in Railtie classes, now users can achieve all these through
+# requiring this single **stackdriver** umbrella gem.
+# @example
+#   require "stackdriver"
+module Stackdriver
+end


### PR DESCRIPTION
I expanded stackdriver gem jsondoc to be more focus on the instrumentation functionalities. I also modified the jsondoc:stackdriver rake task, error reporting jsondoc, and logging jsondocs to help accommodate this goal.

Now the stackdriver jsondoc landing page should be working, and provide description and links about the instrumentation functionalities from stackdriver and other google-cloud-ruby gems.