### PR TITLE
Update Translate for V2

### DIFF
--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -16,15 +16,12 @@ $ gem install google-cloud-translate
 
 ## Authentication
 
-Unlike other Cloud Platform services, which authenticate using a project
-ID and OAuth 2.0 credentials, Translate API requires a public API access
-key. (This may change in future releases of Translate API.) Follow the
-general instructions at [Identifying your application to
-Google](https://cloud.google.com/translate/v2/using_rest#auth), and the
-specific instructions for [Server
-keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
-
-Instructions and configuration options are covered in the [Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/guides/authentication).
+Like other Cloud Platform services, Google Translate API supports
+authentication using a project ID and OAuth 2.0 credentials. In addition,
+it supports authentication using a public API access key. (If both the API
+key and the project and OAuth 2.0 credentials are provided, the API key
+will be used.) Instructions and configuration options are covered in the
+[Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/guides/authentication).
 
 ## Example
 

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -25,20 +25,63 @@ end
 
 # Acceptance tests
 desc "Runs the translate acceptance tests."
-task :acceptance, :key do |t, args|
+task :acceptance, :project, :keyfile, :key do |t, args|
+  project = args[:project]
+  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["TRANSLATE_TEST_PROJECT"]
+  keyfile = args[:keyfile]
+  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["TRANSLATE_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["TRANSLATE_TEST_KEYFILE_JSON"]
+  end
+  if project.nil? || keyfile.nil?
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or TRANSLATE_TEST_PROJECT=test123 TRANSLATE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+  end
   key = args[:key]
   key ||= ENV["GCLOUD_TEST_KEY"] || ENV["TRANSLATE_TEST_KEY"]
-  if key.nil?
-    fail "You must provide a key. e.g. rake acceptance[api_key] or TRANSLATE_TEST_KEY=api_key rake acceptance"
+
+  # run tests with api key credentials when available
+  if key
+    puts "running acceptance tests with API key"
+    # Rake::Task["acceptance:key"].invoke key
+    puts `bundle exec rake acceptance:key[#{key}]`
   end
+
+  # always run tests with service account credentials
+  puts "running acceptance tests with service account"
+
   # always overwrite when running tests
-  ENV["TRANSLATE_KEY"] = key
+  ENV["TRANSLATE_PROJECT"] = project
+  ENV["TRANSLATE_KEYFILE"] = nil
+  ENV["TRANSLATE_KEYFILE_JSON"] = keyfile
+  ENV["TRANSLATE_KEY"] = nil
 
   $LOAD_PATH.unshift "lib", "acceptance"
   Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :acceptance do
+  task :key, :key do |t, args|
+    key = args[:key]
+    key ||= ENV["GCLOUD_TEST_KEY"] || ENV["TRANSLATE_TEST_KEY"]
+    if key.nil?
+      fail "unable to run acceptance tests with api key credentials"
+    end
+    # always overwrite when running tests
+    ENV["TRANSLATE_PROJECT"] = nil
+    ENV["TRANSLATE_KEYFILE"] = nil
+    ENV["GOOGLE_CLOUD_KEYFILE"] = nil
+    ENV["GCLOUD_KEYFILE"] = nil
+    ENV["TRANSLATE_KEYFILE_JSON"] = nil
+    ENV["GOOGLE_CLOUD_KEYFILE_JSON"] = nil
+    ENV["GCLOUD_KEYFILE_JSON"] = nil
+    ENV["TRANSLATE_KEY"] = key
+
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+  end
+
   desc "Runs acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"

--- a/google-cloud-translate/acceptance/translate/translate_test.rb
+++ b/google-cloud-translate/acceptance/translate/translate_test.rb
@@ -44,6 +44,23 @@ describe Google::Cloud::Translate, :translate do
     translations.last.text.must_equal "¿Cómo estás hoy?"
   end
 
+  it "translates input with model attribute" do
+    translation = translate.translate "Hello", to: "es", model: ""
+    translation.text.must_include "Hola"
+    translation.model.must_be :nil?
+
+    translation = translate.translate "How are you today?", to: "es", model: "base"
+    translation.text.must_equal "¿Cómo estás hoy?"
+    translation.model.must_be :nil?
+
+    translations = translate.translate "Hello", "How are you today?", to: :es, model: :nmt
+    translations.count.must_equal 2
+    translations.first.text.must_include "Hola"
+    translations.first.model.must_equal "nmt"
+    translations.last.text.must_equal "¿Cómo estás hoy?"
+    translations.last.model.must_equal "nmt"
+  end
+
   it "lists supported languages" do
     languages = translate.languages
     languages.count.must_be :>, 0

--- a/google-cloud-translate/docs/authentication.md
+++ b/google-cloud-translate/docs/authentication.md
@@ -2,8 +2,52 @@
 
 With `google-cloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
 
-### The API access key
+Like other Cloud Platform services, Google Translate API supports authentication using a project ID and OAuth 2.0 credentials. In addition, it supports authentication using a public API access key. (If both the API key and the project and OAuth 2.0 credentials are provided, the API key will be used.)
 
-Unlike other Cloud Platform services, which authenticate using a project ID and OAuth 2.0 credentials, Google Translate API requires a public API access key. (This may change in future releases of Google Translate API.)
+### Using an API access key
 
 Follow the general instructions at [Identifying your application to Google](https://cloud.google.com/translate/v2/using_rest#auth), and the specific instructions for [Server keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
+
+**API key** is discovered in the following order:
+
+1. Specify API key in code
+2. Discover API key in environment variables
+
+Here are the environment variables (in the order they are checked) for the API key:
+
+1. `TRANSLATE_KEY`
+2. `GOOGLE_CLOUD_KEY`
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `TRANSLATE_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `TRANSLATE_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `TRANSLATE_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents

--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.21.0"
-  gem.add_dependency "google-api-client", "~> 0.9.11"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-translate/lib/google-cloud-translate.rb
+++ b/google-cloud-translate/lib/google-cloud-translate.rb
@@ -36,6 +36,14 @@ module Google
     # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
     #
     # @param [String] key a public API access key (not an OAuth 2.0 token)
+    # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+    #   set of resources and operations that the connection can access. See
+    #   [Using OAuth 2.0 to Access Google
+    #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+    #
+    #   The default scope is:
+    #
+    #   * `https://www.googleapis.com/auth/cloud-platform`
     # @param [Integer] retries Number of times to retry requests on server
     #   error. The default value is `3`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
@@ -62,8 +70,10 @@ module Google
     #   translation = translate.translate "Hello world!", to: "la"
     #   translation.text #=> "Salve mundi!"
     #
-    def translate key = nil, retries: nil, timeout: nil
-      Google::Cloud.translate key, retries: (retries || @retries),
+    def translate key = nil, scope: nil, retries: nil, timeout: nil
+      Google::Cloud.translate key, project: @project, keyfile: @keyfile,
+                                   scope: scope,
+                                   retries: (retries || @retries),
                                    timeout: (timeout || @timeout)
     end
 
@@ -80,6 +90,18 @@ module Google
     # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
     #
     # @param [String] key a public API access key (not an OAuth 2.0 token)
+    # @param [String] project Project identifier for the Translate service you
+    #   are connecting to.
+    # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
+    #   file path the file must be readable.
+    # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+    #   set of resources and operations that the connection can access. See
+    #   [Using OAuth 2.0 to Access Google
+    #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+    #
+    #   The default scope is:
+    #
+    #   * `https://www.googleapis.com/auth/cloud-platform`
     # @param [Integer] retries Number of times to retry requests on server
     #   error. The default value is `3`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
@@ -104,9 +126,12 @@ module Google
     #   translation = translate.translate "Hello world!", to: "la"
     #   translation.text #=> "Salve mundi!"
     #
-    def self.translate key = nil, retries: nil, timeout: nil
+    def self.translate key = nil, project: nil, keyfile: nil, scope: nil,
+                       retries: nil, timeout: nil
       require "google/cloud/translate"
-      Google::Cloud::Translate.new key: key, retries: retries, timeout: timeout
+      Google::Cloud::Translate.new key: key, project: project, keyfile: keyfile,
+                                   scope: scope, retries: retries,
+                                   timeout: timeout
     end
   end
 end

--- a/google-cloud-translate/lib/google-cloud-translate.rb
+++ b/google-cloud-translate/lib/google-cloud-translate.rb
@@ -27,13 +27,12 @@ module Google
     # Creates a new object for connecting to the Translate service.
     # Each call creates a new connection.
     #
-    # Unlike other Cloud Platform services, which authenticate using a project
-    # ID and OAuth 2.0 credentials, Google Translate API requires a public API
-    # access key. (This may change in future releases of Google Translate API.)
-    # Follow the general instructions at [Identifying your application to
-    # Google](https://cloud.google.com/translate/v2/using_rest#auth), and the
-    # specific instructions for [Server
-    # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
+    # Like other Cloud Platform services, Google Translate API supports
+    # authentication using a project ID and OAuth 2.0 credentials. In addition,
+    # it supports authentication using a public API access key. (If both the API
+    # key and the project and OAuth 2.0 credentials are provided, the API key
+    # will be used.) Instructions and configuration options are covered in the
+    # [Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/guides/authentication).
     #
     # @param [String] key a public API access key (not an OAuth 2.0 token)
     # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
@@ -81,13 +80,12 @@ module Google
     # Creates a new object for connecting to the Translate service.
     # Each call creates a new connection.
     #
-    # Unlike other Cloud Platform services, which authenticate using a project
-    # ID and OAuth 2.0 credentials, Google Translate API requires a public API
-    # access key. (This may change in future releases of Google Translate API.)
-    # Follow the general instructions at [Identifying your application to
-    # Google](https://cloud.google.com/translate/v2/using_rest#auth), and the
-    # specific instructions for [Server
-    # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
+    # Like other Cloud Platform services, Google Translate API supports
+    # authentication using a project ID and OAuth 2.0 credentials. In addition,
+    # it supports authentication using a public API access key. (If both the API
+    # key and the project and OAuth 2.0 credentials are provided, the API key
+    # will be used.) Instructions and configuration options are covered in the
+    # [Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/guides/authentication).
     #
     # @param [String] key a public API access key (not an OAuth 2.0 token)
     # @param [String] project Project identifier for the Translate service you

--- a/google-cloud-translate/lib/google/cloud/translate.rb
+++ b/google-cloud-translate/lib/google/cloud/translate.rb
@@ -34,15 +34,25 @@ module Google
     # with translated text back. You don't need to extract your source text or
     # reassemble the translated content.
     #
+    # ## Premium Edition
+    #
+    # Using the `model` parameter, you can set the model used by the service to
+    # perform the translation. The neural machine translation model (`nmt`) is
+    # billed as a premium edition feature. Because neural machine translation is
+    # computationally significantly more resource intensive than the standard
+    # model, the price for the premium edition is higher than the standard
+    # edition. If the `model` parameter not set or is set to `base`, then the
+    # service will return translation using the current standard model and
+    # standard edition pricing.
+    #
     # ## Authenticating
     #
-    # Unlike other Cloud Platform services, which authenticate using a project
-    # ID and OAuth 2.0 credentials, Translate API requires a public API access
-    # key. (This may change in future releases of Translate API.) Follow the
-    # general instructions at [Identifying your application to
-    # Google](https://cloud.google.com/translate/v2/using_rest#auth), and the
-    # specific instructions for [Server
-    # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
+    # Like other Cloud Platform services, Google Translate API supports
+    # authentication using a project ID and OAuth 2.0 credentials. In addition,
+    # it supports authentication using a public API access key. (If both the API
+    # key and the project and OAuth 2.0 credentials are provided, the API key
+    # will be used.) Instructions and configuration options are covered in the
+    # [Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/guides/authentication).
     #
     # ## Translating texts
     #
@@ -211,13 +221,13 @@ module Google
       # Creates a new object for connecting to the Translate service.
       # Each call creates a new connection.
       #
-      # Unlike other Cloud Platform services, which authenticate using a project
-      # ID and OAuth 2.0 credentials, Google Translate API requires a public API
-      # access key. (This may change in future releases of Google Translate
-      # API.) Follow the general instructions at [Identifying your application
-      # to Google](https://cloud.google.com/translate/v2/using_rest#auth), and
-      # the specific instructions for [Server
-      # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
+      # Like other Cloud Platform services, Google Translate API supports
+      # authentication using a project ID and OAuth 2.0 credentials. In
+      # addition, it supports authentication using a public API access key. (If
+      # both the API key and the project and OAuth 2.0 credentials are provided,
+      # the API key will be used.) Instructions and configuration options are
+      # covered in the [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/guides/authentication).
       #
       # @param [String] project Project identifier for the Translate service you
       #   are connecting to.

--- a/google-cloud-translate/lib/google/cloud/translate/api.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/api.rb
@@ -107,6 +107,7 @@ module Google
         # @param [String] format The format of the text. Possible values include
         #   `:text` and `:html`. This is optional. The Translate API default is
         #   `:html`.
+        # @param [String] model The translation model.
         # @param [String] cid The customization id for translate. This is
         #   optional.
         #
@@ -160,7 +161,8 @@ module Google
         #                                     to: :la
         #   translation.text #=> "<strong>Salve</strong> mundi!"
         #
-        def translate *text, to: nil, from: nil, format: nil, cid: nil
+        def translate *text, to: nil, from: nil, format: nil, model: nil,
+                      cid: nil
           return nil if text.empty?
           fail ArgumentError, "to is required" if to.nil?
           to = to.to_s
@@ -168,7 +170,7 @@ module Google
           format = format.to_s if format
           text = Array(text).flatten
           gapi = service.translate text, to: to, from: from,
-                                         format: format, cid: cid
+                                         format: format, model: model, cid: cid
           Translation.from_gapi_list gapi, text, to, from
         end
 

--- a/google-cloud-translate/lib/google/cloud/translate/api.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/api.rb
@@ -25,13 +25,12 @@ module Google
       ##
       # # Api
       #
-      # Represents top-level access to the Google Translate API. Each instance
-      # requires a public API access key. To create a key, follow the general
-      # instructions at [Identifying your application to
-      # Google](https://cloud.google.com/translate/v2/using_rest#auth), and the
-      # specific instructions for [Server
-      # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
-      # See {Google::Cloud#translate}.
+      # Represents top-level access to the Google Translate API. Translate API
+      # supports more than ninety different languages, from Afrikaans to Zulu.
+      # Used in combination, this enables translation between thousands of
+      # language pairs. Also, you can send in HTML and receive HTML with
+      # translated text back. You don't need to extract your source text or
+      # reassemble the translated content.
       #
       # @see https://cloud.google.com/translate/v2/getting_started Translate API
       #   Getting Started
@@ -107,7 +106,17 @@ module Google
         # @param [String] format The format of the text. Possible values include
         #   `:text` and `:html`. This is optional. The Translate API default is
         #   `:html`.
-        # @param [String] model The translation model.
+        # @param [String] model The model used by the service to perform the
+        #   translation. The neural machine translation model (`nmt`) is billed
+        #   as a premium edition feature. If this is set to `base`, then the
+        #   service will return translation using the current standard model.
+        #   The default value is `base`.
+        #
+        #   Acceptable values are:
+        #
+        #   * `nmt` - Use the neural machine translation model
+        #   * `base` - Use the current standard model
+        #
         # @param [String] cid The customization id for translate. This is
         #   optional.
         #
@@ -129,6 +138,18 @@ module Google
         #   translation.origin #=> "Hello world!"
         #   translation.to #=> "la"
         #   translation.text #=> "Salve mundi!"
+        #   translation.model #=> "base"
+        #
+        # @example Using the neural machine translation model:
+        #   require "google/cloud/translate"
+        #
+        #   translate = Google::Cloud::Translate.new
+        #
+        #   translation = translate.translate "Hello world!",
+        #                                     to: "la", model: "nmt"
+        #
+        #   translation.to_s #=> "Salve mundi!"
+        #   translation.model #=> "nmt"
         #
         # @example Setting the `from` language.
         #   require "google/cloud/translate"

--- a/google-cloud-translate/lib/google/cloud/translate/api.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/api.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+require "google/cloud/core/environment"
 require "google/cloud/translate/service"
 require "google/cloud/translate/translation"
 require "google/cloud/translate/detection"
@@ -60,6 +61,32 @@ module Google
         # See {Google::Cloud.translate}
         def initialize service
           @service = service
+        end
+
+        ##
+        # The Translate project connected to.
+        #
+        # @example
+        #   require "google/cloud/translate"
+        #
+        #   translate = Google::Cloud::Translate.new(
+        #     project: "my-todo-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
+        #
+        #   translate.project #=> "my-todo-project"
+        #
+        def project
+          service.project
+        end
+
+        ##
+        # @private Default project.
+        def self.default_project
+          ENV["TRANSLATE_PROJECT"] ||
+            ENV["GOOGLE_CLOUD_PROJECT"] ||
+            ENV["GCLOUD_PROJECT"] ||
+            Google::Cloud::Core::Environment.project_id
         end
 
         ##
@@ -227,7 +254,7 @@ module Google
         def languages language = nil
           language = language.to_s if language
           gapi = service.languages language
-          Array(gapi.languages).map { |g| Language.from_gapi g }
+          Array(gapi["languages"]).map { |g| Language.from_gapi g }
         end
       end
     end

--- a/google-cloud-translate/lib/google/cloud/translate/credentials.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/credentials.rb
@@ -1,0 +1,42 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/credentials"
+
+module Google
+  module Cloud
+    module Translate
+      ##
+      # @private Represents the OAuth 2.0 signing logic for Translate.
+      class Credentials < Google::Cloud::Credentials
+        SCOPE = ["https://www.googleapis.com/auth/cloud-platform"]
+        PATH_ENV_VARS = %w(TRANSLATE_KEYFILE GOOGLE_CLOUD_KEYFILE
+                           GCLOUD_KEYFILE)
+        JSON_ENV_VARS = %w(TRANSLATE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON
+                           GCLOUD_KEYFILE_JSON)
+
+        ##
+        # @private Sign Oauth2 API calls.
+        def sign_http_request request #:nodoc:
+          if @client
+            @client.fetch_access_token! if @client.expires_within? 30
+            @client.generate_authenticated_request request: request
+          end
+          request
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-translate/lib/google/cloud/translate/detection.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/detection.rb
@@ -88,8 +88,8 @@ module Google
         # @private New Detection from a ListDetectionsResponse object as
         # defined by the Google API Client object.
         def self.from_gapi gapi, text
-          res = text.zip(Array(gapi.detections)).map do |txt, detections_gapi|
-            results = detections_gapi.map { |g| Result.from_gapi g }
+          res = text.zip(Array(gapi["detections"])).map do |txt, detections|
+            results = detections.map { |g| Result.from_gapi g }
             new txt, results
           end
           return res.first if res.size == 1
@@ -130,7 +130,7 @@ module Google
           # @private New Detection::Result from a DetectionsResource object as
           # defined by the Google API Client object.
           def self.from_gapi gapi
-            new gapi.confidence, gapi.language
+            new gapi["confidence"], gapi["language"]
           end
         end
       end

--- a/google-cloud-translate/lib/google/cloud/translate/language.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/language.rb
@@ -62,7 +62,7 @@ module Google
         # @private New Language from a LanguagesResource object as defined by
         # the Google API Client object.
         def self.from_gapi gapi
-          new gapi.language, gapi.name
+          new gapi["language"], gapi["name"]
         end
       end
     end

--- a/google-cloud-translate/lib/google/cloud/translate/service.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/service.rb
@@ -44,9 +44,11 @@ module Google
 
         ##
         # Returns Hash of ListTranslationsResponse JSON
-        def translate text, to: nil, from: nil, format: nil, cid: nil
+        def translate text, to: nil, from: nil, format: nil, model: nil,
+                      cid: nil
           body = {
-            q: Array(text), target: to, source: from, format: format, cid: cid
+            q: Array(text), target: to, source: from, format: format,
+            model: model, cid: cid
           }.delete_if { |_k, v| v.nil? }.to_json
 
           post "/language/translate/v2", body

--- a/google-cloud-translate/lib/google/cloud/translate/translation.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/translation.rb
@@ -70,7 +70,18 @@ module Google
         alias_method :source, :from
 
         ##
-        # The translation model.
+        # The model used by the service to perform the translation. When this is
+        # set to `nmt`, the translation was performed using premium neural
+        # machine translation model. If it is not set or model is set to `base`,
+        # then the translation was done using standard model. In almost all
+        # cases, the model type in response should match the model type
+        # requested. However, in some limited situations this might not be the
+        # case. In these cases, the request had `nmt` parameter, but the
+        # response has `base` set or model is not returned. This happens when
+        # neural translation did not give a satisfactory translation and we
+        # completed the translation using the standard model. If this happens,
+        # you will charged at the standard edition rate and not at the premium
+        # rate.
         #
         # @return [String]
         attr_reader :model

--- a/google-cloud-translate/lib/google/cloud/translate/translation.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/translation.rb
@@ -64,16 +64,25 @@ module Google
 
         ##
         # The source language from which the text was translated.
+        #
+        # @return [String]
         attr_reader :from
         alias_method :source, :from
 
         ##
+        # The translation model.
+        #
+        # @return [String]
+        attr_reader :model
+
+        ##
         # @private Create a new object.
-        def initialize text, to, origin, from, detected
+        def initialize text, to, origin, from, model, detected
           @text = text
           @to = to
           @origin = origin
           @from = from
+          @model = model
           @detected = detected
         end
 
@@ -105,7 +114,7 @@ module Google
         def self.from_gapi gapi, to, origin, from
           from ||= gapi["detectedSourceLanguage"]
           detected = !gapi["detectedSourceLanguage"].nil?
-          new gapi["translatedText"], to, origin, from, detected
+          new gapi["translatedText"], to, origin, from, gapi["model"], detected
         end
       end
     end

--- a/google-cloud-translate/lib/google/cloud/translate/translation.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/translation.rb
@@ -92,7 +92,7 @@ module Google
         # @private New Translation from a TranslationsListResponse object as
         # defined by the Google API Client object.
         def self.from_gapi_list gapi, text, to, from
-          res = text.zip(Array(gapi.translations)).map do |origin, g|
+          res = text.zip(Array(gapi["translations"])).map do |origin, g|
             from_gapi g, to, origin, from
           end
           return res.first if res.size == 1
@@ -103,9 +103,9 @@ module Google
         # @private New Translation from a TranslationsResource object as defined
         # by the Google API Client object.
         def self.from_gapi gapi, to, origin, from
-          from ||= gapi.detected_source_language
-          detected = !gapi.detected_source_language.nil?
-          new gapi.translated_text, to, origin, from, detected
+          from ||= gapi["detectedSourceLanguage"]
+          detected = !gapi["detectedSourceLanguage"].nil?
+          new gapi["translatedText"], to, origin, from, detected
         end
       end
     end

--- a/google-cloud-translate/support/doctest_helper.rb
+++ b/google-cloud-translate/support/doctest_helper.rb
@@ -42,49 +42,49 @@ YARD::Doctest.configure do |doctest|
    doctest.before "Google::Cloud#translate" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud#translate@Using API Key from the environment variable." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud.translate" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud.translate@Using API Key from the environment variable." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate.new" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate.new@Using API Key from the environment variable." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
@@ -97,14 +97,14 @@ YARD::Doctest.configure do |doctest|
    doctest.before "Google::Cloud::Translate::Api#translate" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api#translate@Setting the `from` language." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: nil, translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: "en", format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: "en", format: nil, model: nil, cid: nil]
     end
   end
 
@@ -112,14 +112,14 @@ YARD::Doctest.configure do |doctest|
     mock_translate do |mock|
       res_attrs_1 = { detectedSourceLanguage: nil, translatedText: "Salve amice." }
       res_attrs_2 = { detectedSourceLanguage: nil, translatedText: "Vide te mox." }
-      mock.expect :translate, list_translations_response([res_attrs_1, res_attrs_2]), [["Hello my friend.", "See you soon."], to: "la", from: "en", format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs_1, res_attrs_2]), [["Hello my friend.", "See you soon."], to: "la", from: "en", format: nil, model: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api#translate@Preserving HTML tags." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: nil, translatedText: "<strong>Salve</strong> mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["<strong>Hello</strong> world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["<strong>Hello</strong> world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
@@ -170,7 +170,7 @@ YARD::Doctest.configure do |doctest|
    doctest.before "Google::Cloud::Translate::Translation" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 end

--- a/google-cloud-translate/support/doctest_helper.rb
+++ b/google-cloud-translate/support/doctest_helper.rb
@@ -29,10 +29,11 @@ end
 def mock_translate
   Google::Cloud::Translate.stub_new do |*args|
     key = "test-api-key"
-    translate = Google::Cloud::Translate::Api.new(Google::Cloud::Translate::Service.new(key))
+    project = "my-todo-project"
+    translate = Google::Cloud::Translate::Api.new(OpenStruct.new(key: key, project: project))
 
-    translate.service.mocked_service = Minitest::Mock.new
-    yield translate.service.mocked_service
+    translate.service = Minitest::Mock.new
+    yield translate.service
     translate
   end
 end
@@ -40,130 +41,136 @@ end
 YARD::Doctest.configure do |doctest|
    doctest.before "Google::Cloud#translate" do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud#translate@Using API Key from the environment variable." do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud.translate" do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud.translate@Using API Key from the environment variable." do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate.new" do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate.new@Using API Key from the environment variable." do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api" do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
     end
+  end
+
+  doctest.before "Google::Cloud::Translate::Api#project" do
+   mock_translate do |mock|
+     mock.expect :project, "my-todo-project"
+   end
   end
 
    doctest.before "Google::Cloud::Translate::Api#translate" do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api#translate@Setting the `from` language." do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: nil, translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>"en"}]
+      res_attrs = { detectedSourceLanguage: nil, translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: "en", format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api#translate@Retrieving multiple translations." do
     mock_translate do |mock|
-      res_attrs_1 = { detected_source_language: nil, translated_text: "Salve amice." }
-      res_attrs_2 = { detected_source_language: nil, translated_text: "Vide te mox." }
-      mock.expect :list_translations, list_translations_response([res_attrs_1, res_attrs_2]), [["Hello my friend.", "See you soon."], "la", {:cid=>nil, :format=>nil, :source=>"en"}]
+      res_attrs_1 = { detectedSourceLanguage: nil, translatedText: "Salve amice." }
+      res_attrs_2 = { detectedSourceLanguage: nil, translatedText: "Vide te mox." }
+      mock.expect :translate, list_translations_response([res_attrs_1, res_attrs_2]), [["Hello my friend.", "See you soon."], to: "la", from: "en", format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api#translate@Preserving HTML tags." do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: nil, translated_text: "<strong>Salve</strong> mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["<strong>Hello</strong> world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: nil, translatedText: "<strong>Salve</strong> mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["<strong>Hello</strong> world!"], to: "la", from: nil, format: nil, cid: nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api#detect" do
     mock_translate do |mock|
-      res_attrs = { confidence: 0.7100697, language: "en", is_reliable: false }
-      mock.expect :list_detections, list_detections_response([res_attrs]), [["Hello world!"]]
+      res_attrs = { confidence: 0.7100697, language: "en", isReliable: false }
+      mock.expect :detect, list_detections_response([res_attrs]), [["Hello world!"]]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api#detect@Detecting multiple texts." do
     mock_translate do |mock|
-      res_attrs = { confidence: 0.7100697, language: "en", is_reliable: false }
-      res_attrs_2 = { confidence: 0.40440267, language: "fr", is_reliable: false }
-      mock.expect :list_detections, list_detections_response([res_attrs, res_attrs_2]), [["Hello world!", "Bonjour le monde!"]]
+      res_attrs = { confidence: 0.7100697, language: "en", isReliable: false }
+      res_attrs_2 = { confidence: 0.40440267, language: "fr", isReliable: false }
+      mock.expect :detect, list_detections_response([res_attrs, res_attrs_2]), [["Hello world!", "Bonjour le monde!"]]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api#languages" do
     mock_translate do |mock|
       res_attrs = { language: "en", name: nil }
-      mock.expect :list_languages, list_languages_response(res_attrs), [{:target=>nil}]
+      mock.expect :languages, list_languages_response(res_attrs), [nil]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Api#languages@Get all languages with their names in French." do
     mock_translate do |mock|
       res_attrs = { language: "en", name: "Anglais" }
-      mock.expect :list_languages, list_languages_response(res_attrs), [{:target=>"fr"}]
+      mock.expect :languages, list_languages_response(res_attrs), ["fr"]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Detection" do
     mock_translate do |mock|
-      res_attrs = { confidence: 0.7109375, language: "fr", is_reliable: false }
-      res_attrs_2 = { confidence: 0.59922177, language: "en", is_reliable: false }
-      mock.expect :list_detections, list_detections_response([res_attrs, res_attrs_2]), [["chien", "chat"]]
+      res_attrs = { confidence: 0.7109375, language: "fr", isReliable: false }
+      res_attrs_2 = { confidence: 0.59922177, language: "en", isReliable: false }
+      mock.expect :detect, list_detections_response([res_attrs, res_attrs_2]), [["chien", "chat"]]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Language" do
     mock_translate do |mock|
       res_attrs = { language: "af", name: "Afrikaans" }
-      mock.expect :list_languages, list_languages_response(res_attrs), [{:target=>"en"}]
+      mock.expect :languages, list_languages_response(res_attrs), ["en"]
     end
   end
 
    doctest.before "Google::Cloud::Translate::Translation" do
     mock_translate do |mock|
-      res_attrs = { detected_source_language: "en", translated_text: "Salve mundi!" }
-      mock.expect :list_translations, list_translations_response([res_attrs]), [["Hello world!"], "la", {:cid=>nil, :format=>nil, :source=>nil}]
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, cid: nil]
     end
   end
 end
@@ -171,22 +178,15 @@ end
 # Fixture helpers
 
 def list_translations_response attrs_arr
-  translations = attrs_arr.map do |attrs|
-    Google::Cloud::Translate::Service::API::TranslationsResource.new attrs
-  end
-  Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: translations
+  JSON.parse({ translations: attrs_arr }.to_json)
 end
 
 def list_detections_response attrs_arr
-  detections = attrs_arr.map do |attrs|
-    [Google::Cloud::Translate::Service::API::DetectionsResource.new(attrs)]
-  end
-  Google::Cloud::Translate::Service::API::ListDetectionsResponse.new detections: detections
+  detections = attrs_arr.map { |attrs| [attrs] }
+  JSON.parse({ detections: detections }.to_json)
 end
 
 def list_languages_response attrs
-  languages_resources = (1..104).map do
-    Google::Cloud::Translate::Service::API::LanguagesResource.new attrs
-  end
-  Google::Cloud::Translate::Service::API::ListLanguagesResponse.new languages: languages_resources
+  languages_resources = (1..104).map { attrs }
+  JSON.parse({ languages: languages_resources }.to_json)
 end

--- a/google-cloud-translate/support/doctest_helper.rb
+++ b/google-cloud-translate/support/doctest_helper.rb
@@ -39,49 +39,49 @@ def mock_translate
 end
 
 YARD::Doctest.configure do |doctest|
-   doctest.before "Google::Cloud#translate" do
+  doctest.before "Google::Cloud#translate" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
-   doctest.before "Google::Cloud#translate@Using API Key from the environment variable." do
+  doctest.before "Google::Cloud#translate@Using API Key from the environment variable." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
-   doctest.before "Google::Cloud.translate" do
+  doctest.before "Google::Cloud.translate" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
-   doctest.before "Google::Cloud.translate@Using API Key from the environment variable." do
+  doctest.before "Google::Cloud.translate@Using API Key from the environment variable." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
-   doctest.before "Google::Cloud::Translate.new" do
+  doctest.before "Google::Cloud::Translate.new" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
-   doctest.before "Google::Cloud::Translate.new@Using API Key from the environment variable." do
+  doctest.before "Google::Cloud::Translate.new@Using API Key from the environment variable." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Api" do
+  doctest.before "Google::Cloud::Translate::Api" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
@@ -89,26 +89,33 @@ YARD::Doctest.configure do |doctest|
   end
 
   doctest.before "Google::Cloud::Translate::Api#project" do
-   mock_translate do |mock|
-     mock.expect :project, "my-todo-project"
-   end
+    mock_translate do |mock|
+      mock.expect :project, "my-todo-project"
+    end
   end
 
-   doctest.before "Google::Cloud::Translate::Api#translate" do
+  doctest.before "Google::Cloud::Translate::Api#translate" do
     mock_translate do |mock|
-      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!", model: "base" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Api#translate@Setting the `from` language." do
+  doctest.before "Google::Cloud::Translate::Api#translate@Using the neural machine translation model:" do
+    mock_translate do |mock|
+      res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!", model: "nmt" }
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: "nmt", cid: nil]
+    end
+  end
+
+  doctest.before "Google::Cloud::Translate::Api#translate@Setting the `from` language." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: nil, translatedText: "Salve mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: "en", format: nil, model: nil, cid: nil]
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Api#translate@Retrieving multiple translations." do
+  doctest.before "Google::Cloud::Translate::Api#translate@Retrieving multiple translations." do
     mock_translate do |mock|
       res_attrs_1 = { detectedSourceLanguage: nil, translatedText: "Salve amice." }
       res_attrs_2 = { detectedSourceLanguage: nil, translatedText: "Vide te mox." }
@@ -116,21 +123,21 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Api#translate@Preserving HTML tags." do
+  doctest.before "Google::Cloud::Translate::Api#translate@Preserving HTML tags." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: nil, translatedText: "<strong>Salve</strong> mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["<strong>Hello</strong> world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Api#detect" do
+  doctest.before "Google::Cloud::Translate::Api#detect" do
     mock_translate do |mock|
       res_attrs = { confidence: 0.7100697, language: "en", isReliable: false }
       mock.expect :detect, list_detections_response([res_attrs]), [["Hello world!"]]
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Api#detect@Detecting multiple texts." do
+  doctest.before "Google::Cloud::Translate::Api#detect@Detecting multiple texts." do
     mock_translate do |mock|
       res_attrs = { confidence: 0.7100697, language: "en", isReliable: false }
       res_attrs_2 = { confidence: 0.40440267, language: "fr", isReliable: false }
@@ -138,21 +145,21 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Api#languages" do
+  doctest.before "Google::Cloud::Translate::Api#languages" do
     mock_translate do |mock|
       res_attrs = { language: "en", name: nil }
       mock.expect :languages, list_languages_response(res_attrs), [nil]
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Api#languages@Get all languages with their names in French." do
+  doctest.before "Google::Cloud::Translate::Api#languages@Get all languages with their names in French." do
     mock_translate do |mock|
       res_attrs = { language: "en", name: "Anglais" }
       mock.expect :languages, list_languages_response(res_attrs), ["fr"]
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Detection" do
+  doctest.before "Google::Cloud::Translate::Detection" do
     mock_translate do |mock|
       res_attrs = { confidence: 0.7109375, language: "fr", isReliable: false }
       res_attrs_2 = { confidence: 0.59922177, language: "en", isReliable: false }
@@ -160,14 +167,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Language" do
+  doctest.before "Google::Cloud::Translate::Language" do
     mock_translate do |mock|
       res_attrs = { language: "af", name: "Afrikaans" }
       mock.expect :languages, list_languages_response(res_attrs), ["en"]
     end
   end
 
-   doctest.before "Google::Cloud::Translate::Translation" do
+  doctest.before "Google::Cloud::Translate::Translation" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
       mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]

--- a/google-cloud-translate/test/google/cloud/translate/detect_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/detect_test.rb
@@ -22,11 +22,11 @@ describe Google::Cloud::Translate::Api, :detect, :mock_translate do
 
   it "detects a single language" do
     mock = Minitest::Mock.new
-    detections_resource = Google::Cloud::Translate::Service::API::DetectionsResource.new confidence: 0.123, language: "en", is_reliable: false
-    list_detections_resource = Google::Cloud::Translate::Service::API::ListDetectionsResponse.new detections: [[detections_resource]]
-    mock.expect :list_detections, list_detections_resource, [["Hello"]]
+    detections_resource = { confidence: 0.123, language: "en", isReliable: false }
+    list_detections_resource = JSON.parse({ detections: [[detections_resource]] }.to_json)
+    mock.expect :detect, list_detections_resource, [["Hello"]]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     detection = translate.detect "Hello"
     mock.verify
 
@@ -37,12 +37,12 @@ describe Google::Cloud::Translate::Api, :detect, :mock_translate do
 
   it "detects multiple languages" do
     mock = Minitest::Mock.new
-    detections_resource = Google::Cloud::Translate::Service::API::DetectionsResource.new confidence: 0.123, language: "en", is_reliable: false
-    detections_resource_2 = Google::Cloud::Translate::Service::API::DetectionsResource.new confidence: 0.123, language: "es", is_reliable: false
-    list_detections_resource = Google::Cloud::Translate::Service::API::ListDetectionsResponse.new detections: [[detections_resource], [detections_resource_2]]
-    mock.expect :list_detections, list_detections_resource, [["Hello", "Hola"]]
+    detections_resource = { confidence: 0.123, language: "en", isReliable: false }
+    detections_resource_2 = { confidence: 0.123, language: "es", isReliable: false }
+    list_detections_resource = JSON.parse({ detections: [[detections_resource], [detections_resource_2]] }.to_json)
+    mock.expect :detect, list_detections_resource, [["Hello", "Hola"]]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     detections = translate.detect "Hello", "Hola"
     mock.verify
 
@@ -59,12 +59,12 @@ describe Google::Cloud::Translate::Api, :detect, :mock_translate do
 
   it "detects multiple languages in an array" do
     mock = Minitest::Mock.new
-    detections_resource = Google::Cloud::Translate::Service::API::DetectionsResource.new confidence: 0.123, language: "en", is_reliable: false
-    detections_resource_2 = Google::Cloud::Translate::Service::API::DetectionsResource.new confidence: 0.123, language: "es", is_reliable: false
-    list_detections_resource = Google::Cloud::Translate::Service::API::ListDetectionsResponse.new detections: [[detections_resource], [detections_resource_2]]
-    mock.expect :list_detections, list_detections_resource, [["Hello", "Hola"]]
+    detections_resource = { confidence: 0.123, language: "en", isReliable: false }
+    detections_resource_2 = { confidence: 0.123, language: "es", isReliable: false }
+    list_detections_resource = JSON.parse({ detections: [[detections_resource], [detections_resource_2]] }.to_json)
+    mock.expect :detect, list_detections_resource, [["Hello", "Hola"]]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     detections = translate.detect ["Hello", "Hola"]
     mock.verify
 

--- a/google-cloud-translate/test/google/cloud/translate/languages_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/languages_test.rb
@@ -17,11 +17,11 @@ require "helper"
 describe Google::Cloud::Translate::Api, :languages, :mock_translate do
   it "lists languages without a language" do
     mock = Minitest::Mock.new
-    languages_resource = Google::Cloud::Translate::Service::API::LanguagesResource.new language: "af", name: nil
-    list_languages_resource = Google::Cloud::Translate::Service::API::ListLanguagesResponse.new languages: [languages_resource]
-    mock.expect :list_languages, list_languages_resource, [{target: nil}]
+    languages_resource = { language: "af", name: nil }
+    list_languages_resource = JSON.parse({ languages: [languages_resource] }.to_json)
+    mock.expect :languages, list_languages_resource, [nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     languages = translate.languages
     mock.verify
 
@@ -32,11 +32,11 @@ describe Google::Cloud::Translate::Api, :languages, :mock_translate do
 
   it "lists languages with a language" do
     mock = Minitest::Mock.new
-    languages_resource = Google::Cloud::Translate::Service::API::LanguagesResource.new language: "af", name: "Afrikaans"
-    list_languages_resource = Google::Cloud::Translate::Service::API::ListLanguagesResponse.new languages: [languages_resource]
-    mock.expect :list_languages, list_languages_resource, [{target: "en"}]
+    languages_resource = { language: "af", name: "Afrikaans" }
+    list_languages_resource = JSON.parse({ languages: [languages_resource] }.to_json)
+    mock.expect :languages, list_languages_resource, ["en"]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     languages = translate.languages "en"
     mock.verify
 

--- a/google-cloud-translate/test/google/cloud/translate/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/translate_test.rb
@@ -25,11 +25,11 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates a single input" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Hola"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource]
-    mock.expect :list_translations, list_translations_resource, [["Hello"], "es", {cid: nil, format: nil, source: nil}]
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", from: nil, format: nil, cid: nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translation = translate.translate "Hello", to: "es"
     mock.verify
 
@@ -45,11 +45,11 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates a single input with from" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new translated_text: "Hola"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource]
-    mock.expect :list_translations, list_translations_resource, [["Hello"], "es", {cid: nil, format: nil, source: "en"}]
+    translations_resource = { translatedText: "Hola" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", cid: nil, format: nil, from: "en"]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translation = translate.translate "Hello", to: "es", from: :en
     mock.verify
 
@@ -65,11 +65,11 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates a single input with format" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "<h1>Hola</h1>"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource]
-    mock.expect :list_translations, list_translations_resource, [["<h1>Hello</h1>"], "es", {cid: nil, format: "html", source: nil}]
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "<h1>Hola</h1>" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource] }.to_json)
+    mock.expect :translate, list_translations_resource, [["<h1>Hello</h1>"], to: "es", cid: nil, format: "html", from: nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translation = translate.translate "<h1>Hello</h1>", to: "es", format: :html
     mock.verify
 
@@ -85,11 +85,11 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates a single input with cid" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Hola"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource]
-    mock.expect :list_translations, list_translations_resource, [["Hello"], "es", {cid: "user-1234567899", format: nil, source: nil}]
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", cid: "user-1234567899", format: nil, from: nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translation = translate.translate "Hello", to: "es", cid: "user-1234567899"
     mock.verify
 
