### PR TITLE
Add BigQuery Query Parameters

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -87,6 +87,12 @@ describe Google::Cloud::Bigquery, :bigquery do
     rows.count.must_equal 100
   end
 
+  it "should run an query with standard SQL syntax" do
+    rows = bigquery.query "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100", legacy_sql: false
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 100
+  end
+
   it "should run an query job" do
     job = bigquery.query_job publicdata_query
     job.must_be_kind_of Google::Cloud::Bigquery::Job

--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -87,8 +87,14 @@ describe Google::Cloud::Bigquery, :bigquery do
     rows.count.must_equal 100
   end
 
-  it "should run an query with standard SQL syntax" do
+  it "should run an query without legacy SQL syntax" do
     rows = bigquery.query "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100", legacy_sql: false
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 100
+  end
+
+  it "should run an query with standard SQL syntax" do
+    rows = bigquery.query "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100", standard_sql: true
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 100
   end

--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -1,0 +1,67 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bigquery_helper"
+
+describe Google::Cloud::Bigquery, :positional_params, :bigquery do
+  it "queries the data with a string parameter" do
+    rows = bigquery.query "SELECT repository.name, public FROM `publicdata.samples.github_nested` WHERE repository.owner = @owner LIMIT 1", params: { owner: "blowmage" }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+  end
+
+  it "queries the data with an integer parameter" do
+    rows = bigquery.query "SELECT repository.name, repository.forks FROM `publicdata.samples.github_nested` WHERE repository.owner = @owner AND repository.forks > @forks LIMIT 5", params: { owner: "blowmage", forks: 10 }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 5
+  end
+
+  it "queries the data with a float parameter" do
+    rows = bigquery.query "SELECT station_number, year, month, day, snow_depth FROM `publicdata.samples.gsod` WHERE snow_depth >= @depth LIMIT 5", params: { depth: 12.0 }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 5
+  end
+
+  it "queries the data with a boolean parameter" do
+    rows = bigquery.query "SELECT repository.name, public FROM `publicdata.samples.github_nested` WHERE repository.owner = @owner AND public = @public LIMIT 1", params: { owner: "blowmage", public: true }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+  end
+
+  it "queries the data with a date parameter" do
+    skip "Don't know of any sample data that uses DATE values"
+  end
+
+  it "queries the data with a time parameter" do
+    rows = bigquery.query "SELECT subject FROM `bigquery-public-data.github_repos.commits` WHERE author.name = @author AND author.date < @date LIMIT 1", params: { author: "blowmage", date: Time.now }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+  end
+
+  it "queries the data with an array parameter" do
+    rows = bigquery.query "SELECT * FROM UNNEST (@list)", params: { list: [25,26,27,28,29] }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 5
+  end
+
+  it "queries the data with a struct parameter" do
+    skip "Don't know how to query with struct parameters"
+  end
+end

--- a/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
@@ -1,0 +1,67 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bigquery_helper"
+
+describe Google::Cloud::Bigquery, :positional_params, :bigquery do
+  it "queries the data with a string parameter" do
+    rows = bigquery.query "SELECT repository.name, public FROM `publicdata.samples.github_nested` WHERE repository.owner = ? LIMIT 1", params: ["blowmage"]
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+  end
+
+  it "queries the data with an integer parameter" do
+    rows = bigquery.query "SELECT repository.name, repository.forks FROM `publicdata.samples.github_nested` WHERE repository.owner = ? AND repository.forks > ? LIMIT 5", params: ["blowmage", 10]
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 5
+  end
+
+  it "queries the data with a float parameter" do
+    rows = bigquery.query "SELECT station_number, year, month, day, snow_depth FROM `publicdata.samples.gsod` WHERE snow_depth >= ? LIMIT 5", params: [12.0]
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 5
+  end
+
+  it "queries the data with a boolean parameter" do
+    rows = bigquery.query "SELECT repository.name, public FROM `publicdata.samples.github_nested` WHERE repository.owner = ? AND public = ? LIMIT 1", params: ["blowmage", true]
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+  end
+
+  it "queries the data with a date parameter" do
+    skip "Don't know of any sample data that uses DATE values"
+  end
+
+  it "queries the data with a time parameter" do
+    rows = bigquery.query "SELECT subject FROM `bigquery-public-data.github_repos.commits` WHERE author.name = ? AND author.date < ? LIMIT 1", params: ["blowmage", Time.now]
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+  end
+
+  it "queries the data with an array parameter" do
+    rows = bigquery.query "SELECT * FROM UNNEST (?)", params: [[25,26,27,28,29]]
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 5
+  end
+
+  it "queries the data with a struct parameter" do
+    skip "Don't know how to query with struct parameters"
+  end
+end

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.21.0"
-  gem.add_dependency "google-api-client", "~> 0.9.11"
+  gem.add_dependency "google-api-client", "~> 0.9.18"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -524,6 +524,11 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
+        # @param [Array, Hash] params Query parameters for Standard SQL queries.
+        #   If values are provided in an array the query will use positional
+        #   query parameters (`?`). If values are provided in a hash the query
+        #   will use named query parameters (`@myparam`). When values are
+        #   provided the query will be set to use standard SQL.
         # @param [String] priority Specifies a priority for the query. Possible
         #   values include `INTERACTIVE` and `BATCH`. The default value is
         #   `INTERACTIVE`.
@@ -604,11 +609,41 @@ module Google
         #     end
         #   end
         #
+        # @example Query using positional query parameters:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   job = bigquery.query_job "SELECT name FROM my_table WHERE id = ?",
+        #                            params: [1]
+        #
+        #   job.wait_until_done!
+        #   if !job.failed?
+        #     job.query_results.each do |row|
+        #       puts row["name"]
+        #     end
+        #   end
+        #
+        # @example Query using named query parameters:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   job = bigquery.query_job "SELECT name FROM my_table WHERE id = @id",
+        #                            params: { id: 1 }
+        #
+        #   job.wait_until_done!
+        #   if !job.failed?
+        #     job.query_results.each do |row|
+        #       puts row["name"]
+        #     end
+        #   end
+        #
         # @!group Data
         #
-        def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
-                      create: nil, write: nil, large_results: nil, flatten: nil,
-                      legacy_sql: nil, standard_sql: nil, params: nil
+        def query_job query, params: nil, priority: "INTERACTIVE", cache: true,
+                      table: nil, create: nil, write: nil, large_results: nil,
+                      flatten: nil, legacy_sql: nil, standard_sql: nil
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
@@ -631,6 +666,11 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
+        # @param [Array, Hash] params Query parameters for Standard SQL queries.
+        #   If values are provided in an array the query will use positional
+        #   query parameters (`?`). If values are provided in a hash the query
+        #   will use named query parameters (`@myparam`). When values are
+        #   provided the query will be set to use standard SQL.
         # @param [Integer] max The maximum number of rows of data to return per
         #   page of results. Setting this flag to a small value such as 1000 and
         #   then paging through results might improve reliability when the query
@@ -688,10 +728,34 @@ module Google
         #     puts row["name"]
         #   end
         #
+        # @example Query using positional query parameters:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   data = bigquery.query "SELECT name FROM my_table WHERE id = ?",
+        #                         params: [1]
+        #
+        #   data.each do |row|
+        #     puts row["name"]
+        #   end
+        #
+        # @example Query using named query parameters:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   data = bigquery.query "SELECT name FROM my_table WHERE id = @id",
+        #                         params: { id: 1 }
+        #
+        #   data.each do |row|
+        #     puts row["name"]
+        #   end
+        #
         # @!group Data
         #
-        def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  legacy_sql: nil, standard_sql: nil, params: nil
+        def query query, params: nil, max: nil, timeout: 10000, dryrun: nil,
+                  cache: true, legacy_sql: nil, standard_sql: nil
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
                       legacy_sql: legacy_sql, standard_sql: standard_sql,
                       params: params }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -579,11 +579,11 @@ module Google
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                       create: nil, write: nil, large_results: nil, flatten: nil,
-                      use_legacy_sql: true, params: nil
+                      legacy_sql: nil, params: nil
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
-                      use_legacy_sql: use_legacy_sql, params: params }
+                      legacy_sql: legacy_sql, params: params }
           options[:dataset] ||= self
           ensure_service!
           gapi = service.query_job query, options
@@ -638,9 +638,9 @@ module Google
         # @!group Data
         #
         def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  use_legacy_sql: true, params: nil
