### PR TITLE
Remove encryption_key_sha256

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -33,7 +33,6 @@ describe Google::Cloud::Storage::File, :storage do
     cipher.encrypt
     cipher.random_key
   end
-  let(:encryption_key_sha256) { Digest::SHA256.digest encryption_key }
 
   before do
     # always create the bucket
@@ -215,7 +214,7 @@ describe Google::Cloud::Storage::File, :storage do
 
   it "should upload and download a file with customer-supplied encryption key" do
     original = File.new files[:logo][:path], "rb"
-    uploaded = bucket.create_file original, "CloudLogo.png", encryption_key: encryption_key, encryption_key_sha256: encryption_key_sha256
+    uploaded = bucket.create_file original, "CloudLogo.png", encryption_key: encryption_key
 
     Tempfile.open ["CloudLogo", ".png"] do |tmpfile|
       downloaded = uploaded.download tmpfile.path, encryption_key: encryption_key
@@ -270,7 +269,7 @@ describe Google::Cloud::Storage::File, :storage do
   it "should copy an existing file with customer-supplied encryption key" do
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo.png", encryption_key: encryption_key
     copied = try_with_backoff "copying existing file with encryption key" do
-      uploaded.copy "CloudLogoCopy.png", encryption_key: encryption_key, encryption_key_sha256: encryption_key_sha256
+      uploaded.copy "CloudLogoCopy.png", encryption_key: encryption_key
     end
     uploaded.name.must_equal "CloudLogo.png"
     copied.name.must_equal "CloudLogoCopy.png"
@@ -278,7 +277,7 @@ describe Google::Cloud::Storage::File, :storage do
 
     Tempfile.open ["CloudLogo", ".png"] do |tmpfile1|
       Tempfile.open ["CloudLogoCopy", ".png"] do |tmpfile2|
-        downloaded1 = uploaded.download tmpfile1.path, encryption_key: encryption_key, encryption_key_sha256: encryption_key_sha256
+        downloaded1 = uploaded.download tmpfile1.path, encryption_key: encryption_key
         downloaded2 = copied.download tmpfile2.path, encryption_key: encryption_key
         downloaded1.size.must_equal downloaded2.size
 

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -199,14 +199,14 @@ module Google
     # By default, Google Cloud Storage manages server-side encryption keys on
     # your behalf. However, a [customer-supplied encryption
     # key](https://cloud.google.com/storage/docs/encryption#customer-supplied)
-    # can be provided with the `encryption_key` and `encryption_key_sha256`
-    # options. If given, the same key and SHA256 hash also must be provided to
-    # subsequently download or copy the file. If you use customer-supplied
-    # encryption keys, you must securely manage your keys and ensure that they
-    # are not lost. Also, please note that file metadata is not encrypted, with
-    # the exception of the CRC32C checksum and MD5 hash. The names of files and
-    # buckets are also not encrypted, and you can read or update the metadata of
-    # an encrypted file without providing the encryption key.
+    # can be provided with the `encryption_key` option. If given, the same key
+    # must be provided to subsequently download or copy the file. If you use
+    # customer-supplied encryption keys, you must securely manage your keys and
+    # ensure that they are not lost. Also, please note that file metadata is not
+    # encrypted, with the exception of the CRC32C checksum and MD5 hash. The
+    # names of files and buckets are also not encrypted, and you can read or
+    # update the metadata of an encrypted file without providing the encryption
+    # key.
     #
     # ```ruby
     # require "google/cloud/storage"
@@ -219,17 +219,14 @@ module Google
     # cipher = OpenSSL::Cipher.new "aes-256-cfb"
     # cipher.encrypt
     # key = cipher.random_key
-    # key_hash = Digest::SHA256.digest key
     #
     # bucket.create_file "/var/todo-app/avatars/heidi/400x400.png",
     #                    "avatars/heidi/400x400.png",
-    #                    encryption_key: key,
-    #                    encryption_key_sha256: key_hash
+    #                    encryption_key: key
     #
     # # Store your key and hash securely for later use.
     # file = bucket.file "avatars/heidi/400x400.png",