@@ -105,12 +105,12 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates multiple inputs" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Hola"
-    translations_resource_2 = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Como estas hoy?"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource, translations_resource_2]
-    mock.expect :list_translations, list_translations_resource, [["Hello", "How are you today?"], "es", {cid: nil, format: nil, source: nil}]
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
+    translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: nil, format: nil, from: nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translations = translate.translate "Hello", "How are you today?", to: "es"
     mock.verify
 
@@ -137,12 +137,12 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates multiple inputs in an array" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Hola"
-    translations_resource_2 = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Como estas hoy?"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource, translations_resource_2]
-    mock.expect :list_translations, list_translations_resource, [["Hello", "How are you today?"], "es", {cid: nil, format: nil, source: nil}]
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
+    translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: nil, format: nil, from: nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translations = translate.translate ["Hello", "How are you today?"], to: "es"
     mock.verify
 
@@ -169,12 +169,12 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates multiple inputs with from" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new translated_text: "Hola"
-    translations_resource_2 = Google::Cloud::Translate::Service::API::TranslationsResource.new translated_text: "Como estas hoy?"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource, translations_resource_2]
-    mock.expect :list_translations, list_translations_resource, [["Hello", "How are you today?"], "es", {cid: nil, format: nil, source: "en"}]
+    translations_resource = { translatedText: "Hola" }
+    translations_resource_2 = { translatedText: "Como estas hoy?" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: nil, format: nil, from: "en"]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translations = translate.translate "Hello", "How are you today?", to: :es, from: :en
     mock.verify
 
