### PR TITLE
Add doctest for Google::Cloud::Logging::Middleware

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -78,32 +78,36 @@ module Google
         # based on the current environment.
         #
         # @example If both type and labels are provided, it returns resource:
-        #   rc = Middleware.build_monitored_resource "aws_ec2_instance",
-        #                                            { instance_id: "ec2-id",
-        #                                              aws_account: "aws-id" }
+        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource(
+        #          "aws_ec2_instance",
+        #          {
+        #            instance_id: "ec2-id",
+        #            aws_account: "aws-id"
+        #          }
+        #        )
         #   rc.type   #=> "aws_ec2_instance"
         #   rc.labels #=> { instance_id: "ec2-id", aws_account: "aws-id" }
         #
         # @example If running from GAE, returns default resource:
-        #   rc = Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
         #   rc.type   #=> "gae_app"
-        #   rc.labels #=> { module_id: [GAE module name],
-        #             #     version_id: [GAE module version] }
+        #   rc.labels # { module_id: [GAE module name],
+        #             #   version_id: [GAE module version] }
         #
         # @example If running from GKE, returns default resource:
-        #   rc = Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
         #   rc.type   #=> "container"
-        #   rc.labels #=> { cluster_name: [GKE cluster name],
-        #             #     namespace_id: [GKE namespace_id] }
+        #   rc.labels # { cluster_name: [GKE cluster name],
+        #             #   namespace_id: [GKE namespace_id] }
         #
         # @example If running from GCE, return default resource:
-        #   rc = Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
         #   rc.type   #=> "gce_instance"
-        #   rc.labels #=> { instance_id: [GCE VM instance id],
-        #             #     zone: [GCE vm group zone] }
+        #   rc.labels # { instance_id: [GCE VM instance id],
+        #             #   zone: [GCE vm group zone] }
         #
         # @example Otherwise default to generic "global" type:
-        #   rc = Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
         #   rc.type   #=> "global"
         #   rc.labels #=> {}
         #
@@ -132,25 +136,25 @@ module Google
         # the correct monitoring resource types and labels.
         #
         # @example If running from GAE, returns default resource:
-        #   rc = Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
         #   rc.type   #=> "gae_app"
-        #   rc.labels #=> { module_id: [GAE module name],
-        #             #     version_id: [GAE module version] }
+        #   rc.labels # { module_id: [GAE module name],
+        #             #   version_id: [GAE module version] }
         #
         # @example If running from GKE, returns default resource:
-        #   rc = Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
         #   rc.type   #=> "container"
-        #   rc.labels #=> { cluster_name: [GKE cluster name],
-        #             #     namespace_id: [GKE namespace_id] }
+        #   rc.labels # { cluster_name: [GKE cluster name],
+        #             #   namespace_id: [GKE namespace_id] }
         #
         # @example If running from GCE, return default resource:
-        #   rc = Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
         #   rc.type   #=> "gce_instance"
-        #   rc.labels #=> { instance_id: [GCE VM instance id],
-        #             #     zone: [GCE vm group zone] }
+        #   rc.labels # { instance_id: [GCE VM instance id],
+        #             #   zone: [GCE vm group zone] }
         #
         # @example Otherwise default to generic "global" type:
-        #   rc = Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
         #   rc.type   #=> "global"
         #   rc.labels #=> {}
         #

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -114,9 +114,6 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Logging::Sink#end_time="
   doctest.skip "Google::Cloud::Logging::Sink#refresh!"
 
-  # TODO: Add support for Middleware examples, if desired
-  doctest.skip "Google::Cloud::Logging::Middleware"
-
   ##
   # BEFORE (mocking)
   #
@@ -324,6 +321,142 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Logging::Sink::List" do
     mock_logging do |mock, mock_metrics, mock_sinks|
       mock_sinks.expect :list_sinks, list_sinks_res, ["projects/my-project", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GAE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gae? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GAE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gae? do
+      false
+    end
+  end
+
+  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GKE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gke? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GKE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gke? do
+      false
+    end
+  end
+
+  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GCE, return default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gce? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GCE, return default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gce? do
+      false
+    end
+  end
+  doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GAE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gae? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GAE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gae? do
+      false
+    end
+  end
+
+  doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GKE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gke? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GKE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gke? do
+      false
+    end
+  end
+
+  doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GCE, return default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gce? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GCE, return default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gce? do
+      false
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GAE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gae? do
+      false
+    end
+  end
+
+  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GKE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gke? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GKE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gke? do
+      false
+    end
+  end
+
+  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GCE, return default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gce? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GCE, return default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gce? do
+      false
+    end
+  end
+  doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GAE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gae? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GAE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gae? do
+      false
+    end
+  end
+
+  doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GKE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gke? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GKE, returns default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gke? do
+      false
+    end
+  end
+
+  doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GCE, return default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gce? do
+      true
+    end
+  end
+
+  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GCE, return default resource" do
+    Google::Cloud::Core::Environment.define_singleton_method :gce? do
+      false
     end
   end
 end


### PR DESCRIPTION
This PR is a follow up PR to #1110 to add doctest for Google::Cloud::Logging::Middleware. It stubs depened functions from Google::Cloud::Core::Environment, so the existing examples from Logging::Middleware can execute properly.

[refs #226]