### PR TITLE
Remove "beta" and "whitelisting" from Resource Manager docs

### DIFF
--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -9,21 +9,9 @@ programmatically manage  container resources such as Organizations and Projects,
 * Delete projects
 * Undelete, or recover, projects that you don't want to delete
 
-The Resource Manager API is a Beta release and is not covered by any SLA or deprecation policy and may be subject to backward-incompatible changes.
-
 - [google-cloud-resource_manager API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-resource_manager/master/google/cloud/resourcemanager)
 - [google-cloud-resource_manager on RubyGems](https://rubygems.org/gems/google-cloud-resource_manager)
 - [Google Cloud Resource Manager documentation](https://cloud.google.com/resource-manager/)
-
-## Accessing the Service
-
-Currently, the full functionality of the Resource Manager API is available
-only to white-listed users. (Contact your account manager or a member of
-the Google Cloud sales team if you are interested in access.) Read-only
-methods such as {ResourceManager::Manager#projects} and
-{ResourceManager::Manager#project} are accessible to any user who enables
-the Resource Manager API in the [Developers
-Console](https://console.developers.google.com).
 
 ## Quick Start
 

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
@@ -33,19 +33,6 @@ module Google
     # * Delete projects
     # * Undelete, or recover, projects that you don't want to delete
     #
-    # The Resource Manager API is a Beta release and is not covered by any SLA
-    # or deprecation policy and may be subject to backward-incompatible changes.
-    #
-    # ## Accessing the Service
-    #
-    # Currently, the full functionality of the Resource Manager API is available
-    # only to whitelisted users. (Contact your account manager or a member of
-    # the Google Cloud sales team if you are interested in access.) Read-only
-    # methods such as {ResourceManager::Manager#projects} and
-    # {ResourceManager::Manager#project} are accessible to any user who enables
-    # the Resource Manager API in the [Developers
-    # Console](https://console.developers.google.com).
-    #
     # ## Authentication
     #
     # The Resource Manager API currently requires authentication of a [User


### PR DESCRIPTION
Remove mention of "beta" and "whitelisting", since Cloud Resource Manager is now `v1`.