### PR TITLE
Update jbuilder version to be compatible with Rails 5 test app

### DIFF
--- a/gcloud-jsondoc.gemspec
+++ b/gcloud-jsondoc.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'yard', "~> 0.8"
   s.add_dependency 'kramdown', "~> 1.9"
-  s.add_dependency 'jbuilder', "~> 2.3.0"
+  s.add_dependency 'jbuilder', "~> 2.5.0"
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-autotest", "~> 1.0"


### PR DESCRIPTION
Update jbuilder version to 2.5, which is compatible with any Rails 5 apps.

Ran unit tests, all passed, with a lot warning statements. The warning messages don't see to be caused by this change. 