### PR TITLE
Add require boilerplate to Datastore examples

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -223,6 +223,10 @@ module Google
     # child of the parent entity.
     #
     # ```ruby
+    # require "google/cloud/datastore"
+    #
+    # datastore = Google::Cloud::Datastore.new
+    #
     # task_key = datastore.key "Task", "sampleTask"
     # task_key.parent = datastore.key "TaskList", "default"
     #
@@ -366,6 +370,10 @@ module Google
     # namespaces used in your application entities.
     #
     # ```ruby
+    # require "google/cloud/datastore"
+    #
+    # datastore = Google::Cloud::Datastore.new
+    #
     # query = datastore.query("__namespace__").
     #   select("__key__").
     #   where("__key__", ">=", datastore.key("__namespace__", "g")).
@@ -380,6 +388,10 @@ module Google
     # kinds used in your application.
     #
     # ```ruby
+    # require "google/cloud/datastore"
+    #
+    # datastore = Google::Cloud::Datastore.new
+    #
     # query = datastore.query("__kind__").
     #   select("__key__")
     #
@@ -393,6 +405,10 @@ module Google
     # are not included.)
     #
     # ```ruby
+    # require "google/cloud/datastore"
+    #
+    # datastore = Google::Cloud::Datastore.new
+    #
     # query = datastore.query("__property__").
     #   select("__key__")
     #
@@ -412,6 +428,10 @@ module Google
     # representations of `p`'s value in any entity of kind `k`.
     #
     # ```ruby
+    # require "google/cloud/datastore"
+    #
+    # datastore = Google::Cloud::Datastore.new
+    #
     # ancestor_key = datastore.key "__kind__", "Task"
     # query = datastore.query("__property__").
     #   ancestor(ancestor_key)
@@ -429,6 +449,10 @@ module Google
     # `__property__` entities.
     #
     # ```ruby
+    # require "google/cloud/datastore"
+    #
+    # datastore = Google::Cloud::Datastore.new
+    #
     # start_key = datastore.key "__property__", "priority"
     # start_key.parent = datastore.key "__kind__", "Task"
     # query = datastore.query("__property__").

--- a/google-cloud-datastore/lib/google/cloud/datastore/commit.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/commit.rb
@@ -23,7 +23,10 @@ module Google
       # made in a single commit.
       #
       # @example
+      #   require "google/cloud/datastore"
+      #
       #   datastore = Google::Cloud::Datastore.new
+      #
       #   datastore.commit do |c|
       #     c.save task1, task2
       #     c.delete entity1, entity2
@@ -47,7 +50,10 @@ module Google
         # @param [Entity] entities One or more Entity objects to save.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   datastore.commit do |c|
         #     c.save task1, task2
         #   end
@@ -66,7 +72,10 @@ module Google
         # @param [Entity] entities One or more Entity objects to insert.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   datastore.commit do |c|
         #     c.insert task1, task2
         #   end
@@ -84,7 +93,10 @@ module Google
         # @param [Entity] entities One or more Entity objects to update.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   datastore.commit do |c|
         #     c.update task1, task2
         #   end
@@ -103,7 +115,10 @@ module Google
         #   objects to remove.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   datastore.commit do |c|
         #     c.delete task1, task2
         #   end

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -101,6 +101,10 @@ module Google
         # @return [Array<Google::Cloud::Datastore::Key>]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_key = datastore.key "Task"
         #   task_keys = datastore.allocate_ids task_key, 5
         #
@@ -124,6 +128,10 @@ module Google
         # @return [Array<Google::Cloud::Datastore::Entity>]
         #
         # @example Insert a new entity:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.entity "Task" do |t|
         #     t["type"] = "Personal"
         #     t["done"] = false
@@ -135,6 +143,10 @@ module Google
         #   task.key.id #=> 123456
         #
         # @example Insert multiple new entities in a batch:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task1 = datastore.entity "Task" do |t|
         #     t["type"] = "Personal"
         #     t["done"] = false
