### PR TITLE
New CI tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ task :each, :bundleupdate do |t, args|
         header "RUBOCOP, JSONDOC, TESTS FOR #{gem}"
         sh "bundle exec rake rubocop"
         sh "bundle exec rake jsondoc"
+        sh "bundle exec rake doctest"
         sh "bundle exec rake test"
       end
     end

--- a/Rakefile
+++ b/Rakefile
@@ -655,6 +655,24 @@ task :ci, :bundleupdate do |t, args|
     end
   end
 end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests, for all gems."
+  task :acceptance, :bundleupdate do |t, args|
+    bundleupdate = args[:bundleupdate]
+    gems.each do |gem|
+      Dir.chdir gem do
+        Bundler.with_clean_env do
+          sh "bundle update" if bundleupdate
+          sh "bundle exec rake ci[yes]"
+        end
+      end
+    end
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
+  end
+end
 
 namespace :integration do
   desc "Run integration:gae for all gems"

--- a/Rakefile
+++ b/Rakefile
@@ -527,16 +527,9 @@ namespace :travis do
     gems.each do |gem|
       Dir.chdir gem do
         Bundler.with_clean_env do
-          header "BUILDING #{gem}"
           sh "bundle update"
-          header "#{gem} rubocop", "*"
-          run_task_if_exists "rubocop"
-          header "#{gem} jsondoc", "*"
-          run_task_if_exists "jsondoc"
-          header "#{gem} doctest", "*"
-          run_task_if_exists "doctest"
-          header "#{gem} test", "*"
-          sh "bundle exec rake test"
+          sh "bundle exec rake ci"
+
           if run_acceptance
             header "#{gem} acceptance", "*"
             sh "bundle exec rake acceptance -v"
@@ -628,8 +621,6 @@ namespace :appveyor do
     gems.each do |gem|
       Dir.chdir gem do
         Bundler.with_clean_env do
-          header "BUILDING #{gem}"
-
           # Fix acceptance/data symlinks on windows
           require "fileutils"
           FileUtils.mkdir_p "acceptance"
@@ -637,14 +628,8 @@ namespace :appveyor do
           sh "call mklink /j acceptance\\data ..\\acceptance\\data"
 
           sh "bundle update"
-          header "#{gem} rubocop", "*"
-          run_task_if_exists "rubocop"
-          header "#{gem} jsondoc", "*"
-          run_task_if_exists "jsondoc"
-          header "#{gem} doctest", "*"
-          run_task_if_exists "doctest"
-          header "#{gem} test", "*"
-          sh "bundle exec rake test"
+          sh "bundle exec rake ci"
+
           if run_acceptance
             # Set the SSL certificate so connections can be made
             ENV["SSL_CERT_FILE"] = ssl_cert_file
@@ -653,6 +638,19 @@ namespace :appveyor do
             sh "bundle exec rake acceptance -v"
           end
         end
+      end
+    end
+  end
+end
+
+desc "Run the CI build for all gems."
+task :ci, :bundleupdate do |t, args|
+  bundleupdate = args[:bundleupdate]
+  gems.each do |gem|
+    Dir.chdir gem do
+      Bundler.with_clean_env do
+        sh "bundle update" if bundleupdate
+        sh "bundle exec rake ci"
       end
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -20,10 +20,15 @@ task :each, :bundleupdate do |t, args|
   gems.each do |gem|
     Dir.chdir gem do
       Bundler.with_clean_env do
-        header "RUBOCOP, JSONDOC, TESTS FOR #{gem}"
-        sh "bundle exec rake rubocop"
-        sh "bundle exec rake jsondoc"
-        sh "bundle exec rake doctest"
+        header "RUNNING #{gem}"
+        sh "bundle update" if bundleupdate
+        header "#{gem} rubocop", "*"
+        run_task_if_exists "rubocop"
+        header "#{gem} jsondoc", "*"
+        run_task_if_exists "jsondoc"
+        header "#{gem} doctest", "*"
+        run_task_if_exists "doctest"
+        header "#{gem} test", "*"
         sh "bundle exec rake test"
       end
     end

--- a/Rakefile
+++ b/Rakefile
@@ -538,7 +538,7 @@ namespace :travis do
       end
     end
     # Build coverage report
-    Rake::Task["test:coveralls"].invoke
+    Rake::Task["test:coveralls"].invoke if ENV["GCLOUD_BUILD_DOCS"] == "true"
   end
 
   desc "Runs post-build logic on Travis-CI."