+                  legacy_sql: nil, params: nil
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
-                      use_legacy_sql: use_legacy_sql, params: params }
+                      legacy_sql: legacy_sql, params: params }
           options[:dataset] ||= dataset_id
           options[:project] ||= project_id
           ensure_service!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -565,6 +565,13 @@ module Google
         #   false, the values of `large_results` and `flatten` are ignored;
         #   query will be run as if `large_results` is true and `flatten` is
         #   false. Optional. The default value is true.
+        # @param [Boolean] standard_sql Specifies whether to use BigQuery's
+        #   standard SQL dialect for this query. If set to true, the query will
+        #   use BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/sql-reference/)  When set to
+        #   true, the values of `large_results` and `flatten` are ignored; query
+        #   will be run as if `large_results` is true and `flatten` is false.
+        #   Optional. The default value is false.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -588,7 +595,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   job = bigquery.query_job "SELECT name FROM my_table",
-        #                            legacy_sql: false
+        #                            standard_sql: true
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -601,11 +608,12 @@ module Google
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                       create: nil, write: nil, large_results: nil, flatten: nil,
-                      legacy_sql: nil, params: nil
+                      legacy_sql: nil, standard_sql: nil, params: nil
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
-                      legacy_sql: legacy_sql, params: params }
+                      legacy_sql: legacy_sql, standard_sql: standard_sql,
+                      params: params }
           options[:dataset] ||= self
           ensure_service!
           gapi = service.query_job query, options
@@ -649,6 +657,11 @@ module Google
         #   BigQuery's [standard
         #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
         #   default value is true.
+        # @param [Boolean] standard_sql Specifies whether to use BigQuery's
+        #   standard SQL dialect for this query. If set to true, the query will
+        #   use BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
+        #   default value is false.
         #
         # @return [Google::Cloud::Bigquery::QueryData]
         #
@@ -669,7 +682,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name FROM my_table",
-        #                         legacy_sql: false
+        #                         standard_sql: true
         #
         #   data.each do |row|
         #     puts row["name"]
@@ -678,9 +691,10 @@ module Google
         # @!group Data
         #
         def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  legacy_sql: nil, params: nil
+                  legacy_sql: nil, standard_sql: nil, params: nil
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
-                      legacy_sql: legacy_sql, params: params }
+                      legacy_sql: legacy_sql, standard_sql: standard_sql,
+                      params: params }
           options[:dataset] ||= dataset_id
           options[:project] ||= project_id
           ensure_service!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -524,11 +524,13 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
-        # @param [Array, Hash] params Query parameters for Standard SQL queries.
-        #   If values are provided in an array the query will use positional
-        #   query parameters (`?`). If values are provided in a hash the query
-        #   will use named query parameters (`@myparam`). When values are
-        #   provided the query will be set to use standard SQL.
+        # @param [Array, Hash] params Standard SQL only. Used to pass query
+        #   arguments when the `query` string contains either positional (`?`)
+        #   or named (`@myparam`) query parameters. If value passed is an array
+        #   `["foo"]`, the query must use positional query parameters. If value
+        #   passed is a hash `{ myparam: "foo" }`, the query must use named
+        #   query parameters. When set, `legacy_sql` will automatically be set
+        #   to false and `standard_sql` to true.
         # @param [String] priority Specifies a priority for the query. Possible
         #   values include `INTERACTIVE` and `BATCH`. The default value is
         #   `INTERACTIVE`.
@@ -563,20 +565,25 @@ module Google
         # @param [Boolean] flatten Flattens all nested and repeated fields in
         #   the query results. The default value is `true`. `large_results`
         #   parameter must be `true` if this is set to `false`.
-        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's legacy
-        #   SQL dialect for this query. If set to false, the query will use
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect for this query. If set to false, the query will use
         #   BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/sql-reference/)  When set to
-        #   false, the values of `large_results` and `flatten` are ignored;
-        #   query will be run as if `large_results` is true and `flatten` is
-        #   false. Optional. The default value is true.
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   When set to false, the values of `large_results` and `flatten` are
+        #   ignored; the query will be run as if `large_results` is true and
+        #   `flatten` is false. Optional. The default value is true.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
-        #   standard SQL dialect for this query. If set to true, the query will
-        #   use BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/sql-reference/)  When set to
-        #   true, the values of `large_results` and `flatten` are ignored; query
-        #   will be run as if `large_results` is true and `flatten` is false.
-        #   Optional. The default value is false.
+        #   [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   dialect for this query. If set to true, the query will use standard
+        #   SQL rather than the [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect. When set to true, the values of `large_results` and
+        #   `flatten` are ignored; the query will be run as if `large_results`
+        #   is true and `flatten` is false. Optional. The default value is
+        #   false.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -666,11 +673,13 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
-        # @param [Array, Hash] params Query parameters for Standard SQL queries.
-        #   If values are provided in an array the query will use positional
-        #   query parameters (`?`). If values are provided in a hash the query
-        #   will use named query parameters (`@myparam`). When values are
-        #   provided the query will be set to use standard SQL.
+        # @param [Array, Hash] params Standard SQL only. Used to pass query
+        #   arguments when the `query` string contains either positional (`?`)
+        #   or named (`@myparam`) query parameters. If value passed is an array
+        #   `["foo"]`, the query must use positional query parameters. If value
+        #   passed is a hash `{ myparam: "foo" }`, the query must use named
+        #   query parameters. When set, `legacy_sql` will automatically be set
+        #   to false and `standard_sql` to true.
         # @param [Integer] max The maximum number of rows of data to return per
         #   page of results. Setting this flag to a small value such as 1000 and
         #   then paging through results might improve reliability when the query
@@ -692,16 +701,25 @@ module Google
         #   whenever tables in the query are modified. The default value is
         #   true. For more information, see [query
         #   caching](https://developers.google.com/bigquery/querying-data).
-        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's legacy
-        #   SQL dialect for this query. If set to false, the query will use
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect for this query. If set to false, the query will use
         #   BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
-        #   default value is true.
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   When set to false, the values of `large_results` and `flatten` are
+        #   ignored; the query will be run as if `large_results` is true and
+        #   `flatten` is false. Optional. The default value is true.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
-        #   standard SQL dialect for this query. If set to true, the query will
-        #   use BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
-        #   default value is false.
+        #   [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   dialect for this query. If set to true, the query will use standard
+        #   SQL rather than the [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect. When set to true, the values of `large_results` and
+        #   `flatten` are ignored; the query will be run as if `large_results`
+        #   is true and `flatten` is false. Optional. The default value is
+        #   false.
         #
         # @return [Google::Cloud::Bigquery::QueryData]
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -638,9 +638,9 @@ module Google
         # @!group Data
         #
         def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  use_legacy_sql: true
+                  use_legacy_sql: true, params: nil
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
-                      use_legacy_sql: use_legacy_sql }
+                      use_legacy_sql: use_legacy_sql, params: params }
           options[:dataset] ||= dataset_id
           options[:project] ||= project_id
           ensure_service!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -558,6 +558,13 @@ module Google
         # @param [Boolean] flatten Flattens all nested and repeated fields in
         #   the query results. The default value is `true`. `large_results`
         #   parameter must be `true` if this is set to `false`.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's legacy
+        #   SQL dialect for this query. If set to false, the query will use
+        #   BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/sql-reference/)  When set to
+        #   false, the values of `large_results` and `flatten` are ignored;
+        #   query will be run as if `large_results` is true and `flatten` is
+        #   false. Optional. The default value is true.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -567,6 +574,21 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   job = bigquery.query_job "SELECT name FROM my_table"
+        #
+        #   job.wait_until_done!
+        #   if !job.failed?
+        #     job.query_results.each do |row|
+        #       puts row["name"]
+        #     end
+        #   end
+        #
+        # @example Query using standard SQL:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   job = bigquery.query_job "SELECT name FROM my_table",
+        #                            legacy_sql: false
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -622,6 +644,11 @@ module Google
         #   whenever tables in the query are modified. The default value is
         #   true. For more information, see [query
         #   caching](https://developers.google.com/bigquery/querying-data).
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's legacy
+        #   SQL dialect for this query. If set to false, the query will use
+        #   BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
+        #   default value is true.
         #
         # @return [Google::Cloud::Bigquery::QueryData]
         #
