### PR TITLE
Fix issue 1036

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -702,7 +702,7 @@ namespace :integration do
         "sure gcloud SDK is logged in and a valid project ID is configured." unless project_id
       # If project_uri not given, default to "http://[project_id].appspot.com"
       project_uri = args[:project_uri] ||
-                    "http://#{project_id}.appspot.com"
+                    "http://#{project_id}.appspot-preview.com"
 
       fail "You must provide a project_uri. e.g. rake " \
         "integration:gae[http://my-project.appspot.com]" if project_uri.nil?

--- a/google-cloud-core/lib/google/cloud/core/environment.rb
+++ b/google-cloud-core/lib/google/cloud/core/environment.rb
@@ -73,7 +73,8 @@ module Google
         # @return [Boolean] True if all three GAE environment variables are
         #   defined
         def self.gae?
-          ENV["GAE_VM"] && gae_module_id && gae_module_version
+          # TODO: Remove ENV["GAE_VM"] when GAE Flex goes GA
+          (ENV["GAE_VM"] || ENV["GAE_INSTANCE"]) && gae_module_id && gae_module_version
         end
 
         def self.project_id
@@ -84,13 +85,15 @@ module Google
         ##
         # Retrieve GAE module name
         def self.gae_module_id
-          ENV["GAE_MODULE_NAME"]
+          # TODO: Remove ENV["GAE_MODULE_NAME"] when GAE Flex goes GA
+          ENV["GAE_MODULE_NAME"] || ENV["GAE_SERVICE"]
         end
 
         ##
         # Retrieve GAE module version
         def self.gae_module_version
-          ENV["GAE_MODULE_VERSION"]
+          # TODO: Remove ENV["GAE_MODULE_VERSION"] when GAE Flex goes GA
+          ENV["GAE_MODULE_VERSION"] || ENV["GAE_VERSION"]
         end
 
         ##

--- a/google-cloud-core/lib/google/cloud/core/environment.rb
+++ b/google-cloud-core/lib/google/cloud/core/environment.rb
@@ -74,7 +74,8 @@ module Google
         #   defined
         def self.gae?
           # TODO: Remove ENV["GAE_VM"] when GAE Flex goes GA
-          (ENV["GAE_VM"] || ENV["GAE_INSTANCE"]) && gae_module_id && gae_module_version
+          (ENV["GAE_VM"] || ENV["GAE_INSTANCE"]) &&
+            gae_module_id && gae_module_version
         end
 
         def self.project_id

--- a/integration/deploy.rb
+++ b/integration/deploy.rb
@@ -26,6 +26,8 @@ def deploy_gae_flex app_dir
   end
 
   begin
+    ensure_gcloud_beta!
+
     last_gae_version = get_gae_versions.last
     sh "gcloud app deploy -q" do |ok, res|
       if ok
@@ -100,6 +102,8 @@ end
 def deploy_gke_image image_name, image_location
   return unless image_name && image_location
 
+  ensure_gcloud_beta!
+
   # Create default acceptace_rc.yaml if one doesn't already exist
   rc_yaml_file_name = "integration_rc.yaml"
   if File.file? rc_yaml_file_name
@@ -150,4 +154,11 @@ end
 # Check if an executable exists
 def executable_exists? executable
   !`which #{executable}`.empty?
+end
+
+##
+# Ensure gcloud SDK beta component is installed
+def ensure_gcloud_beta!
+  Open3.capture3("yes | gcloud beta --help")
+  nil
 end

--- a/integration/deploy.rb
+++ b/integration/deploy.rb
@@ -29,6 +29,12 @@ def deploy_gae_flex app_dir
     last_gae_version = get_gae_versions.last
     sh "gcloud app deploy -q" do |ok, res|
       if ok
+        # GAE Flex has a bug that the service is really avaible shortly after
+        # the deployment commands returns successfully. So we explicitly sleeps
+        # for 30 seconds before accessing the GAE Flex service.
+        # TODO: Remove this sleep when GAE Flex deployment becomes smooth
+        sleep 30
+
         yield
 
         # Delete the last version of Google App Engine if successfully deployed

--- a/integration/rails4_app/app.yaml.example
+++ b/integration/rails4_app/app.yaml.example
@@ -1,5 +1,5 @@
 runtime: ruby
-vm: true
+env: flex
 entrypoint: cd integration/rails4_app; bundle install; bundle exec rackup -p 8080 config.ru
 health_check:
   enable_health_check: False

--- a/integration/rails5_app/app.yaml.example
+++ b/integration/rails5_app/app.yaml.example
@@ -1,5 +1,5 @@
 runtime: ruby
-vm: true
+env: flex
 entrypoint: cd integration/rails5_app; bundle install; bundle exec rackup -p 8080 config.ru
 health_check:
   enable_health_check: False

--- a/integration/sinatra1_app/app.yaml.example
+++ b/integration/sinatra1_app/app.yaml.example
@@ -1,5 +1,5 @@
 runtime: ruby
-vm: true
+env: flex
 entrypoint: bundle exec ruby integration/sinatra1_app/app.rb
 health_check:
   enable_health_check: False

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["hxiong388@gmail.com"]
   gem.description   = "stackdriver is the official library for Google Stackdriver APIs."
   gem.summary       = "API Client library for Google Stackdriver"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +


### PR DESCRIPTION
Add support for the new GAE Flex beta environment. Also add a minor tweak to ensure gcloud SDK beta component is installed before integration tests are called, and improved the stackdriver gemspec's home page link.

To test all of these changes except for the home page link, simply run `bundle exec rake integration:gae` to cover deployment with new GAE Flex flag and new Core::Environment code.

close #1036 