### PR TITLE
Fix issue #1011 by removing the undefined variable references.

### DIFF
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -58,10 +58,8 @@ module Google
             keyfile = er_config.keyfile || gcp_config.keyfile
 
             channel = self.class.grpc_channel keyfile
-            service_name = er_config.service_name ||
-              error_reporting.class.default_service_name
-            service_version = er_config.service_version ||
-              error_reporting.class.default_service_version
+            service_name = er_config.service_name
+            service_version = er_config.service_version
 
             error_reporting =
               Google::Cloud::ErrorReporting::V1beta1::ReportErrorsServiceApi.new channel: channel,


### PR DESCRIPTION
The error_reporting references were there when I had the Veneer Error Reporting library, and the code is to set default Error Reporting service_name and service_version. During the refactoring of PR #961, the Veneer library code was removed and the default values are now set in google/cloud/error_reporting/middleware.rb. So simply remove the left over references will suffice. 