@@ -631,6 +658,19 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name FROM my_table"
+        #
+        #   data.each do |row|
+        #     puts row["name"]
+        #   end
+        #
+        # @example Query using standard SQL:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   data = bigquery.query "SELECT name FROM my_table",
+        #                         legacy_sql: false
+        #
         #   data.each do |row|
         #     puts row["name"]
         #   end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -579,11 +579,11 @@ module Google
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                       create: nil, write: nil, large_results: nil, flatten: nil,
-                      use_legacy_sql: true
+                      use_legacy_sql: true, params: nil
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
-                      use_legacy_sql: use_legacy_sql }
+                      use_legacy_sql: use_legacy_sql, params: params }
           options[:dataset] ||= self
           ensure_service!
           gapi = service.query_job query, options

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -99,11 +99,13 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
-        # @param [Array, Hash] params Query parameters for Standard SQL queries.
-        #   If values are provided in an array the query will use positional
-        #   query parameters (`?`). If values are provided in a hash the query
-        #   will use named query parameters (`@myparam`). When values are
-        #   provided the query will be set to use standard SQL.
+        # @param [Array, Hash] params Standard SQL only. Used to pass query
+        #   arguments when the `query` string contains either positional (`?`)
+        #   or named (`@myparam`) query parameters. If value passed is an array
+        #   `["foo"]`, the query must use positional query parameters. If value
+        #   passed is a hash `{ myparam: "foo" }`, the query must use named
+        #   query parameters. When set, `legacy_sql` will automatically be set
+        #   to false and `standard_sql` to true.
         # @param [String] priority Specifies a priority for the query. Possible
         #   values include `INTERACTIVE` and `BATCH`. The default value is
         #   `INTERACTIVE`.
@@ -140,20 +142,25 @@ module Google
         #   parameter must be `true` if this is set to `false`.
         # @param [Dataset, String] dataset Specifies the default dataset to use
         #   for unqualified table names in the query.
-        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's legacy
-        #   SQL dialect for this query. If set to false, the query will use
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect for this query. If set to false, the query will use
         #   BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/sql-reference/)  When set to
-        #   false, the values of `large_results` and `flatten` are ignored;
-        #   query will be run as if `large_results` is true and `flatten` is
-        #   false. Optional. The default value is true.
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   When set to false, the values of `large_results` and `flatten` are
+        #   ignored; the query will be run as if `large_results` is true and
+        #   `flatten` is false. Optional. The default value is true.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
-        #   standard SQL dialect for this query. If set to true, the query will
-        #   use BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/sql-reference/)  When set to
-        #   true, the values of `large_results` and `flatten` are ignored;
-        #   query will be run as if `large_results` is true and `flatten` is
-        #   false. Optional. The default value is false.
+        #   [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   dialect for this query. If set to true, the query will use standard
+        #   SQL rather than the [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect. When set to true, the values of `large_results` and
+        #   `flatten` are ignored; the query will be run as if `large_results`
+        #   is true and `flatten` is false. Optional. The default value is
+        #   false.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -244,11 +251,13 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
-        # @param [Array, Hash] params Query parameters for Standard SQL queries.
-        #   If values are provided in an array the query will use positional
-        #   query parameters (`?`). If values are provided in a hash the query
-        #   will use named query parameters (`@myparam`). When values are
-        #   provided the query will be set to use standard SQL.
+        # @param [Array, Hash] params Standard SQL only. Used to pass query
+        #   arguments when the `query` string contains either positional (`?`)
+        #   or named (`@myparam`) query parameters. If value passed is an array
+        #   `["foo"]`, the query must use positional query parameters. If value
+        #   passed is a hash `{ myparam: "foo" }`, the query must use named
+        #   query parameters. When set, `legacy_sql` will automatically be set
+        #   to false and `standard_sql` to true.
         # @param [Integer] max The maximum number of rows of data to return per
         #   page of results. Setting this flag to a small value such as 1000 and
         #   then paging through results might improve reliability when the query
@@ -277,16 +286,25 @@ module Google
         # @param [String] project Specifies the default projectId to assume for
         #   any unqualified table names in the query. Only used if `dataset`
         #   option is set.
-        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's legacy
-        #   SQL dialect for this query. If set to false, the query will use
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect for this query. If set to false, the query will use
         #   BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
-        #   default value is true.
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   When set to false, the values of `large_results` and `flatten` are
+        #   ignored; the query will be run as if `large_results` is true and
+        #   `flatten` is false. Optional. The default value is true.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
-        #   standard SQL dialect for this query. If set to true, the query will
-        #   use BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
-        #   default value is false.
+        #   [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   dialect for this query. If set to true, the query will use standard
+        #   SQL rather than the [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect. When set to true, the values of `large_results` and
+        #   `flatten` are ignored; the query will be run as if `large_results`
+        #   is true and `flatten` is false. Optional. The default value is
+        #   false.
         #
         # @return [Google::Cloud::Bigquery::QueryData]
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -99,6 +99,11 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
+        # @param [Array, Hash] params Query parameters for Standard SQL queries.
+        #   If values are provided in an array the query will use positional
+        #   query parameters (`?`). If values are provided in a hash the query
+        #   will use named query parameters (`@myparam`). When values are
+        #   provided the query will be set to use standard SQL.
         # @param [String] priority Specifies a priority for the query. Possible
         #   values include `INTERACTIVE` and `BATCH`. The default value is
         #   `INTERACTIVE`.
@@ -183,10 +188,44 @@ module Google
         #     end
         #   end
         #
-        def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
-                      create: nil, write: nil, large_results: nil, flatten: nil,
-                      dataset: nil, legacy_sql: nil, standard_sql: nil,
-                      params: nil
+        # @example Query using positional query parameters:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   job = bigquery.query_job "SELECT name FROM " \
+        #                            "`my_proj.my_data.my_table`" \
+        #                            " WHERE id = ?",
+        #                            params: [1]
+        #
+        #   job.wait_until_done!
+        #   if !job.failed?
+        #     job.query_results.each do |row|
+        #       puts row["name"]
+        #     end
+        #   end
+        #
+        # @example Query using named query parameters:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   job = bigquery.query_job "SELECT name FROM " \
+        #                            "`my_proj.my_data.my_table`" \
+        #                            " WHERE id = @id",
+        #                            params: { id: 1 }
+        #
+        #   job.wait_until_done!
+        #   if !job.failed?
+        #     job.query_results.each do |row|
+        #       puts row["name"]
+        #     end
+        #   end
+        #
+        def query_job query, params: nil, priority: "INTERACTIVE", cache: true,
+                      table: nil, create: nil, write: nil, large_results: nil,
+                      flatten: nil, dataset: nil, legacy_sql: nil,
+                      standard_sql: nil
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
@@ -205,6 +244,11 @@ module Google
         #   syntax](https://cloud.google.com/bigquery/query-reference), of the
         #   query to execute. Example: "SELECT count(f1) FROM
         #   [myProjectId:myDatasetId.myTableId]".
+        # @param [Array, Hash] params Query parameters for Standard SQL queries.
+        #   If values are provided in an array the query will use positional
+        #   query parameters (`?`). If values are provided in a hash the query
+        #   will use named query parameters (`@myparam`). When values are
+        #   provided the query will be set to use standard SQL.
         # @param [Integer] max The maximum number of rows of data to return per
         #   page of results. Setting this flag to a small value such as 1000 and
         #   then paging through results might improve reliability when the query
@@ -280,9 +324,37 @@ module Google
         #     puts row["name"]
         #   end
         #
-        def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  dataset: nil, project: nil, legacy_sql: nil,
-                  standard_sql: nil, params: nil
+        # @example Query using positional query parameters:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   data = bigquery.query "SELECT name " \
+        #                         "FROM [my_proj:my_data.my_table]" \
+        #                         "WHERE id = ?",
+        #                         params: [1]
+        #
+        #   data.each do |row|
+        #     puts row["name"]
+        #   end
+        #
+        # @example Query using named query parameters:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   data = bigquery.query "SELECT name " \
+        #                         "FROM [my_proj:my_data.my_table]" \
+        #                         "WHERE id = @id",
+        #                         params: { id: 1 }
+        #
+        #   data.each do |row|
+        #     puts row["name"]
+        #   end
+        #
+        def query query, params: nil, max: nil, timeout: 10000, dryrun: nil,
+                  cache: true, dataset: nil, project: nil, legacy_sql: nil,
+                  standard_sql: nil
           ensure_service!
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
                       dataset: dataset, project: project,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -142,6 +142,13 @@ module Google
         #   false, the values of `large_results` and `flatten` are ignored;
         #   query will be run as if `large_results` is true and `flatten` is
         #   false. Optional. The default value is true.