--- a/Rakefile
+++ b/Rakefile
@@ -528,11 +528,11 @@ namespace :travis do
       Dir.chdir gem do
         Bundler.with_clean_env do
           sh "bundle update"
-          sh "bundle exec rake ci"
 
           if run_acceptance
-            header "#{gem} acceptance", "*"
-            sh "bundle exec rake acceptance -v"
+            sh "bundle exec rake ci:acceptance"
+          else
+            sh "bundle exec rake ci"
           end
         end
       end
@@ -628,14 +628,14 @@ namespace :appveyor do
           sh "call mklink /j acceptance\\data ..\\acceptance\\data"
 
           sh "bundle update"
-          sh "bundle exec rake ci"
 
           if run_acceptance
             # Set the SSL certificate so connections can be made
             ENV["SSL_CERT_FILE"] = ssl_cert_file
 
-            header "#{gem} acceptance", "*"
-            sh "bundle exec rake acceptance -v"
+            sh "bundle exec rake ci:acceptance"
+          else
+            sh "bundle exec rake ci"
           end
         end
       end
@@ -663,7 +663,7 @@ namespace :ci do
       Dir.chdir gem do
         Bundler.with_clean_env do
           sh "bundle update" if bundleupdate
-          sh "bundle exec rake ci[yes]"
+          sh "bundle exec rake ci:acceptance"
         end
       end
     end

--- a/gcloud/Rakefile
+++ b/gcloud/Rakefile
@@ -72,9 +72,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING gcloud"
   header "gcloud rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -84,9 +82,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "gcloud test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "gcloud acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/gcloud/Rakefile
+++ b/gcloud/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -23,19 +24,20 @@ namespace :test do
   end
 end
 
-desc "Runs acceptance tests."
+desc "Run acceptance tests."
 task :acceptance do
   puts "The gcloud gem does not have acceptance tests."
 end
 
 namespace :acceptance do
-  desc "Runs acceptance cleanup."
+  desc "Run acceptance cleanup."
   task :cleanup do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The gcloud gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -69,4 +71,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING gcloud"
+  header "gcloud rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "gcloud jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "gcloud doctest", "*"
+  sh "bundle exec rake doctest"
+  header "gcloud test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "gcloud acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the bigquery acceptance tests."
+desc "Run the bigquery acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["BIGQUERY_TEST_PROJECT"]
@@ -51,7 +52,7 @@ task :acceptance, :project, :keyfile do |t, args|
 end
 
 namespace :acceptance do
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -96,8 +97,9 @@ namespace :acceptance do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-bigquery gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -130,4 +132,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-bigquery"
+  header "google-cloud-bigquery rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-bigquery jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-bigquery doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-bigquery test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-bigquery acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -133,9 +133,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-bigquery"
   header "google-cloud-bigquery rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -145,9 +143,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-bigquery test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-bigquery acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-core/Rakefile
+++ b/google-cloud-core/Rakefile
@@ -71,9 +71,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-core"
   header "google-cloud-core rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -83,9 +81,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-core test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-core acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-core/Rakefile
+++ b/google-cloud-core/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -23,19 +24,20 @@ namespace :test do
   end
 end
 
-desc "Runs acceptance tests."
+desc "Run acceptance tests."
 task :acceptance do
   puts "The google-cloud-core gem does not have acceptance tests."
 end
 
 namespace :acceptance do
-  desc "Runs acceptance cleanup."
+  desc "Run acceptance cleanup."
   task :cleanup do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-core gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -68,4 +70,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-core"
+  header "google-cloud-core rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-core jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-core doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-core test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-core acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the datastore acceptance tests."
+desc "Run the datastore acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DATASTORE_TEST_PROJECT"]
@@ -48,7 +49,7 @@ task :acceptance, :project, :keyfile do |t, args|
 end
 
 namespace :acceptance do
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -60,15 +61,16 @@ namespace :acceptance do
     Rake::Task["acceptance"].invoke
   end
 
-  desc "Runs acceptance cleanup."
+  desc "Run acceptance cleanup."
   task :cleanup do
   end
 
   # TODO: Add a setup task to create indexes for the datastore
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-datastore gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -101,4 +103,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-datastore"
+  header "google-cloud-datastore rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-datastore jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-datastore doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-datastore test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-datastore acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -104,9 +104,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-datastore"
   header "google-cloud-datastore rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -116,9 +114,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-datastore test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-datastore acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -129,9 +129,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-dns"
   header "google-cloud-dns rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -141,9 +139,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-dns test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-dns acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the dns acceptance tests."
