### PR TITLE
Fix empty protobuf as return type

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_api.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_api.rb
@@ -389,6 +389,7 @@ module Google
               sink_name: sink_name
             }.delete_if { |_, v| v.nil? })
             @delete_sink.call(req, options)
+            nil
           end
         end
       end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_api.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_api.rb
@@ -234,6 +234,7 @@ module Google
               log_name: log_name
             }.delete_if { |_, v| v.nil? })
             @delete_log.call(req, options)
+            nil
           end
 
           # Writes log entries to Stackdriver Logging.  All log entries are

--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_api.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_api.rb
@@ -390,6 +390,7 @@ module Google
               metric_name: metric_name
             }.delete_if { |_, v| v.nil? })
             @delete_log_metric.call(req, options)
+            nil
           end
         end
       end

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_api.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_api.rb
@@ -421,6 +421,7 @@ module Google
               name: name
             }.delete_if { |_, v| v.nil? })
             @delete_group.call(req, options)
+            nil
           end
 
           # Lists the monitored resources that are members of a group.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_api.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_api.rb
@@ -505,6 +505,7 @@ module Google
               name: name
             }.delete_if { |_, v| v.nil? })
             @delete_metric_descriptor.call(req, options)
+            nil
           end
 
           # Lists time series that match a filter. This method does not require a Stackdriver account.
@@ -633,6 +634,7 @@ module Google
               time_series: time_series
             }.delete_if { |_, v| v.nil? })
             @create_time_series.call(req, options)
+            nil
           end
         end
       end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_api.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_api.rb
@@ -477,6 +477,7 @@ module Google
               topic: topic
             }.delete_if { |_, v| v.nil? })
             @delete_topic.call(req, options)
+            nil
           end
 
           # Sets the access control policy on the specified resource. Replaces any

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_api.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_api.rb
@@ -452,6 +452,7 @@ module Google
               subscription: subscription
             }.delete_if { |_, v| v.nil? })
             @delete_subscription.call(req, options)
+            nil
           end
 
           # Modifies the ack deadline for a specific message. This method is useful
@@ -496,6 +497,7 @@ module Google
               ack_deadline_seconds: ack_deadline_seconds
             }.delete_if { |_, v| v.nil? })
             @modify_ack_deadline.call(req, options)
+            nil
           end
 
           # Acknowledges the messages associated with the +ack_ids+ in the
@@ -534,6 +536,7 @@ module Google
               ack_ids: ack_ids
             }.delete_if { |_, v| v.nil? })
             @acknowledge.call(req, options)
+            nil
           end
 
           # Pulls messages from the server. Returns an empty list if there are no
@@ -620,6 +623,7 @@ module Google
               push_config: push_config
             }.delete_if { |_, v| v.nil? })
             @modify_push_config.call(req, options)
+            nil
           end
 
           # Sets the access control policy on the specified resource. Replaces any

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -60,7 +60,7 @@ describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
   end
 
   it "can acknowledge" do
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), [rec_message.ack_id], options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -71,7 +71,7 @@ describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
   end
 
   it "can ack" do
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), [rec_message.ack_id], options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -83,7 +83,7 @@ describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
 
   it "can delay" do
     new_deadline = 42
-    mad_res = Google::Protobuf::Empty.new
+    mad_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(subscription_name), [rec_message.ack_id], new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
   it "can acknowledge an ack id" do
     ack_id = rec_message1.ack_id
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [ack_id], options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -45,7 +45,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
   it "can acknowledge many ack ids" do
     ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -57,7 +57,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
   it "can acknowledge many ack ids in an array" do
     ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -68,7 +68,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
   end
 
   it "can acknowledge a message" do
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [rec_message1.ack_id], options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -81,7 +81,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
   it "can acknowledge many messages" do
     rec_messages  = [rec_message1, rec_message3, rec_message3]
     ack_ids = rec_messages.map(&:ack_id)
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -94,7 +94,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
   it "can acknowledge many messages in an array" do
     rec_messages  = [rec_message1, rec_message3, rec_message3]
     ack_ids = rec_messages.map(&:ack_id)
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -112,7 +112,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
     it "can acknowledge an ack id" do
       ack_id = rec_message1.ack_id
