### PR TITLE
Update yard-doctest helpers, RELEASING.md, and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to google-cloud-ruby
+# Contributing to Google Cloud Ruby Client
 
 1. **Sign one of the contributor license agreements below.**
 2. Fork the repo, develop and test your code changes.
@@ -46,13 +46,37 @@ $ bundle exec rake console
 
 Tests are very important part of google-cloud-ruby. All contributions should include tests that ensure the contributed code behaves as expected.
 
+To run the unit tests, documentation tests, and code style checks together:
+
+``` sh
+$ rake ci
+```
+
 ### Unit Tests
 
-To run the unit tests, simply run:
+
+The project uses the [minitest](https://github.com/seattlerb/minitest) library, including [specs](https://github.com/seattlerb/minitest#specs), [mocks](https://github.com/seattlerb/minitest#mocks) and [minitest-autotest](https://github.com/seattlerb/minitest-autotest).
+
+To run the unit tests:
 
 ``` sh
 $ rake test
 ```
+
+### Documentation Tests
+
+The project tests the code examples in the each gem's [YARD]()-based documentation.
+
+The example testing functions in a way that is very similar to unit testing, and in fact the library providing it, [yard-doctest](https://github.com/p0deje/yard-doctest), is based on the project's unit test library, [minitest](https://github.com/seattlerb/minitest).
+
+To run the documentation tests:
+
+``` sh
+$ rake jsondoc
+$ rake doctest
+```
+
+ If you add, remove or modify documentation examples when working on a pull request, you may need to update the setup for the tests. The stubs and mocks required to run the tests are located in `support/doctest_helper.rb` for each package. Please note that much of the setup is matched by the title of the [`@example`](http://www.rubydoc.info/gems/yard/file/docs/Tags.md#example) tag. If you alter an example's title, you may encounter breaking tests.
 
 ### Acceptance Tests
 
@@ -67,7 +91,6 @@ The google-cloud-ruby acceptance tests interact with the following live service 
 Follow the instructions in the [Authentication guide](AUTHENTICATION.md) for enabling APIs. Some of the APIs may not yet be generally available, making it difficult for some contributors to successfully run the entire acceptance test suite. However, please ensure that you do successfully run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google Developers Console, as described in the [Authentication guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and the KEYFILE location on your system.
-
 
 #### Datastore acceptance tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,6 @@ The example testing functions in a way that is very similar to unit testing, and
 To run the documentation tests:
 
 ``` sh
-$ rake jsondoc
 $ rake doctest
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ To run the unit tests, documentation tests, and code style checks together:
 $ rake ci
 ```
 
+To run the command above, plus all acceptance tests, use `rake ci:acceptance` or its handy alias, `rake ci:a`.
+
 ### Unit Tests
 
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,12 @@
-# Releasing google-cloud-ruby
+# Releasing Google Cloud Ruby Client
 
-These instructions apply to every gem within the google-cloud-ruby project. Each gem should be released separately.
+These instructions apply to every gem within the Google Cloud Ruby Client project.
 
-The google-cloud-ruby project uses [semantic versioning](http://semver.org). Replace the `<prev_version>` and `<version>` placeholders shown in the examples below with the appropriate numbers, e.g. `0.1.0` and `0.2.0`. Replace the `<gem>` placeholder with the appropriate full name of the package, e.g. `google-cloud-datastore`.
+**Each gem must be released separately.** In order for the docs for the `google-cloud` package to build correctly, the only entry in `docs/manifest.json` that can be updated in the version commit preceding the release tag is the entry for the gem in the tag. The docs build will fail if you attempt to release multiple gems in parallel, since the first tag build will not yet find the listed docs for the other gems in the `gh-pages` branch.
 
-After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ruby/pulls) for a release have been merged and all [Travis CI builds](https://travis-ci.org/GoogleCloudPlatform/google-cloud-ruby) and [Appveyor CI builds](https://ci.appveyor.com/project/GoogleCloudPlatform/google-cloud-ruby) are green, you may create a release as follows:
+The Google Cloud Ruby Client project uses [semantic versioning](http://semver.org). Replace the `<prev_version>` and `<version>` placeholders shown in the examples below with the appropriate numbers, e.g. `0.1.0` and `0.2.0`. Replace the `<gem>` placeholder with the appropriate full name of the package, e.g. `google-cloud-datastore`.
+
+After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ruby/pulls) for a release have been merged and all [Circle CI builds](https://circleci.com/gh/GoogleCloudPlatform/google-cloud-ruby) are green, you may create a release as follows:
 
 1. Build the gem locally.
 
@@ -38,7 +40,9 @@ After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ru
 
 1. Edit the gem's `CHANGELOG.md`. Using your notes from the previous step, write bullet-point lists of the major and minor changes. You can also add examples, fixes, thank yous, and anything else helpful or relevant. See google-cloud-node [v0.18.0](https://github.com/GoogleCloudPlatform/google-cloud-node/releases/tag/v0.18.0) for an example with all the bells and whistles.
 
-1. Edit the gem's `version.rb`, changing the value of `VERSION` to your new version number.
+1. Edit the gem's `version.rb` file, changing the value of `VERSION` to your new version number.
+
+1. Edit the gem's entry in `docs/manifest.json`, adding your new version number to the head of the list, and moving `"master"` to be just below it.
 
 1. Commit your changes. Copy and paste the significant points from your `CHANGELOG.md` edit as the description in your commit message.
 
@@ -74,12 +78,14 @@ After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ru
 
 1. Click `Publish release`.
 
-1. Check that the [Travis CI build](https://travis-ci.org/GoogleCloudPlatform/google-cloud-ruby) has passed for the version commit.
+1. Check that the [Circle CI build](https://circleci.com/gh/GoogleCloudPlatform/google-cloud-ruby) has passed for the tag. Also, inspect the build logs to confirm that the `release` task completed successfully, and that the docs build succeeded. This can fail on a green build because it is an "after" action in the build.
 
 1. Confirm that the gem for the new version is available on [RubyGems.org](https://rubygems.org/gems/google-cloud).
 
 1. Confirm that the new version is displayed after "Latest release" on the [google-cloud-ruby gh-pages site](http://googlecloudplatform.github.io/google-cloud-ruby/).
 
 1. Confirm that the new version is displayed in the packages pulldown and the version switcher on the [google-cloud-ruby docs site](https://googlecloudplatform.github.io/google-cloud-ruby/#/). Verify that the new docs version contains the public API changes in the release.
+
+1. Some time later, after they have completed, confirm that [Travis CI (Mac OS X)](https://travis-ci.org/GoogleCloudPlatform/google-cloud-ruby) and [Appveyor CI (Windows)](https://ci.appveyor.com/project/GoogleCloudPlatform/google-cloud-ruby) builds are also green.
 
 High fives all around!

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -98,7 +98,7 @@ namespace :acceptance do
 end
 
 desc "Run yard-doctest example tests."
-task :doctest do
+task doctest: :yard do
   sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -69,7 +69,7 @@ namespace :acceptance do
 end
 
 desc "Run yard-doctest example tests."
-task :doctest do
+task doctest: :yard do
   sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -52,6 +52,10 @@ module Google
           yield *args
         end
       end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
     end
   end
 end

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -94,7 +94,7 @@ namespace :acceptance do
 end
 
 desc "Run yard-doctest example tests."
-task :doctest do
+task doctest: :yard do
   sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end

--- a/google-cloud-dns/support/doctest_helper.rb
+++ b/google-cloud-dns/support/doctest_helper.rb
@@ -37,6 +37,10 @@ module Google
           yield *args
         end
       end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
     end
   end
 end

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -93,7 +93,7 @@ namespace :acceptance do
 end
 
 desc "Run yard-doctest example tests."
-task :doctest do
+task doctest: :yard do
   sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -35,6 +35,32 @@ module Google
           yield *args
         end
       end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
+    end
+    module Logging
+      def self.stub_new
+        define_singleton_method :new do |*args|
+          yield *args
+        end
+      end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
+    end
+    module Core
+      module Environment
+      # Create default unmocked methods that will raise if ever called
+        def self.gce_vm? connection: nil
+          raise "This code example is not yet mocked"
+        end
+        def self.get_metadata_attribute uri, attr_name, connection: nil
+          raise "This code example is not yet mocked"
+        end
+      end
     end
   end
 end
@@ -49,18 +75,6 @@ def mock_storage
     yield storage.service.mocked_service if block_given?
 
     storage
-  end
-end
-
-module Google
-  module Cloud
-    module Logging
-      def self.stub_new
-        define_singleton_method :new do |*args|
-          yield *args
-        end
-      end
-    end
   end
 end
 

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -66,7 +66,7 @@ namespace :acceptance do
 end
 
 desc "Run yard-doctest example tests."
-task :doctest do
+task doctest: :yard do
   sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end

--- a/google-cloud-speech/support/doctest_helper.rb
+++ b/google-cloud-speech/support/doctest_helper.rb
@@ -64,6 +64,21 @@ module Google
           yield *args
         end
       end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
+    end
+    module Storage
+      def self.stub_new
+        define_singleton_method :new do |*args|
+          yield *args
+        end
+      end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
     end
   end
 end
@@ -79,18 +94,6 @@ def mock_speech
       yield speech.service.mocked_service, speech.service.mocked_ops
     end
     speech
-  end
-end
-
-module Google
-  module Cloud
-    module Storage
-      def self.stub_new
-        define_singleton_method :new do |*args|
-          yield *args
-        end
-      end
-    end
   end
 end
 

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -97,7 +97,7 @@ namespace :acceptance do
 end
 
 desc "Run yard-doctest example tests."
-task :doctest do
+task doctest: :yard do
   sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -65,6 +65,10 @@ module Google
           yield *args
         end
       end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
     end
   end
 end

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -97,7 +97,7 @@ namespace :acceptance do
 end
 
 desc "Run yard-doctest example tests."
-task :doctest do
+task doctest: :yard do
   sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end

--- a/google-cloud-translate/support/doctest_helper.rb
+++ b/google-cloud-translate/support/doctest_helper.rb
@@ -22,6 +22,10 @@ module Google
           yield *args
         end
       end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
     end
   end
 end


### PR DESCRIPTION
This PR stubs service factory methods and `Core` methods to raise errors if invoked. The purpose is to detect leaks in the doctest mocks that invoke actual backend resources.