### PR TITLE
Add Logging Project#entries resources argument

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
@@ -70,9 +70,9 @@ module Google
           def next
             return nil unless next?
             ensure_service!
-            grpc = @service.list_entries token: token, projects: @projects,
+            grpc = @service.list_entries token: token, resources: @resources,
                                          filter: @filter, order: @order,
-                                         max: @max
+                                         max: @max, projects: @projects
             self.class.from_grpc grpc, @service
           end
 
@@ -144,8 +144,8 @@ module Google
           ##
           # @private New Entry::List from a
           # Google::Logging::V2::ListLogEntryResponse object.
-          def self.from_grpc grpc_list, service, projects: nil, filter: nil,
-                             order: nil, max: nil
+          def self.from_grpc grpc_list, service, resources: nil, filter: nil,
+                             order: nil, max: nil, projects: nil
             entries = new(Array(grpc_list.entries).map do |grpc_entry|
               Entry.from_grpc grpc_entry
             end)
@@ -154,6 +154,7 @@ module Google
             entries.instance_variable_set "@token", token
             entries.instance_variable_set "@service", service
             entries.instance_variable_set "@projects", projects
+            entries.instance_variable_set "@resources", resources
             entries.instance_variable_set "@filter", filter
             entries.instance_variable_set "@order", order
             entries.instance_variable_set "@max", max

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -88,9 +88,9 @@ module Google
         # Lists log entries. Use this method to retrieve log entries from Cloud
         # Logging.
         #
-        # @param [String, Array] projects One or more project IDs or project
-        #   numbers from which to retrieve log entries. If `nil`, the ID of the
-        #   receiving project instance will be used.
+        # @param [String, Array<String>] resources One or more cloud resources
+        #   from which to retrieve log entries. Example:
+        #   `"projects/my-project-1A"`, `"projects/1234567890"`.
         # @param [String] filter An [advanced logs
         #   filter](https://cloud.google.com/logging/docs/view/advanced_filters).
         #   The filter is compared against all log entries in the projects
@@ -102,6 +102,10 @@ module Google
         # @param [String] token A previously-returned page token representing
         #   part of the larger set of results to view.
         # @param [Integer] max Maximum number of entries to return.
+        # @param [String, Array<String>] projects One or more project IDs or
+        #   project numbers from which to retrieve log entries. If `nil`, the ID
+        #   of the receiving project instance will be used. This is deprecated
+        #   in favor of `resources`.
         #
         # @return [Array<Google::Cloud::Logging::Entry>] (See
         #   {Google::Cloud::Logging::Entry::List})
@@ -143,13 +147,16 @@ module Google
         #     puts "[#{e.timestamp}] #{e.log_name} #{e.payload.inspect}"
         #   end
         #
-        def entries projects: nil, filter: nil, order: nil, token: nil, max: nil
+        def entries resources: nil, filter: nil, order: nil, token: nil,
+                    max: nil, projects: nil
           ensure_service!
-          list_grpc = service.list_entries projects: projects, filter: filter,
-                                           order: order, token: token, max: max
+          list_grpc = service.list_entries resources: resources, filter: filter,
+                                           order: order, token: token, max: max,
+                                           projects: projects
           Entry::List.from_grpc list_grpc, service,
-                                projects: projects, max: max,
-                                filter: filter, order: order
+                                resources: resources, max: max,
+                                filter: filter, order: order,
+                                projects: projects
         end
         alias_method :find_entries, :entries
 

--- a/google-cloud-logging/lib/google/cloud/logging/service.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/service.rb
@@ -93,10 +93,15 @@ module Google
           credentials == :this_channel_is_insecure
         end
 
-        def list_entries projects: nil, filter: nil, order: nil, token: nil,
-                         max: nil
+        def list_entries resources: nil, filter: nil, order: nil, token: nil,
+                         max: nil, projects: nil
 