@@ -152,6 +164,10 @@ module Google
         #   task_key1, task_key2 = datastore.save(task1, task2).map(&:key)
         #
         # @example Update an existing entity:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.find "Task", "sampleTask"
         #   task["priority"] = 5
         #   datastore.save task
@@ -170,6 +186,10 @@ module Google
         # @return [Array<Google::Cloud::Datastore::Entity>]
         #
         # @example Insert a new entity:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.entity "Task" do |t|
         #     t["type"] = "Personal"
         #     t["done"] = false
@@ -181,6 +201,10 @@ module Google
         #   task.key.id #=> 123456
         #
         # @example Insert multiple new entities in a batch:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task1 = datastore.entity "Task" do |t|
         #     t["type"] = "Personal"
         #     t["done"] = false
@@ -210,11 +234,19 @@ module Google
         # @return [Array<Google::Cloud::Datastore::Entity>]
         #
         # @example Update an existing entity:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.find "Task", "sampleTask"
         #   task["done"] = true
         #   datastore.save task
         #
         # @example update multiple new entities in a batch:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = datastore.query("Task").where("done", "=", false)
         #   tasks = datastore.run query
         #   tasks.each { |t| t["done"] = true }
@@ -233,7 +265,10 @@ module Google
         # @return [Boolean] Returns `true` if successful
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   datastore.delete task1, task2
         #
         def delete *entities_or_keys
@@ -251,7 +286,10 @@ module Google
         #   were persisted.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   datastore.commit do |c|
         #     c.save task3, task4
         #     c.delete task1, task2
@@ -292,10 +330,18 @@ module Google
         # @return [Google::Cloud::Datastore::Entity, nil]
         #
         # @example Finding an entity with a key:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_key = datastore.key "Task", "sampleTask"
         #   task = datastore.find task_key
         #
         # @example Finding an entity with a `kind` and `id`/`name`:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.find "Task", "sampleTask"
         #
         def find key_or_kind, id_or_name = nil, consistency: nil
@@ -324,6 +370,8 @@ module Google
         # @return [Google::Cloud::Datastore::Dataset::LookupResults]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   datastore = Google::Cloud::Datastore.new
         #
         #   task_key1 = datastore.key "Task", "sampleTask1"
@@ -356,11 +404,19 @@ module Google
         # @return [Google::Cloud::Datastore::Dataset::QueryResults]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = datastore.query("Task").
         #     where("done", "=", false)
         #   tasks = datastore.run query
         #
         # @example Run an ancestor query with eventual consistency:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_list_key = datastore.key "TaskList", "default"
         #   query.kind("Task").
         #     ancestor(task_list_key)
@@ -368,16 +424,28 @@ module Google
         #   tasks = datastore.run query, consistency: :eventual
         #
         # @example Run the query within a namespace with the `namespace` option:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = datastore.query("Task").
         #     where("done", "=", false)
         #   tasks = datastore.run query, namespace: "ns~todo-project"
         #
         # @example Run the query with a GQL string.
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   gql_query = datastore.gql "SELECT * FROM Task WHERE done = @done",
         #                             done: false
         #   tasks = datastore.run gql_query
         #
         # @example Run the GQL query within a namespace with `namespace` option:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   gql_query = datastore.gql "SELECT * FROM Task WHERE done = @done",
         #                             done: false
         #   tasks = datastore.run gql_query, namespace: "ns~todo-project"
@@ -468,11 +536,19 @@ module Google
         # @return [Google::Cloud::Datastore::Query]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = datastore.query("Task").
         #     where("done", "=", false)
         #   tasks = datastore.run query
         #
         # @example The previous example is equivalent to:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new.
         #     kind("Task").
         #     where("done", "=", false)