-      ack_res = Google::Protobuf::Empty.new
+      ack_res = nil
       mock = Minitest::Mock.new
       mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [ack_id], options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -124,7 +124,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
     it "can acknowledge many ack ids" do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
-      ack_res = Google::Protobuf::Empty.new
+      ack_res = nil
       mock = Minitest::Mock.new
       mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -136,7 +136,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
     it "can acknowledge many ack ids in an array" do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
-      ack_res = Google::Protobuf::Empty.new
+      ack_res = nil
       mock = Minitest::Mock.new
       mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -147,7 +147,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "can acknowledge a message" do
-      ack_res = Google::Protobuf::Empty.new
+      ack_res = nil
       mock = Minitest::Mock.new
       mock.expect :acknowledge, ack_res, [subscription_path(sub_name), [rec_message1.ack_id], options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -160,7 +160,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     it "can acknowledge many messages" do
       rec_messages  = [rec_message1, rec_message3, rec_message3]
       ack_ids = rec_messages.map(&:ack_id)
-      ack_res = Google::Protobuf::Empty.new
+      ack_res = nil
       mock = Minitest::Mock.new
       mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -173,7 +173,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :mock_pubsub do
     it "can acknowledge many messages in an array" do
       rec_messages  = [rec_message1, rec_message3, rec_message3]
       ack_ids = rec_messages.map(&:ack_id)
-      ack_res = Google::Protobuf::Empty.new
+      ack_res = nil
       mock = Minitest::Mock.new
       mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]
       subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -42,7 +42,7 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
   it "can update the endpoint" do
     new_push_endpoint = "https://foo.bar/baz"
     push_config = Google::Pubsub::V1::PushConfig.new(push_endpoint: new_push_endpoint)
-    mpc_res = Google::Protobuf::Empty.new
+    mpc_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_push_config, mpc_res, [subscription_path(sub_name), push_config, options: default_options]
     pubsub.service.mocked_subscriber = mock
@@ -97,7 +97,7 @@ describe Google::Cloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     it "makes an HTTP API call to update endpoint" do
       new_push_endpoint = "https://foo.bar/baz"
       push_config = Google::Pubsub::V1::PushConfig.new(push_endpoint: new_push_endpoint)
-      mpc_res = Google::Protobuf::Empty.new
+      mpc_res = nil
       mock = Minitest::Mock.new
       mock.expect :modify_push_config, mpc_res, [subscription_path(sub_name), push_config, options: default_options]
       pubsub.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delay_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
   it "can delay an ack id" do
     ack_id = rec_message1.ack_id
     new_deadline = 42
-    mad_res = Google::Protobuf::Empty.new
+    mad_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [ack_id], new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -44,7 +44,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
   it "can delay many ack ids" do
     ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
     new_deadline = 42
-    mad_res = Google::Protobuf::Empty.new
+    mad_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -57,7 +57,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
   it "can delay many ack ids in an array" do
     ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
     new_deadline = 42
-    mad_res = Google::Protobuf::Empty.new
+    mad_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -69,7 +69,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
 
   it "can delay a message" do
     new_deadline = 42
-    mad_res = Google::Protobuf::Empty.new
+    mad_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [rec_message1.ack_id], new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -82,7 +82,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
   it "can delay many messages" do
     rec_messages = [rec_message1, rec_message3, rec_message3]
     new_deadline = 42
-    mad_res = Google::Protobuf::Empty.new
+    mad_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -95,7 +95,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
   it "can delay many messages in an array" do
     rec_messages = [rec_message1, rec_message3, rec_message3]
     new_deadline = 42
-    mad_res = Google::Protobuf::Empty.new
+    mad_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -114,7 +114,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     it "can delay an ack id" do
       ack_id = rec_message1.ack_id
       new_deadline = 42
-      mad_res = Google::Protobuf::Empty.new
+      mad_res = nil
       mock = Minitest::Mock.new
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [ack_id], new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -127,7 +127,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     it "can delay many ack ids" do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
-      mad_res = Google::Protobuf::Empty.new
+      mad_res = nil
       mock = Minitest::Mock.new
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -140,7 +140,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     it "can delay many ack ids in an array" do
       ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
