### PR TITLE
Include Datastore and Logging GAPIC/gRPC code in YARD docs

### DIFF
--- a/google-cloud-datastore/.yardopts
+++ b/google-cloud-datastore/.yardopts
@@ -1,8 +1,5 @@
 --no-private
 --title=Google Cloud Datastore
---exclude lib/google/datastore
---exclude lib/google/cloud/datastore/v1
---exclude lib/google/cloud/datastore/v1.rb
 --markup markdown
 
 ./lib/**/*.rb

--- a/google-cloud-logging/.yardopts
+++ b/google-cloud-logging/.yardopts
@@ -1,8 +1,5 @@
 --no-private
 --title=Stackdriver Logging
---exclude lib/google/logging
---exclude lib/google/cloud/logging/v2
---exclude lib/google/cloud/logging/v2.rb
 --markup markdown
 
 ./lib/**/*.rb


### PR DESCRIPTION
@swcloud wrote:

> Please also make sure the GAPIC/GRPC doc will surface on rubydoc.info website as well. I think once gapic code is included in the .yardopts, they should surface there.

A PR exposing this code on the gh-pages site will follow, but as I am afraid it may be somewhat delayed by design issues, please merge this one now.

[refs #1071, refs #1073]