@@ -497,11 +573,19 @@ module Google
         # @return [Google::Cloud::Datastore::GqlQuery]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   gql_query = datastore.gql "SELECT * FROM Task WHERE done = @done",
         #                             done: false
         #   tasks = datastore.run gql_query
         #
         # @example The previous example is equivalent to:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   gql_query = Google::Cloud::Datastore::GqlQuery.new
         #   gql_query.query_string = "SELECT * FROM Task WHERE done = @done"
         #   gql_query.named_bindings = {done: false}
@@ -528,23 +612,45 @@ module Google
         # @return [Google::Cloud::Datastore::Key]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_key = datastore.key "Task", "sampleTask"
         #
         # @example The previous example is equivalent to:
+        #   require "google/cloud/datastore"
+        #
         #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
         #
         # @example Create an empty key:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   key = datastore.key
         #
         # @example Create an incomplete key:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   key = datastore.key "User"
         #
         # @example Create a key with a parent:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   key = datastore.key [["TaskList", "default"],
         #                        ["Task", "sampleTask"]]
         #   key.path #=> [["TaskList", "default"], ["Task", "sampleTask"]]
         #
         # @example Create a key with multi-level ancestry:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   key = datastore.key([
         #     ["User", "alice"],
         #     ["TaskList", "default"],
@@ -553,10 +659,18 @@ module Google
         #   key.path #=> [["User", "alice"], ["TaskList", "default"], [ ... ]]
         #
         # @example Create an incomplete key with a parent:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   key = datastore.key "TaskList", "default", "Task"
         #   key.path #=> [["TaskList", "default"], ["Task", nil]]
         #
         # @example Create a key with a project and namespace:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   key = datastore.key ["TaskList", "default"], ["Task", "sampleTask"],
         #                       project: "my-todo-project",
         #                       namespace: "ns~todo-project"
@@ -592,24 +706,44 @@ module Google
         # @return [Google::Cloud::Datastore::Entity]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.entity
         #
         # @example The previous example is equivalent to:
+        #   require "google/cloud/datastore"
+        #
         #   task = Google::Cloud::Datastore::Entity.new
         #
         # @example The key can also be passed in as an object:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_key = datastore.key "Task", "sampleTask"
         #   task = datastore.entity task_key
         #
         # @example Or the key values can be passed in as parameters:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.entity "Task", "sampleTask"
         #
         # @example The previous example is equivalent to:
+        #   require "google/cloud/datastore"
+        #
         #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
         #   task = Google::Cloud::Datastore::Entity.new
         #   task.key = task_key
         #
         # @example The newly created entity can also be configured using block:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.entity "Task", "sampleTask" do |t|
         #     t["type"] = "Personal"
         #     t["done"] = false
@@ -618,6 +752,8 @@ module Google
         #   end
         #
         # @example The previous example is equivalent to:
+        #   require "google/cloud/datastore"
+        #
         #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
         #   task = Google::Cloud::Datastore::Entity.new
         #   task.key = task_key

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
@@ -29,12 +29,20 @@ module Google
         # Many common Array methods will return a new Array instance.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   tasks = datastore.find_all task_key1, task_key2, task_key3
         #   tasks.size #=> 3
         #   tasks.deferred #=> []
         #   tasks.missing #=> []
         #
         # @example Caution, many Array methods will return a new Array instance:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   tasks = datastore.find_all task_key1, task_key2, task_key3
         #   tasks.size #=> 3
         #   tasks.deferred #=> []
@@ -65,6 +73,8 @@ module Google
           # @return [Boolean]
           #
           # @example
+          #   require "google/cloud/datastore"
+          #
           #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"
@@ -84,6 +94,8 @@ module Google
           # @return [LookupResults]
           #
           # @example
+          #   require "google/cloud/datastore"
+          #
           #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"
@@ -121,6 +133,8 @@ module Google
           # @return [Enumerator]
           #
           # @example Iterating each result by passing a block:
+          #   require "google/cloud/datastore"
+          #
           #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"
@@ -131,6 +145,8 @@ module Google
           #   end
           #
           # @example Using the enumerator by not passing a block:
+          #   require "google/cloud/datastore"
+          #
           #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"