+        # @param [Boolean] standard_sql Specifies whether to use BigQuery's
+        #   standard SQL dialect for this query. If set to true, the query will
+        #   use BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/sql-reference/)  When set to
+        #   true, the values of `large_results` and `flatten` are ignored;
+        #   query will be run as if `large_results` is true and `flatten` is
+        #   false. Optional. The default value is false.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -167,7 +174,7 @@ module Google
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "`my_proj.my_data.my_table`",
-        #                            legacy_sql: false
+        #                            standard_sql: true
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -178,13 +185,14 @@ module Google
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                       create: nil, write: nil, large_results: nil, flatten: nil,
-                      dataset: nil, legacy_sql: nil, params: nil
+                      dataset: nil, legacy_sql: nil, standard_sql: nil,
+                      params: nil
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
                       dataset: dataset, legacy_sql: legacy_sql,
-                      params: params }
+                      standard_sql: standard_sql, params: params }
           gapi = service.query_job query, options
           Job.from_gapi gapi, service
         end
@@ -230,6 +238,11 @@ module Google
         #   BigQuery's [standard
         #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
         #   default value is true.
+        # @param [Boolean] standard_sql Specifies whether to use BigQuery's
+        #   standard SQL dialect for this query. If set to true, the query will
+        #   use BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
+        #   default value is false.
         #
         # @return [Google::Cloud::Bigquery::QueryData]
         #
@@ -250,7 +263,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name FROM `my_proj.my_data.my_table`",
-        #                         legacy_sql: false
+        #                         standard_sql: true
         #
         #   data.each do |row|
         #     puts row["name"]
@@ -268,11 +281,13 @@ module Google
         #   end
         #
         def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  dataset: nil, project: nil, legacy_sql: nil, params: nil
+                  dataset: nil, project: nil, legacy_sql: nil,
+                  standard_sql: nil, params: nil
           ensure_service!
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
                       dataset: dataset, project: project,
-                      legacy_sql: legacy_sql, params: params }
+                      legacy_sql: legacy_sql, standard_sql: standard_sql,
+                      params: params }
           gapi = service.query query, options
           QueryData.from_gapi gapi, service
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -135,6 +135,13 @@ module Google
         #   parameter must be `true` if this is set to `false`.
         # @param [Dataset, String] dataset Specifies the default dataset to use
         #   for unqualified table names in the query.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's legacy
+        #   SQL dialect for this query. If set to false, the query will use
+        #   BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/sql-reference/)  When set to
+        #   false, the values of `large_results` and `flatten` are ignored;
+        #   query will be run as if `large_results` is true and `flatten` is
+        #   false. Optional. The default value is true.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -145,6 +152,22 @@ module Google
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "[my_proj:my_data.my_table]"
+        #
+        #   job.wait_until_done!
+        #   if !job.failed?
+        #     job.query_results.each do |row|
+        #       puts row["name"]
+        #     end
+        #   end
+        #
+        # @example Query using standard SQL:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   job = bigquery.query_job "SELECT name FROM " \
+        #                            "`my_proj.my_data.my_table`",
+        #                            legacy_sql: false
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -202,6 +225,11 @@ module Google
         # @param [String] project Specifies the default projectId to assume for
         #   any unqualified table names in the query. Only used if `dataset`
         #   option is set.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's legacy
+        #   SQL dialect for this query. If set to false, the query will use
+        #   BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/sql-reference/) Optional. The
+        #   default value is true.
         #
         # @return [Google::Cloud::Bigquery::QueryData]
         #
@@ -211,6 +239,19 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name FROM [my_proj:my_data.my_table]"
+        #
+        #   data.each do |row|
+        #     puts row["name"]
+        #   end
+        #
+        # @example Query using standard SQL:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   data = bigquery.query "SELECT name FROM `my_proj.my_data.my_table`",
+        #                         legacy_sql: false
+        #
         #   data.each do |row|
         #     puts row["name"]
         #   end
@@ -221,6 +262,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name FROM [my_proj:my_data.my_table]"
+        #
         #   data.all do |row|
         #     puts row["name"]
         #   end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -155,12 +155,13 @@ module Google
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                       create: nil, write: nil, large_results: nil, flatten: nil,
-                      dataset: nil, use_legacy_sql: true
+                      dataset: nil, use_legacy_sql: true, params: nil
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
-                      dataset: dataset, use_legacy_sql: use_legacy_sql }
+                      dataset: dataset, use_legacy_sql: use_legacy_sql,
+                      params: params }
           gapi = service.query_job query, options
           Job.from_gapi gapi, service
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -155,12 +155,12 @@ module Google
         #
         def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                       create: nil, write: nil, large_results: nil, flatten: nil,
-                      dataset: nil, use_legacy_sql: true, params: nil
+                      dataset: nil, legacy_sql: nil, params: nil
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
-                      dataset: dataset, use_legacy_sql: use_legacy_sql,
+                      dataset: dataset, legacy_sql: legacy_sql,
                       params: params }
           gapi = service.query_job query, options
           Job.from_gapi gapi, service
@@ -226,11 +226,11 @@ module Google
         #   end
         #
         def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  dataset: nil, project: nil, use_legacy_sql: true, params: nil
+                  dataset: nil, project: nil, legacy_sql: nil, params: nil
           ensure_service!
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
                       dataset: dataset, project: project,
-                      use_legacy_sql: use_legacy_sql, params: params }
+                      legacy_sql: legacy_sql, params: params }
           gapi = service.query query, options
           QueryData.from_gapi gapi, service
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -225,11 +225,11 @@ module Google
         #   end
         #
         def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
-                  dataset: nil, project: nil, use_legacy_sql: true
+                  dataset: nil, project: nil, use_legacy_sql: true, params: nil
           ensure_service!
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
                       dataset: dataset, project: project,
-                      use_legacy_sql: use_legacy_sql }
+                      use_legacy_sql: use_legacy_sql, params: params }
           gapi = service.query query, options
           QueryData.from_gapi gapi, service
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -100,10 +100,16 @@ module Google
 
         ##
         # Checks if the query job is using legacy sql.
-        def use_legacy_sql?
+        def legacy_sql?
           val = @gapi.configuration.query.use_legacy_sql
-          return false if val.nil?
+          return true if val.nil?
           val
+        end
+
+        ##
+        # Checks if the query job is using standard sql.
+        def standard_sql?
+          !legacy_sql?
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -537,31 +537,6 @@ module Google
           v
         end
 
-        def query_param_type value
-          if TrueClass === value
-            return "BOOLEAN"
-          elsif FalseClass === value
-            return "BOOLEAN"
-          elsif Integer === value
-            return "INT64"
-          elsif Float === value
-            return "FLOAT64"
-          elsif String === value
-            return "STRING"
-          elsif defined?(Date) && Date === value
-            return "DATE"
-          # ActiveSupport adds to_time to Numeric, which is awful...
-          elsif value.respond_to? :to_time
-            return "TIMESTAMP"
-          elsif Array === value
-            return "ARRAY"
-          elsif Hash === value
-            return "STRUCT"
-          else
-            fail "A query parameter of type #{value.class} is not supported."
-          end
-        end
-
         # rubocop:enable all
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -467,12 +467,12 @@ module Google
         def to_query_param value
           if TrueClass === value
             return API::QueryParameter.new(
-              parameter_type:  API::QueryParameterType.new(type: "BOOLEAN"),
+              parameter_type:  API::QueryParameterType.new(type: "BOOL"),
               parameter_value: API::QueryParameterValue.new(value: true)
             )
           elsif FalseClass === value
             return API::QueryParameter.new(
-              parameter_type:  API::QueryParameterType.new(type: "BOOLEAN"),
+              parameter_type:  API::QueryParameterType.new(type: "BOOL"),
               parameter_value: API::QueryParameterValue.new(value: false)
             )
           elsif Integer === value

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -501,13 +501,47 @@ module Google
                 value: value.to_time)
             )
           elsif Array === value
-            fail "Not yet implemented"
+            array_params = value.map { |param| to_query_param param }
+            return API::QueryParameter.new(
+              parameter_type: API::QueryParameterType.new(
+                type: "ARRAY",
+                array_type: array_params.first.parameter_type
+              ),
+              parameter_value: API::QueryParameterValue.new(
+                array_values: array_params.map(&:parameter_value)
+              )
+            )
           elsif Hash === value
             fail "Not yet implemented"
           else
             fail "A query parameter of type #{value.class} is not supported."
           end
           v