@@ -201,12 +201,12 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates multiple inputs in an array with from" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new translated_text: "Hola"
-    translations_resource_2 = Google::Cloud::Translate::Service::API::TranslationsResource.new translated_text: "Como estas hoy?"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource, translations_resource_2]
-    mock.expect :list_translations, list_translations_resource, [["Hello", "How are you today?"], "es", {cid: nil, format: nil, source: "en"}]
+    translations_resource = { translatedText: "Hola" }
+    translations_resource_2 = { translatedText: "Como estas hoy?" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: nil, format: nil, from: "en"]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translations = translate.translate ["Hello", "How are you today?"], to: :es, from: :en
     mock.verify
 
@@ -233,12 +233,12 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates multiple inputs with format" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "<h1>Hola</h1>"
-    translations_resource_2 = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Como estas <em>hoy</em>?"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource, translations_resource_2]
-    mock.expect :list_translations, list_translations_resource, [["<h1>Hello</h1>", "How are <em>you</em> today?"], "es", {cid: nil, format: "html", source: nil}]
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "<h1>Hola</h1>" }
+    translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas <em>hoy</em>?" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["<h1>Hello</h1>", "How are <em>you</em> today?"], to: "es", cid: nil, format: "html", from: nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translations = translate.translate "<h1>Hello</h1>", "How are <em>you</em> today?", to: "es", format: :html
     mock.verify
 