-    #                    encryption_key: key,
-    #                    encryption_key_sha256: key_hash
+    #                    encryption_key: key
     # ```
     #
     # ## Downloading a File

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -413,21 +413,16 @@ module Google
         #
         # If a [customer-supplied encryption
         # key](https://cloud.google.com/storage/docs/encryption#customer-supplied)
-        # was used with {#create_file}, the `encryption_key` and
-        # `encryption_key_sha256` options must be provided or else the file's
-        # CRC32C checksum and MD5 hash will not be returned.
+        # was used with {#create_file}, the `encryption_key` option must be
+        # provided or else the file's CRC32C checksum and MD5 hash will not be
+        # returned.
         #
         # @param [String] path Name (path) of the file.
         # @param [Integer] generation When present, selects a specific revision
         #   of this object. Default is the latest version.
         # @param [String] encryption_key Optional. The customer-supplied,
         #   AES-256 encryption key used to encrypt the file, if one was provided
-        #   to {#create_file}. Must be provided if `encryption_key_sha256` is
-        #   provided.
-        # @param [String] encryption_key_sha256 Optional. The SHA256 hash of the
-        #   customer-supplied, AES-256 encryption key used to encrypt the file,
-        #   if one was provided to {#create_file}. Must be provided if
-        #   `encryption_key` is provided.
+        #   to {#create_file}.
         #
         # @return [Google::Cloud::Storage::File, nil] Returns nil if file does
         #   not exist
@@ -442,11 +437,9 @@ module Google
         #   file = bucket.file "path/to/my-file.ext"
         #   puts file.name
         #
-        def file path, generation: nil, encryption_key: nil,
-                 encryption_key_sha256: nil
+        def file path, generation: nil, encryption_key: nil
           ensure_service!
-          options = { generation: generation, key: encryption_key,
-                      key_sha256: encryption_key_sha256 }
+          options = { generation: generation, key: encryption_key }
           gapi = service.get_file name, path, options
           File.from_gapi gapi, service
         rescue Google::Cloud::NotFoundError
@@ -461,13 +454,11 @@ module Google
         # #### Customer-supplied encryption keys
         #
         # By default, Google Cloud Storage manages server-side encryption keys
-        # on your behalf. However, a [customer-supplied encryption
-        # key](https://cloud.google.com/storage/docs/encryption#customer-supplied)
-        # can be provided with the `encryption_key` and `encryption_key_sha256`
-        # options. If given, the same key and SHA256 hash also must be provided
-        # to subsequently download or copy the file. If you use
-        # customer-supplied encryption keys, you must securely manage your keys
-        # and ensure that they are not lost. Also, please note that file
+        # on your behalf. However, a [customer-supplied encryption key](https://cloud.google.com/storage/docs/encryption#customer-supplied)
+        # can be provided with the `encryption_key` option. If given, the same
+        # key must be provided to subsequently download or copy the file. If you
+        # use customer-supplied encryption keys, you must securely manage your
+        # keys and ensure that they are not lost. Also, please note that file
         # metadata is not encrypted, with the exception of the CRC32C checksum
         # and MD5 hash. The names of files and buckets are also not encrypted,
         # and you can read or update the metadata of an encrypted file without
@@ -524,11 +515,7 @@ module Google
         #   and arbitrary string values that will returned with requests for the
         #   file as "x-goog-meta-" response headers.
         # @param [String] encryption_key Optional. A customer-supplied, AES-256
-        #   encryption key that will be used to encrypt the file. Must be
-        #   provided if `encryption_key_sha256` is provided.
-        # @param [String] encryption_key_sha256 Optional. The SHA256 hash of the
-        #   customer-supplied, AES-256 encryption key that will be used to
-        #   encrypt the file. Must be provided if `encryption_key` is provided.
+        #   encryption key that will be used to encrypt the file.
         #
         # @return [Google::Cloud::Storage::File]
         #
@@ -562,30 +549,27 @@ module Google
         #   cipher = OpenSSL::Cipher.new "aes-256-cfb"
         #   cipher.encrypt
         #   key = cipher.random_key
-        #   key_hash = Digest::SHA256.digest key
         #
         #   bucket.create_file "path/to/local.file.ext",
         #                      "destination/path/file.ext",
