### PR TITLE
Fix false positive Rails intergration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,12 +139,14 @@ $ rake integration:gae
 
 #### Running integration tests on Google Container Engine 
 
-Google Container Engine requires [docker](https://www.docker.com/) for building docker images, and the [Kubernetes commandline tool](http://kubernetes.io/docs/user-guide/kubectl-overview/) for image deployment. Follow the [docker website](https://www.docker.com/products/docker) for installation instructions.
+Additinoal to Cloud SDK, Google Container Engine requires [docker](https://www.docker.com/) for building docker images, and the [Kubernetes commandline tool](http://kubernetes.io/docs/user-guide/kubectl-overview/) for image deployment. 
 
-The Kubernetes commandline tool can be installed through Cloud SDK:
+Follow the [docker website](https://www.docker.com/products/docker) for docker installation instructions. The Kubernetes commandline tool can be installed through Cloud SDK:
 ```sh
-$ gcloud components update kubectl
+$ gcloud components install kubectl
 ```
+Make sure a [Google Container Engine Cluster](https://cloud.google.com/container-engine/docs/clusters/operations) is properly setup and ready to use.
+
 To run the integration tests on Google Container Engine:
 ```sh
 $ rake integration:gke

--- a/google-cloud-error_reporting/integration/common_error_reporting_test.rb
+++ b/google-cloud-error_reporting/integration/common_error_reporting_test.rb
@@ -24,6 +24,6 @@ describe Google::Cloud::ErrorReporting do
 
     # TODO: Find a better way to verify response. Or even better, validate the
     # error event was indeed reported to ErrorReporting
-    response.must_match token.to_s
+    response.must_match /Test error from .*: #{token}/
   end
 end

--- a/integration/deploy.rb
+++ b/integration/deploy.rb
@@ -78,8 +78,9 @@ def build_docker_image app_dir, project_id
     sh "docker build -t #{image_location} ."
     yield image_name, image_location
   ensure
-    sh "docker rmi #{image_location}"
     FileUtils.rm "Dockerfile" if temp_dockerfile
+    puts "docker rmi #{image_location}"
+    Open3.capture3 "docker rmi #{image_location}"
   end
 end
 
@@ -159,6 +160,6 @@ end
 ##
 # Ensure gcloud SDK beta component is installed
 def ensure_gcloud_beta!
-  Open3.capture3("yes | gcloud beta --help")
+  Open3.capture3 "yes | gcloud beta --help"
   nil
 end


### PR DESCRIPTION
Currently the Rails Error Reporting integration test may be false positive, because the test is looking for a embedded token on the result error page, which in most cases exists, because Rails prints out query parameters regardless what application error it is. We fix this false positive scenario by making the Error Reporting test check for the full error message. So the test only pass when the expected error is raised.

I'm also making a few minor changes to improve the GKE integration tests workflow. Thanks to @quartzmo for finding these.