### PR TITLE
Change product and API name to Stackdriver Error Reporting

### DIFF
--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -1,18 +1,18 @@
-Stackdriver Clouderrorreporting API for Ruby
+Stackdriver Error Reporting API for Ruby
 =================================================
 
 google-cloud-error_reporting uses [Google API extensions][google-gax] to provide an
-easy-to-use client library for the [Stackdriver Clouderrorreporting API][] (v1beta1) defined in the [googleapis][] git repository
+easy-to-use client library for the [Stackdriver Error Reporting API][] (v1beta1) defined in the [googleapis][] git repository
 
 
 [googleapis]: https://github.com/googleapis/googleapis/tree/master/google/google/devtools/clouderrorreporting/v1beta1
 [google-gax]: https://github.com/googleapis/gax-ruby
-[Stackdriver Clouderrorreporting API]: https://developers.google.com/apis-explorer/#p/clouderrorreporting/v1beta1/
+[Stackdriver Error Reporting API]: https://developers.google.com/apis-explorer/#p/clouderrorreporting/v1beta1/
 
 Getting started
 ---------------
 
-google-cloud-error_reporting will allow you to connect to the [Stackdriver Clouderrorreporting API][] and access all its methods.
+google-cloud-error_reporting will allow you to connect to the [Stackdriver Error Reporting API][] and access all its methods.
 
 In order to achieve so you need to set up authentication as well as install the library locally.
 

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Google Inc"]
   gem.email         = ["googleapis-packages@google.com"]
   gem.description   = "a grpc-based api"
-  gem.summary       = "Google client library for the Stackdriver Clouderrorreporting service"
+  gem.summary       = "Google client library for the Stackdriver Error Reporting service"
   gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
   gem.license       = "Apache-2.0"
 


### PR DESCRIPTION
As we can read on https://developers.google.com/apis-explorer/#p/clouderrorreporting/v1beta1/ the product and API name is "Stackdriver Error Reporting"

"Stackdriver Clouderrorreporting" has never been defined and should NOT be used.