@@ -265,12 +265,12 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates multiple inputs in an array with format" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "<h1>Hola</h1>"
-    translations_resource_2 = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Como estas <em>hoy</em>?"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource, translations_resource_2]
-    mock.expect :list_translations, list_translations_resource, [["<h1>Hello</h1>", "How are <em>you</em> today?"], "es", {cid: nil, format: "html", source: nil}]
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "<h1>Hola</h1>" }
+    translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas <em>hoy</em>?" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["<h1>Hello</h1>", "How are <em>you</em> today?"], to: "es", cid: nil, format: "html", from: nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translations = translate.translate ["<h1>Hello</h1>", "How are <em>you</em> today?"], to: "es", format: :html
     mock.verify
 
@@ -297,12 +297,12 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates multiple inputs with cid" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Hola"
-    translations_resource_2 = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Como estas hoy?"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource, translations_resource_2]
-    mock.expect :list_translations, list_translations_resource, [["Hello", "How are you today?"], "es", {cid: "user-1234567899", format: nil, source: nil}]
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
+    translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: "user-1234567899", format: nil, from: nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translations = translate.translate "Hello", "How are you today?", to: "es", cid: "user-1234567899"
     mock.verify
 
@@ -329,12 +329,12 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
 
   it "translates multiple inputs in an array with cid" do
     mock = Minitest::Mock.new
