### PR TITLE
Add Datastore and Logging GAPIC code to gh-pages site nav

### DIFF
--- a/google-cloud-datastore/docs/toc.json
+++ b/google-cloud-datastore/docs/toc.json
@@ -53,11 +53,11 @@
     },
     {
       "title": "Datastore::V1",
-      "type": "google/datastore/v1",
+      "type": "google/cloud/datastore/v1/datastoreclient",
       "nav": [
         {
-          "title": "Service",
-          "type": "google/datastore/v1/datastore/service"
+          "title": "DatastoreClient",
+          "type": "google/cloud/datastore/v1/datastoreclient"
         },
         {
           "title": "BoolValue",

--- a/google-cloud-datastore/docs/toc.json
+++ b/google-cloud-datastore/docs/toc.json
@@ -50,6 +50,52 @@
           "type": "google/cloud/datastore/key"
         }
       ]
+    },
+    {
+      "title": "Datastore::V1",
+      "type": "google/datastore/v1",
+      "nav": [
+        {
+          "title": "Service",
+          "type": "google/datastore/v1/datastore/service"
+        },
+        {
+          "title": "BoolValue",
+          "type": "google/protobuf/boolvalue"
+        },
+        {
+          "title": "BytesValue",
+          "type": "google/protobuf/bytesvalue"
+        },
+        {
+          "title": "DoubleValue",
+          "type": "google/protobuf/doublevalue"
+        },
+        {
+          "title": "FloatValue",
+          "type": "google/protobuf/floatvalue"
+        },
+        {
+          "title": "Int32Value",
+          "type": "google/protobuf/int32value"
+        },
+        {
+          "title": "Int64Value",
+          "type": "google/protobuf/int64value"
+        },
+        {
+          "title": "StringValue",
+          "type": "google/protobuf/stringvalue"
+        },
+        {
+          "title": "UInt32Value",
+          "type": "google/protobuf/uint32value"
+        },
+        {
+          "title": "UInt64Value",
+          "type": "google/protobuf/uint64value"
+        }
+      ]
     }
   ]
 }

