### PR TITLE
logger creates entries with timestamp

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -335,6 +335,7 @@ module Google
         # @private Write a log entry to the Stackdriver Logging service.
         def write_entry severity, message
           entry = Entry.new.tap do |e|
+            e.timestamp = Time.now
             e.severity = gcloud_severity(severity)
             e.payload = message
           end

--- a/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
@@ -28,9 +28,15 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:severity) { :DEBUG }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
+  let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
 
   def write_req_args
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
+    timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
+                                                     nanos: timestamp.nsec
+
+    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+                                                 severity: severity,
+                                                 timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
@@ -46,32 +52,44 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
 
   describe :debug do
     it "creates a log entry using :debug" do
-      logger.add :debug, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :debug, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using 'debug'" do
-      logger.add "debug", "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "debug", "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using Logger::DEBUG" do
-      logger.add ::Logger::DEBUG, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::DEBUG, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using :debug with a block" do
-      logger.add :debug do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :debug do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using 'debug' with a block" do
-      logger.add "debug" do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "debug" do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using Logger::DEBUG with a block" do
-      logger.add ::Logger::DEBUG do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::DEBUG do
+          "Danger Will Robinson!"
+        end
       end
     end
   end
@@ -80,32 +98,44 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :INFO }
 
     it "creates a log entry using :info" do
-      logger.add :info, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :info, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using 'info'" do
-      logger.add "info", "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "info", "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using Logger::INFO" do
-      logger.add ::Logger::INFO, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::INFO, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using :info with a block" do
-      logger.add :info do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :info do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using 'info' with a block" do
-      logger.add "info" do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "info" do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using Logger::INFO with a block" do
-      logger.add ::Logger::INFO do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::INFO do
+          "Danger Will Robinson!"
+        end
       end
     end
   end
@@ -114,32 +144,44 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :WARNING }
 
     it "creates a log entry using :warn" do
-      logger.add :warn, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :warn, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using 'warn'" do
-      logger.add "warn", "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "warn", "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using Logger::WARN" do
-      logger.add ::Logger::WARN, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::WARN, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using :warn with a block" do
-      logger.add :warn do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :warn do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using 'warn' with a block" do
-      logger.add "warn" do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "warn" do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using Logger::WARN with a block" do
-      logger.add ::Logger::WARN do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::WARN do
+          "Danger Will Robinson!"
+        end
       end
     end
   end
@@ -148,32 +190,44 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :ERROR }
 
     it "creates a log entry using :error" do
-      logger.add :error, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :error, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using 'error'" do
-      logger.add "error", "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "error", "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using Logger::ERROR" do
-      logger.add ::Logger::ERROR, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::ERROR, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using :error with a block" do
-      logger.add :error do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :error do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using 'error' with a block" do
-      logger.add "error" do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "error" do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using Logger::ERROR with a block" do
-      logger.add ::Logger::ERROR do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::ERROR do
+          "Danger Will Robinson!"
+        end
       end
     end
   end
@@ -182,32 +236,44 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :CRITICAL }
 
     it "creates a log entry using :fatal" do
-      logger.add :fatal, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :fatal, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using 'fatal'" do
-      logger.add "fatal", "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "fatal", "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using Logger::FATAL" do
-      logger.add ::Logger::FATAL, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::FATAL, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using :fatal with a block" do
-      logger.add :fatal do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :fatal do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using 'fatal' with a block" do
-      logger.add "fatal" do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "fatal" do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using Logger::FATAL with a block" do
-      logger.add ::Logger::FATAL do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::FATAL do
+          "Danger Will Robinson!"
+        end
       end
     end
   end
@@ -216,32 +282,44 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
     let(:severity) { :DEFAULT }
 
     it "creates a log entry using :unknown" do
-      logger.add :unknown, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :unknown, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using 'unknown'" do
-      logger.add "unknown", "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "unknown", "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using Logger::UNKNOWN" do
-      logger.add ::Logger::UNKNOWN, "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::UNKNOWN, "Danger Will Robinson!"
+      end
     end
 
     it "creates a log entry using :unknown with a block" do
-      logger.add :unknown do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add :unknown do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using 'unknown' with a block" do
-      logger.add "unknown" do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add "unknown" do
+          "Danger Will Robinson!"
+        end
       end
     end
 
     it "creates a log entry using Logger::UNKNOWN with a block" do
-      logger.add ::Logger::UNKNOWN do
-        "Danger Will Robinson!"
+      Time.stub :now, timestamp do
+        logger.add ::Logger::UNKNOWN do
+          "Danger Will Robinson!"
+        end
       end
     end
   end

--- a/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
@@ -27,9 +27,14 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
   let(:labels) { { "env" => "production" } }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
+  let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
 
   def write_req_args severity
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
+    timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
+                                                     nanos: timestamp.nsec
+    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+                                                 severity: severity,
+                                                 timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
@@ -50,9 +55,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)
     logging.service.mocked_logging = mock
 
-    logger.debug "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.debug "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #info" do
@@ -60,9 +67,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    logger.info "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.info "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #warn" do
@@ -70,9 +79,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    logger.warn "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.warn "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #error" do
@@ -80,9 +91,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    logger.error "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.error "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #fatal" do
@@ -90,9 +103,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.fatal "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown" do
@@ -100,9 +115,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.unknown "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #debug with a block" do
@@ -110,9 +127,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)
     logging.service.mocked_logging = mock
 