-    translations_resource = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Hola"
-    translations_resource_2 = Google::Cloud::Translate::Service::API::TranslationsResource.new detected_source_language: "en", translated_text: "Como estas hoy?"
-    list_translations_resource = Google::Cloud::Translate::Service::API::ListTranslationsResponse.new translations: [translations_resource, translations_resource_2]
-    mock.expect :list_translations, list_translations_resource, [["Hello", "How are you today?"], "es", {cid: "user-1234567899", format: nil, source: nil}]
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
+    translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: "user-1234567899", format: nil, from: nil]
 
-    translate.service.mocked_service = mock
+    translate.service = mock
     translations = translate.translate ["Hello", "How are you today?"], to: "es", cid: "user-1234567899"
     mock.verify
 

--- a/google-cloud-translate/test/google/cloud/translate/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/translate_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     mock = Minitest::Mock.new
     translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
     list_translations_resource = JSON.parse({ translations: [translations_resource] }.to_json)
-    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", from: nil, format: nil, cid: nil]
+    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", from: nil, format: nil, model: nil, cid: nil]
 
     translate.service = mock
     translation = translate.translate "Hello", to: "es"
@@ -40,6 +40,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translation.target.must_equal "es"
     translation.from.must_equal "en"
     translation.source.must_equal "en"