-          project_ids = Array(projects || @project)
+          project_ids = Array(projects)
+          resource_names = Array(resources)
+          if project_ids.empty? && resource_names.empty?
+            resource_names = ["projects/#{@project}"]
+          end
+          resource_names = nil if resource_names.empty?
           call_opts = default_options
           if token
             call_opts = Google::Gax::CallOptions.new(kwargs: default_headers,
@@ -104,11 +109,9 @@ module Google
           end
 
           execute do
-            paged_enum = logging.list_log_entries project_ids,
-                                                  filter: filter,
-                                                  order_by: order,
-                                                  page_size: max,
-                                                  options: call_opts
+            paged_enum = logging.list_log_entries \
+              project_ids, resource_names: resource_names, filter: filter,
+                           order_by: order, page_size: max, options: call_opts
             paged_enum.page.response
           end
         end

--- a/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(num_entries))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     entries = logging.entries
@@ -38,7 +38,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(num_entries))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     entries = logging.find_entries
@@ -54,8 +54,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries
@@ -78,8 +78,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
-    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: token_options("next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], resource_names: nil, filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], resource_names: nil, filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries projects: ["project1", "project2", "project3"],
@@ -107,8 +107,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries
@@ -130,8 +130,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
-    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: token_options("next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], resource_names: nil, filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], resource_names: nil, filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries projects: ["project1", "project2", "project3"],
@@ -155,8 +155,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries.all.to_a
@@ -172,8 +172,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
-    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: token_options("next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [["project1", "project2", "project3"], resource_names: nil, filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [["project1", "project2", "project3"], resource_names: nil, filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries(projects: ["project1", "project2", "project3"],
@@ -191,8 +191,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries.all.take(5)
@@ -208,8 +208,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "second_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
-    mock.expect :list_log_entries, second_list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
+    mock.expect :list_log_entries, first_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, second_list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: token_options("next_page_token")]
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries.all(request_limit: 1).to_a
@@ -224,7 +224,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [["project1"], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, list_res, [["project1"], resource_names: nil, filter: nil, order_by: nil, page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     entries = logging.entries projects: "project1"
@@ -241,10 +241,27 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [["project1", "project2", "project3"], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, list_res, [["project1", "project2", "project3"], resource_names: nil, filter: nil, order_by: nil, page_size: nil, options: default_options]
     logging.service.mocked_logging = mock
 
     entries = logging.entries projects: ["project1", "project2", "project3"]
+
+    mock.verify
+
+    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
+    entries.count.must_equal 3
+    entries.token.wont_be :nil?
+    entries.token.must_equal "next_page_token"
+  end
+
+  it "paginates entries with multiple resources" do
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_log_entries, list_res, [[], resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    logging.service.mocked_logging = mock
+
+    entries = logging.entries resources: ["projects/project1", "projects/project2", "projects/project3"]
 
     mock.verify
 
@@ -260,7 +277,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: adv_logs_filter, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, list_res, [[], resource_names: ["projects/#{project}"], filter: adv_logs_filter, order_by: nil, page_size: nil, options: default_options]
 
     logging.service.mocked_logging = mock
 
@@ -278,7 +295,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: "timestamp", page_size: nil, options: default_options]
+    mock.expect :list_log_entries, list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: "timestamp", page_size: nil, options: default_options]
 
     logging.service.mocked_logging = mock
 
@@ -296,7 +313,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: "timestamp desc", page_size: nil, options: default_options]
+    mock.expect :list_log_entries, list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: "timestamp desc", page_size: nil, options: default_options]
 
     logging.service.mocked_logging = mock
 
@@ -314,7 +331,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: 3, options: default_options]
+    mock.expect :list_log_entries, list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: 3, options: default_options]
 
     logging.service.mocked_logging = mock
 
@@ -332,7 +349,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [[project], filter: nil, order_by: nil, page_size: nil, options: default_options]
+    mock.expect :list_log_entries, list_res, [[], resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, options: default_options]
 
     logging.service.mocked_logging = mock
 


### PR DESCRIPTION
Effectively replaces the projects argument, which is deprecated and will eventually be removed.

Now that the generated GAPIC code has been updated and no longer raises we can implement this change.

[closes #971]