### PR TITLE
Update google-cloud-logging to use trace context tracking from core

### DIFF
--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -18,6 +18,7 @@ gem "google-cloud-speech", path: "../google-cloud-speech"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "google-cloud-translate", path: "../google-cloud-translate"
 gem "google-cloud-vision", path: "../google-cloud-vision"
+gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -43,7 +43,9 @@ Style/ClassVars:
   Enabled: false
 Style/TrivialAccessors:
   Enabled: false
+Style/CaseEquality:
+  Enabled: false
 Style/FileName:
   Enabled: false # for lib/google-cloud-logging.rb file
-Style/RescueException:
+Lint/RescueException:
   Enabled: false # for lib/google/cloud/logging/rails.rb file

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-storage", path: "../google-cloud-storage"
-
+gem "stackdriver-core", path: "../stackdriver-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-protobuf", "~> 3.0"
   gem.add_dependency "googleapis-common-protos", "~> 1.3"
   gem.add_dependency "orderedhash", "= 0.0.6"
+  gem.add_dependency "stackdriver-core", "~> 0.21.0"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -122,8 +122,8 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     }
 
     it "associates given info to current Thread ID" do
-      logger.add_request_info request_info
-      logger.request_info[Thread.current.object_id].must_equal request_info
+      logger.add_request_info info: request_info
+      logger.request_info.must_equal request_info
     end
 
     it "doesn't record more than 10_000 RequestInfo records" do
@@ -136,11 +136,12 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       # evaluate outside the block
       logger.stub :current_thread_id, stubbed_thread_id do
         10_001.times do
-          logger.add_request_info request_info
+          logger.add_request_info info: request_info
         end
-        logger.request_info.size.must_equal 10_000
-        logger.request_info[first_thread_id].must_be_nil
-        logger.request_info[last_thread_id].must_equal request_info
+        request_info_hash = logger.instance_variable_get :@request_info
+        request_info_hash.size.must_equal 10_000
+        request_info_hash[first_thread_id].must_be_nil
+        request_info_hash[last_thread_id].must_equal request_info
       end
     end
 
@@ -153,7 +154,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
       info = Google::Cloud::Logging::Logger::RequestInfo.new \
         "my_trace_id", "my_app_log"
-      logger.add_request_info info
+      logger.add_request_info info: info
 
       Time.stub :now, timestamp do
         logger.error "Danger Will Robinson!"

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -29,13 +29,19 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
   let(:write_res) { Google::Logging::V2::WriteLogEntriesResponse.new }
   let(:timestamp) { Time.parse "2016-10-02T15:01:23.045123456Z" }
 