+        end
+
+        def query_param_type value
+          if TrueClass === value
+            return "BOOLEAN"
+          elsif FalseClass === value
+            return "BOOLEAN"
+          elsif Integer === value
+            return "INT64"
+          elsif Float === value
+            return "FLOAT64"
+          elsif String === value
+            return "STRING"
+          elsif defined?(Date) && Date === value
+            return "DATE"
+          # ActiveSupport adds to_time to Numeric, which is awful...
+          elsif value.respond_to? :to_time
+            return "TIMESTAMP"
+          elsif Array === value
+            return "ARRAY"
+          elsif Hash === value
+            return "STRUCT"
+          else
+            fail "A query parameter of type #{value.class} is not supported."
+          end
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -400,7 +400,7 @@ module Google
                 allow_large_results: options[:large_results],
                 flatten_results: options[:flatten],
                 default_dataset: default_dataset,
-                use_legacy_sql: options[:use_legacy_sql]
+                use_legacy_sql: options[:legacy_sql]
               )
             )
           )
@@ -438,7 +438,7 @@ module Google
             timeout_ms: options[:timeout],
             dry_run: options[:dryrun],
             use_query_cache: options[:cache],
-            use_legacy_sql: options[:use_legacy_sql]
+            use_legacy_sql: options[:legacy_sql]
           )
 
           if options[:params]

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -400,7 +400,8 @@ module Google
                 allow_large_results: options[:large_results],
                 flatten_results: options[:flatten],
                 default_dataset: default_dataset,
-                use_legacy_sql: options[:legacy_sql]
+                use_legacy_sql: resolve_legacy_sql(options[:legacy_sql],
+                                                   options[:standard_sql])
               )
             )
           )
@@ -438,7 +439,8 @@ module Google
             timeout_ms: options[:timeout],
             dry_run: options[:dryrun],
             use_query_cache: options[:cache],
-            use_legacy_sql: options[:legacy_sql]
+            use_legacy_sql: resolve_legacy_sql(options[:legacy_sql],
+                                               options[:standard_sql])
           )
 
           if options[:params]
@@ -538,6 +540,11 @@ module Google
         end
 
         # rubocop:enable all
+
+        def resolve_legacy_sql legacy_sql, standard_sql
+          return legacy_sql unless legacy_sql.nil?
+          return !standard_sql unless standard_sql.nil?
+        end
 
         ##
         # Job description for copy job

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -418,10 +418,22 @@ module Google
           )
 
           if options[:params]
-            req.use_legacy_sql = false
-            req.parameter_mode = "POSITIONAL"
-            req.query_parameters = options[:params].map do |param|
-              to_query_param param
+            if Array === options[:params]
+              req.use_legacy_sql = false
+              req.parameter_mode = "POSITIONAL"
+              req.query_parameters = options[:params].map do |param|
+                to_query_param param
+              end
+            elsif Hash === options[:params]
+              req.use_legacy_sql = false
+              req.parameter_mode = "NAMED"
+              req.query_parameters = options[:params].map do |name, param|
+                to_query_param(param).tap do |named_param|
+                  named_param.name = String name
+                end
+              end
+            else
+              fail "Query parameters must be an Array or a Hash."
             end
           end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -493,14 +493,14 @@ module Google
           elsif defined?(Date) && Date === value
             return API::QueryParameter.new(
               parameter_type:  API::QueryParameterType.new(type: "DATE"),
-              parameter_value: API::QueryParameterValue.new(value: value)
+              parameter_value: API::QueryParameterValue.new(value: value.to_s)
             )
-          # ActiveSupport adds to_time to Numeric, which is awful...
+          # ActiveSupport adds to_time to String, which is awful...
           elsif value.respond_to? :to_time
             return API::QueryParameter.new(
               parameter_type:  API::QueryParameterType.new(type: "TIMESTAMP"),
               parameter_value: API::QueryParameterValue.new(
-                value: value.to_time)
+                value: value.to_time.strftime("%Y-%m-%d %H:%M:%S.%3N%:z"))
             )
           elsif Array === value
             array_params = value.map { |param| to_query_param param }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -512,7 +512,23 @@ module Google
               )
             )
           elsif Hash === value
-            fail "Not yet implemented"
+            struct_pairs = value.map do |name, param|
+              struct_param = to_query_param param
+              [API::QueryParameterType::StructType.new(
+                name: String(name),
+                type: struct_param.parameter_type
+              ), struct_param.parameter_value]
+            end
+
+            return API::QueryParameter.new(
+              parameter_type: API::QueryParameterType.new(
+                type: "STRUCT",
+                struct_types: struct_pairs.map(&:first)
+              ),
+              parameter_value: API::QueryParameterValue.new(
+                struct_values: struct_pairs.map(&:last)
+              )
+            )
           else
             fail "A query parameter of type #{value.class} is not supported."
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -380,6 +380,8 @@ module Google
           )
         end
 
+        # rubocop:disable all
+
         ##
         # Job description for query job
         def query_table_config query, options
@@ -559,6 +561,8 @@ module Google
             fail "A query parameter of type #{value.class} is not supported."
           end
         end
+
+        # rubocop:enable all
 
         ##
         # Job description for copy job

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -367,12 +367,10 @@ module Google
         #
         # @!group Data
         #
-        def data max: nil, timeout: 10000, cache: true, dryrun: nil,
-                 use_legacy_sql: true
+        def data max: nil, timeout: 10000, cache: true, dryrun: nil
           sql = "SELECT * FROM #{query_id}"
           ensure_service!
-          options = { max: max, timeout: timeout, cache: cache, dryrun: dryrun,
-                      use_legacy_sql: use_legacy_sql }
+          options = { max: max, timeout: timeout, cache: cache, dryrun: dryrun }
           gapi = service.query sql, options
           QueryData.from_gapi gapi, service
         end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -1,0 +1,294 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  let(:query_job_gapi) do
+    Google::Apis::BigqueryV2::Job.from_json(query_job_json("SELECT * FROM tbl")).tap do |r|
+      r.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(dataset_id: dataset_id, project_id: project)
+      r.configuration.query.use_legacy_sql = false
+      r.configuration.query.parameter_mode = "NAMED"
+    end
+  end
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+
+  it "queries the data with a string parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE name = @name"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "name",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with an integer parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age > @age"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE age > @age", params: { age: 35 }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a float parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE score > @score"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "score",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE score > @score", params: { score: 90.0 }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a true parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE active = @active"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE active = @active", params: { active: true }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a false parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE active = @active"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: false
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE active = @active", params: { active: false }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a date parameter" do
+    today = Date.today
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE create_date = @date"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "date",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE create_date = @date", params: { date: today }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a time parameter" do
+    now = Time.now
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE update_timestamp < @time"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "time",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE update_timestamp < @time", params: { time: now }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with many parameters" do
+    today = Date.today
+    now = Time.now
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE name = @name" +
+                                                       " AND age > @age" +
+                                                       " AND score > @score" +
+                                                       " AND active = @active" +
+                                                       " AND create_date = @date" +
+                                                       " AND update_timestamp < @time"
+
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "name",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "score",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "date",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "time",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE name = @name" +
+                                     " AND age > @age" +
+                                     " AND score > @score" +
+                                     " AND active = @active" +
+                                     " AND create_date = @date" +
+                                     " AND update_timestamp < @time",
+                          params: { name: "Testy McTesterson",
+                                    age: 35,
+                                    score: 90.0,
+                                    active: true,
+                                    date: today,
+                                    time: now }
+
+
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -291,4 +291,35 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
+
+  it "queries the data with an array parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE name IN @names"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+      name: "names",
+      parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+        type: "ARRAY",
+        array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        )
+      ),
+      parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+        array_values: [
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
+        ]
+      )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -107,7 +107,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -131,7 +131,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: false
@@ -243,7 +243,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -339,7 +339,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "active",
-              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOL")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "score",
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -296,20 +296,20 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     query_job_gapi.configuration.query.query = "#{query} WHERE name IN @names"
     query_job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
-      name: "names",
-      parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-        type: "ARRAY",
-        array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "STRING"
+        name: "names",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "STRING"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
+          ]
         )
-      ),
-      parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-        array_values: [
-          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
-          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
-          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
-        ]
-      )
       )
     ]
 
