### PR TITLE
Allow Speech language to be a Symbol

### DIFF
--- a/google-cloud-speech/acceptance/speech/async_test.rb
+++ b/google-cloud-speech/acceptance/speech/async_test.rb
@@ -113,6 +113,22 @@ describe "Asynchonous Recognition", :speech do
     results.first.alternatives.must_be :empty?
   end
 
+  it "recognizes audio from Audio object, preserving attributes, language (Symbol)" do
+    audio = speech.audio gcs_url, encoding: :raw, sample_rate: 16000, language: :en
+    job = speech.recognize_job audio
+
+    job.must_be_kind_of Google::Cloud::Speech::Job
+    job.wont_be :done?
+    job.wait_until_done!
+    job.must_be :done?
+
+    results = job.results
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+  end
+
   it "recognizes audio from Audio object, overriding attributes" do
     audio = speech.audio gcs_url, encoding: :flac, sample_rate: 48000, language: "es"
     job = speech.recognize_job audio, encoding: :raw, sample_rate: 16000, language: "en"

--- a/google-cloud-speech/acceptance/speech/stream_test.rb
+++ b/google-cloud-speech/acceptance/speech/stream_test.rb
@@ -227,7 +227,7 @@ describe "Streaming Recognition", :speech do
 
       results.count.must_equal 1
       results.first.transcript.must_equal "how old is the Brooklyn Bridge"
-      results.first.confidence.must_be_close_to 0.9545454382896423
+      results.first.confidence.must_be_close_to 0.98267895
       results.first.alternatives.must_be :empty?
 
       counters[:interim].must_equal 0
@@ -279,7 +279,7 @@ describe "Streaming Recognition", :speech do
 
       results.count.must_equal 1
       results.first.transcript.must_equal "how old is the Brooklyn Bridge"
-      results.first.confidence.must_be_close_to 0.9545454382896423
+      results.first.confidence.must_be_close_to 0.98267895
       results.first.alternatives.must_be :empty?
 
       counters[:interim].must_equal 0

--- a/google-cloud-speech/acceptance/speech/sync_test.rb
+++ b/google-cloud-speech/acceptance/speech/sync_test.rb
@@ -77,6 +77,16 @@ describe "Synchonous Recognition", :speech do
     results.first.alternatives.must_be :empty?
   end
 
+  it "recognizes audio from Audio object, preserving attributes, language (Symbol)" do
+    audio = speech.audio gcs_url
+    results = speech.recognize audio, encoding: :raw, sample_rate: 16000, language: :en
+
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+  end
+
   it "recognizes audio from Audio object, overriding attributes" do
     audio = speech.audio gcs_url, encoding: :flac, sample_rate: 48000, language: "es"
     results = speech.recognize audio, encoding: :raw, sample_rate: 16000, language: "en"

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -509,6 +509,7 @@ module Google
                          phrases: nil
           context = nil
           context = V1beta1::SpeechContext.new(phrases: phrases) if phrases
+          language = String(language) unless language.nil?
           V1beta1::RecognitionConfig.new({
             encoding: convert_encoding(encoding),
             sample_rate: sample_rate,

--- a/google-cloud-speech/test/google/cloud/speech/audio/recognize_job_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/recognize_job_test.rb
@@ -38,4 +38,22 @@ describe Google::Cloud::Speech::Audio, :recognize_job, :mock_speech do
     job.must_be_kind_of Google::Cloud::Speech::Job
     job.wont_be :done?
   end
+
+  it "recognizes audio job with language (Symbol)" do
+    config_grpc = Google::Cloud::Speech::V1beta1::RecognitionConfig.new(encoding: :LINEAR16, sample_rate: 16000, language_code: "en")
+
+    mock = Minitest::Mock.new
+    mock.expect :async_recognize, job_grpc, [config_grpc, audio_grpc, options: default_options]
+
+    audio.encoding = :raw
+    audio.sample_rate = 16000
+    audio.language = :en
+
+    speech.service.mocked_service = mock
+    job = audio.recognize_job
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Speech::Job
+    job.wont_be :done?
+  end
 end

--- a/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
@@ -41,4 +41,24 @@ describe Google::Cloud::Speech::Audio, :recognize, :mock_speech do
     results.first.confidence.must_be_close_to 0.98267895
     results.first.alternatives.must_be :empty?
   end
+
+  it "recognizes audio with language (Symbol)" do
+    config_grpc = Google::Cloud::Speech::V1beta1::RecognitionConfig.new(encoding: :LINEAR16, sample_rate: 16000, language_code: "en")
+
+    mock = Minitest::Mock.new
+    mock.expect :sync_recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
+
+    audio.encoding = :raw
+    audio.sample_rate = 16000
+    audio.language = :en
+
+    speech.service.mocked_service = mock
+    results = audio.recognize
+    mock.verify
+
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+  end
 end

--- a/google-cloud-speech/test/google/cloud/speech/project_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project_test.rb
@@ -29,5 +29,26 @@ describe Google::Cloud::Speech::Project, :mock_speech do
     audio.must_be_kind_of Google::Cloud::Speech::Audio
     audio.must_be :content?
     audio.wont_be :url?
+    audio.language.must_be :nil?
+  end
+
+  it "builds an audio from filepath and language (String) input" do
+    audio = speech.audio filepath, language: "en"
+
+    audio.wont_be :nil?
+    audio.must_be_kind_of Google::Cloud::Speech::Audio
+    audio.must_be :content?
+    audio.wont_be :url?
+    audio.language.wont_be :nil?
+  end
+
+  it "builds an audio from filepath and language (Symbol) input" do
+    audio = speech.audio filepath, language: :en
+
+    audio.wont_be :nil?
+    audio.must_be_kind_of Google::Cloud::Speech::Audio
+    audio.must_be :content?
+    audio.wont_be :url?
+    audio.language.wont_be :nil?
   end
 end


### PR DESCRIPTION
This PR allows `language` to be a Symbol. Most of the time `language` is documented as being a String, but [`Audio#language`](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-speech/master/google/cloud/speech/audio?method=language-instance) does say it can also be a Symbol. Unit and acceptance tests coverage for this was added.