-  def write_req_args severity
+  def write_req_args severity, extra_labels: {}, log_name_override: nil
     timestamp_grpc = Google::Protobuf::Timestamp.new seconds: timestamp.to_i,
                                                      nanos: timestamp.nsec
     entries = [Google::Logging::V2::LogEntry.new(text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
-    [entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, options: default_options]
+    [
+      entries,
+      log_name: "projects/test/logs/#{log_name_override || log_name}",
+      resource: resource.to_grpc,
+      labels: labels.merge(extra_labels),
+      options: default_options
+    ]
   end
 
   it "creates a DEBUG log entry with #debug" do
@@ -110,15 +116,17 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     end
   end
 
-  describe "#add_trace_id" do
-    let(:trace_id) { "a-unique-identifier" }
+  describe "#add_request_info" do
+    let(:request_info) {
+      Google::Cloud::Logging::Logger::RequestInfo.new "unique-identifier", nil
+    }
 
-    it "associates given trace_id to current Thread ID" do
-      logger.add_trace_id trace_id
-      logger.trace_ids[Thread.current.object_id].must_equal trace_id
+    it "associates given info to current Thread ID" do
+      logger.add_request_info request_info
+      logger.request_info[Thread.current.object_id].must_equal request_info
     end
 
-    it "doesn't record more than 10_000 trace_ids" do
+    it "doesn't record more than 10_000 RequestInfo records" do
       last_thread_id = first_thread_id = 1
       stubbed_thread_id = ->(){
         last_thread_id += 1
@@ -128,11 +136,28 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       # evaluate outside the block
       logger.stub :current_thread_id, stubbed_thread_id do
         10_001.times do
-          logger.add_trace_id trace_id
+          logger.add_request_info request_info
         end
-        logger.trace_ids.size.must_equal 10_000
-        logger.trace_ids[first_thread_id].must_be :nil?
-        logger.trace_ids[last_thread_id].must_equal trace_id
+        logger.request_info.size.must_equal 10_000
+        logger.request_info[first_thread_id].must_be_nil
+        logger.request_info[last_thread_id].must_equal request_info
+      end
+    end
+
+    it "passes request info to log writes" do
+      mock = Minitest::Mock.new
+      args = write_req_args :ERROR, log_name_override: "my_app_log",
+                            extra_labels: { "traceId" => "my_trace_id" }
+      mock.expect :write_log_entries, write_res, args
+      logging.service.mocked_logging = mock
+
+      info = Google::Cloud::Logging::Logger::RequestInfo.new \
+        "my_trace_id", "my_app_log"
+      logger.add_request_info info
+
+      Time.stub :now, timestamp do
+        logger.error "Danger Will Robinson!"
+        mock.verify
       end
     end
   end

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -56,9 +56,9 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
     end
 
     it "calls logger.add_request_info to track trace_id and log_name" do
-      stubbed_add_request_info = ->(this_request_info) {
-        this_request_info.trace_id.must_equal trace_id
-        this_request_info.log_name.must_equal "ruby_health_check_log"
+      stubbed_add_request_info = ->(args) {
+        args[:trace_id].must_equal trace_id
+        args[:log_name].must_equal "ruby_health_check_log"
       }
       logger.stub :add_request_info, stubbed_add_request_info do
         middleware.call rack_env

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -19,10 +19,11 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
   let(:app_exception_msg) { "A serious error from application" }
   let(:service_name) { "My microservice" }
   let(:service_version) { "Version testing" }
-  let(:trace_id) { "a-very-unique-identifier" }
-  let(:trace_context) { "#{trace_id}/a-span-id/options" }
+  let(:trace_id) { "1234567890abcdef1234567890abcdef" }
+  let(:trace_context) { "#{trace_id}/123456;o=1" }
   let(:rack_env) {{
-    "HTTP_X_CLOUD_TRACE_CONTEXT" => trace_context
+    "HTTP_X_CLOUD_TRACE_CONTEXT" => trace_context,
+    "PATH_INFO" => "/_ah/health"
   }}
   let(:app_exception) { StandardError.new(app_exception_msg) }
   let(:rack_app) {
@@ -54,23 +55,24 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
       end
     end
 
-    it "calls logger.add_trace_id to track trace_id" do
-      stubbed_add_trace_id = ->(this_trace_id) {
-        this_trace_id.must_equal trace_id
+    it "calls logger.add_request_info to track trace_id and log_name" do
+      stubbed_add_request_info = ->(this_request_info) {
+        this_request_info.trace_id.must_equal trace_id
+        this_request_info.log_name.must_equal "ruby_health_check_log"
       }
-      logger.stub :add_trace_id, stubbed_add_trace_id do
+      logger.stub :add_request_info, stubbed_add_request_info do
         middleware.call rack_env
       end
     end
 
-    it "calls logger.delete_trace_id when exiting even app.call fails" do
+    it "calls logger.delete_request_info when exiting even app.call fails" do
       method_called = false
-      stubbed_delete_trace_id = ->() {
+      stubbed_delete_request_info = ->() {
         method_called = true
       }
       stubbed_call = ->(_) { raise "die" }
 
-      logger.stub :delete_trace_id, stubbed_delete_trace_id do
+      logger.stub :delete_request_info, stubbed_delete_request_info do
         rack_app.stub :call, stubbed_call do
           assert_raises StandardError do
             middleware.call rack_env
@@ -78,12 +80,6 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
           method_called.must_equal true
         end
       end
-    end
-  end
-
-  describe "#extract_trace_id" do
-    it "extracts trace_id from trace_context" do
-      middleware.extract_trace_id(rack_env).must_equal trace_id
     end
   end
 

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -17,6 +17,7 @@ gem "google-cloud-speech", path: "../google-cloud-speech"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "google-cloud-translate", path: "../google-cloud-translate"
 gem "google-cloud-vision", path: "../google-cloud-vision"
+gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -7,6 +7,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-error_reporting", path: "../google-cloud-error_reporting"
 gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "google-cloud-monitoring", path: "../google-cloud-monitoring"
+gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",


### PR DESCRIPTION
This PR includes two related changes in google-cloud-logging.

* The middleware uses stackdriver-core to obtain trace context instead of attempting to read it itself. As a result, stackdriver-core is now a gem dependency (as well as a dependency of gcloud, google-cloud, and stackdriver)
* The middleware allows setting the log name by path (so that, e.g. health checks in App Engine Flex can be directed to a separate log and don't spam the main app log.)

This PR is being directed to a feature branch for now because it is dependent on the release of the stackdriver-core gem.