### PR TITLE
Fix docs in Speech and Logging

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -324,7 +324,7 @@ module Google
         ##
         # Untrack the trace_id that's associated with current Thread
         #
-        # @return The trace_id that's being deleted
+        # @return [String] The trace_id that's being deleted
         def delete_trace_id
           trace_ids.delete current_thread_id
         end

--- a/google-cloud-speech/lib/google/cloud/speech/audio.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/audio.rb
@@ -102,9 +102,9 @@ module Google
 
         ##
         # The language of the supplied audio as a
-        # [https://www.rfc-editor.org/rfc/bcp/bcp47.txt](BCP-47) language code.
+        # [BCP-47](https://tools.ietf.org/html/bcp47) language code.
         # If not specified, the language defaults to "en-US".  See [Language
-        # Support](https://cloud.google.com/speech/docs/best-practices#language_support)
+        # Support](https://cloud.google.com/speech/docs/languages)
         # for a list of the currently supported language codes.
         #
         # @return [String,Symbol]

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -127,10 +127,10 @@ module Google
         #   Hz. If that's not possible, use the native sample rate of the audio
         #   source (instead of re-sampling). Optional.
         # @param [String] language The language of the supplied audio as a
-        #   [https://www.rfc-editor.org/rfc/bcp/bcp47.txt](BCP-47) language
+        #   [BCP-47](https://tools.ietf.org/html/bcp47) language
         #   code. If not specified, the language defaults to "en-US".  See
         #   [Language
-        #   Support](https://cloud.google.com/speech/docs/best-practices#language_support)
+        #   Support](https://cloud.google.com/speech/docs/languages)
         #   for a list of the currently supported language codes. Optional.
         #
         # @return [Audio] The audio file to be recognized.
@@ -223,10 +223,10 @@ module Google
         #   Hz. If that's not possible, use the native sample rate of the audio
         #   source (instead of re-sampling). Optional.
         # @param [String] language The language of the supplied audio as a
-        #   [https://www.rfc-editor.org/rfc/bcp/bcp47.txt](BCP-47) language
+        #   [BCP-47](https://tools.ietf.org/html/bcp47) language
         #   code. If not specified, the language defaults to "en-US".  See
         #   [Language
-        #   Support](https://cloud.google.com/speech/docs/best-practices#language_support)
+        #   Support](https://cloud.google.com/speech/docs/languages)
         #   for a list of the currently supported language codes. Optional.
         # @param [String] max_alternatives The Maximum number of recognition
         #   hypotheses to be returned. Default is 1. The service may return
@@ -320,10 +320,10 @@ module Google
         #   Hz. If that's not possible, use the native sample rate of the audio
         #   source (instead of re-sampling). Optional.
         # @param [String] language The language of the supplied audio as a
-        #   [https://www.rfc-editor.org/rfc/bcp/bcp47.txt](BCP-47) language
+        #   [BCP-47](https://tools.ietf.org/html/bcp47) language
         #   code. If not specified, the language defaults to "en-US".  See
         #   [Language
-        #   Support](https://cloud.google.com/speech/docs/best-practices#language_support)
+        #   Support](https://cloud.google.com/speech/docs/languages)
         #   for a list of the currently supported language codes. Optional.
         # @param [String] max_alternatives The Maximum number of recognition
         #   hypotheses to be returned. Default is 1. The service may return
@@ -429,10 +429,10 @@ module Google
         #   Hz. If that's not possible, use the native sample rate of the audio
         #   source (instead of re-sampling). Optional.
         # @param [String] language The language of the supplied audio as a
-        #   [https://www.rfc-editor.org/rfc/bcp/bcp47.txt](BCP-47) language
+        #   [BCP-47](https://tools.ietf.org/html/bcp47) language
         #   code. If not specified, the language defaults to "en-US".  See
         #   [Language
-        #   Support](https://cloud.google.com/speech/docs/best-practices#language_support)
+        #   Support](https://cloud.google.com/speech/docs/languages)
         #   for a list of the currently supported language codes. Optional.
         # @param [String] max_alternatives The Maximum number of recognition
         #   hypotheses to be returned. Default is 1. The service may return

--- a/google-cloud-speech/lib/google/cloud/speech/v1beta1/doc/google/cloud/speech/v1beta1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1beta1/doc/google/cloud/speech/v1beta1/cloud_speech.rb
@@ -105,7 +105,7 @@ module Google
         #     [Optional] The language of the supplied audio as a BCP-47 language tag.
         #     Example: "en-GB"  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
         #     If omitted, defaults to "en-US". See
-        #     {Language Support}[https://cloud.google.com/speech/docs/best-practices#language_support]
+        #     {Language Support}[https://cloud.google.com/speech/docs/languages]
         #     for a list of the currently supported language codes.
         # @!attribute [rw] max_alternatives
         #   @return [Integer]


### PR DESCRIPTION
This PR fixes broken links in Speech.

It also adds a missing return type in Logging. The return type is critical. Its absence causes the gh-pages site app to fail while rendering this view: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/v0.22.0/google/cloud/logging/logger /cc @hxiong388 

[fixes #1072]


