### PR TITLE
Fix for Storage headers support

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -781,7 +781,7 @@ module Google
             fail SignedUrlUnavailable unless i && s
 
             sig = generate_signature s, options
-            generate_signed_url i, sig, options[:expires], options[:headers]
+            generate_signed_url i, sig, options[:expires]
           end
 
           def generate_signature signing_key, options = {}
@@ -791,7 +791,7 @@ module Google
             signing_key.sign OpenSSL::Digest::SHA256.new, signature_str(options)
           end
 
-          def generate_signed_url issuer, signed_string, expires, headers = nil
+          def generate_signed_url issuer, signed_string, expires
             signature = Base64.strict_encode64(signed_string).delete("\n")
             "#{ext_url}?GoogleAccessId=#{CGI.escape issuer}" \
               "&Expires=#{expires}" \
@@ -800,10 +800,11 @@ module Google
 
           def format_extension_headers headers
             return "" if headers.nil?
-            raise "Headers must be given in a Hash" unless headers.is_a? Hash
+            fail "Headers must be given in a Hash" unless headers.is_a? Hash
             flatten = headers.map do |key, value|
-              "#{key.to_s.downcase}:#{value.gsub /\s+/, ' '}\n"
-            end.delete_if { |h| h.start_with? "x-goog-encryption-key" }
+              "#{key.to_s.downcase}:#{value.gsub(/\s+/, ' ')}\n"
+            end
+            flatten.reject! { |h| h.start_with? "x-goog-encryption-key" }
             flatten.sort.join
           end
         end


### PR DESCRIPTION
Rubocop failed due to these violations. Unfortunately, CircleCI was not running builds for PRs from forked repos at the time.