-        #                      encryption_key: key,
-        #                      encryption_key_sha256: key_hash
+        #                      encryption_key: key
         #
         #   # Store your key and hash securely for later use.
         #   file = bucket.file "destination/path/file.ext",
-        #                      encryption_key: key,
-        #                      encryption_key_sha256: key_hash
+        #                      encryption_key: key
         #
         def create_file file, path = nil, acl: nil, cache_control: nil,
                         content_disposition: nil, content_encoding: nil,
                         content_language: nil, content_type: nil,
                         crc32c: nil, md5: nil, metadata: nil,
-                        encryption_key: nil, encryption_key_sha256: nil
+                        encryption_key: nil
           ensure_service!
           options = { acl: File::Acl.predefined_rule_for(acl), md5: md5,
                       cache_control: cache_control, content_type: content_type,
                       content_disposition: content_disposition, crc32c: crc32c,
                       content_encoding: content_encoding,
                       content_language: content_language, metadata: metadata,
-                      key: encryption_key, key_sha256: encryption_key_sha256 }
+                      key: encryption_key }
           ensure_file_exists! file
           # TODO: Handle file as an IO and path is missing more gracefully
           path ||= Pathname(file).to_path

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -307,8 +307,8 @@ module Google
         #
         # If a [customer-supplied encryption
         # key](https://cloud.google.com/storage/docs/encryption#customer-supplied)
-        # was used with {Bucket#create_file}, the `encryption_key` and
-        # `encryption_key_sha256` options must be provided.
+        # was used with {Bucket#create_file}, the `encryption_key` option must
+        # be provided.
         #
         # @param [String] path The path on the local file system to write the
         #   data to. The path provided must be writable.
@@ -324,12 +324,7 @@ module Google
         #
         # @param [String] encryption_key Optional. The customer-supplied,
         #   AES-256 encryption key used to encrypt the file, if one was provided
-        #   to {Bucket#create_file}. Must be provided if `encryption_key_sha256`
-        #   is provided.
-        # @param [String] encryption_key_sha256 Optional. The SHA256 hash of the
-        #   customer-supplied, AES-256 encryption key used to encrypt the file,
-        #   if one was provided to {Bucket#create_file}. Must be provided if
-        #   `encryption_key` is provided.
+        #   to {Bucket#create_file}.
         #
         # @return [File] Returns a `::File` object on the local file system
         #
@@ -373,12 +368,11 @@ module Google
         #   file = bucket.file "path/to/my-file.ext"
         #   file.download "path/to/downloaded/file.ext", verify: :none
         #
-        def download path, verify: :md5, encryption_key: nil,
-                     encryption_key_sha256: nil
+        def download path, verify: :md5, encryption_key: nil
           ensure_service!
           service.download_file \
             bucket, name, path,
-            key: encryption_key, key_sha256: encryption_key_sha256
+            key: encryption_key
           verify_file! ::File.new(path), verify
         end
 
@@ -387,8 +381,8 @@ module Google
         #
         # If a [customer-supplied encryption
         # key](https://cloud.google.com/storage/docs/encryption#customer-supplied)
-        # was used with {Bucket#create_file}, the `encryption_key` and
-        # `encryption_key_sha256` options must be provided.
+        # was used with {Bucket#create_file}, the `encryption_key` option must
+        # be provided.
         #
         # @param [String] dest_bucket_or_path Either the bucket to copy the file
         #   to, or the path to copy the file to in the current bucket.
@@ -417,12 +411,7 @@ module Google
         #   copy. The default is the latest version.
         # @param [String] encryption_key Optional. The customer-supplied,
         #   AES-256 encryption key used to encrypt the file, if one was provided
-        #   to {Bucket#create_file}. Must be provided if `encryption_key_sha256`
-        #   is provided.
-        # @param [String] encryption_key_sha256 Optional. The SHA256 hash of the
-        #   customer-supplied, AES-256 encryption key used to encrypt the file,
-        #   if one was provided to {Bucket#create_file}. Must be provided if
-        #   `encryption_key` is provided.
+        #   to {Bucket#create_file}.
         #
         # @return [Google::Cloud::Storage::File]
         #