-      mad_res = Google::Protobuf::Empty.new
+      mad_res = nil
       mock = Minitest::Mock.new
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), ack_ids, new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -152,7 +152,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
 
     it "can delay a message" do
       new_deadline = 42
-      mad_res = Google::Protobuf::Empty.new
+      mad_res = nil
       mock = Minitest::Mock.new
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), [rec_message1.ack_id], new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -165,7 +165,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     it "can delay many messages" do
       rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
-      mad_res = Google::Protobuf::Empty.new
+      mad_res = nil
       mock = Minitest::Mock.new
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock
@@ -178,7 +178,7 @@ describe Google::Cloud::Pubsub::Subscription, :delay, :mock_pubsub do
     it "can delay many messages in an array" do
       rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
-      mad_res = Google::Protobuf::Empty.new
+      mad_res = nil
       mock = Minitest::Mock.new
       mock.expect :modify_ack_deadline, mad_res, [subscription_path(sub_name), rec_messages.map(&:ack_id), new_deadline, options: default_options]
       subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Pubsub::Subscription, :delete, :mock_pubsub do
   let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc sub_grpc, pubsub.service }
 
   it "can delete itself" do
-    del_res = Google::Protobuf::Empty.new
+    del_res = nil
     mock = Minitest::Mock.new
     mock.expect :delete_subscription, del_res, [subscription_path(sub_name), options: default_options]
     pubsub.service.mocked_subscriber = mock
@@ -40,7 +40,7 @@ describe Google::Cloud::Pubsub::Subscription, :delete, :mock_pubsub do
     end
 
     it "can delete itself" do
-      del_res = Google::Protobuf::Empty.new
+      del_res = nil
       mock = Minitest::Mock.new
       mock.expect :delete_subscription, del_res, [subscription_path(sub_name), options: default_options]
       pubsub.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_autoack_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_autoack_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Pubsub::Subscription, :pull, :autoack, :mock_pubsub do
 
   it "can auto acknowledge when pulling messages" do
     ack_ids = [rec_msg1.ack_id, rec_msg2.ack_id, rec_msg3.ack_id]
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     pull_res = Google::Pubsub::V1::PullResponse.decode_json rec_msgs_json
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(sub_name), ack_ids, options: default_options]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
@@ -41,7 +41,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
   it "can update the endpoint" do
     new_push_endpoint = "https://foo.bar/baz"
     push_config = Google::Pubsub::V1::PushConfig.new(push_endpoint: new_push_endpoint)
-    mpc_res = Google::Protobuf::Empty.new
+    mpc_res = nil
     mock = Minitest::Mock.new
     mock.expect :modify_push_config, mpc_res, [subscription_path(subscription_name), push_config, options: default_options]
     pubsub.service.mocked_subscriber = mock
@@ -52,7 +52,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "can delete itself" do
-    del_res = Google::Protobuf::Empty.new
+    del_res = nil
     mock = Minitest::Mock.new
     mock.expect :delete_subscription, del_res, [subscription_path(subscription_name), options: default_options]
     pubsub.service.mocked_subscriber = mock
@@ -78,7 +78,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "can acknowledge one message" do
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), ["ack-id-1"], options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -89,7 +89,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "can acknowledge many messages" do
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), ["ack-id-1", "ack-id-2", "ack-id-3"], options: default_options]
     subscription.service.mocked_subscriber = mock
@@ -100,7 +100,7 @@ describe Google::Cloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "can acknowledge with ack" do
-    ack_res = Google::Protobuf::Empty.new
+    ack_res = nil
     mock = Minitest::Mock.new
     mock.expect :acknowledge, ack_res, [subscription_path(subscription_name), ["ack-id-1"], options: default_options]
     subscription.service.mocked_subscriber = mock

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -36,7 +36,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
   end
 
   it "can delete itself" do
-    get_res = Google::Protobuf::Empty.new
+    get_res = nil
     mock = Minitest::Mock.new
     mock.expect :delete_topic, get_res, [topic_path(topic_name), options: default_options]
     pubsub.service.mocked_publisher = mock


### PR DESCRIPTION
Based on our usability study results, for those API returning google.protobuf.empty as the return type (Google::Protobuf::Empty), we should just return 'nil' to avoid exposing the low-level grpc details to the user.