+desc "Run the dns acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DNS_TEST_PROJECT"]
@@ -48,7 +49,7 @@ task :acceptance, :project, :keyfile do |t, args|
 end
 
 namespace :acceptance do
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -92,7 +93,7 @@ namespace :acceptance do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
   sh "bundle exec yard doctest"
 end
@@ -127,4 +128,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-dns"
+  header "google-cloud-dns rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-dns jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-dns doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-dns test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-dns acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -16,37 +16,41 @@
 require "bundler/setup"
 require "bundler/gem_tasks"
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
   end
 end
 
-desc "Runs acceptance tests."
+desc "Run acceptance tests."
 task :acceptance do
   puts "The google-cloud-error_reporting gem does not have acceptance tests."
 end
 
 namespace :acceptance do
-  desc "Runs acceptance cleanup."
+  desc "Run acceptance cleanup."
   task :cleanup do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-error_reporting gem does not have doctest tests."
 end
 
+desc "Run rubocop."
 task :rubocop do
+  puts "The google-cloud-error_reporting gem does not use rubocop."
 end
 
 namespace :integration do
-  desc "Runs integration tests against GAE"
+  desc "Run integration tests against GAE"
   task :gae, :project_uri do |t, args|
     fail "You must provide a project_uri. e.g. rake " \
       "integration:gae[http://my-project.appspot.com]" if args[:project_uri].nil?
@@ -57,7 +61,7 @@ namespace :integration do
     Dir.glob("integration/gae/**/*_test.rb").each { |file| require_relative file }
   end
 
-  desc "Runs integration tests against GKE"
+  desc "Run integration tests against GKE"
   task :gke, :pod_name do |t, args|
     fail "You must provide the GKE pod name. e.g. " \
       "rake integration:gke[google-cloud-ruby-test]" if args[:pod_name].nil?
@@ -71,6 +75,17 @@ end
 
 desc "Start an interactive shell."
 task :console do
+  require "irb"
+  require "irb/completion"
+  require "pp"
+
+  $LOAD_PATH.unshift "lib"
+
+  require "google-cloud-error_reporting"
+  def gcloud; @gcloud ||= Google::Cloud.new; end
+
+  ARGV.clear
+  IRB.start
 end
 
 require "yard"
