### PR TITLE
Revert pr 1027

### DIFF
--- a/gcloud-jsondoc.gemspec
+++ b/gcloud-jsondoc.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'yard', "~> 0.8"
   s.add_dependency 'kramdown', "~> 1.9"
-  s.add_dependency 'jbuilder', "~> 2.5.0"
+  s.add_dependency 'jbuilder', "~> 2.3.0"
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-autotest", "~> 1.0"


### PR DESCRIPTION
PR #1027 and #1028 were submitted to make gcloud-json gem compatible with the soon to be added Rails 5 test app. But then I found an alternative solution to make a Rails 5 test app work without mixing the Rails 5 gem sets with google-cloud-ruby gems' gem sets.

After discussing with @blowmage, we decided to revert changes from PR #1027 and PR #1028.