### PR TITLE
Rename parent to project in logging API

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
@@ -69,11 +69,11 @@ module Google
             "https://www.googleapis.com/auth/logging.write"
           ].freeze
 
-          PARENT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+          PROJECT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
             "projects/{project}"
           )
 
-          private_constant :PARENT_PATH_TEMPLATE
+          private_constant :PROJECT_PATH_TEMPLATE
 
           SINK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
             "projects/{project}/sinks/{sink}"
@@ -81,11 +81,11 @@ module Google
 
           private_constant :SINK_PATH_TEMPLATE
 
-          # Returns a fully-qualified parent resource name string.
+          # Returns a fully-qualified project resource name string.
           # @param project [String]
           # @return [String]
-          def self.parent_path project
-            PARENT_PATH_TEMPLATE.render(
+          def self.project_path project
+            PROJECT_PATH_TEMPLATE.render(
               :"project" => project
             )
           end
@@ -101,11 +101,11 @@ module Google
             )
           end
 
-          # Parses the project from a parent resource.
-          # @param parent_name [String]
+          # Parses the project from a project resource.
+          # @param project_name [String]
           # @return [String]
-          def self.match_project_from_parent_name parent_name
-            PARENT_PATH_TEMPLATE.match(parent_name)["project"]
+          def self.match_project_from_project_name project_name
+            PROJECT_PATH_TEMPLATE.match(project_name)["project"]
           end
 
           # Parses the project from a sink resource.
@@ -156,6 +156,7 @@ module Google
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/logging/v2/logging_config_services_pb"
+
 
             google_api_client = "#{app_name}/#{app_version} " \
               "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " \
@@ -237,7 +238,7 @@ module Google
           #   ConfigServiceV2Client = Google::Cloud::Logging::V2::ConfigServiceV2Client
           #
           #   config_service_v2_client = ConfigServiceV2Client.new
-          #   formatted_parent = ConfigServiceV2Client.parent_path("[PROJECT]")
+          #   formatted_parent = ConfigServiceV2Client.project_path("[PROJECT]")
           #
           #   # Iterate over all results.
           #   config_service_v2_client.list_sinks(formatted_parent).each do |element|
@@ -321,7 +322,7 @@ module Google
           #   LogSink = Google::Logging::V2::LogSink
           #
           #   config_service_v2_client = ConfigServiceV2Client.new
-          #   formatted_parent = ConfigServiceV2Client.parent_path("[PROJECT]")
+          #   formatted_parent = ConfigServiceV2Client.project_path("[PROJECT]")
           #   sink = LogSink.new
           #   response = config_service_v2_client.create_sink(formatted_parent, sink)
 

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/label.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/label.rb
@@ -1,0 +1,41 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Api
+    # A description of a label.
+    # @!attribute [rw] key
+    #   @return [String]
+    #     The label key.
+    # @!attribute [rw] value_type
+    #   @return [Google::Api::LabelDescriptor::ValueType]
+    #     The type of data that can be assigned to the label.
+    # @!attribute [rw] description
+    #   @return [String]
+    #     A human-readable description for the label.
+    class LabelDescriptor
+      # Value types that can be used as label values.
+      module ValueType
+        # A variable-length string. This is the default.
+        STRING = 0
+
+        # Boolean; true or false.
+        BOOL = 1
+
+        # A 64-bit signed integer.
+        INT64 = 2
+      end
+    end
+  end
+end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
@@ -72,11 +72,11 @@ module Google
             "https://www.googleapis.com/auth/logging.write"
           ].freeze
 
-          PARENT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+          PROJECT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
             "projects/{project}"
           )
 
-          private_constant :PARENT_PATH_TEMPLATE
+          private_constant :PROJECT_PATH_TEMPLATE
 
           LOG_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
             "projects/{project}/logs/{log}"
@@ -84,11 +84,11 @@ module Google
 
           private_constant :LOG_PATH_TEMPLATE
 
