### PR TITLE
Fix doctest task on CI

### DIFF
--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -99,6 +99,7 @@ end
 
 desc "Run yard-doctest example tests."
 task :doctest do
+  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -70,6 +70,7 @@ end
 
 desc "Run yard-doctest example tests."
 task :doctest do
+  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -95,6 +95,7 @@ end
 
 desc "Run yard-doctest example tests."
 task :doctest do
+  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -94,6 +94,7 @@ end
 
 desc "Run yard-doctest example tests."
 task :doctest do
+  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -67,6 +67,7 @@ end
 
 desc "Run yard-doctest example tests."
 task :doctest do
+  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -98,6 +98,7 @@ end
 
 desc "Run yard-doctest example tests."
 task :doctest do
+  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -98,6 +98,7 @@ end
 
 desc "Run yard-doctest example tests."
 task :doctest do
+  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 


### PR DESCRIPTION
Add autoload configuration to ensure that the YARD doctest plugin is found so it can be run.

[fixes #1088]