+    translation.model.must_be :nil?
     translation.must_be :detected?
   end
 
@@ -47,7 +48,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     mock = Minitest::Mock.new
     translations_resource = { translatedText: "Hola" }
     list_translations_resource = JSON.parse({ translations: [translations_resource] }.to_json)
-    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", cid: nil, format: nil, from: "en"]
+    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", model: nil, cid: nil, format: nil, from: "en"]
 
     translate.service = mock
     translation = translate.translate "Hello", to: "es", from: :en
@@ -60,6 +61,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translation.target.must_equal "es"
     translation.from.must_equal "en"
     translation.source.must_equal "en"
+    translation.model.must_be :nil?
     translation.wont_be :detected?
   end
 
@@ -67,7 +69,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     mock = Minitest::Mock.new
     translations_resource = { detectedSourceLanguage: "en", translatedText: "<h1>Hola</h1>" }
     list_translations_resource = JSON.parse({ translations: [translations_resource] }.to_json)
-    mock.expect :translate, list_translations_resource, [["<h1>Hello</h1>"], to: "es", cid: nil, format: "html", from: nil]
+    mock.expect :translate, list_translations_resource, [["<h1>Hello</h1>"], to: "es", model: nil, cid: nil, format: "html", from: nil]
 
     translate.service = mock
     translation = translate.translate "<h1>Hello</h1>", to: "es", format: :html
@@ -80,6 +82,28 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translation.target.must_equal "es"
     translation.from.must_equal "en"
     translation.source.must_equal "en"
+    translation.model.must_be :nil?
+    translation.must_be :detected?
+  end
+
+  it "translates a single input with model" do
+    mock = Minitest::Mock.new
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola", model: "nmt" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", format: nil, from: nil, model: :nmt, cid: nil]
+
+    translate.service = mock
+    translation = translate.translate "Hello", to: "es", model: :nmt
+    mock.verify
+
+    translation.text.must_equal "Hola"
+    translation.origin.must_equal "Hello"
+    translation.to.must_equal "es"
+    translation.language.must_equal "es"
+    translation.target.must_equal "es"
+    translation.from.must_equal "en"
+    translation.source.must_equal "en"
+    translation.model.must_equal "nmt"
     translation.must_be :detected?
   end
 
@@ -87,7 +111,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     mock = Minitest::Mock.new
     translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
     list_translations_resource = JSON.parse({ translations: [translations_resource] }.to_json)
-    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", cid: "user-1234567899", format: nil, from: nil]
+    mock.expect :translate, list_translations_resource, [["Hello"], to: "es", cid: "user-1234567899", format: nil, from: nil, model: nil]
 
     translate.service = mock
     translation = translate.translate "Hello", to: "es", cid: "user-1234567899"
@@ -100,6 +124,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translation.target.must_equal "es"
     translation.from.must_equal "en"
     translation.source.must_equal "en"
+    translation.model.must_be :nil?
     translation.must_be :detected?
   end
 
@@ -108,7 +133,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
     translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?" }
     list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
-    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: nil, format: nil, from: nil]
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", model: nil, cid: nil, format: nil, from: nil]
 
     translate.service = mock
     translations = translate.translate "Hello", "How are you today?", to: "es"
@@ -123,6 +148,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
+    translations.first.model.must_be :nil?
     translations.first.must_be :detected?
 
     translations.last.text.must_equal "Como estas hoy?"
@@ -132,6 +158,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
+    translations.last.model.must_be :nil?
     translations.last.must_be :detected?
   end
 
@@ -140,7 +167,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
     translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?" }
     list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
-    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: nil, format: nil, from: nil]
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", model: nil, cid: nil, format: nil, from: nil]
 
     translate.service = mock
     translations = translate.translate ["Hello", "How are you today?"], to: "es"
@@ -155,6 +182,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
+    translations.first.model.must_be :nil?
     translations.first.must_be :detected?
 
     translations.last.text.must_equal "Como estas hoy?"