@@ -141,6 +157,8 @@ module Google
           #   end
           #
           # @example Limit the number of API calls made:
+          #   require "google/cloud/datastore"
+          #
           #   datastore = Google::Cloud::Datastore.new
           #
           #   task_key1 = datastore.key "Task", "sampleTask1"

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -123,6 +123,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #
@@ -143,6 +144,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #
@@ -170,6 +172,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #
@@ -199,6 +202,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.each_with_cursor do |task, cursor|
@@ -232,6 +236,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all do |task|
@@ -242,6 +247,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all.map(&:key).each do |key|
@@ -252,6 +258,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all(request_limit: 10) do |task|
@@ -300,6 +307,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all_with_cursor do |task, cursor|
@@ -310,6 +318,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all_with_cursor.count #=> number of result/cursor pairs
@@ -318,6 +327,7 @@ module Google
           #   require "google/cloud/datastore"
           #
           #   datastore = Google::Cloud::Datastore.new
+          #
           #   query = datastore.query "Task"
           #   tasks = datastore.run query
           #   tasks.all_with_cursor(request_limit: 10) do |task, cursor|

--- a/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
@@ -34,6 +34,10 @@ module Google
       #   Properties, and Keys
       #
       # @example Create a new entity using a block:
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new
+      #
       #   task = datastore.entity "Task", "sampleTask" do |t|
       #     t["type"] = "Personal"
       #     t["created"] = Time.now
@@ -44,6 +48,10 @@ module Google
       #   end
       #
       # @example Create a new entity belonging to an existing parent entity:
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new
+      #
       #   task_key = datastore.key "Task", "sampleTask"
       #   task_key.parent = datastore.key "TaskList", "default"
       #
@@ -84,6 +92,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.find "Task", "sampleTask"
         #   task["description"] #=> "Learn Cloud Datastore"
         #
@@ -91,6 +100,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.find "Task", "sampleTask"
         #   task[:description] #=> "Learn Cloud Datastore"
         #
@@ -98,6 +108,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   user = datastore.find "User", "alice"
         #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
         #
@@ -105,6 +116,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   user = datastore.find "User", "alice"
         #   user["location"] #=> { longitude: -122.0862462,
         #                    #     latitude: 37.4220041 }
@@ -113,6 +125,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   user = datastore.find "User", "alice"
         #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
         #
@@ -137,6 +150,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.find "Task", "sampleTask"
         #   task["description"] = "Learn Cloud Datastore"
         #   task["tags"] = ["fun", "programming"]
@@ -145,6 +159,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.find "Task", "sampleTask"
         #   task[:description] = "Learn Cloud Datastore"
         #   task[:tags] = ["fun", "programming"]
@@ -153,6 +168,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   user = datastore.find "User", "alice"
         #   user["avatar"] = File.open "/avatars/alice.png"
         #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
@@ -161,6 +177,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   user = datastore.find "User", "alice"
         #   user["location"] = { longitude: -122.0862462, latitude: 37.4220041 }
         #
@@ -168,6 +185,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   user = datastore.find "User", "alice"
         #   user["avatar"] = File.open "/avatars/alice.png"
         #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
@@ -183,6 +201,12 @@ module Google
         # @return [Google::Cloud::Datastore::Properties]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.find "Task", "sampleTask"
+        #
         #   task.properties[:description] = "Learn Cloud Datastore"
         #   task.properties["description"] #=> "Learn Cloud Datastore"
         #
@@ -191,15 +215,33 @@ module Google
         #   end
         #
         # @example A property's existence can be determined by calling `exist?`:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.find "Task", "sampleTask"
+        #
         #   task.properties.exist? :description #=> true
         #   task.properties.exist? "description" #=> true
         #   task.properties.exist? :expiration #=> false
         #
         # @example A property can be removed from the entity:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.find "Task", "sampleTask"
+        #
         #   task.properties.delete :description
         #   task.save
         #
         # @example The properties can be converted to a hash:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.find "Task", "sampleTask"