--- a/google-cloud-logging/docs/toc.json
+++ b/google-cloud-logging/docs/toc.json
@@ -62,19 +62,19 @@
     },
     {
       "title": "Logging::V2",
-      "type": "google/logging/v2",
+      "type": "google/cloud/logging/v2/loggingservicev2client",
       "nav": [
         {
-          "title": "ConfigServiceV2",
-          "type": "google/logging/v2/configservicev2"
+          "title": "ConfigServiceV2Client",
+          "type": "google/cloud/logging/v2/configservicev2client"
         },
         {
-          "title": "LoggingServiceV2",
-          "type": "google/logging/v2/loggingservicev2"
+          "title": "LoggingServiceV2Client",
+          "type": "google/cloud/logging/v2/loggingservicev2client"
         },
         {
-          "title": "MetricsServiceV2",
-          "type": "google/logging/v2/metricsservicev2"
+          "title": "MetricsServiceV2Client",
+          "type": "google/cloud/logging/v2/metricsservicev2client"
         },
         {
           "title": "Any",

--- a/google-cloud-logging/docs/toc.json
+++ b/google-cloud-logging/docs/toc.json
@@ -59,6 +59,36 @@
           "type": "google/cloud/logging/railtie"
         }
       ]
+    },
+    {
+      "title": "Logging::V2",
+      "type": "google/logging/v2",
+      "nav": [
+        {
+          "title": "ConfigServiceV2",
+          "type": "google/logging/v2/configservicev2"
+        },
+        {
+          "title": "LoggingServiceV2",
+          "type": "google/logging/v2/loggingservicev2"
+        },
+        {
+          "title": "MetricsServiceV2",
+          "type": "google/logging/v2/metricsservicev2"
+        },
+        {
+          "title": "Any",
+          "type": "google/protobuf/any"
+        },
+        {
+          "title": "Duration",
+          "type": "google/protobuf/duration"
+        },
+        {
+          "title": "Timestamp",
+          "type": "google/protobuf/timestamp"
+        }
+      ]
     }
   ]
 }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -204,6 +204,36 @@
       ]
     },
     {
+      "title": "Logging::V2",
+      "type": "google/logging/v2",
+      "nav": [
+        {
+          "title": "ConfigServiceV2",
+          "type": "google/logging/v2/configservicev2"
+        },
+        {
+          "title": "LoggingServiceV2",
+          "type": "google/logging/v2/loggingservicev2"
+        },
+        {
+          "title": "MetricsServiceV2",
+          "type": "google/logging/v2/metricsservicev2"
+        },
+        {
+          "title": "Any",
+          "type": "google/protobuf/any"
+        },
+        {
+          "title": "Duration",
+          "type": "google/protobuf/duration"
+        },
+        {
+          "title": "Timestamp",
+          "type": "google/protobuf/timestamp"
+        }
+      ]
+    },
+    {
       "title": "Natural Language",
       "type": "google/cloud/language",
       "nav": [

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -205,19 +205,19 @@
     },
     {
       "title": "Logging::V2",
-      "type": "google/logging/v2",
+      "type": "google/cloud/logging/v2/loggingservicev2client",
       "nav": [
         {
-          "title": "ConfigServiceV2",
-          "type": "google/logging/v2/configservicev2"
+          "title": "ConfigServiceV2Client",
+          "type": "google/cloud/logging/v2/configservicev2client"
         },
         {
-          "title": "LoggingServiceV2",
-          "type": "google/logging/v2/loggingservicev2"
+          "title": "LoggingServiceV2Client",
+          "type": "google/cloud/logging/v2/loggingservicev2client"
         },
         {
-          "title": "MetricsServiceV2",
-          "type": "google/logging/v2/metricsservicev2"
+          "title": "MetricsServiceV2Client",
+          "type": "google/cloud/logging/v2/metricsservicev2client"
         },
         {
           "title": "Any",

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -89,11 +89,11 @@
     },
     {
       "title": "Datastore::V1",
-      "type": "google/datastore/v1",
+      "type": "google/cloud/datastore/v1/datastoreclient",
       "nav": [
         {
-          "title": "Service",
-          "type": "google/datastore/v1/datastore/service"
+          "title": "DatastoreClient",
+          "type": "google/cloud/datastore/v1/datastoreclient"
         },
         {
           "title": "BoolValue",

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -88,6 +88,52 @@
       ]
     },
     {
+      "title": "Datastore::V1",
+      "type": "google/datastore/v1",
+      "nav": [
+        {
+          "title": "Service",
+          "type": "google/datastore/v1/datastore/service"
+        },
+        {
+          "title": "BoolValue",
+          "type": "google/protobuf/boolvalue"
+        },
+        {
+          "title": "BytesValue",
+          "type": "google/protobuf/bytesvalue"
+        },
+        {
+          "title": "DoubleValue",
+          "type": "google/protobuf/doublevalue"
+        },
+        {
+          "title": "FloatValue",
+          "type": "google/protobuf/floatvalue"
+        },
+        {
+          "title": "Int32Value",
+          "type": "google/protobuf/int32value"
+        },
+        {
+          "title": "Int64Value",
+          "type": "google/protobuf/int64value"
+        },
+        {
+          "title": "StringValue",
+          "type": "google/protobuf/stringvalue"
+        },
+        {
+          "title": "UInt32Value",
+          "type": "google/protobuf/uint32value"
+        },
+        {
+          "title": "UInt64Value",
+          "type": "google/protobuf/uint64value"
+        }
+      ]
+    },
+    {
       "title": "DNS",
       "type": "google/cloud/dns",
       "nav": [


### PR DESCRIPTION
This PR adds GAPIC and gRPC types to the JSON docs for the gh-pages site. It also adds select Datastore and Logging GAPIC and gRPC types to the left navigation in the site.

Demo site: [Datastore]https://quartzmo.github.io/google-cloud-ruby/#/docs/google-cloud/master/google/cloud/datastore/v1/datastoreclient) and [Logging](https://quartzmo.github.io/google-cloud-ruby/#/docs/google-cloud/master/google/cloud/logging/v2/loggingservicev2client)

![datastore-gapic-2](https://cloud.githubusercontent.com/assets/205445/21030117/1f393446-bd5a-11e6-84bb-3948b6af6baf.png)

Known issues:

* As I [commented in the gcloud-common issue #207](https://github.com/GoogleCloudPlatform/gcloud-common/issues/207#issuecomment-265621244), I get errors when I try to configure a left nav with items nested more than one level deep. Therefore, `Datastore::V1` and `Logging::V2` are "flattened" into the top level of the left nav. This is also the reason there are no "Data Types" sub-directories in the left nav. Fixing this will probably involve changes to the Angular site app.
* Because YARD (our docs library) generates output that is scoped to Ruby classes and modules, Protobuf types that are exposed as Ruby constants are not currently published. So links to types like `Google::Datastore::V1::BeginTransactionResponse` (defined as a constant in `lib/google/datastore/v1/datastore_pb.rb`) are broken.
* Clicking on nav items such as `Datastore::V1 -> BoolValue` displays the correct content, but the left nav loses focus and collapses. I am not sure why this occurs, but fixing it will probably involve changes to the Angular site app.



