### PR TITLE
Allow integration tests to run on different Ruby docker images

### DIFF
--- a/integration/deploy.rb
+++ b/integration/deploy.rb
@@ -66,7 +66,6 @@ end
 def build_docker_image app_dir, project_id
   image_name = "google-cloud-ruby-test-%.08x" % rand(0x100000000)
   image_location = "us.gcr.io/#{project_id}/#{image_name}"
-  temp_dockerfile = false
   begin
     # Create default Dockerfile if one doesn't already exist
     if File.file? "Dockerfile"
@@ -75,14 +74,14 @@ def build_docker_image app_dir, project_id
       # Copy example Dockerfile and update with correct content
       File.open "#{app_dir}/Dockerfile.example" do |source_file|
         File.open "Dockerfile", "w" do |dest_file|
-          temp_dockerfile = true
           base_image_tag = ENV["GAE_RUBY_BASE_IMAGE_TAG"] || "latest"
           file_content = source_file.read % {
             base_image_tag: base_image_tag
           }
-          dest_file.puts file_content
+          dest_file.write file_content
         end
       end
+      temp_dockerfile = true
     end
 
     sh "docker build -t #{image_location} ."
@@ -117,7 +116,6 @@ def deploy_gke_image image_name, image_location
 
   # Create default acceptace_rc.yaml if one doesn't already exist
   rc_yaml_file_name = "integration_rc.yaml"
-  temp_rc_yaml = false
   if File.file? rc_yaml_file_name
     fail "The #{rc_yaml_file_name} file already exist. Please omit it and " \
   "try again."
@@ -125,14 +123,14 @@ def deploy_gke_image image_name, image_location
     # Copy example yaml file and update with correct content
     File.open "integration/integration_rc.yaml.example" do |source_file|
       File.open rc_yaml_file_name, "w" do |dest_file|
-        temp_rc_yaml = true
         file_content = source_file.read % {
                          image_name: image_name,
                          image_location: image_location
                        }
-        dest_file.puts file_content
+        dest_file.write file_content
       end
     end
+    temp_rc_yaml = true
   end
 
   # Use kubectl to deploy GKE service and validate the GKE pods is running

--- a/integration/integration_rc.yaml.example
+++ b/integration/integration_rc.yaml.example
@@ -1,20 +1,20 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: [[image_name]]
+  name: %{image_name}
   labels:
-    name: [[image_name]]
+    name: %{image_name}
 spec:
   replicas: 1
   selector:
-    name: [[image_name]]
+    name: %{image_name}
   template:
     metadata:
       labels:
-        name: [[image_name]]
+        name: %{image_name}
     spec:
       containers:
-      - name: [[image_name]]
-        image: [[image_location]]
+      - name: %{image_name}
+        image: %{image_location}
         ports:
         - containerPort: 8080

--- a/integration/rails4_app/Dockerfile.example
+++ b/integration/rails4_app/Dockerfile.example
@@ -6,7 +6,7 @@
 # * A recent version of NodeJS
 # * A recent version of the standard Ruby runtime to use by default
 # * The bundler gem
-FROM gcr.io/google_appengine/ruby
+FROM gcr.io/google_appengine/ruby:%{base_image_tag}
 
 # If your application requires a specific ruby version (compatible with rbenv),
 # set it here. Leave blank to use the currently recommended default.

--- a/integration/rails5_app/Dockerfile.example
+++ b/integration/rails5_app/Dockerfile.example
@@ -6,7 +6,7 @@
 # * A recent version of NodeJS
 # * A recent version of the standard Ruby runtime to use by default
 # * The bundler gem
-FROM gcr.io/google_appengine/ruby
+FROM gcr.io/google_appengine/ruby:%{base_image_tag}
 
 # If your application requires a specific ruby version (compatible with rbenv),
 # set it here. Leave blank to use the currently recommended default.

--- a/integration/sinatra1_app/Dockerfile.example
+++ b/integration/sinatra1_app/Dockerfile.example
@@ -6,7 +6,7 @@
 # * A recent version of NodeJS
 # * A recent version of the standard Ruby runtime to use by default
 # * The bundler gem
-FROM gcr.io/google_appengine/ruby
+FROM gcr.io/google_appengine/ruby:%{base_image_tag}
 
 # If your application requires a specific ruby version (compatible with rbenv),
 # set it here. Leave blank to use the currently recommended default.


### PR DESCRIPTION
gcloud SDK currently has a feature to deploy GAE apps on base docker image with the customized tag defined in GAE_RUBY_BASE_IMAGE_TAG. This feature allows us to run the GAE integration tests from this repo to validate staging docker images. This PR enables the same flexibility for GKE integration tests.

To test the changes, run `GAE_RUBY_BASE_IMAGE_TAG=staging bundle exec rake integration:gke`. The first step of building the docker image should say pulling from `gcr.io/google_appengine/ruby:staging` instead of the latest image. Currently the staging docker image is same version as the latest, so all the GKE integration tests should pass.