@@ -459,11 +448,10 @@ module Google
         #             generation: 123456
         #
         def copy dest_bucket_or_path, dest_path = nil, acl: nil,
-                 generation: nil, encryption_key: nil,
-                 encryption_key_sha256: nil
+                 generation: nil, encryption_key: nil
           ensure_service!
           options = { acl: acl, generation: generation,
-                      key: encryption_key, key_sha256: encryption_key_sha256 }
+                      key: encryption_key }
           dest_bucket, dest_path, options = fix_copy_args dest_bucket_or_path,
                                                           dest_path, options
 

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -171,7 +171,7 @@ module Google
                         cache_control: nil, content_disposition: nil,
                         content_encoding: nil, content_language: nil,
                         content_type: nil, crc32c: nil, md5: nil, metadata: nil,
-                        key: nil, key_sha256: nil
+                        key: nil
           file_obj = Google::Apis::StorageV1::Object.new \
             cache_control: cache_control, content_type: content_type,
             content_disposition: content_disposition, md5_hash: md5,
@@ -183,19 +183,18 @@ module Google
               bucket_name, file_obj,
               name: path, predefined_acl: acl, upload_source: source,
               content_encoding: content_encoding, content_type: content_type,
-              options: key_options(key: key, key_sha256: key_sha256)
+              options: key_options(key)
           end
         end
 
         ##
         # Retrieves an object or its metadata.
-        def get_file bucket_name, file_path, generation: nil, key: nil,
-                     key_sha256: nil
+        def get_file bucket_name, file_path, generation: nil, key: nil
           execute do
             service.get_object \
               bucket_name, file_path,
               generation: generation,
-              options: key_options(key: key, key_sha256: key_sha256)
+              options: key_options(key)
           end
         end
 
@@ -210,20 +209,19 @@ module Google
               destination_bucket_name, destination_file_path,
               destination_predefined_acl: options[:acl],
               source_generation: options[:generation],
-              options: key_options(key: options[:key],
-                                   key_sha256: options[:key_sha256])
+              options: key_options(options[:key])
           end
         end
 
         ##
         # Download contents of a file.
         def download_file bucket_name, file_path, target_path, generation: nil,
-                          key: nil, key_sha256: nil
+                          key: nil
           execute do
             service.get_object \
               bucket_name, file_path,
               download_dest: target_path, generation: generation,
-              options: key_options(key: key, key_sha256: key_sha256)
+              options: key_options(key)
           end
         end
 
@@ -285,13 +283,13 @@ module Google
 
         protected
 
-        def key_options key: nil, key_sha256: nil
+        def key_options key
           options = {}
           if key
+            key_sha256 = Digest::SHA256.digest key
             headers = {}
             headers["x-goog-encryption-algorithm"] = "AES256"
             headers["x-goog-encryption-key"] = Base64.strict_encode64 key
-            key_sha256 ||= Digest::SHA256.digest key
             headers["x-goog-encryption-key-sha256"] = \
               Base64.strict_encode64 key_sha256
             options[:header] = headers

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -44,8 +44,7 @@ module Google
   module Cloud
     module Storage
       class File
-        def download path, verify: :md5, encryption_key: nil,
-                     encryption_key_sha256: nil
+        def download path, verify: :md5, encryption_key: nil
           # no-op stub, but ensures that calls match this copied signature
         end
         def signed_url method: nil, expires: nil, content_type: nil,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -289,25 +289,6 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     end
   end
 
-  it "creates a file with customer-supplied encryption key and sha" do
-    new_file_name = random_file_path
-
-    Tempfile.open ["google-cloud", ".txt"] do |tmpfile|
-      tmpfile.write "Hello world"
-      tmpfile.rewind
-
-      mock = Minitest::Mock.new
-      mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: key_options]
-
-      bucket.service.mocked_service = mock
-
-      bucket.create_file tmpfile, new_file_name, encryption_key: encryption_key, encryption_key_sha256: encryption_key_sha256
-
-      mock.verify
-    end
-  end
-
   it "raises when given a file that does not exist" do
     bad_file_path = "/this/file/does/not/exist.ext"
 