@@ -318,6 +318,49 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
 
     job = dataset.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a struct parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE meta = @meta"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "meta",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "name",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "STRING")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "active",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "score",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -160,7 +160,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       )
     ]
@@ -186,7 +186,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]
@@ -255,7 +255,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -264,7 +264,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -154,7 +154,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       )
     ]
@@ -179,7 +179,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]
@@ -242,7 +242,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -250,7 +250,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -103,7 +103,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     query_job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -126,7 +126,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     query_job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: false
@@ -231,7 +231,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -318,7 +318,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "active",
-              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOL")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "score",
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -1,0 +1,275 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  let(:query_job_gapi) do
+    Google::Apis::BigqueryV2::Job.from_json(query_job_json("SELECT * FROM tbl")).tap do |r|
+      r.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(dataset_id: dataset_id, project_id: project)
+      r.configuration.query.use_legacy_sql = false
+      r.configuration.query.parameter_mode = "POSITIONAL"
+    end
+  end
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+
+  it "queries the data with a string parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE name = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE name = ?", params: ["Testy McTesterson"]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with an integer parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age > ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE age > ?", params: [35]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a float parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE score > ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE score > ?", params: [90.0]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a true parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE active = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE active = ?", params: [true]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a false parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE active = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: false
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE active = ?", params: [false]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a date parameter" do
+    today = Date.today
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE create_date = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE create_date = ?", params: [today]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a time parameter" do
+    now = Time.now
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE update_timestamp < ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE update_timestamp < ?", params: [now]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with many parameters" do
+    today = Date.today
+    now = Time.now
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE name = ?" +
+                                                       " AND age > ?" +
+                                                       " AND score > ?" +
+                                                       " AND active = ?" +
+                                                       " AND create_date = ?" +
+                                                       " AND update_timestamp < ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE name = ?" +
+                                    " AND age > ?" +
+                                    " AND score > ?" +
+                                    " AND active = ?" +
+                                    " AND create_date = ?" +
+                                    " AND update_timestamp < ?",
+      params: ["Testy McTesterson", 35, 90.0, true, today, now]
+
+
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -272,4 +272,34 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
+
+  it "queries the data with an array parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE name IN ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+      parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+        type: "ARRAY",
+        array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        )
+      ),
+      parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+        array_values: [
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
+        ]
+      )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -115,7 +115,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -140,7 +140,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: false
@@ -255,7 +255,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -353,7 +353,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "active",
-              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOL")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "score",
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -1,0 +1,326 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  let(:query_request_gapi) do
+    Google::Apis::BigqueryV2::QueryRequest.new(
+      query: query,
+      timeout_ms: 10000,
+      use_query_cache: true,
+      use_legacy_sql: false,
+      parameter_mode: "NAMED",
+      default_dataset: Google::Apis::BigqueryV2::DatasetReference.new(dataset_id: dataset_id, project_id: project),
+      dry_run: nil,
+      max_results: nil
+    )
+  end
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+
+  it "queries the data with a string parameter" do
+    query_request_gapi.query = "#{query} WHERE name = @name"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "name",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with an integer parameter" do
+    query_request_gapi.query = "#{query} WHERE age > @age"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE age > @age", params: { age: 35 }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a float parameter" do
+    query_request_gapi.query = "#{query} WHERE score > @score"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "score",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE score > @score", params: { score: 90.0 }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a true parameter" do
+    query_request_gapi.query = "#{query} WHERE active = @active"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE active = @active", params: { active: true }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a false parameter" do
+    query_request_gapi.query = "#{query} WHERE active = @active"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: false
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE active = @active", params: { active: false }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a date parameter" do
+    today = Date.today
+
+    query_request_gapi.query = "#{query} WHERE create_date = @date"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "date",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE create_date = @date", params: { date: today }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a time parameter" do
+    now = Time.now
+
+    query_request_gapi.query = "#{query} WHERE update_timestamp < @time"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "time",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE update_timestamp < @time", params: { time: now }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with many parameters" do
+    today = Date.today
+    now = Time.now
+
+    query_request_gapi.query = "#{query} WHERE name = @name" +
+                                       " AND age > @age" +
+                                       " AND score > @score" +
+                                       " AND active = @active" +
+                                       " AND create_date = @date" +
+                                       " AND update_timestamp < @time"
+
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "name",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "score",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "date",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "time",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE name = @name" +
+                                  " AND age > @age" +
+                                  " AND score > @score" +
+                                  " AND active = @active" +
+                                  " AND create_date = @date" +
+                                  " AND update_timestamp < @time",
+                          params: { name: "Testy McTesterson",
+                                    age: 35,
+                                    score: 90.0,
+                                    active: true,
+                                    date: today,
+                                    time: now }
+
+
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  def assert_valid_data data
+    data.count.must_equal 3
+    data[0].must_be_kind_of Hash
+    data[0]["name"].must_equal "Heidi"
+    data[0]["age"].must_equal 36
+    data[0]["score"].must_equal 7.65
+    data[0]["active"].must_equal true
+    data[1].must_be_kind_of Hash
+    data[1]["name"].must_equal "Aaron"
+    data[1]["age"].must_equal 42
+    data[1]["score"].must_equal 8.15
+    data[1]["active"].must_equal false
+    data[2].must_be_kind_of Hash
+    data[2]["name"].must_equal "Sally"
+    data[2]["age"].must_equal nil
+    data[2]["score"].must_equal nil
+    data[2]["active"].must_equal nil
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -170,7 +170,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       )
     ]
@@ -197,7 +197,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]
@@ -267,7 +267,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -276,7 +276,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -305,6 +305,38 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     assert_valid_data data
   end
 
+  it "queries the data with an array parameter" do
+    query_request_gapi.query = "#{query} WHERE name IN @names"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+      name: "names",
+      parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+        type: "ARRAY",
+        array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        )
+      ),
+      parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+        array_values: [
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
+        ]
+      )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
   def assert_valid_data data
     data.count.must_equal 3
     data[0].must_be_kind_of Hash

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -164,7 +164,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       )
     ]
@@ -190,7 +190,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]
@@ -254,7 +254,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -262,7 +262,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -1,0 +1,307 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  let(:query_request_gapi) do
+    Google::Apis::BigqueryV2::QueryRequest.new(
+      query: query,
+      timeout_ms: 10000,
+      use_query_cache: true,
+      use_legacy_sql: false,
+      parameter_mode: "POSITIONAL",
+      default_dataset: Google::Apis::BigqueryV2::DatasetReference.new(dataset_id: dataset_id, project_id: project),
+      dry_run: nil,
+      max_results: nil
+    )
+  end
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+
+  it "queries the data with a string parameter" do
+    query_request_gapi.query = "#{query} WHERE name = ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE name = ?", params: ["Testy McTesterson"]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with an integer parameter" do
+    query_request_gapi.query = "#{query} WHERE age > ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE age > ?", params: [35]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a float parameter" do
+    query_request_gapi.query = "#{query} WHERE score > ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE score > ?", params: [90.0]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a true parameter" do
+    query_request_gapi.query = "#{query} WHERE active = ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE active = ?", params: [true]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a false parameter" do
+    query_request_gapi.query = "#{query} WHERE active = ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: false
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE active = ?", params: [false]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a date parameter" do
+    today = Date.today
+
+    query_request_gapi.query = "#{query} WHERE create_date = ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE create_date = ?", params: [today]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a time parameter" do
+    now = Time.now
+
+    query_request_gapi.query = "#{query} WHERE update_timestamp < ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE update_timestamp < ?", params: [now]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with many parameters" do
+    today = Date.today
+    now = Time.now
+
+    query_request_gapi.query = "#{query} WHERE name = ?" +
+                                       " AND age > ?" +
+                                       " AND score > ?" +
+                                       " AND active = ?" +
+                                       " AND create_date = ?" +
+                                       " AND update_timestamp < ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE name = ?" +
+                                  " AND age > ?" +
+                                  " AND score > ?" +
+                                  " AND active = ?" +
+                                  " AND create_date = ?" +
+                                  " AND update_timestamp < ?",
+      params: ["Testy McTesterson", 35, 90.0, true, today, now]
+
+
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  def assert_valid_data data
+    data.count.must_equal 3
+    data[0].must_be_kind_of Hash
+    data[0]["name"].must_equal "Heidi"
+    data[0]["age"].must_equal 36
+    data[0]["score"].must_equal 7.65
+    data[0]["active"].must_equal true
+    data[1].must_be_kind_of Hash
+    data[1]["name"].must_equal "Aaron"
+    data[1]["age"].must_equal 42
+    data[1]["score"].must_equal 8.15
+    data[1]["active"].must_equal false
+    data[2].must_be_kind_of Hash
+    data[2]["name"].must_equal "Sally"
+    data[2]["age"].must_equal nil
+    data[2]["score"].must_equal nil
+    data[2]["active"].must_equal nil
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -304,4 +304,35 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data[2]["score"].must_equal nil
     data[2]["active"].must_equal nil
   end
