### PR TITLE
Fix Error Reporting load error

### DIFF
--- a/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##
+# This file is here to be autorequired by bundler, so that the .logging and
+# #logging methods can be available, but the library and all dependencies won't
+# be loaded until required and used.
+
+
+gem "google-cloud-core"
+require "google/cloud"
+
+# There is no Google::Cloud integration to add.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+require "google/cloud/core/environment"
+require "google/cloud/error_reporting/v1beta1"
 require "rack"
 require "rack/request"
 

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+require "google/cloud/core/environment"
 require "google/cloud/error_reporting/v1beta1"
 require "google/cloud/credentials"
 

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1.rb
@@ -19,6 +19,3 @@ require "google/cloud/error_reporting/v1beta1/error_stats_service_api"
 require "google/cloud/error_reporting/v1beta1/report_errors_service_api"
 # Require the protobufs so we can create objects before GRPC is loaded.
 require "google/devtools/clouderrorreporting/v1beta1/report_errors_service_pb"
-
-require "google/cloud/core/environment"
-require "google/cloud/error_reporting/middleware"

--- a/google-cloud-monitoring/lib/google-cloud-monitoring.rb
+++ b/google-cloud-monitoring/lib/google-cloud-monitoring.rb
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##
+# This file is here to be autorequired by bundler, so that the .logging and
+# #logging methods can be available, but the library and all dependencies won't
+# be loaded until required and used.
+
+
+gem "google-cloud-core"
+require "google/cloud"
+
+# There is no Google::Cloud integration to add.

--- a/google-cloud-trace/lib/google-cloud-trace.rb
+++ b/google-cloud-trace/lib/google-cloud-trace.rb
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##
+# This file is here to be autorequired by bundler, so that the .logging and
+# #logging methods can be available, but the library and all dependencies won't
+# be loaded until required and used.
+
+
+gem "google-cloud-core"
+require "google/cloud"
+
+# There is no Google::Cloud integration to add.

--- a/google-cloud/lib/google-cloud.rb
+++ b/google-cloud/lib/google-cloud.rb
@@ -18,24 +18,5 @@
 # be loaded until required and used.
 
 
-gem "google-cloud-bigquery"
-gem "google-cloud-datastore"
-gem "google-cloud-dns"
-gem "google-cloud-logging"
-gem "google-cloud-pubsub"
-gem "google-cloud-resource_manager"
-gem "google-cloud-storage"
-gem "google-cloud-translate"
-gem "google-cloud-vision"
-gem "google-cloud-error_reporting"
-
-require "google-cloud-bigquery"
-require "google-cloud-datastore"
-require "google-cloud-dns"
-require "google-cloud-logging"
-require "google-cloud-pubsub"
-require "google-cloud-resource_manager"
-require "google-cloud-storage"
-require "google-cloud-translate"
-require "google-cloud-vision"
-require "google/cloud/error_reporting/v1beta1"
+gem "google-cloud-core"
+require "google/cloud"

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -17,9 +17,10 @@ gem "google-cloud-error_reporting"
 gem "google-cloud-logging"
 gem "google-cloud-monitoring"
 
-require "google/cloud/error_reporting/v1beta1"
 require "google/cloud/logging"
 require "google/cloud/monitoring/v3"
+
+require "google/cloud/error_reporting/middleware" if defined? ::Rack
 
 if defined? ::Rails::Railtie
   require "google/cloud/error_reporting/rails"

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -18,7 +18,6 @@ gem "google-cloud-logging"
 gem "google-cloud-monitoring"
 
 require "google/cloud/logging"
-require "google/cloud/monitoring/v3"
 
 require "google/cloud/error_reporting/middleware" if defined? ::Rack
 

--- a/stackdriver/test/stackdriver_test.rb
+++ b/stackdriver/test/stackdriver_test.rb
@@ -24,10 +24,6 @@ describe Stackdriver do
     defined?(Google::Cloud::Logging).wont_be_nil
   end
 
-  it "requires google-cloud-monitoring" do
-    defined?(Google::Cloud::Monitoring).wont_be_nil
-  end
-
   it "requires google-cloud-error_reporting rails module" do
     defined?(Google::Cloud::ErrorReporting::Railtie).wont_be_nil
   end


### PR DESCRIPTION
The Ruby Google Cloud library can raise an error due to a missing dependency when calling `require "google-cloud"`. This is usually done by Bundler when the auto-require feature is enabled, like it usually is in Rails.

```
$ irb
irb(main):001:0> require "google-cloud"
LoadError: cannot load such file -- rack
```

Users are directed to call `require "google/cloud"`, which does not have this issue:

```
$ irb
irb(main):001:0> require "google/cloud"
=> true
```

The load error was because google-cloud is loading Error Reporting's GAPIC require (v1beta1), which in turn is loading the rack integration hook. This PR makes the following changes:

- [x] Stop loading rack integration code when loading the Error Reporting API/GAPIC code
- [x] Change Error Reporting rack integration hook to require the Error Reporting API/GAPIC code
- [x] Change Error Reporting rails integration hook to require the Error Reporting API/GAPIC code
- [x] Remove hard-coded requires from `google-cloud`. Instead require `google/cloud` which will load dependencies at runtime
- [x] Add `google-cloud-error_reporting` file
- [x] Add `google-cloud-monitoring` file
- [x] Add `google-cloud-trace` file