@@ -713,22 +694,6 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     bucket.service.mocked_service = mock
 
     file = bucket.file file_name, encryption_key: encryption_key
-
-    mock.verify
-
-    file.name.must_equal file_name
-  end
-
-  it "finds a file with customer-supplied encryption key and sha" do
-    file_name = "file.ext"
-
-    mock = Minitest::Mock.new
-    mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: nil, options: key_options]
-
-    bucket.service.mocked_service = mock
-
-    file = bucket.file file_name, encryption_key: encryption_key, encryption_key_sha256: encryption_key_sha256
 
     mock.verify
 

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -115,28 +115,6 @@ describe Google::Cloud::Storage::File, :mock_storage do
     end
   end
 
-  it "can download itself with customer-supplied encryption key and sha" do
-    # Stub the md5 to match.
-    def file.md5
-      "1B2M2Y8AsgTpgAmY7PhCfg=="
-    end
-
-    Tempfile.open "google-cloud" do |tmpfile|
-      # write to the file since the mocked call won't
-      tmpfile.write "yay!"
-
-      mock = Minitest::Mock.new
-      mock.expect :get_object, file_gapi,
-        [bucket.name, file.name, download_dest: tmpfile, generation: nil, options: key_options]
-
-      bucket.service.mocked_service = mock
-
-      file.download tmpfile, encryption_key: encryption_key, encryption_key_sha256: encryption_key_sha256
-
-      mock.verify
-    end
-  end
-
   describe "verified downloads" do
     it "verifies m5d by default" do
       # Stub these values
@@ -365,18 +343,6 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
-  it "can copy itself with customer-supplied encryption key and sha" do
-    mock = Minitest::Mock.new
-    mock.expect :copy_object, file_gapi,
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: nil, source_generation: nil, options: key_options]
-
-    file.service.mocked_service = mock
-
-    file.copy "new-file.ext", encryption_key: encryption_key, encryption_key_sha256: encryption_key_sha256
-
-    mock.verify
-  end
-
   it "can copy itself to a different bucket" do
     mock = Minitest::Mock.new
     mock.expect :copy_object, file_gapi,
@@ -433,18 +399,6 @@ describe Google::Cloud::Storage::File, :mock_storage do
     file.service.mocked_service = mock
 
     file.copy "new-bucket", "new-file.ext", encryption_key: encryption_key
-
-    mock.verify
-  end
-
-  it "can copy itself to a different bucket with customer-supplied encryption key and sha" do
-    mock = Minitest::Mock.new
-    mock.expect :copy_object, file_gapi,
-      [bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: nil, source_generation: nil, options: key_options]
-
-    file.service.mocked_service = mock
-
-    file.copy "new-bucket", "new-file.ext", encryption_key: encryption_key, encryption_key_sha256: encryption_key_sha256
 
     mock.verify
   end


### PR DESCRIPTION
## Reasoning
@remi and I have been working on creating code samples to demonstrate encryption of Google Cloud Storage files using customer-supplied encryption keys. 

For consistency we reviewed other language samples currently shown in the Google Cloud Storage documentation ([storage/docs/encryption#sample_code](https://cloud.google.com/storage/docs/encryption#sample_code)) which demonstrate uploading files, providing an encryption key *only*.

Currently, the documentation for [Bucket#create_file](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/v0.22.0/google/cloud/storage/bucket?method=create_file-instance) says that the `encryption_key_sha256` parameter *"Must be provided if encryption_key is provided"*.  If the SHA256 hash is not passed, however, the library currently [sets it by hashing the key](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/850fd5a5cb376d59ed379122ea18f23df937b8d0/google-cloud-storage/lib/google/cloud/storage/service.rb#L294).

To make using customer-supplied encryption keys easier and more consistent with other google-cloud libraries, this change removes the `encryption_key_sha256` parameter and updates the documentation. However, we did keep File#encryption_key_sha256 to get the SHA256 of an uploaded file. 

## Updates
Remove encryption_key_sha256 parameter from the following methods:

 - Bucket#file
 - Bucket#create_file
 - File#download
 - File#copy
 - File#get_file

The x-goog-encryption-key-sha256 header will be set to the SHA256 hash of the
encryption key provided.