+
+  it "queries the data with an array parameter" do
+    query_request_gapi.query = "#{query} WHERE name IN ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+      parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+        type: "ARRAY",
+        array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        )
+      ),
+      parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+        array_values: [
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
+        ]
+      )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = dataset.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -111,7 +111,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     query_request_gapi.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -135,7 +135,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     query_request_gapi.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: false
@@ -243,7 +243,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -332,7 +332,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "active",
-              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOL")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "score",
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -1,0 +1,297 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  let(:table_id) { "my_table" }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+
+  let(:query_job_gapi) do
+    Google::Apis::BigqueryV2::Job.from_json(query_job_json("SELECT * FROM tbl")).tap do |r|
+      r.configuration.query.use_legacy_sql = false
+      r.configuration.query.parameter_mode = "NAMED"
+    end
+  end
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:table_gapi) { random_table_gapi dataset_id, table_id }
+
+  it "queries the data with a string parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE name = @name"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "name",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with an integer parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age > @age"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE age > @age", params: { age: 35 }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a float parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE score > @score"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "score",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE score > @score", params: { score: 90.0 }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a true parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE active = @active"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE active = @active", params: { active: true }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a false parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE active = @active"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: false
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE active = @active", params: { active: false }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a date parameter" do
+    today = Date.today
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE create_date = @date"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "date",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE create_date = @date", params: { date: today }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a time parameter" do
+    now = Time.now
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE update_timestamp < @time"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "time",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE update_timestamp < @time", params: { time: now }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with many parameters" do
+    today = Date.today
+    now = Time.now
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE name = @name" +
+                                                       " AND age > @age" +
+                                                       " AND score > @score" +
+                                                       " AND active = @active" +
+                                                       " AND create_date = @date" +
+                                                       " AND update_timestamp < @time"
+
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "name",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "score",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "date",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "time",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE name = @name" +
+                                     " AND age > @age" +
+                                     " AND score > @score" +
+                                     " AND active = @active" +
+                                     " AND create_date = @date" +
+                                     " AND update_timestamp < @time",
+                          params: { name: "Testy McTesterson",
+                                    age: 35,
+                                    score: 90.0,
+                                    active: true,
+                                    date: today,
+                                    time: now }
+
+
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -110,7 +110,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -134,7 +134,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: false
@@ -246,7 +246,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -342,7 +342,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "active",
-              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOL")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "score",
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -299,20 +299,20 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     query_job_gapi.configuration.query.query = "#{query} WHERE name IN @names"
     query_job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
-      name: "names",
-      parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-        type: "ARRAY",
-        array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "STRING"
+        name: "names",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "STRING"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
+          ]
         )
-      ),
-      parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-        array_values: [
-          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
-          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
-          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
-        ]
-      )
       )
     ]
 
@@ -321,6 +321,49 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
 
     job = bigquery.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a struct parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE meta = @meta"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "meta",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "name",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "STRING")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "active",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "score",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -294,4 +294,35 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
+
+  it "queries the data with an array parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE name IN @names"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+      name: "names",
+      parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+        type: "ARRAY",
+        array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        )
+      ),
+      parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+        array_values: [
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
+          Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
+        ]
+      )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -163,7 +163,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       )
     ]
@@ -189,7 +189,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]
@@ -258,7 +258,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -267,7 +267,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -305,4 +305,46 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
+
+  it "queries the data with a struct parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE meta = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "name",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "STRING")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "active",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "score",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -275,4 +275,34 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
+
+  it "queries the data with an array parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE name = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "STRING"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE name = ?", params: [%w{name1 name2 name3}]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -106,7 +106,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     query_job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -129,7 +129,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     query_job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: false
@@ -234,7 +234,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -321,7 +321,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "active",
-              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOL")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "score",
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -1,0 +1,278 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  let(:table_id) { "my_table" }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+
+  let(:query_job_gapi) do
+    Google::Apis::BigqueryV2::Job.from_json(query_job_json("SELECT * FROM tbl")).tap do |r|
+      r.configuration.query.use_legacy_sql = false
+      r.configuration.query.parameter_mode = "POSITIONAL"
+    end
+  end
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:table_gapi) { random_table_gapi dataset_id, table_id }
+
+  it "queries the data with a string parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE name = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE name = ?", params: ["Testy McTesterson"]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with an integer parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age > ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE age > ?", params: [35]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a float parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE score > ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE score > ?", params: [90.0]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a true parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE active = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE active = ?", params: [true]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a false parameter" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE active = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: false
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE active = ?", params: [false]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a date parameter" do
+    today = Date.today
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE create_date = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE create_date = ?", params: [today]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a time parameter" do
+    now = Time.now
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE update_timestamp < ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE update_timestamp < ?", params: [now]
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with many parameters" do
+    today = Date.today
+    now = Time.now
+
+    query_job_gapi.configuration.query.query = "#{query} WHERE name = ?" +
+                                                       " AND age > ?" +
+                                                       " AND score > ?" +
+                                                       " AND active = ?" +
+                                                       " AND create_date = ?" +
+                                                       " AND update_timestamp < ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE name = ?" +
+                                           " AND age > ?" +
+                                           " AND score > ?" +
+                                           " AND active = ?" +
+                                           " AND create_date = ?" +
+                                           " AND update_timestamp < ?",
+      params: ["Testy McTesterson", 35, 90.0, true, today, now]
+
+
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -157,7 +157,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       )
     ]
@@ -182,7 +182,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]
@@ -245,7 +245,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -253,7 +253,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -174,7 +174,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       )
     ]
@@ -201,7 +201,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]
@@ -271,7 +271,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -280,7 +280,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -119,7 +119,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -144,7 +144,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: false
@@ -259,7 +259,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
       Google::Apis::BigqueryV2::QueryParameter.new(
         name: "active",
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -357,7 +357,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "active",
-              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOL")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "score",
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -1,0 +1,330 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  let(:table_id) { "my_table" }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+
+  let(:query_request_gapi) do
+    Google::Apis::BigqueryV2::QueryRequest.new(
+      query: query,
+      timeout_ms: 10000,
+      use_query_cache: true,
+      use_legacy_sql: false,
+      parameter_mode: "NAMED",
+      default_dataset: nil,
+      dry_run: nil,
+      max_results: nil
+    )
+  end
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:table_gapi) { random_table_gapi dataset_id, table_id }
+
+  it "queries the data with a string parameter" do
+    query_request_gapi.query = "#{query} WHERE name = @name"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "name",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with an integer parameter" do
+    query_request_gapi.query = "#{query} WHERE age > @age"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE age > @age", params: { age: 35 }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a float parameter" do
+    query_request_gapi.query = "#{query} WHERE score > @score"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "score",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE score > @score", params: { score: 90.0 }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a true parameter" do
+    query_request_gapi.query = "#{query} WHERE active = @active"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE active = @active", params: { active: true }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a false parameter" do
+    query_request_gapi.query = "#{query} WHERE active = @active"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: false
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE active = @active", params: { active: false }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a date parameter" do
+    today = Date.today
+
+    query_request_gapi.query = "#{query} WHERE create_date = @date"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "date",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE create_date = @date", params: { date: today }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a time parameter" do
+    now = Time.now
+
+    query_request_gapi.query = "#{query} WHERE update_timestamp < @time"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "time",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE update_timestamp < @time", params: { time: now }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with many parameters" do
+    today = Date.today
+    now = Time.now
+
+    query_request_gapi.query = "#{query} WHERE name = @name" +
+                                       " AND age > @age" +
+                                       " AND score > @score" +
+                                       " AND active = @active" +
+                                       " AND create_date = @date" +
+                                       " AND update_timestamp < @time"
+
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "name",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "score",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "active",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "date",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "time",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE name = @name" +
+                                  " AND age > @age" +
+                                  " AND score > @score" +
+                                  " AND active = @active" +
+                                  " AND create_date = @date" +
+                                  " AND update_timestamp < @time",
+                          params: { name: "Testy McTesterson",
+                                    age: 35,
+                                    score: 90.0,
+                                    active: true,
+                                    date: today,
+                                    time: now }
+
+
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  def assert_valid_data data
+    data.count.must_equal 3
+    data[0].must_be_kind_of Hash
+    data[0]["name"].must_equal "Heidi"
+    data[0]["age"].must_equal 36
+    data[0]["score"].must_equal 7.65
+    data[0]["active"].must_equal true
+    data[1].must_be_kind_of Hash
+    data[1]["name"].must_equal "Aaron"
+    data[1]["age"].must_equal 42
+    data[1]["score"].must_equal 8.15
+    data[1]["active"].must_equal false
+    data[2].must_be_kind_of Hash
+    data[2]["name"].must_equal "Sally"
+    data[2]["age"].must_equal nil
+    data[2]["score"].must_equal nil
+    data[2]["active"].must_equal nil
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -341,6 +341,50 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     assert_valid_data data
   end
 