+        #
         #   prop_hash = task.properties.to_h
         #
         attr_reader :properties
@@ -214,6 +256,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = Google::Cloud::Datastore::Entity.new
         #   task.key = datastore.key "Task"
         #   datastore.save task
@@ -222,6 +265,7 @@ module Google
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.find "Task", "sampleTask"
         #   task.persisted? #=> true
         #   task.key = datastore.key "Task" #=> RuntimeError
@@ -268,10 +312,22 @@ module Google
         #   Unindexed properties
         #
         # @example Single property values will return a single flag setting:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.find "Task", "sampleTask"
+        #
         #   task["priority"] = 4
         #   task.exclude_from_indexes? "priority" #=> false
         #
         # @example A multi-valued property will return array of flag settings:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.find "Task", "sampleTask"
+        #
         #   task["tags"] = ["fun", "programming"]
         #   task.exclude_from_indexes! "tags", [true, false]
         #
@@ -311,18 +367,42 @@ module Google
         #   Unindexed properties
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   entity = datastore.find "Task", "sampleTask"
+        #
         #   entity["priority"] = 4
         #   entity.exclude_from_indexes! "priority", true
         #
         # @example Multi-valued properties can be given multiple exclude flags:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   entity = datastore.find "Task", "sampleTask"
+        #
         #   entity["tags"] = ["fun", "programming"]
         #   entity.exclude_from_indexes! "tags", [true, false]
         #
         # @example Or, a single flag can be applied to all values in a property:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   entity = datastore.find "Task", "sampleTask"
+        #
         #   entity["tags"] = ["fun", "programming"]
         #   entity.exclude_from_indexes! "tags", true
         #
         # @example Flags can also be set with a block:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   entity = datastore.find "Task", "sampleTask"
+        #
         #   entity["priority"] = 4
         #   entity.exclude_from_indexes! "priority" do |priority|
         #     priority > 4

--- a/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
@@ -31,6 +31,10 @@ module Google
       #   Reference
       #
       # @example
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new
+      #
       #   gql_query = Google::Cloud::Datastore::GqlQuery.new
       #   gql_query.query_string = "SELECT * FROM Task ORDER BY created ASC"
       #   tasks = datastore.run gql_query
@@ -40,6 +44,8 @@ module Google
         # Returns a new GqlQuery instance.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   gql_query = Google::Cloud::Datastore::GqlQuery.new
         #
         def initialize
@@ -102,6 +108,8 @@ module Google
         #   literal values
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   gql_query = Google::Cloud::Datastore::GqlQuery.new
         #   gql_query.query_string = "SELECT * FROM Task " \
         #                            "WHERE completed = false AND priority = 4"
@@ -138,6 +146,8 @@ module Google
         #   names in the query string to valid GQL arguments
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   gql_query = Google::Cloud::Datastore::GqlQuery.new
         #   gql_query.query_string = "SELECT * FROM Task " \
         #                            "WHERE done = @done " \
@@ -186,6 +196,8 @@ module Google
         #   of the numbered binding sites in the query string
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   gql_query = Google::Cloud::Datastore::GqlQuery.new
         #   gql_query.query_string = "SELECT * FROM Task" \
         #                            "WHERE completed = @1 AND priority = @2"

--- a/google-cloud-datastore/lib/google/cloud/datastore/key.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/key.rb
@@ -25,6 +25,8 @@ module Google
       # integer numeric ID, assigned automatically by Datastore.
       #
       # @example
+      #   require "google/cloud/datastore"
+      #
       #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
       #
       class Key
@@ -34,6 +36,8 @@ module Google
         # @return [String]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   key = Google::Cloud::Datastore::Key.new "TaskList"
         #   key.kind #=> "TaskList"
         #   key.kind = "Task"
@@ -88,6 +92,8 @@ module Google
         # @return [Google::Cloud::Datastore::Dataset::Key]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
         #
         def initialize kind = nil, id_or_name = nil
