### PR TITLE
Pin Rake at version 11.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "minitest", "~> 5.9"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.1"

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud", path: "../google-cloud"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-bigquery", path: "../google-cloud-bigquery"

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "gcloud-jsondoc",

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-api-client", "~> 0.9.11"
 gem "grpc", "~> 1.0"
 gem "google-protobuf", "~> 3.0"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-language/Gemfile
+++ b/google-cloud-language/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "gcloud-jsondoc",

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-monitoring/Gemfile
+++ b/google-cloud-monitoring/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-speech/Gemfile
+++ b/google-cloud-speech/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "gcloud-jsondoc",

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"

--- a/google-cloud-translate/Gemfile
+++ b/google-cloud-translate/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "gcloud-jsondoc",

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-bigquery", path: "../google-cloud-bigquery"
 gem "google-cloud-datastore", path: "../google-cloud-datastore"

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
+gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-error_reporting", path: "../google-cloud-error_reporting"
 gem "google-cloud-logging", path: "../google-cloud-logging"


### PR DESCRIPTION
Rake `12.0.0` breaks Rubocop `<= 0.35.1`, so this PR makes a temporary fix by pinning Rake at `11.3.0`, pending a more involved effort to update of styles for newer Rubocop rules.

[fixes #1106]