+  it "queries the data with a struct parameter" do
+    query_request_gapi.query = "#{query} WHERE meta = @meta"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "meta",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "name",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "STRING")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "active",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "score",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
   def assert_valid_data data
     data.count.must_equal 3
     data[0].must_be_kind_of Hash

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -168,7 +168,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       )
     ]
@@ -194,7 +194,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]
@@ -258,7 +258,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "DATE"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: today
+          value: today.to_s
         )
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -266,7 +266,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "TIMESTAMP"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: now
+          value: now.strftime("%Y-%m-%d %H:%M:%S.%3N%:z")
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -1,0 +1,311 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  let(:table_id) { "my_table" }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+
+  let(:query_request_gapi) do
+    Google::Apis::BigqueryV2::QueryRequest.new(
+      query: query,
+      timeout_ms: 10000,
+      use_query_cache: true,
+      use_legacy_sql: false,
+      parameter_mode: "POSITIONAL",
+      default_dataset: nil,
+      dry_run: nil,
+      max_results: nil
+    )
+  end
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:table_gapi) { random_table_gapi dataset_id, table_id }
+
+  it "queries the data with a string parameter" do
+    query_request_gapi.query = "#{query} WHERE name = ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE name = ?", params: ["Testy McTesterson"]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with an integer parameter" do
+    query_request_gapi.query = "#{query} WHERE age > ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE age > ?", params: [35]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a float parameter" do
+    query_request_gapi.query = "#{query} WHERE score > ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE score > ?", params: [90.0]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a true parameter" do
+    query_request_gapi.query = "#{query} WHERE active = ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE active = ?", params: [true]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a false parameter" do
+    query_request_gapi.query = "#{query} WHERE active = ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: false
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE active = ?", params: [false]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a date parameter" do
+    today = Date.today
+
+    query_request_gapi.query = "#{query} WHERE create_date = ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE create_date = ?", params: [today]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with a time parameter" do
+    now = Time.now
+
+    query_request_gapi.query = "#{query} WHERE update_timestamp < ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE update_timestamp < ?", params: [now]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  it "queries the data with many parameters" do
+    today = Date.today
+    now = Time.now
+
+    query_request_gapi.query = "#{query} WHERE name = ?" +
+                                       " AND age > ?" +
+                                       " AND score > ?" +
+                                       " AND active = ?" +
+                                       " AND create_date = ?" +
+                                       " AND update_timestamp < ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRING"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "Testy McTesterson"
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 35
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "FLOAT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: 90.0
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BOOLEAN"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: true
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "DATE"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: today
+        )
+      ),
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "TIMESTAMP"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: now
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE name = ?" +
+                                  " AND age > ?" +
+                                  " AND score > ?" +
+                                  " AND active = ?" +
+                                  " AND create_date = ?" +
+                                  " AND update_timestamp < ?",
+      params: ["Testy McTesterson", 35, 90.0, true, today, now]
+
+
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
+  def assert_valid_data data
+    data.count.must_equal 3
+    data[0].must_be_kind_of Hash
+    data[0]["name"].must_equal "Heidi"
+    data[0]["age"].must_equal 36
+    data[0]["score"].must_equal 7.65
+    data[0]["active"].must_equal true
+    data[1].must_be_kind_of Hash
+    data[1]["name"].must_equal "Aaron"
+    data[1]["age"].must_equal 42
+    data[1]["score"].must_equal 8.15
+    data[1]["active"].must_equal false
+    data[2].must_be_kind_of Hash
+    data[2]["name"].must_equal "Sally"
+    data[2]["age"].must_equal nil
+    data[2]["score"].must_equal nil
+    data[2]["active"].must_equal nil
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -115,7 +115,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     query_request_gapi.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -139,7 +139,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     query_request_gapi.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: false
@@ -247,7 +247,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
       ),
       Google::Apis::BigqueryV2::QueryParameter.new(
         parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
-          type: "BOOLEAN"
+          type: "BOOL"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
           value: true
@@ -336,7 +336,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "active",
-              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOL")),
             Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
               name: "score",
               type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -321,6 +321,49 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     assert_valid_data data
   end
 
+  it "queries the data with a struct parameter" do
+    query_request_gapi.query = "#{query} WHERE meta = ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "name",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "STRING")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "active",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "BOOLEAN")),
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "score",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "FLOAT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
   def assert_valid_data data
     data.count.must_equal 3
     data[0].must_be_kind_of Hash

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -290,6 +290,37 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     assert_valid_data data
   end
 
+  it "queries the data with an array parameter" do
+    query_request_gapi.query = "#{query} WHERE name IN ?"
+    query_request_gapi.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "STRING"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "name3")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :query_job, query_data_gapi, [project, query_request_gapi]
+
+    data = bigquery.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::QueryData
+    assert_valid_data data
+  end
+
   def assert_valid_data data
     data.count.must_equal 3
     data[0].must_be_kind_of Hash

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
@@ -201,7 +201,7 @@ describe Google::Cloud::Bigquery::QueryJob, :query_results, :mock_bigquery do
       "allowLargeResults" => true,
       "useQueryCache" => true,
       "flattenResults" => true,
-      "useLegacySql" => true,
+      "useLegacySql" => nil,
     }
     hash
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -45,7 +45,8 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     job.must_be :large_results?
     job.must_be :cache?
     job.must_be :flatten?
-    job.must_be :use_legacy_sql?
+    job.must_be :legacy_sql?
+    job.wont_be :standard_sql?
   end
 
   it "knows its statistics data" do
@@ -84,7 +85,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
       "allowLargeResults" => true,
       "useQueryCache" => true,
       "flattenResults" => true,
-      "useLegacySql" => true
+      "useLegacySql" => nil
     }
     hash["statistics"]["query"] = {
       "cacheHit" => false,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
@@ -19,6 +19,7 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
     qrg = query_request_gapi
     qrg.default_dataset = nil
     qrg.query = "SELECT * FROM [test-project:my_dataset.my_view]"
+    qrg.use_legacy_sql = nil
     qrg
   }
   let(:dataset_id) { "my_dataset" }

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -329,7 +329,7 @@ class MockBigquery < Minitest::Spec
           "allowLargeResults" => nil,
           "useQueryCache" => true,
           "flattenResults" => nil,
-          "useLegacySql" => true
+          "useLegacySql" => nil
         }
       }
     }.to_json
@@ -345,7 +345,7 @@ class MockBigquery < Minitest::Spec
       query: "SELECT name, age, score, active FROM [some_project:some_dataset.users]",
       timeout_ms: 10000,
       use_query_cache: true,
-      use_legacy_sql: true,
+      use_legacy_sql: nil,
     )
   end
 


### PR DESCRIPTION
Implement BigQuery Query Parameters.

Positional Query Parameters:

```ruby
require "google/cloud/bigquery"

bigquery = Google::Cloud::Bigquery.new

dataset = bigquery.dataset "my_dataset"
data = dataset.query "SELECT * FROM users WHERE id = ?", 
                     params: [1234567890]
```

Named Query Parameters:

```ruby
require "google/cloud/bigquery"

bigquery = Google::Cloud::Bigquery.new

dataset = bigquery.dataset "my_dataset"
data = dataset.query "SELECT * FROM users WHERE id = @id", 
                     params: { id: 1234567890 }
```

- [x] Implement Query Parameters
- [x] Unit Tests
- [x] Acceptance Tests
- [x] Method-level Documentation
- [x] LegacySQL Documentation
- [ ] Overview Documentation

[closes #1070]