### PR TITLE
Use async_writer in Logging::Railtie

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -72,9 +72,7 @@ module Google
                                                            resource_labels
             log_name = log_config.log_name || DEFAULT_LOG_NAME
 
-            app.config.logger = Google::Cloud::Logging::Logger.new logging,
-                                                                   log_name,
-                                                                   resource
+            app.config.logger = logging.logger log_name, resource
             app.middleware.insert_before Rails::Rack::Logger,
                                          Google::Cloud::Logging::Middleware,
                                          logger: app.config.logger


### PR DESCRIPTION
Changing the Logging::Railtie to use Logging::Project#logger for creating the logger, which correctly sets async_writer as the writer underneath.

This code is in Railtie initializer again, which we're not covering in unit tests yet. I will try cover this as well in my next integration test revamp.

close #1021 