@@ -106,6 +112,8 @@ module Google
         # @return [Integer, nil]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
         #   task_key.id #=> nil
         #   task_key.name #=> "sampleTask"
@@ -124,6 +132,8 @@ module Google
         # @return [Integer, nil]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   task_key = Google::Cloud::Datastore::Key.new "Task", 123456
         #   task_key.id #=> 123456
         #
@@ -136,6 +146,8 @@ module Google
         # @return [String, nil]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   task_key = Google::Cloud::Datastore::Key.new "Task", 123456
         #   task_key.id #=> 123456
         #   task_key.name #=> nil
@@ -154,6 +166,8 @@ module Google
         # @return [String, nil]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
         #   task_key.name #=> "sampleTask"
         #
@@ -165,11 +179,15 @@ module Google
         # @return [Key, nil]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   parent_key = Google::Cloud::Datastore::Key.new "TaskList", "default"
         #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
         #   task_key.parent = parent_key
         #
         # @example With multiple levels:
+        #   require "google/cloud/datastore"
+        #
         #   user_key = Google::Cloud::Datastore::Key.new "User", "alice"
         #   list_key = Google::Cloud::Datastore::Key.new "TaskList", "default"
         #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
@@ -208,6 +226,8 @@ module Google
         # @return [Array<Array<(String, String)>>]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   parent_key = Google::Cloud::Datastore::Key.new "TaskList", "default"
         #   task_key = Google::Cloud::Datastore::Key.new "Task", "sampleTask"
         #   task_key.parent = parent_key

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -30,6 +30,10 @@ module Google
       #   Datastore Metadata
       #
       # @example
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new
+      #
       #   query = Google::Cloud::Datastore::Query.new
       #   query.kind("Task").
       #     where("done", "=", false).
@@ -43,6 +47,8 @@ module Google
         # Returns a new query object.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #
         def initialize
@@ -57,6 +63,10 @@ module Google
         # queries](https://cloud.google.com/datastore/docs/concepts/metadataqueries).
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind "Task"
         #
@@ -76,6 +86,10 @@ module Google
         # Add a property filter to the query.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     where("done", "=", false)
@@ -83,6 +97,10 @@ module Google
         #   tasks = datastore.run query
         #
         # @example Add a composite property filter:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     where("done", "=", false).
@@ -91,6 +109,10 @@ module Google
         #   tasks = datastore.run query
         #
         # @example Add an inequality filter on a **single** property only:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     where("created", ">=", Time.utc(1990, 1, 1)).
@@ -99,6 +121,10 @@ module Google
         #   tasks = datastore.run query
         #
         # @example Add a composite filter on an array property:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     where("tag", "=", "fun").
@@ -107,6 +133,10 @@ module Google
         #   tasks = datastore.run query
         #
         # @example Add an inequality filter on an array property :
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     where("tag", ">", "learn").
@@ -115,6 +145,10 @@ module Google
         #   tasks = datastore.run query
         #
         # @example Add a key filter using the special property `__key__`:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     where("__key__", ">", datastore.key("Task", "someTask"))
@@ -122,6 +156,10 @@ module Google
         #   tasks = datastore.run query
         #
         # @example Add a key filter to a *kindless* query:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   last_seen_key = datastore.key "Task", "a"
         #   query = Google::Cloud::Datastore::Query.new
         #   query.where("__key__", ">", last_seen_key)
@@ -152,6 +190,10 @@ module Google
         # Add a filter for entities that inherit from a key.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_list_key = datastore.key "TaskList", "default"
         #
         #   query = Google::Cloud::Datastore::Query.new
@@ -173,6 +215,10 @@ module Google
         # of a string or symbol that starts with "d".
         #
         # @example With ascending sort order:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     order("created")
@@ -180,6 +226,10 @@ module Google
         #   tasks = datastore.run query
         #
         # @example With descending sort order:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     order("created", :desc)