-          # Returns a fully-qualified parent resource name string.
+          # Returns a fully-qualified project resource name string.
           # @param project [String]
           # @return [String]
-          def self.parent_path project
-            PARENT_PATH_TEMPLATE.render(
+          def self.project_path project
+            PROJECT_PATH_TEMPLATE.render(
               :"project" => project
             )
           end
@@ -104,11 +104,11 @@ module Google
             )
           end
 
-          # Parses the project from a parent resource.
-          # @param parent_name [String]
+          # Parses the project from a project resource.
+          # @param project_name [String]
           # @return [String]
-          def self.match_project_from_parent_name parent_name
-            PARENT_PATH_TEMPLATE.match(parent_name)["project"]
+          def self.match_project_from_project_name project_name
+            PROJECT_PATH_TEMPLATE.match(project_name)["project"]
           end
 
           # Parses the project from a log resource.
@@ -159,6 +159,7 @@ module Google
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/logging/v2/logging_services_pb"
+
 
             google_api_client = "#{app_name}/#{app_version} " \
               "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " \

--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
@@ -68,11 +68,11 @@ module Google
             "https://www.googleapis.com/auth/logging.write"
           ].freeze
 
-          PARENT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+          PROJECT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
             "projects/{project}"
           )
 
-          private_constant :PARENT_PATH_TEMPLATE
+          private_constant :PROJECT_PATH_TEMPLATE
 
           METRIC_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
             "projects/{project}/metrics/{metric}"
@@ -80,11 +80,11 @@ module Google
 
           private_constant :METRIC_PATH_TEMPLATE
 
-          # Returns a fully-qualified parent resource name string.
+          # Returns a fully-qualified project resource name string.
           # @param project [String]
           # @return [String]
-          def self.parent_path project
-            PARENT_PATH_TEMPLATE.render(
+          def self.project_path project
+            PROJECT_PATH_TEMPLATE.render(
               :"project" => project
             )
           end
@@ -100,11 +100,11 @@ module Google
             )
           end
 
-          # Parses the project from a parent resource.
-          # @param parent_name [String]
+          # Parses the project from a project resource.
+          # @param project_name [String]
           # @return [String]
-          def self.match_project_from_parent_name parent_name
-            PARENT_PATH_TEMPLATE.match(parent_name)["project"]
+          def self.match_project_from_project_name project_name
+            PROJECT_PATH_TEMPLATE.match(project_name)["project"]
           end
 
           # Parses the project from a metric resource.
@@ -155,6 +155,7 @@ module Google
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/logging/v2/logging_metrics_services_pb"
+
 
             google_api_client = "#{app_name}/#{app_version} " \
               "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " \
@@ -235,7 +236,7 @@ module Google
           #   MetricsServiceV2Client = Google::Cloud::Logging::V2::MetricsServiceV2Client
           #
           #   metrics_service_v2_client = MetricsServiceV2Client.new
-          #   formatted_parent = MetricsServiceV2Client.parent_path("[PROJECT]")
+          #   formatted_parent = MetricsServiceV2Client.project_path("[PROJECT]")
           #
           #   # Iterate over all results.
           #   metrics_service_v2_client.list_log_metrics(formatted_parent).each do |element|
@@ -313,7 +314,7 @@ module Google
           #   MetricsServiceV2Client = Google::Cloud::Logging::V2::MetricsServiceV2Client
           #
           #   metrics_service_v2_client = MetricsServiceV2Client.new
-          #   formatted_parent = MetricsServiceV2Client.parent_path("[PROJECT]")
+          #   formatted_parent = MetricsServiceV2Client.project_path("[PROJECT]")
           #   metric = LogMetric.new
           #   response = metrics_service_v2_client.create_log_metric(formatted_parent, metric)
 


### PR DESCRIPTION
Please refer to https://github.com/googleapis/googleapis/pull/208.

Seems to be low-risk to me. @blowmage @quartzmo Could you please evaluate the risk to the veneer layer to see if we can make the change into the new release?