### PR TITLE
jsondoc: Raise error if return types is missing.

### DIFF
--- a/lib/gcloud/jsondoc/generator.rb
+++ b/lib/gcloud/jsondoc/generator.rb
@@ -58,5 +58,8 @@ module Gcloud
         end
       end
     end
+
+    class YardSyntaxError < RuntimeError
+    end
   end
 end

--- a/lib/gcloud/jsondoc/method.rb
+++ b/lib/gcloud/jsondoc/method.rb
@@ -44,6 +44,9 @@ module Gcloud
           json.description md(t.text)
         end
         json.returns object.docstring.tags(:return) do |t|
+          if !t.types.is_a?(Array) || t.types.empty?
+            fail YardSyntaxError, "The types list for #{@object.path} must be a non-empty array."
+          end
           json.types format_types(t.types)
           json.description md(t.text)
         end
@@ -64,7 +67,6 @@ module Gcloud
       #   to their respective descriptions.
       #
       def format_types(typelist, brackets = true)
-        return unless typelist.is_a?(Array)
         typelist.map do |type|
           type = type.gsub(/([<>])/) { h($1) }
           type.gsub(/([\w:]+)/) { $1 == "lt" || $1 == "gt" ? $1 : linkify($1, $1) }

--- a/test/error_fixtures/my_module.rb
+++ b/test/error_fixtures/my_module.rb
@@ -1,0 +1,13 @@
+##
+# The outermost module in the test fixtures.
+#
+module MyModule
+  ##
+  # Returns an integer
+  #
+  # @return an integer
+  #
+  def self.example_method
+    1
+  end
+end

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+describe Gcloud::Jsondoc, :module do
+
+  before do
+    registry = YARD::Registry.load(["test/error_fixtures/**/*.rb"], true)
+    @generator = Gcloud::Jsondoc::Generator.new registry
+  end
+
+  it "raises RuntimeError if @return has no type" do
+
+    assert_raises Gcloud::Jsondoc::YardSyntaxError do
+      @generator.build!
+    end
+  end
+end


### PR DESCRIPTION
I tested this change locally with all packages in `master`, `rake jsondoc` succeeded for all.

[closes #1080]

/cc @hxiong388 