@@ -187,6 +237,10 @@ module Google
         #   tasks = datastore.run query
         #
         # @example With multiple sort orders:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     order("priority", :desc).
@@ -195,6 +249,10 @@ module Google
         #   tasks = datastore.run query
         #
         # @example A property used in inequality filter must be ordered first:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     where("priority", ">", 3).
@@ -217,6 +275,10 @@ module Google
         # Set a limit on the number of results to be returned.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     limit(5)
@@ -233,6 +295,10 @@ module Google
         # Set an offset for the results to be returned.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     limit(5).
@@ -250,6 +316,10 @@ module Google
         # Set the cursor to start the results at.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     limit(page_size).
@@ -274,6 +344,10 @@ module Google
         # Retrieve only select properties from the matched entities.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     select("priority", "percent_complete")
@@ -286,6 +360,10 @@ module Google
         #   end
         #
         # @example A keys-only query using the special property `__key__`:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     select("__key__")
@@ -308,6 +386,10 @@ module Google
         # Group results by a list of properties.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new
         #   query.kind("Task").
         #     distinct_on("type", "priority").

--- a/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
@@ -27,6 +27,10 @@ module Google
       #   Transactions
       #
       # @example Transactional update:
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new
+      #
       #   def transfer_funds from_key, to_key, amount
       #     datastore.transaction do |tx|
       #       from = tx.find from_key
@@ -47,6 +51,10 @@ module Google
       #   end
       #
       # @example Transactional read:
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new
+      #
       #   task_list_key = datastore.key "TaskList", "default"
       #   datastore.transaction do |tx|
       #     task_list = tx.find task_list_key
@@ -70,6 +78,10 @@ module Google
         # Persist entities in a transaction.
         #
         # @example Transactional get or create:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_key = datastore.key "Task", "sampleTask"
         #
         #   task = nil
@@ -98,6 +110,10 @@ module Google
         # if the entities cannot be inserted.
         #
         # @example Transactional insert:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_key = datastore.key "Task", "sampleTask"
         #
         #   task = nil
@@ -125,6 +141,10 @@ module Google
         # if the entities cannot be updated.
         #
         # @example Transactional update:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_key = datastore.key "Task", "sampleTask"
         #
         #   task = nil
@@ -146,6 +166,10 @@ module Google
         # Remove entities in a transaction.
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   datastore.transaction do |tx|
         #     if tx.find(task_list.key).nil?
         #       tx.delete task1, task2
@@ -167,10 +191,18 @@ module Google
         # @return [Google::Cloud::Datastore::Entity, nil]
         #
         # @example Finding an entity with a key:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_key = datastore.key "Task", "sampleTask"
         #   task = datastore.find task_key
         #
         # @example Finding an entity with a `kind` and `id`/`name`:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   task = datastore.find "Task", "sampleTask"
         #
         def find key_or_kind, id_or_name = nil
@@ -191,7 +223,10 @@ module Google
         # @return [Google::Cloud::Datastore::Dataset::LookupResults]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
         #   datastore = Google::Cloud::Datastore.new
+        #
         #   task_key1 = datastore.key "Task", 123456
         #   task_key2 = datastore.key "Task", 987654
         #   tasks = datastore.find_all task_key1, task_key2
@@ -214,6 +249,10 @@ module Google
         # @return [Google::Cloud::Datastore::Dataset::QueryResults]
         #
         # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = datastore.query("Task").
         #     where("done", "=", false)
         #   datastore.transaction do |tx|
@@ -221,6 +260,10 @@ module Google
         #   end
         #
         # @example Run the query within a namespace with the `namespace` option:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
         #   query = Google::Cloud::Datastore::Query.new.kind("Task").
         #     where("done", "=", false)
         #   datastore.transaction do |tx|


### PR DESCRIPTION
Consistently begin each code example with the following setup:

```ruby
# @example
#   require "google/cloud/datastore"
#
#   datastore = Google::Cloud::Datastore.new
#
#   ...
#
```

[refs #226]
