### PR TITLE
New spec to show encoding problem

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -89,6 +89,17 @@ describe Google::Cloud::Storage::File, :storage do
     uploaded.delete
   end
 
+  it "should upload and delete a file with strange filename" do
+    original = File.new files[:logo][:path]
+    uploaded = bucket.create_file original, "#{[101, 769].pack("U*")}.png",
+      cache_control: "public, max-age=3600",
+      content_disposition: "attachment; filename=filename.ext",
+      content_language: "en",
+      content_type: "text/plain",
+      metadata: { player: "Alice", score: 101 }
+    uploaded.delete
+  end
+
   it "should upload and download a larger file" do
     original = File.new files[:big][:path]
     uploaded = bucket.create_file original, "BigLogo.png"


### PR DESCRIPTION
Hi,

I'm having some issues to perform actions on files with strange filename. Files has been uploaded with [fog-google](https://github.com/fog/fog-google) without sanitizing the filename. Files can be listed but nothing can be done on them. Here is a sample:
```ruby
bucket = Google::Cloud::Storage.new.bucket 'my-bucket-name'
bucket.files.first.reload! # -> raises Google::Cloud::NotFoundError
bucket.files.first.delete # -> raises Google::Cloud::NotFoundError
```

I'm able to delete files via the [console](https://console.cloud.google.com/storage) and the problem might be an encoding problem. `#{[101, 769].pack("U*")}.png` is encoded `%C3%A9.png` [here](https://github.com/google/google-api-ruby-client/blob/master/lib/google/apis/core/http_command.rb#L146) but it should be encoded `e%CC%81.png`

```ruby
# url from the gem
`/storage/v1/b/gcloud-ruby-acceptance-2016-12-02t16-00-31z-06b8fa78/o/%C3%A9.png
# url from the google cloud storage console`
`/storage/v1_internal/b/gcloud-ruby-acceptance-2016-12-02t16-00-31z-06b8fa78/o/e%CC%81.png`
```