@@ -88,4 +103,32 @@ task :jsondoc => :yard do
   cp ["docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-error_reporting"
+  header "google-cloud-error_reporting rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-error_reporting jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-error_reporting doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-error_reporting test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-error_reporting acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -104,9 +104,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-error_reporting"
   header "google-cloud-error_reporting rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -116,9 +114,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-error_reporting test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-error_reporting acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the language acceptance tests."
+desc "Run the language acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["LANGUAGE_TEST_PROJECT"]
@@ -51,7 +52,7 @@ task :acceptance, :project, :keyfile do |t, args|
 end
 
 namespace :acceptance do
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -64,8 +65,9 @@ namespace :acceptance do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-language gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -98,4 +100,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-language"
+  header "google-cloud-language rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-language jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-language doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-language test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-language acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -101,9 +101,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-language"
   header "google-cloud-language rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -113,9 +111,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-language test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-language acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -152,9 +152,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-logging"
   header "google-cloud-logging rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -164,9 +162,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-logging test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-logging acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the logging acceptance tests."
+desc "Run the logging acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["LOGGING_TEST_PROJECT"]
@@ -48,7 +49,7 @@ task :acceptance, :project, :keyfile do |t, args|
 end
 
 namespace :acceptance do
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -91,12 +92,13 @@ namespace :acceptance do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-logging gem does not have doctest tests."
 end
 
 namespace :integration do
-  desc "Runs integration tests against GAE"
+  desc "Run integration tests against GAE"
   task :gae, :project_uri do |t, args|
     raise "You must provide a project_uri. e.g. rake " \
       "integration:gae[http://my-project.appspot.com]" if args[:project_uri].nil?
@@ -107,7 +109,7 @@ namespace :integration do
     Dir.glob("integration/gae/**/*_test.rb").each { |file| require_relative file }
   end
 
-  desc "Runs integration tests against GKE"
+  desc "Run integration tests against GKE"
   task :gke, :pod_name do |t, args|
     fail "You must provide the GKE pod name. e.g. " \
       "rake integration:gke[google-cloud-ruby-test]" if args[:pod_name].nil?
@@ -149,4 +151,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-logging"
+  header "google-cloud-logging rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-logging jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-logging doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-logging test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-logging acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-monitoring/Rakefile
+++ b/google-cloud-monitoring/Rakefile
@@ -69,9 +69,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-monitoring"
   header "google-cloud-monitoring rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -81,9 +79,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-monitoring test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-monitoring acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-monitoring/Rakefile
+++ b/google-cloud-monitoring/Rakefile
@@ -16,36 +16,41 @@
 require "bundler/setup"
 require "bundler/gem_tasks"
 
+desc "Run tests."
 task :test do
+  puts "The google-cloud-monitoring gem does not have tests."
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
   end
 end
 
 # Acceptance tests
-desc "Runs the monitoring acceptance tests."
+desc "Run the monitoring acceptance tests."
 task :acceptance do
   puts "The google-cloud-monitoring gem does not have acceptance tests."
 end
 
 namespace :acceptance do
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage do
   end
 
-  desc "Runs acceptance cleanup."
+  desc "Run acceptance cleanup."
   task :cleanup do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-monitoring gem does not have doctest tests."
 end
 
+desc "Run rubocop."
 task :rubocop do
+  puts "The google-cloud-monitoring gem does not use rubocop."
 end
 
 require "yard"
@@ -63,4 +68,32 @@ task :jsondoc => :yard do
   cp ["docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-monitoring"
+  header "google-cloud-monitoring rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-monitoring jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-monitoring doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-monitoring test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-monitoring acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the pubsub acceptance tests."
+desc "Run the pubsub acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["PUBSUB_TEST_PROJECT"]
@@ -48,7 +49,7 @@ task :acceptance, :project, :keyfile do |t, args|
 end
 
 namespace :acceptance do
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -87,8 +88,9 @@ namespace :acceptance do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-pubsub gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -121,4 +123,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-pubsub"
+  header "google-cloud-pubsub rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-pubsub jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-pubsub doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-pubsub test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-pubsub acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -124,9 +124,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-pubsub"
   header "google-cloud-pubsub rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -136,9 +134,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-pubsub test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-pubsub acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-resource_manager/Rakefile
+++ b/google-cloud-resource_manager/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -23,19 +24,20 @@ namespace :test do
   end
 end
 
-desc "Runs acceptance tests."
+desc "Run acceptance tests."
 task :acceptance do
   puts "The google-cloud-resource_manager gem does not have acceptance tests."
 end
 
 namespace :acceptance do
-  desc "Runs acceptance cleanup."
+  desc "Run acceptance cleanup."
   task :cleanup do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-resource_manager gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -68,4 +70,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-resource_manager"
+  header "google-cloud-resource_manager rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-resource_manager jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-resource_manager doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-resource_manager test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-resource_manager acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-resource_manager/Rakefile
+++ b/google-cloud-resource_manager/Rakefile
@@ -71,9 +71,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-resource_manager"
   header "google-cloud-resource_manager rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -83,9 +81,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-resource_manager test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-resource_manager acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the speech acceptance tests."
+desc "Run the speech acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["SPEECH_TEST_PROJECT"]
@@ -51,7 +52,7 @@ task :acceptance, :project, :keyfile do |t, args|
 end
 
 namespace :acceptance do
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -64,7 +65,7 @@ namespace :acceptance do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
   sh "bundle exec yard doctest"
 end
@@ -99,4 +100,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-speech"
+  header "google-cloud-speech rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-speech jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-speech doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-speech test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-speech acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -101,9 +101,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-speech"
   header "google-cloud-speech rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -113,9 +111,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-speech test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-speech acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the storage acceptance tests."
+desc "Run the storage acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["STORAGE_TEST_PROJECT"]
@@ -48,7 +49,7 @@ task :acceptance, :project, :keyfile do |t, args|
 end
 
 namespace :acceptance do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -95,8 +96,9 @@ namespace :acceptance do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-storage gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -129,4 +131,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-storage"
+  header "google-cloud-storage rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-storage jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-storage doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-storage test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-storage acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -132,9 +132,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-storage"
   header "google-cloud-storage rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -144,9 +142,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-storage test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-storage acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -132,9 +132,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-translate"
   header "google-cloud-translate rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -144,9 +142,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-translate test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-translate acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the translate acceptance tests."
+desc "Run the translate acceptance tests."
 task :acceptance, :project, :keyfile, :key do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["TRANSLATE_TEST_PROJECT"]
@@ -82,7 +83,7 @@ namespace :acceptance do
     Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
   end
 
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -95,7 +96,7 @@ namespace :acceptance do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
   sh "bundle exec yard doctest"
 end
@@ -130,4 +131,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-translate"
+  header "google-cloud-translate rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-translate jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-translate doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-translate test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-translate acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -101,9 +101,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud-vision"
   header "google-cloud-vision rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -113,9 +111,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud-vision test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud-vision acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -24,7 +25,7 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Runs the vision acceptance tests."
+desc "Run the vision acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["VISION_TEST_PROJECT"]
@@ -51,7 +52,7 @@ task :acceptance, :project, :keyfile do |t, args|
 end
 
 namespace :acceptance do
-  desc "Runs acceptance tests with coverage."
+  desc "Run acceptance tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     require "simplecov"
     SimpleCov.start do
@@ -64,8 +65,9 @@ namespace :acceptance do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-vision gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -98,4 +100,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud-vision"
+  header "google-cloud-vision rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-vision jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-vision doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-vision test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud-vision acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud/Rakefile
+++ b/google-cloud/Rakefile
@@ -4,13 +4,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -23,19 +24,20 @@ namespace :test do
   end
 end
 
-desc "Runs acceptance tests."
+desc "Run acceptance tests."
 task :acceptance do
   puts "The google-cloud gem does not have acceptance tests."
 end
 
 namespace :acceptance do
-  desc "Runs acceptance cleanup."
+  desc "Run acceptance cleanup."
   task :cleanup do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -69,4 +71,32 @@ task :jsondoc => :yard do
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING google-cloud"
+  header "google-cloud rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "google-cloud acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud/Rakefile
+++ b/google-cloud/Rakefile
@@ -72,9 +72,7 @@ task :jsondoc => :yard do
 end
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING google-cloud"
   header "google-cloud rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -84,9 +82,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "google-cloud test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "google-cloud acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -87,9 +87,7 @@ require "yard/rake/yardoc_task"
 YARD::Rake::YardocTask.new
 
 desc "Run the CI build"
-task :ci, :acceptance do |t, args|
-  run_acceptance = args[:acceptance]
-
+task :ci do
   header "BUILDING stackdriver"
   header "stackdriver rubocop", "*"
   sh "bundle exec rake rubocop"
@@ -99,9 +97,17 @@ task :ci, :acceptance do |t, args|
   sh "bundle exec rake doctest"
   header "stackdriver test", "*"
   sh "bundle exec rake test"
-  if run_acceptance
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
     header "stackdriver acceptance", "*"
     sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 

--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -19,13 +19,14 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
+desc "Run tests."
 task :test do
   $LOAD_PATH.unshift "lib", "test"
   Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Runs tests with coverage."
+  desc "Run tests with coverage."
   task :coverage do
     require "simplecov"
     SimpleCov.start do
@@ -38,18 +39,20 @@ namespace :test do
   end
 end
 
-desc "Runs acceptance tests."
+desc "Run acceptance tests."
 task :acceptance do
+  puts "The stackdriver gem does not have acceptance tests."
 end
 
 namespace :acceptance do
-  desc "Runs acceptance cleanup."
+  desc "Run acceptance cleanup."
   task :cleanup do
   end
 end
 
-desc "Runs yard-doctest example tests."
+desc "Run yard-doctest example tests."
 task :doctest do
+  puts "The stackdriver gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."
@@ -83,4 +86,32 @@ require "yard"
 require "yard/rake/yardoc_task"
 YARD::Rake::YardocTask.new
 
+desc "Run the CI build"
+task :ci, :acceptance do |t, args|
+  run_acceptance = args[:acceptance]
+
+  header "BUILDING stackdriver"
+  header "stackdriver rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "stackdriver jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "stackdriver doctest", "*"
+  sh "bundle exec rake doctest"
+  header "stackdriver test", "*"
+  sh "bundle exec rake test"
+  if run_acceptance
+    header "stackdriver acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+end
+
 task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end


### PR DESCRIPTION
This PR adds `rake ci` and `rake ci:acceptance` tasks to the top-level project as well as every individual cloud service project. We have found it desirable to run the CI tasks locally before creating a PR. But as we add more tasks, such as `rubocop`, `jsondoc`, `doctest`, etc, we sometimes forget to run one. The `rake ci` task will run all the same tasks that CI runs. The `rake ci:acceptance` task will also run all the same tasks that CI runs, as well as the acceptance tests.

This PR also limits the coveralls report to only be run once per build, instead of running on every job in the build.