@@ -164,6 +192,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
+    translations.last.model.must_be :nil?
     translations.last.must_be :detected?
   end
 
@@ -172,7 +201,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations_resource = { translatedText: "Hola" }
     translations_resource_2 = { translatedText: "Como estas hoy?" }
     list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
-    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: nil, format: nil, from: "en"]
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", model: nil, cid: nil, format: nil, from: "en"]
 
     translate.service = mock
     translations = translate.translate "Hello", "How are you today?", to: :es, from: :en
@@ -187,6 +216,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
+    translations.first.model.must_be :nil?
     translations.first.wont_be :detected?
 
     translations.last.text.must_equal "Como estas hoy?"
@@ -196,6 +226,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
+    translations.last.model.must_be :nil?
     translations.last.wont_be :detected?
   end
 
@@ -204,7 +235,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations_resource = { translatedText: "Hola" }
     translations_resource_2 = { translatedText: "Como estas hoy?" }
     list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
-    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: nil, format: nil, from: "en"]
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", model: nil, cid: nil, format: nil, from: "en"]
 
     translate.service = mock
     translations = translate.translate ["Hello", "How are you today?"], to: :es, from: :en
@@ -219,6 +250,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
+    translations.first.model.must_be :nil?
     translations.first.wont_be :detected?
 
     translations.last.text.must_equal "Como estas hoy?"
@@ -228,6 +260,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
+    translations.last.model.must_be :nil?
     translations.last.wont_be :detected?
   end
 
@@ -236,7 +269,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations_resource = { detectedSourceLanguage: "en", translatedText: "<h1>Hola</h1>" }
     translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas <em>hoy</em>?" }
     list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
-    mock.expect :translate, list_translations_resource, [["<h1>Hello</h1>", "How are <em>you</em> today?"], to: "es", cid: nil, format: "html", from: nil]
+    mock.expect :translate, list_translations_resource, [["<h1>Hello</h1>", "How are <em>you</em> today?"], to: "es", model: nil, cid: nil, format: "html", from: nil]
 
     translate.service = mock
     translations = translate.translate "<h1>Hello</h1>", "How are <em>you</em> today?", to: "es", format: :html
@@ -251,6 +284,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
+    translations.first.model.must_be :nil?
     translations.first.must_be :detected?
 
     translations.last.text.must_equal "Como estas <em>hoy</em>?"
@@ -260,6 +294,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
+    translations.last.model.must_be :nil?
     translations.last.must_be :detected?
   end
 
@@ -268,7 +303,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations_resource = { detectedSourceLanguage: "en", translatedText: "<h1>Hola</h1>" }
     translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas <em>hoy</em>?" }
     list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
-    mock.expect :translate, list_translations_resource, [["<h1>Hello</h1>", "How are <em>you</em> today?"], to: "es", cid: nil, format: "html", from: nil]
+    mock.expect :translate, list_translations_resource, [["<h1>Hello</h1>", "How are <em>you</em> today?"], to: "es", model: nil, cid: nil, format: "html", from: nil]
 
     translate.service = mock
     translations = translate.translate ["<h1>Hello</h1>", "How are <em>you</em> today?"], to: "es", format: :html
@@ -283,6 +318,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
+    translations.first.model.must_be :nil?
     translations.first.must_be :detected?
 
     translations.last.text.must_equal "Como estas <em>hoy</em>?"
@@ -292,6 +328,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
+    translations.last.model.must_be :nil?
     translations.last.must_be :detected?
   end
 
@@ -300,7 +337,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
     translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?" }
     list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
-    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: "user-1234567899", format: nil, from: nil]
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: "user-1234567899", format: nil, from: nil, model: nil]
 
     translate.service = mock
     translations = translate.translate "Hello", "How are you today?", to: "es", cid: "user-1234567899"
@@ -315,6 +352,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
+    translations.first.model.must_be :nil?
     translations.first.must_be :detected?
 
     translations.last.text.must_equal "Como estas hoy?"
@@ -324,6 +362,75 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
+    translations.last.model.must_be :nil?
+    translations.last.must_be :detected?
+  end
+
+  it "translates multiple inputs in an array with model" do
+    mock = Minitest::Mock.new
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
+    translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?", model: "nmt" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", format: nil, from: nil, model: "base", cid: nil]
+
+    translate.service = mock
+    translations = translate.translate ["Hello", "How are you today?"], to: "es", model: "base"
+    mock.verify
+
+    translations.count.must_equal 2
+
+    translations.first.text.must_equal "Hola"
+    translations.first.origin.must_equal "Hello"
+    translations.first.to.must_equal "es"
+    translations.first.language.must_equal "es"
+    translations.first.target.must_equal "es"
+    translations.first.from.must_equal "en"
+    translations.first.source.must_equal "en"
+    translations.first.model.must_be :nil?
+    translations.first.must_be :detected?
+
+    translations.last.text.must_equal "Como estas hoy?"
+    translations.last.origin.must_equal "How are you today?"
+    translations.last.to.must_equal "es"
+    translations.last.language.must_equal "es"
+    translations.last.target.must_equal "es"
+    translations.last.from.must_equal "en"
+    translations.last.source.must_equal "en"
+    translations.last.model.must_equal "nmt"
+    translations.last.must_be :detected?
+  end
+
+  it "translates multiple inputs with model" do
+    mock = Minitest::Mock.new
+    translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola", model: "base" }
+    translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?", model: "nmt" }
+    list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", format: nil, from: nil, model: :nmt, cid: nil]
+
+    translate.service = mock
+    translations = translate.translate "Hello", "How are you today?", to: "es", model: :nmt
+    mock.verify
+
+    translations.count.must_equal 2
+
+    translations.first.text.must_equal "Hola"
+    translations.first.origin.must_equal "Hello"
+    translations.first.to.must_equal "es"
+    translations.first.language.must_equal "es"
+    translations.first.target.must_equal "es"
+    translations.first.from.must_equal "en"
+    translations.first.source.must_equal "en"
+    translations.first.model.must_equal "base"
+    translations.first.must_be :detected?
+
+    translations.last.text.must_equal "Como estas hoy?"
+    translations.last.origin.must_equal "How are you today?"
+    translations.last.to.must_equal "es"
+    translations.last.language.must_equal "es"
+    translations.last.target.must_equal "es"
+    translations.last.from.must_equal "en"
+    translations.last.source.must_equal "en"
+    translations.last.model.must_equal "nmt"
     translations.last.must_be :detected?
   end
 
@@ -332,7 +439,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations_resource = { detectedSourceLanguage: "en", translatedText: "Hola" }
     translations_resource_2 = { detectedSourceLanguage: "en", translatedText: "Como estas hoy?" }
     list_translations_resource = JSON.parse({ translations: [translations_resource, translations_resource_2] }.to_json)
-    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: "user-1234567899", format: nil, from: nil]
+    mock.expect :translate, list_translations_resource, [["Hello", "How are you today?"], to: "es", cid: "user-1234567899", format: nil, from: nil, model: nil]
 
     translate.service = mock
     translations = translate.translate ["Hello", "How are you today?"], to: "es", cid: "user-1234567899"
@@ -347,6 +454,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
+    translations.first.model.must_be :nil?
     translations.first.must_be :detected?
 
     translations.last.text.must_equal "Como estas hoy?"
@@ -356,6 +464,7 @@ describe Google::Cloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
+    translations.last.model.must_be :nil?
     translations.last.must_be :detected?
   end
 end

--- a/google-cloud-translate/test/google/cloud/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate_test.rb
@@ -19,8 +19,28 @@ describe Google::Cloud do
   describe "#translate" do
     it "calls out to Google::Cloud.translate" do
       gcloud = Google::Cloud.new
