### PR TITLE
Fix logging/middleware.rb doctest

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -136,25 +136,29 @@ module Google
         # the correct monitoring resource types and labels.
         #
         # @example If running from GAE, returns default resource:
-        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.send \
+        #          :default_monitored_resource
         #   rc.type   #=> "gae_app"
         #   rc.labels # { module_id: [GAE module name],
         #             #   version_id: [GAE module version] }
         #
         # @example If running from GKE, returns default resource:
-        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.send \
+        #          :default_monitored_resource
         #   rc.type   #=> "container"
         #   rc.labels # { cluster_name: [GKE cluster name],
         #             #   namespace_id: [GKE namespace_id] }
         #
         # @example If running from GCE, return default resource:
-        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.send \
+        #          :default_monitored_resource
         #   rc.type   #=> "gce_instance"
         #   rc.labels # { instance_id: [GCE VM instance id],
         #             #   zone: [GCE vm group zone] }
         #
         # @example Otherwise default to generic "global" type:
-        #   rc = Google::Cloud::Logging::Middleware.build_monitored_resource
+        #   rc = Google::Cloud::Logging::Middleware.send \
+        #          :default_monitored_resource
         #   rc.type   #=> "global"
         #   rc.labels #=> {}
         #

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -114,6 +114,9 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Logging::Sink#end_time="
   doctest.skip "Google::Cloud::Logging::Sink#refresh!"
 
+  # Skip private methods
+  doctest.skip "Google::Cloud::Logging::Middleware.default_monitored_resource"
+
   ##
   # BEFORE (mocking)
   #
@@ -339,24 +342,6 @@ YARD::Doctest.configure do |doctest|
 
     Google::Cloud::Core::Environment.define_singleton_method :get_metadata_attribute do |_, _|
       nil
-    end
-  end
-
-  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GAE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gae? do
-      true
-    end
-  end
-
-  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GKE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gke? do
-      true
-    end
-  end
-
-  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GCE, return default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gce? do
-      true
     end
   end
 

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -324,27 +324,33 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Logging::Middleware" do
+    Google::Cloud::Core::Environment.define_singleton_method :gae? do
+      false
+    end
+
+    Google::Cloud::Core::Environment.define_singleton_method :gke? do
+      false
+    end
+
+    Google::Cloud::Core::Environment.define_singleton_method :gce? do
+      false
+    end
+
+    Google::Cloud::Core::Environment.define_singleton_method :get_metadata_attribute do |_, _|
+      nil
+    end
+  end
+
   doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GAE, returns default resource" do
     Google::Cloud::Core::Environment.define_singleton_method :gae? do
       true
     end
   end
 
-  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GAE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gae? do
-      false
-    end
-  end
-
   doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GKE, returns default resource" do
     Google::Cloud::Core::Environment.define_singleton_method :gke? do
       true
-    end
-  end
-
-  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GKE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gke? do
-      false
     end
   end
 
@@ -354,20 +360,9 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GCE, return default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gce? do
-      false
-    end
-  end
   doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GAE, returns default resource" do
     Google::Cloud::Core::Environment.define_singleton_method :gae? do
       true
-    end
-  end
-
-  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GAE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gae? do
-      false
     end
   end
 
@@ -377,86 +372,9 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GKE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gke? do
-      false
-    end
-  end
-
   doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GCE, return default resource" do
     Google::Cloud::Core::Environment.define_singleton_method :gce? do
       true
-    end
-  end
-
-  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GCE, return default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gce? do
-      false
-    end
-  end
-
-  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GAE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gae? do
-      false
-    end
-  end
-
-  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GKE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gke? do
-      true
-    end
-  end
-
-  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GKE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gke? do
-      false
-    end
-  end
-
-  doctest.before "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GCE, return default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gce? do
-      true
-    end
-  end
-
-  doctest.after "Google::Cloud::Logging::Middleware.default_monitored_resource@If running from GCE, return default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gce? do
-      false
-    end
-  end
-  doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GAE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gae? do
-      true
-    end
-  end
-
-  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GAE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gae? do
-      false
-    end
-  end
-
-  doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GKE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gke? do
-      true
-    end
-  end
-
-  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GKE, returns default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gke? do
-      false
-    end
-  end
-
-  doctest.before "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GCE, return default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gce? do
-      true
-    end
-  end
-
-  doctest.after "Google::Cloud::Logging::Middleware.build_monitored_resource@If running from GCE, return default resource" do
-    Google::Cloud::Core::Environment.define_singleton_method :gce? do
-      false
     end
   end
 end


### PR DESCRIPTION
Fix doctest for logging/middleware.rb. This time, properly stub Google::Cloud::Core::Environment.get_metadata_attribute before each Middleware doctest, so no network connection is made from doctests.