### PR TITLE
Fix activesupport version dependency

### DIFF
--- a/gcloud-jsondoc.gemspec
+++ b/gcloud-jsondoc.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-autotest", "~> 1.0"
+  s.add_development_dependency "activesupport", "~> 4.0"
 end


### PR DESCRIPTION
Pin activesupport to "~> 4.0", so bundler won't try to use activesupport 5.0 that's not compatible with the Travis building environments using Ruby < 2.2.

To test this change, try use a Ruby version older than 2.2. Then do `bundle update` and it should succeed without error. 