-      stubbed_translate = ->(key, retries: nil, timeout: nil) {
+      stubbed_translate = ->(key, project: nil, keyfile: nil, scope: nil, retries: nil, timeout: nil) {
+        project.must_be :nil?
+        keyfile.must_be :nil?
+        key.must_be :nil?
+        scope.must_be :nil?
+        retries.must_be :nil?
+        timeout.must_be :nil?
+        "translate-project-object-empty"
+      }
+      Google::Cloud.stub :translate, stubbed_translate do
+        project = gcloud.translate
+        project.must_equal "translate-project-object-empty"
+      end
+    end
+
+    it "passes key to Google::Cloud.translate" do
+      gcloud = Google::Cloud.new
+      stubbed_translate = ->(key, project: nil, keyfile: nil, scope: nil, retries: nil, timeout: nil) {
         key.must_equal "this-is-the-api-key"
+        project.must_be :nil?
+        keyfile.must_be :nil?
+        scope.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
         "translate-api-object-empty"
@@ -31,44 +51,73 @@ describe Google::Cloud do
       end
     end
 
+    it "passes key and options to Google::Cloud.translate" do
+      gcloud = Google::Cloud.new
+      stubbed_translate = ->(key, project: nil, keyfile: nil, scope: nil, retries: nil, timeout: nil) {
+        key.must_equal "this-is-the-api-key"
+        project.must_be :nil?
+        keyfile.must_be :nil?
+        scope.must_be :nil?
+        retries.must_equal 5
+        timeout.must_equal 60
+        "translate-api-object-empty"
+      }
+      Google::Cloud.stub :translate, stubbed_translate do
+        api = gcloud.translate "this-is-the-api-key", retries: 5, timeout: 60
+        api.must_equal "translate-api-object-empty"
+      end
+    end
+
     it "passes project and keyfile to Google::Cloud.translate" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_translate = ->(key, retries: nil, timeout: nil) {
-        key.must_equal "this-is-the-api-key"
+      stubbed_translate = ->(key, project: nil, keyfile: nil, scope: nil, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        keyfile.must_equal "keyfile-path"
+        scope.must_be :nil?
+        key.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
         "translate-api-object"
       }
       Google::Cloud.stub :translate, stubbed_translate do
-        api = gcloud.translate "this-is-the-api-key"
+        api = gcloud.translate
         api.must_equal "translate-api-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.translate" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_translate = ->(key, retries: nil, timeout: nil) {
-        key.must_equal "this-is-the-api-key"
+      stubbed_translate = ->(key, project: nil, keyfile: nil, scope: nil, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        keyfile.must_equal "keyfile-path"
+        scope.must_be :nil?
+        key.must_be :nil?
         retries.must_equal 5
         timeout.must_equal 60
         "translate-api-object-scoped"
       }
       Google::Cloud.stub :translate, stubbed_translate do
-        api = gcloud.translate "this-is-the-api-key", retries: 5, timeout: 60
+        api = gcloud.translate retries: 5, timeout: 60
         api.must_equal "translate-api-object-scoped"
       end
     end
   end
 
   describe ".translate" do
-    it "gets defaults for api_key" do
+    let(:default_credentials) { OpenStruct.new empty: true }
+    let(:found_credentials) { "{}" }
+
+    it "gets defaults for api key" do
       stubbed_env = ->(name) {
         "found-api-key" if name == "GOOGLE_CLOUD_KEY"
       }
-      stubbed_service = ->(key, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
         key.must_equal "found-api-key"
-        retries.must_equal nil
-        timeout.must_equal nil
+        project.must_be :empty?
+        keyfile.must_be :nil?
+        scope.must_be :nil?
+        retries.must_be :nil?
+        timeout.must_be :nil?
         OpenStruct.new key: key
       }
 
@@ -84,11 +133,14 @@ describe Google::Cloud do
       end
     end
 
-    it "uses provided project_id and keyfile" do
-      stubbed_service = ->(key, retries: nil, timeout: nil) {
+    it "uses provided api key" do
+      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
         key.must_equal "my-api-key"
-        retries.must_equal nil
-        timeout.must_equal nil
+        project.must_be :empty?
+        keyfile.must_be :nil?
+        scope.must_be :nil?
+        retries.must_be :nil?
+        timeout.must_be :nil?
         OpenStruct.new key: key
       }
 
@@ -102,17 +154,71 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "gets defaults for project_id and keyfile" do
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
+          Google::Cloud::Translate::Credentials.stub :default, default_credentials do
+            translate = Google::Cloud.translate
+            translate.must_be_kind_of Google::Cloud::Translate::Api
+            translate.project.must_equal "project-id"
+            translate.service.credentials.must_equal default_credentials
+          end
+        end
+      end
+    end
+
+    it "uses provided project_id and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "translate-credentials"
+      }
+      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
+        project.must_equal "project-id"
+        keyfile.must_equal "translate-credentials"
+        scope.must_be :nil?
+        key.must_be :nil?
+        retries.must_be :nil?
+        timeout.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Translate::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Translate::Service.stub :new, stubbed_service do
+                translate = Google::Cloud.translate project: "project-id", keyfile: "path/to/keyfile.json"
+                translate.must_be_kind_of Google::Cloud::Translate::Api
+                translate.project.must_equal "project-id"
+                translate.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "Translate.new" do
-    it "gets defaults for api_key" do
+    let(:default_credentials) { OpenStruct.new empty: true }
+    let(:found_credentials) { "{}" }
+
+    it "gets defaults for api key" do
       stubbed_env = ->(name) {
         "found-api-key" if name == "GOOGLE_CLOUD_KEY"
       }
-      stubbed_service = ->(key, retries: nil, timeout: nil) {
+      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
         key.must_equal "found-api-key"
-        retries.must_equal nil
-        timeout.must_equal nil
+        project.must_be :empty?
+        keyfile.must_be :nil?
+        scope.must_be :nil?
+        retries.must_be :nil?
+        timeout.must_be :nil?
         OpenStruct.new key: key
       }
 
@@ -128,11 +234,14 @@ describe Google::Cloud do
       end
     end
 
-    it "uses provided project_id and keyfile" do
-      stubbed_service = ->(key, retries: nil, timeout: nil) {
+    it "uses provided api key" do
+      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
         key.must_equal "my-api-key"
-        retries.must_equal nil
-        timeout.must_equal nil
+        project.must_be :empty?
+        keyfile.must_be :nil?
+        scope.must_be :nil?
+        retries.must_be :nil?
+        timeout.must_be :nil?
         OpenStruct.new key: key
       }
 
@@ -143,6 +252,54 @@ describe Google::Cloud do
           translate.must_be_kind_of Google::Cloud::Translate::Api
           translate.service.must_be_kind_of OpenStruct
           translate.service.key.must_equal "my-api-key"
+        end
+      end
+    end
+
+    it "gets defaults for project_id and keyfile" do
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
+          Google::Cloud::Translate::Credentials.stub :default, default_credentials do
+            translate = Google::Cloud::Translate.new
+            translate.must_be_kind_of Google::Cloud::Translate::Api
+            translate.project.must_equal "project-id"
+            translate.service.credentials.must_equal default_credentials
+          end
+        end
+      end
+    end
+
+    it "uses provided project_id and keyfile" do
+      stubbed_credentials = ->(keyfile, scope: nil) {
+        keyfile.must_equal "path/to/keyfile.json"
+        scope.must_be :nil?
+        "translate-credentials"
+      }
+      stubbed_service = ->(project, credentials, scope: nil, key: nil, retries: nil, timeout: nil) {
+        project.must_equal "project-id"
+        credentials.must_equal "translate-credentials"
+        scope.must_be :nil?
+        key.must_be :nil?
+        retries.must_be :nil?
+        timeout.must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        File.stub :file?, true, ["path/to/keyfile.json"] do
+          File.stub :read, found_credentials, ["path/to/keyfile.json"] do
+            Google::Cloud::Translate::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::Translate::Service.stub :new, stubbed_service do
+                translate = Google::Cloud::Translate.new project: "project-id", keyfile: "path/to/keyfile.json"
+                translate.must_be_kind_of Google::Cloud::Translate::Api
+                translate.project.must_equal "project-id"
+                translate.service.must_be_kind_of OpenStruct
+              end
+            end
+          end
         end
       end
     end

--- a/google-cloud-translate/test/helper.rb
+++ b/google-cloud-translate/test/helper.rb
@@ -21,23 +21,10 @@ require "json"
 require "base64"
 require "google/cloud/translate"
 
-##
-# Monkey-Patch Google API Client to support Mocks
-module Google::Apis::Core::Hashable
-  ##
-  # Minitest Mock depends on === to match same-value objects.
-  # By default, the Google API Client objects do not match with ===.
-  # Therefore, we must add this capability.
-  # This module seems like as good a place as any...
-  def === other
-    return(to_h === other.to_h) if other.respond_to? :to_h
-    super
-  end
-end
-
 class MockTranslate < Minitest::Spec
-  let(:key) { "test-api-key" }
-  let(:translate) { Google::Cloud::Translate::Api.new(Google::Cloud::Translate::Service.new(key)) }
+  let(:project) { "test" }
+  let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
+  let(:translate) { Google::Cloud::Translate::Api.new(Google::Cloud::Translate::Service.new(project, credentials)) }
 
   # Register this spec type for when :mock_translate is used.
   register_spec_type(self) do |desc, *addl|


### PR DESCRIPTION
Update translate gem to use the new API endpoint. This requires that we replace the use of Google API Client with custom code. But this allows us to accomplish the following:

- [x] Use new URL
- [x] Support service accounts using OAuth2
- [x] Switch to POST for all API calls
- [x] Add `model` argument and attribute