-    logger.debug { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.debug { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #info with a block" do
@@ -120,9 +139,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    logger.info { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.info { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #warn with a block" do
@@ -130,9 +151,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    logger.warn { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.warn { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #error with a block" do
@@ -140,9 +163,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    logger.error { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.error { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #fatal with a block" do
@@ -150,9 +175,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.fatal { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown with a block" do
@@ -160,8 +187,10 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.unknown { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
@@ -27,9 +27,14 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
   let(:labels) { { "env" => "production" } }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
+  let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
 
   def write_req_args severity
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
+    timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
+                                                     nanos: timestamp.nsec
+    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+                                                 severity: severity,
+                                                 timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
@@ -62,9 +67,11 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    logger.error "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.error "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #fatal" do
@@ -72,9 +79,11 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.fatal "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown" do
@@ -82,9 +91,11 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.unknown "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "does not create a log entry with #debug with a block" do
@@ -104,9 +115,11 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    logger.error { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.error { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #fatal with a block" do
@@ -114,9 +127,11 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.fatal { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown with a block" do
@@ -124,8 +139,10 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.unknown { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
@@ -27,9 +27,14 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
   let(:labels) { { "env" => "production" } }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
+  let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
 
   def write_req_args severity
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
+    timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
+                                                     nanos: timestamp.nsec
+    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+                                                 severity: severity,
+                                                 timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
@@ -66,9 +71,11 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.fatal "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown" do
@@ -76,9 +83,11 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.unknown "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "does not create a log entry with #debug with a block" do
@@ -102,9 +111,11 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.fatal { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown with a block" do
@@ -112,8 +123,10 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.unknown { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
@@ -27,9 +27,14 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
   let(:labels) { { "env" => "production" } }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
+  let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
 
   def write_req_args severity
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
+    timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
+                                                     nanos: timestamp.nsec
+    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+                                                 severity: severity,
+                                                 timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
@@ -54,9 +59,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    logger.info "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.info "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #warn" do
@@ -64,9 +71,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    logger.warn "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.warn "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #error" do
@@ -74,9 +83,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    logger.error "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.error "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #fatal" do
@@ -84,9 +95,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.fatal "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown" do
@@ -94,9 +107,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.unknown "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "does not create a log entry with #debug with a block" do
@@ -108,9 +123,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    logger.info { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.info { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #warn with a block" do
@@ -118,9 +135,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    logger.warn { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.warn { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #error with a block" do
@@ -128,9 +147,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    logger.error { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.error { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #fatal with a block" do
@@ -138,9 +159,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.fatal { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown with a block" do
@@ -148,8 +171,10 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.unknown { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
@@ -27,9 +27,14 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
   let(:labels) { { "env" => "production" } }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
+  let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
 
   def write_req_args severity
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
+    timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
+                                                     nanos: timestamp.nsec
+    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+                                                 severity: severity,
+                                                 timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
@@ -58,9 +63,11 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    logger.warn "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.warn "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #error" do
@@ -68,9 +75,11 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    logger.error "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.error "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #fatal" do
@@ -78,9 +87,11 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.fatal "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown" do
@@ -88,9 +99,11 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.unknown "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "does not create a log entry with #debug with a block" do
@@ -106,9 +119,11 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    logger.warn { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.warn { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #error with a block" do
@@ -116,9 +131,11 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    logger.error { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.error { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #fatal with a block" do
@@ -126,9 +143,11 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.fatal { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a log entry with #unknown with a block" do
@@ -136,8 +155,10 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown { "Danger Will Robinson!" }
+    Time.stub :now, timestamp do
+      logger.unknown { "Danger Will Robinson!" }
 
-    mock.verify
+      mock.verify
+    end
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -27,9 +27,14 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
   let(:labels) { { "env" => "production" } }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
+  let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
 
   def write_req_args severity
-    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!", severity: severity)]
+    timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
+                                                     nanos: timestamp.nsec
+    entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
+                                                 severity: severity,
+                                                 timestamp: timestamp_grpc)]
     [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
   end
 
@@ -38,9 +43,11 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)
     logging.service.mocked_logging = mock
 
-    logger.debug "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.debug "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates an INFO log entry with #info" do
@@ -48,9 +55,11 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
-    logger.info "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.info "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a WARNING log entry with #warn" do
@@ -58,9 +67,11 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
-    logger.warn "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.warn "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a ERROR log entry with #error" do
@@ -68,9 +79,11 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
-    logger.error "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.error "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a CRITICAL log entry with #fatal" do
@@ -78,9 +91,11 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
-    logger.fatal "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.fatal "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   it "creates a DEFAULT log entry with #unknown" do
@@ -88,9 +103,11 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
-    logger.unknown "Danger Will Robinson!"
+    Time.stub :now, timestamp do
+      logger.unknown "Danger Will Robinson!"
 
-    mock.verify
+      mock.verify
+    end
   end
 
   describe "#add_trace_id" do


### PR DESCRIPTION
Logging::Logger methods now creates Logging::Entry with timestamp at creation, which will provide a reliable chronological order of log entries getting send to Stackdriver Logging service.

close #1022 