### PR TITLE
Trace instrumentation

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -191,6 +191,14 @@
       ]
     },
     {
+      "id": "google-cloud-trace",
+      "name": "google-cloud-trace",
+      "defaultService": "google/cloud/trace",
+      "versions": [
+        "master"
+      ]
+    },
+    {
       "id": "google-cloud-translate",
       "name": "google-cloud-translate",
       "defaultService": "google/cloud/translate",

--- a/google-cloud-trace/.autotest
+++ b/google-cloud-trace/.autotest
@@ -1,0 +1,15 @@
+# -*- ruby -*-
+
+require "autotest/suffix"
+
+# Autotest.add_hook :initialize do |at|
+#   at.clear_mappings
+#
+#   at.add_mapping %r%^lib/(.*)\.rb$% do |_, m|
+#     at.files_matching %r%^test/#{m[1]}.*_test.rb$%
+#   end
+#
+#   at.add_mapping %r%^test/.*_test\.rb$% do |filename, _|
+#     filename
+#   end
+# end

--- a/google-cloud-trace/.rubocop.yml
+++ b/google-cloud-trace/.rubocop.yml
@@ -46,5 +46,11 @@ Style/ClassVars:
   Enabled: false
 Style/TrivialAccessors:
   Enabled: false
+Style/CaseEquality:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
 Style/FileName:
   Enabled: false # for lib/google-cloud-trace.rb file
+Lint/RescueException:
+  Enabled: false # for lib/google/cloud/logging/rails.rb file

--- a/google-cloud-trace/.yardopts
+++ b/google-cloud-trace/.yardopts
@@ -1,5 +1,6 @@
 --no-private
---title=Stackdriver Trace 
+--title=Stackdriver Trace
+--markup markdown
 
 ./lib/**/*.rb
 -

--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,1 @@
 # Release History
-
-### 0.21.0 / 2016-11-03
-
-* First release

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 11.0"
+gem "stackdriver-core", path: "../stackdriver-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -21,34 +21,79 @@ RuboCop::RakeTask.new
 
 desc "Run tests."
 task :test do
-  puts "The google-cloud-trace gem does not have tests."
+  $LOAD_PATH.unshift "lib", "test"
+  Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :test do
-  desc "Run tests with coverage."
+  desc "Runs tests with coverage."
   task :coverage do
+    require "simplecov"
+    SimpleCov.start do
+      command_name "google-cloud-trace"
+      track_files "lib/**/*.rb"
+      add_filter "test/"
+    end
+
+    Rake::Task["test"].invoke
   end
 end
 
 # Acceptance tests
-desc "Run the trace acceptance tests."
-task :acceptance do
-  puts "The google-cloud-trace gem does not have acceptance tests."
+desc "Runs the trace acceptance tests."
+task :acceptance, :project, :keyfile do |t, args|
+  project = args[:project]
+  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["TRACE_TEST_PROJECT"]
+  keyfile = args[:keyfile]
+  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["TRACE_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["TRACE_TEST_KEYFILE_JSON"]
+  end
+  if project.nil? || keyfile.nil?
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or TRACE_TEST_PROJECT=test123 TRACE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+  end
+  # always overwrite when running tests
+  ENV["TRACE_PROJECT"] = project
+  ENV["TRACE_KEYFILE"] = nil
+  ENV["TRACE_KEYFILE_JSON"] = keyfile
+
+  $LOAD_PATH.unshift "lib", "acceptance"
+  Dir.glob("acceptance/trace/**/*_test.rb").each { |file| require_relative file }
 end
 
 namespace :acceptance do
-  desc "Run acceptance tests with coverage."
-  task :coverage do
-  end
+  desc "Runs acceptance tests with coverage."
+  task :coverage, :project, :keyfile do |t, args|
+    require "simplecov"
+    SimpleCov.start do
+      command_name "google-cloud-trace"
+      track_files "lib/**/*.rb"
+      add_filter "acceptance/"
+    end
 
-  desc "Run acceptance cleanup."
-  task :cleanup do
+    Rake::Task["acceptance"].invoke
   end
 end
 
-desc "Run yard-doctest example tests."
+desc "Runs yard-doctest example tests."
 task :doctest do
-  puts "The google-cloud-trace gem does not have doctest tests."
+end
+
+desc "Start an interactive shell."
+task :console do
+  require "irb"
+  require "irb/completion"
+  require "pp"
+
+  $LOAD_PATH.unshift "lib"
+
+  require "google-cloud-trace"
+  def gcloud; @gcloud ||= Google::Cloud.new; end
+
+  ARGV.clear
+  IRB.start
 end
 
 require "yard"

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -79,6 +79,7 @@ end
 
 desc "Runs yard-doctest example tests."
 task :doctest do
+  puts "The google-cloud-trace gem does not have doctest tests."
 end
 
 desc "Start an interactive shell."

--- a/google-cloud-trace/docs/toc.json
+++ b/google-cloud-trace/docs/toc.json
@@ -1,8 +1,71 @@
 {
-  "guides": [],
+  "guides": [
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
   "services": [
     {
-      "title": "TraceServiceApi",
+      "title": "Google::Cloud",
+      "type": "google/cloud"
+    },
+    {
+      "title": "Google::Cloud::Trace",
+      "type": "google/cloud/trace",
+      "nav": [
+        {
+          "title": "LabelKey",
+          "type": "google/cloud/trace/labelkey"
+        },
+        {
+          "title": "Middleware",
+          "type": "google/cloud/trace/middleware"
+        },
+        {
+          "title": "Notifications",
+          "type": "google/cloud/trace/notifications"
+        },
+        {
+          "title": "Project",
+          "type": "google/cloud/trace/project"
+        },
+        {
+          "title": "Railtie",
+          "type": "google/cloud/trace/railtie"
+        },
+        {
+          "title": "ResultSet",
+          "type": "google/cloud/trace/resultset"
+        },
+        {
+          "title": "Span",
+          "type": "google/cloud/trace/span"
+        },
+        {
+          "title": "SpanKind",
+          "type": "google/cloud/trace/spankind"
+        },
+        {
+          "title": "TimeSampler",
+          "type": "google/cloud/trace/timesampler"
+        },
+        {
+          "title": "TraceRecord",
+          "type": "google/cloud/trace/tracerecord"
+        },
+      ]
+    },
+    {
+      "title": "Low-Level API",
       "type": "google/cloud/trace/v1/traceserviceapi"
     }
   ]

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -1,14 +1,14 @@
-# -*- ruby -*-
-# encoding: utf-8
+# -*- encoding: utf-8 -*-
+require File.expand_path("../lib/google/cloud/trace/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-trace"
-  gem.version       = "0.21.0"
+  gem.version       = Google::Cloud::Trace::VERSION
 
-  gem.authors       = ["Google Inc"]
-  gem.email         = ["googleapis-packages@google.com"]
+  gem.authors       = ["Daniel Azuma"]
+  gem.email         = ["dazuma@google.com"]
   gem.description   = "google-cloud-trace is the official library for Stackdriver Trace."
-  gem.summary       = "API Client library for Stackdriver Trace"
+  gem.summary       = "Application Instrumentation and API Client library for Stackdriver Trace"
   gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
   gem.license       = "Apache-2.0"
 
@@ -24,6 +24,17 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-gax", "~> 0.6.0"
   gem.add_dependency "google-protobuf", "~> 3.0"
   gem.add_dependency "googleapis-common-protos", "~> 1.3"
+  gem.add_dependency "google-cloud-core", "~> 0.21.0"
+  gem.add_dependency "stackdriver-core", "~> 0.21.0"
 
+  gem.add_development_dependency "minitest", "~> 5.9"
+  gem.add_development_dependency "minitest-autotest", "~> 1.0"
+  gem.add_development_dependency "minitest-focus", "~> 1.1"
+  gem.add_development_dependency "minitest-rg", "~> 5.2"
+  gem.add_development_dependency "autotest-suffix", "~> 1.1"
+  gem.add_development_dependency "railties", "~> 4.0"
   gem.add_development_dependency "rubocop", "<= 0.35.1"
+  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
 end

--- a/google-cloud-trace/lib/google-cloud-trace.rb
+++ b/google-cloud-trace/lib/google-cloud-trace.rb
@@ -13,12 +13,85 @@
 # limitations under the License.
 
 ##
-# This file is here to be autorequired by bundler, so that the .logging and
-# #logging methods can be available, but the library and all dependencies won't
+# This file is here to be autorequired by bundler, so that the .trace and
+# #trace methods can be available, but the library and all dependencies won't
 # be loaded until required and used.
 
 
 gem "google-cloud-core"
 require "google/cloud"
 
-# There is no Google::Cloud integration to add.
+module Google
+  module Cloud
+    ##
+    # Creates a new object for connecting to the Stackdriver Trace service.
+    # Each call creates a new connection.
+    #
+    # For more information on connecting to Google Cloud see the [Authentication
+    # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+    #
+    # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+    #   set of resources and operations that the connection can access. See
+    #   [Using OAuth 2.0 to Access Google
+    #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+    #   The default scope is `https://www.googleapis.com/auth/cloud-platform`
+    # @param [Integer] timeout Default timeout to use in requests. Optional.
+    #
+    # @return [Google::Cloud::Trace::Project]
+    #
+    # @example
+    #   require "google/cloud"
+    #
+    #   gcloud = Google::Cloud.new
+    #   trace_client = gcloud.trace
+    #
+    #   traces = trace_client.list_traces Time.now - 3600, Time.now
+    #   traces.each do |trace|
+    #     puts "Retrieved trace ID: #{trace.trace_id}"
+    #   end
+    #
+    def trace scope: nil, timeout: nil, client_config: nil
+      Google::Cloud.trace @project, @keyfile, scope: scope,
+                                              timeout: (timeout || @timeout),
+                                              client_config: client_config
+    end
+
+    ##
+    # Creates a new object for connecting to the Stackdriver Trace service.
+    # Each call creates a new connection.
+    #
+    # For more information on connecting to Google Cloud see the [Authentication
+    # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+    #
+    # @param [String] project Project identifier for the Stackdriver Trace
+    #   service.
+    # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud:
+    #   either the JSON data or the path to a readable file.
+    # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+    #   set of resources and operations that the connection can access. See
+    #   [Using OAuth 2.0 to Access Google
+    #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+    #   The default scope is `https://www.googleapis.com/auth/cloud-platform`
+    # @param [Integer] timeout Default timeout to use in requests. Optional.
+    #
+    # @return [Google::Cloud::Trace::Project]
+    #
+    # @example
+    #   require "google/cloud"
+    #
+    #   trace_client = Google::Cloud.trace
+    #
+    #   traces = trace_client.list_traces Time.now - 3600, Time.now
+    #   traces.each do |trace|
+    #     puts "Retrieved trace ID: #{trace.trace_id}"
+    #   end
+    #
+    def self.trace project = nil, keyfile = nil, scope: nil, timeout: nil,
+                   client_config: nil
+      require "google/cloud/trace"
+      Google::Cloud::Trace.new project: project, keyfile: keyfile,
+                               scope: scope, timeout: timeout,
+                               client_config: client_config
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -15,6 +15,7 @@
 
 require "stackdriver/core/trace_context"
 require "google-cloud-trace"
+require "google/cloud/trace/version"
 require "google/cloud/trace/credentials"
 require "google/cloud/trace/label_key"
 require "google/cloud/trace/middleware"
@@ -27,7 +28,6 @@ require "google/cloud/trace/span"
 require "google/cloud/trace/span_kind"
 require "google/cloud/trace/trace_record"
 require "google/cloud/trace/utils"
-require "google/cloud/trace/version"
 
 module Google
   module Cloud

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -1,0 +1,256 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "stackdriver/core/trace_context"
+require "google-cloud-trace"
+require "google/cloud/trace/credentials"
+require "google/cloud/trace/label_key"
+require "google/cloud/trace/middleware"
+require "google/cloud/trace/notifications"
+require "google/cloud/trace/project"
+require "google/cloud/trace/result_set"
+require "google/cloud/trace/sampling"
+require "google/cloud/trace/service"
+require "google/cloud/trace/span"
+require "google/cloud/trace/span_kind"
+require "google/cloud/trace/trace_record"
+require "google/cloud/trace/utils"
+require "google/cloud/trace/version"
+
+module Google
+  module Cloud
+    ##
+    # # Stackdriver Trace
+    #
+    # The Stackdriver Trace service collects and stores latency data from your
+    # application and displays it in the Google Cloud Platform Console, giving
+    # you detailed near-real-time insight into application performance.
+    #
+    # The Stackdriver Trace Ruby library, `google-cloud-trace`, provides:
+    #
+    # *   Easy-to-use trace instrumentation that collects and collates latency
+    #     data for your Ruby application. If you just want latency trace data
+    #     for your application to appear on the Google Cloud Platform Console,
+    #     see the section on [instrumenting your app](#instrumenting-your-app).
+    # *   An idiomatic Ruby API for querying, analyzing, and manipulating trace
+    #     data in your Ruby application. For an introduction to the Trace API,
+    #     see the section on the [Trace API](#stackdriver-trace-api).
+    #
+    # ## Instrumenting Your App
+    #
+    # If your application uses Ruby on Rails, the easiest way to instrument
+    # your application for all Stackdriver diagnostic and monitoring services
+    # is to install the `stackdriver` gem. Add it to your Gemfile and deploy
+    # your application to Google Cloud. Then open the Google Cloud Console in
+    # your web browser and navigate to the "Trace" section. Your application
+    # latency traces will appear there; no additional coding is required.
+    #
+    # You may also adopt Stackdriver diagnostic services "a la carte" by
+    # installing individual gems. To instrument your app for the Trace service,
+    # add this gem, `google-cloud-trace`, to your Gemfile. Then add the
+    # following line to your `config/application.rb` file:
+    #
+    # ```ruby
+    # require "google/cloud/trace/rails"
+    # ```
+    #
+    # See the {Google::Cloud::Trace::Railtie} class for more information,
+    # including how to customize your application traces.
+    #
+    # If your application uses a different Rack-based web framework, you may
+    # instrument your app by installing the trace middleware. See the
+    # {Google::Cloud::Trace::Middleware} documentation for more information.
+    #
+    # ## Stackdriver Trace API
+    #
+    # Using the Stackdriver Trace API, your application can query and analyze
+    # its own traces and traces of other projects. Here is an example query
+    # for all traces in the past hour.
+    #
+    # ```ruby
+    # require "google/cloud/trace"
+    # trace_client = Google::Cloud::Trace.new
+    #
+    # traces = trace_client.list_traces Time.now - 3600, Time.now
+    # traces.each do |trace|
+    #   puts "Retrieved trace ID: #{trace.trace_id}"
+    # end
+    # ```
+    #
+    # Each trace is an object of type {Google::Cloud::Trace::TraceRecord},
+    # which provides methods for analyzing tasks that took place during the
+    # request trace. See https://cloud.google.com/trace for more information
+    # on the kind of data you can capture in a trace.
+    #
+    # Usually it is easiest to use this library's trace instrumentation
+    # features to collect and record application trace information. However,
+    # you may also use the trace API to update this data. Here is an example:
+    #
+    # ```ruby
+    # require "google/cloud/trace"
+    #
+    # trace_client = Google::Cloud::Trace.new
+    #
+    # trace = Google::Cloud::Trace.new
+    # trace.in_span "root_span" do
+    #   # Do stuff...
+    # end
+    #
+    # trace_client.patch_traces trace
+    # ```
+    #
+    # For further information on the trace API, see
+    # {Google::Cloud::Trace::Project}.
+    #
+    module Trace
+      THREAD_KEY = :__stackdriver_trace_span__
+
+      ##
+      # Creates a new object for connecting to the Stackdriver Trace service.
+      # Each call creates a new connection.
+      #
+      # For more information on connecting to Google Cloud see the
+      # [Authentication
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
+      #
+      # @param [String] project Project identifier for the Stackdriver Trace
+      #   service.
+      # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud:
+      #   either the JSON data or the path to a readable file.
+      # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
+      #   the set of resources and operations that the connection can access.
+      #   See [Using OAuth 2.0 to Access Google
+      #   APIs](https://developers.google.com/identity/protocols/OAuth2).
+      #   The default scope is `https://www.googleapis.com/auth/cloud-platform`
+      # @param [Integer] timeout Default timeout to use in requests. Optional.
+      #
+      # @return [Google::Cloud::Trace::Project]
+      #
+      # @example
+      #   require "google/cloud/trace"
+      #
+      #   trace_client = Google::Cloud::Trace.new
+      #
+      #   traces = trace_client.list_traces Time.now - 3600, Time.now
+      #   traces.each do |trace|
+      #     puts "Retrieved trace ID: #{trace.trace_id}"
+      #   end
+      #
+      def self.new project: nil, keyfile: nil, scope: nil, timeout: nil,
+                   client_config: nil
+        project ||= Google::Cloud::Trace::Project.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
+        credentials =
+          Google::Cloud::Trace::Credentials.credentials_with_scope keyfile,
+                                                                   scope
+
+        Google::Cloud::Trace::Project.new(
+          Google::Cloud::Trace::Service.new(
+            project, credentials, timeout: timeout,
+                                  client_config: client_config))
+      end
+
+      ##
+      # Set the current trace span being measured for the current thread, or
+      # the current trace if no span is currently open. This may be used with
+      # web frameworks that assign a thread to each request, to track the
+      # trace instrumentation state for the request being handled. You may use
+      # {Google::Cloud::Trace.get} to retrieve the data.
+      #
+      # @param [Google::Cloud::Trace::TraceSpan, Google::Cloud::Trace::Trace,
+      #     nil] trace The current span being measured, the current trace
+      #     object, or `nil` if none.
+      #
+      # @example
+      #   require "google/cloud/trace"
+      #
+      #   trace = Google::Cloud::Trace::Trace.new
+      #   Google::Cloud::Trace.set trace
+      #
+      #   # Later...
+      #   Google::Cloud::Trace.get.create_span "my_span"
+      #
+      def self.set trace
+        trace_context = trace ? trace.trace_context : nil
+        Stackdriver::Core::TraceContext.set trace_context
+        Thread.current[THREAD_KEY] = trace
+      end
+
+      ##
+      # Retrieve the current trace span or trace object for the current thread.
+      # This data should previously have been set using
+      # {Google::Cloud::Trace.set}.
+      #
+      # @return [Google::Cloud::Trace::TraceSpan, Google::Cloud::Trace::Trace,
+      #     nil] The span or trace object, or `nil`.
+      #
+      # @example
+      #   require "google/cloud/trace"
+      #
+      #   trace = Google::Cloud::Trace::Trace.new
+      #   Google::Cloud::Trace.set trace
+      #
+      #   # Later...
+      #   Google::Cloud::Trace.get.create_span "my_span"
+      #
+      def self.get
+        Thread.current[THREAD_KEY]
+      end
+
+      ##
+      # Open a new span for the current thread, instrumenting the given block.
+      # The span is created within the current thread's trace context as set by
+      # {Google::Cloud::Trace.set}. The context is updated so any further calls
+      # within the block will create subspans. The new span is also yielded to
+      # the block.
+      #
+      # Does nothing if there is no trace context for the current thread.
+      #
+      # @param [String] name Name of the span to create
+      # @param [Google::Cloud::Trace::SpanKind] kind Kind of span to create.
+      #     Optional.
+      # @param [Hash{String => String}] labels Labels for the span
+      #
+      # @example
+      #   require "google/cloud/trace"
+      #
+      #   trace = Google::Cloud::Trace::Trace.new
+      #   Google::Cloud::Trace.set trace
+      #
+      #   Google::Cloud::Trace.in_span "my_span" do |span|
+      #     # Do stuff...
+      #   end
+      #
+      def self.in_span name, kind: Google::Cloud::Trace::SpanKind::UNSPECIFIED,
+                       labels: {}
+        parent = get
+        if parent
+          parent.in_span name, kind: kind, labels: labels do |child|
+            set child
+            begin
+              yield child
+            ensure
+              set parent
+            end
+          end
+        else
+          yield nil
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/credentials.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/credentials.rb
@@ -1,0 +1,41 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/credentials"
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # @private Represents the OAuth 2.0 signing logic for Trace.
+      class Credentials < Google::Cloud::Credentials
+        SCOPE = ["https://www.googleapis.com/auth/cloud-platform"]
+        PATH_ENV_VARS = %w(TRACE_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
+        JSON_ENV_VARS = %w(TRACE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON
+                           GCLOUD_KEYFILE_JSON)
+
+        ##
+        # @private Create credentials with given scope and/or keyfile
+        def self.credentials_with_scope keyfile, scope = nil
+          if keyfile.nil?
+            default(scope: scope)
+          else
+            new(keyfile, scope: scope)
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/label_key.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/label_key.rb
@@ -1,0 +1,130 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "json"
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # A collection of well-known label keys for trace spans.
+      #
+      module LabelKey
+        AGENT = "/agent"
+        COMPONENT = "/component"
+        ERROR_MESSAGE = "/error/message"
+        ERROR_NAME = "/error/name"
+        HTTP_CLIENT_CITY = "/http/client_city"
+        HTTP_CLIENT_COUNTRY = "/http/client_country"
+        HTTP_CLIENT_PROTOCOL = "/http/client_protocol"
+        HTTP_CLIENT_REGION = "/http/client_region"
+        HTTP_HOST = "/http/host"
+        HTTP_METHOD = "/http/method"
+        HTTP_REDIRECTED_URL = "/http/redirected_url"
+        HTTP_REQUEST_SIZE = "/http/request/size"
+        HTTP_RESPONSE_SIZE = "/http/response/size"
+        HTTP_STATUS_CODE = "/http/status_code"
+        HTTP_URL = "/http/url"
+        HTTP_USER_AGENT = "/http/user_agent"
+        PID = "/pid"
+        STACKTRACE = "/stacktrace"
+        TID = "/tid"
+
+        GAE_APPLICATION_ERROR = "g.co/gae/application_error"
+        GAE_APP_MODULE = "g.co/gae/app/module"
+        GAE_APP_MODULE_VERSION = "g.co/gae/app/module_version"
+        GAE_APP_VERSION = "g.co/gae/app/version"
+        GAE_DATASTORE_COUNT = "g.co/gae/datastore/count"
+        GAE_DATASTORE_CURSOR = "g.co/gae/datastore/cursor"
+        GAE_DATASTORE_ENTITY_WRITES = "g.co/gae/datastore/entity_writes"
+        GAE_DATASTORE_HAS_ANCESTOR = "g.co/gae/datastore/has_ancestor"
+        GAE_DATASTORE_HAS_CURSOR = "g.co/gae/datastore/has_cursor"
+        GAE_DATASTORE_HAS_TRANSACTION = "g.co/gae/datastore/has_transaction"
+        GAE_DATASTORE_INDEX_WRITES = "g.co/gae/datastore/index_writes"
+        GAE_DATASTORE_KIND = "g.co/gae/datastore/kind"
+        GAE_DATASTORE_LIMIT = "g.co/gae/datastore/limit"
+        GAE_DATASTORE_MORE_RESULTS = "g.co/gae/datastore/more_results"
+        GAE_DATASTORE_OFFSET = "g.co/gae/datastore/offset"
+        GAE_DATASTORE_REQUESTED_ENTITY_DELETES =
+          "g.co/gae/datastore/requested_entity_deletes"
+        GAE_DATASTORE_REQUESTED_ENTITY_PUTS =
+          "g.co/gae/datastore/requested_entity_puts"
+        GAE_DATASTORE_SIZE = "g.co/gae/datastore/size"
+        GAE_DATASTORE_SKIPPED = "g.co/gae/datastore/skipped"
+        GAE_DATASTORE_TRANSACTION_HANDLE =
+          "g.co/gae/datastore/transaction_handle"
+        GAE_ERROR_MESSAGE = "g.co/gae/error_message"
+        GAE_MEMCACHE_COUNT = "g.co/gae/memcache/count"
+        GAE_MEMCACHE_SIZE = "g.co/gae/memcache/size"
+        GAE_REQUEST_LOG_ID = "g.co/gae/request_log_id"
+
+        ##
+        # Set the stack trace label in the given labels hash. The current call
+        # stack is formatted so the Stackdriver UI will display it.
+        #
+        # @param [Hash] labels The labels hash in which to set the stack trace
+        #     label value.
+        # @param [Array<Thread::Backtrace::Location>] stack_frames The current
+        #     caller stack as returned from `::Kernel.caller_locations`. If
+        #     not set, `::Kernel.caller_locations` is called internally.
+        # @param [Integer] skip_frames Passed to the internal invocation of
+        #     `::Kernel.caller_locations` if one is needed.
+        # @param [Proc] truncate_stack A procedure that allows skipping of
+        #     the "topmost" stack frames. Stack frames, represented by
+        #     instances of `Thread::Backtrace::Location`, are passed to this
+        #     proc beginning with the topmost frame. As long as the proc
+        #     returns a falsy value, those frames are dropped. Once the proc
+        #     returns true for the first time, that frame and all remaining
+        #     frames (possibly subject to `filter_stack`) are used. If not set,
+        #     no frames are skipped.
+        # @param [Proc] filter_stack A procedure that allows skipping of
+        #     stack frames in the middle of the stack trace. After possibly
+        #     skipping frames using `truncate_stack`, all remaining frames are
+        #     passed to this proc as `Thread::Backtrace::Location` objects.
+        #     Those for whom the proc returns a falsy value are skipped. If
+        #     this parameter is not set, no filtering is done and all frames
+        #     are presented in the stack trace.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace = Google::Cloud::Trace.new
+        #   span = trace.create_span "root_span"
+        #   Google::Cloud::Trace::LabelKey.set_stack_trace span.labels
+        #
+        def self.set_stack_trace labels,
+                                 stack_frames: nil, skip_frames: 1,
+                                 truncate_stack: nil, filter_stack: nil
+          stack_frames ||= ::Kernel.caller_locations skip_frames
+          json_frames = []
+          collecting_frames = !truncate_stack
+          stack_frames.each do |frame|
+            collecting_frames ||= truncate_stack.call(frame)
+            next unless collecting_frames
+            next unless !filter_stack || filter_stack.call(frame)
+            json_frames <<
+              {
+                file_name: frame.absolute_path,
+                line_number: frame.lineno,
+                method_name: frame.label
+              }
+          end
+          json_object = { stack_frame: json_frames }
+          labels[STACKTRACE] = JSON.generate json_object
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -1,0 +1,333 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/core/environment"
+require "stackdriver/core/trace_context"
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # A Rack middleware that manages trace context and captures a trace of
+      # the request. Specifically, it:
+      #
+      # *   Reads the trace context from the request headers, if present.
+      #     Otherwise, generates a new trace context.
+      # *   Makes a sampling decision if one is not already specified.
+      # *   Records a span measuring the entire handling of the request,
+      #     annotated with a set of standard request data.
+      # *   Makes the trace context available so downstream middlewares and the
+      #     app can add further spans to the trace.
+      # *   Sends the completed trace to the Stackdriver service.
+      #
+      # To use this middleware, simply install it in your middleware stack.
+      # If your application uses Ruby On Rails, you may also use the provided
+      # {Google::Cloud::Trace::Railtie} for close integration with Rails and
+      # ActiveRecord.
+      #
+      # @example
+      #   # config.ru for simple Rack application
+      #
+      #   require "google/cloud/trace"
+      #   use Google::Cloud::Trace::Middleware
+      #
+      #   run MyApp
+      #
+      # @example
+      #   # Simple sinatra application
+      #
+      #   require "sinatra"
+      #   require "google/cloud/trace"
+      #
+      #   use Google::Cloud::Trace::Middleware
+      #
+      #   get "/" do
+      #     "Hello World"
+      #   end
+      #
+      class Middleware
+        ##
+        # Default list of paths for which to disable traces. Currently includes
+        # App Engine Flex health checks.
+        DEFAULT_PATH_BLACKLIST = ["/_ah/health"].freeze
+
+        ##
+        # The name of this trace agent as reported to the Stackdriver backend.
+        AGENT_NAME = "ruby #{Google::Cloud::Trace::VERSION}".freeze
+
+        ##
+        # Create a new Middleware for traces
+        #
+        # @param [Rack Application] app Rack application
+        # @param [Google::Cloud::Trace::Service] service The service object.
+        #     Optional if running on GCE.
+        # @param [Array{String,Regex}] path_blacklist An array of paths or
+        #     path patterns indicating URIs that should never be traced.
+        #     Default is DEFAULT_PATH_BLACKLIST.
+        # @param [Boolean] capture_stack Whether to capture stack traces for
+        #     each span. Default is false.
+        # @param [#check] sampler A sampler to use, or nil to use the default.
+        #     See {Google::Cloud::Trace.sampler=}
+        #
+        def initialize app,
+                       service: nil,
+                       path_blacklist: nil,
+                       capture_stack: false,
+                       sampler: nil,
+                       span_id_generator: nil
+          @app = app
+          @path_blacklist = path_blacklist || DEFAULT_PATH_BLACKLIST
+          @capture_stack = capture_stack
+          @sampler = sampler
+          @span_id_generator = span_id_generator
+          if service
+            @service = service
+          else
+            project_id = Google::Cloud::Trace::Project.default_project
+            @service = Google::Cloud::Trace.new.service if project_id
+          end
+        end
+
+        ##
+        # Implementation of the trace middleware. Creates a trace for this
+        # request, populates it with a root span for the entire request, and
+        # ensures it is reported back to Stackdriver.
+        #
+        # @param [Hash] env Rack environment hash
+        # @return [Rack::Response] The response from downstream Rack app
+        #
+        def call env
+          trace = create_trace env
+          begin
+            Google::Cloud::Trace.set trace
+            Google::Cloud::Trace.in_span "rack-request" do |span|
+              configure_span span, env
+              result = @app.call env
+              configure_result span, result
+              result
+            end
+          ensure
+            Google::Cloud::Trace.set nil
+            send_trace trace, env
+          end
+        end
+
+        ##
+        # Gets the current trace context from the given Rack environment.
+        # Makes a sampling decision if one has not been made already.
+        #
+        # @private
+        # @param [Hash] env Rack environment hash
+        # @return [Stackdriver::Core::TraceContext] The trace context.
+        #
+        def get_trace_context env
+          Stackdriver::Core::TraceContext.parse_rack_env(env) do |tc|
+            if tc.sampled?.nil?
+              path = get_path env
+              if @path_blacklist.find { |p| p === path }
+                sampled = false
+              elsif @sampler
+                sampled = @sampler.check {}
+              else
+                sampled = Google::Cloud::Trace.check_sampler
+              end
+              tc = Stackdriver::Core::TraceContext.new \
+                trace_id: tc.trace_id,
+                span_id: tc.span_id,
+                sampled: sampled,
+                capture_stack: sampled && @capture_stack
+            end
+            tc
+          end
+        end
+
+        ##
+        # Create a new trace for this request.
+        #
+        # @private
+        # @param [Hash] env The Rack environment.
+        #
+        def create_trace env
+          trace_context = get_trace_context env
+
+          # TEMP: Drop the context parent span because a bug is preventing
+          # such traces from appearing in Flex apps. We expect this bug to
+          # be fixed around 2016.12.16, so re-check around that time.
+          trace_context = trace_context.with span_id: nil
+
+          Google::Cloud::Trace::TraceRecord.new \
+            @service.project,
+            trace_context,
+            span_id_generator: @span_id_generator
+        end
+
+        ##
+        # Send the given trace to the trace service, if requested.
+        #
+        # @private
+        # @param [Google::Cloud::Trace::TraceRecord] trace The trace to send.
+        # @param [Hash] env The Rack environment.
+        #
+        def send_trace trace, env
+          if @service && trace.trace_context.sampled?
+            begin
+              @service.patch_traces trace
+            rescue => ex
+              msg = "Transmit to Stackdriver Trace failed: #{ex.inspect}"
+              logger = env["rack.logger"]
+              if logger
+                logger.error msg
+              else
+                warn msg
+              end
+            end
+          end
+        end
+
+        ##
+        # Gets the URI path from the given Rack environment.
+        #
+        # @private
+        # @param [Hash] env Rack environment hash
+        # @return [String] The URI path.
+        #
+        def get_path env
+          path = "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}"
+          path = "/#{path}" unless path.start_with? "/"
+          path
+        end
+
+        ##
+        # Gets the URI hostname from the given Rack environment.
+        #
+        # @private
+        # @param [Hash] env Rack environment hash
+        # @return [String] The hostname.
+        #
+        def get_host env
+          env["HTTP_HOST"] || env["SERVER_NAME"]
+        end
+
+        ##
+        # Gets the full URL from the given Rack environment.
+        #
+        # @private
+        # @param [Hash] env Rack environment hash
+        # @return [String] The URL.
+        #
+        def get_url env
+          path = get_path env
+          host = get_host env
+          scheme = env["rack.url_scheme"]
+          query_string = env["QUERY_STRING"].to_s
+          url = "#{scheme}://#{host}#{path}"
+          url = "#{url}?#{query_string}" unless query_string.empty?
+          url
+        end
+
+        ##
+        # Configures the root span for this request. This may be called
+        # before the request is actually handled because it doesn't depend
+        # on the result.
+        #
+        # @private
+        # @param [Google::Cloud::Trace::TraceSpan] span The root span to
+        #     configure.
+        # @param [Hash] env Rack environment hash
+        #
+        def configure_span span, env
+          span.name = get_path env
+          set_basic_labels span.labels, env
+          set_extended_labels span.labels,
+                              span.trace.trace_context.capture_stack?
+          span
+        end
+
+        ##
+        # Configures standard labels.
+        # @private
+        #
+        def set_basic_labels labels, env
+          set_label labels, Google::Cloud::Trace::LabelKey::AGENT, AGENT_NAME
+          set_label labels, Google::Cloud::Trace::LabelKey::HTTP_HOST,
+                    get_host(env)
+          set_label labels, Google::Cloud::Trace::LabelKey::HTTP_METHOD,
+                    env["REQUEST_METHOD"]
+          set_label labels,
+                    Google::Cloud::Trace::LabelKey::HTTP_CLIENT_PROTOCOL,
+                    env["SERVER_PROTOCOL"]
+          set_label labels, Google::Cloud::Trace::LabelKey::HTTP_USER_AGENT,
+                    env["HTTP_USER_AGENT"]
+          set_label labels, Google::Cloud::Trace::LabelKey::HTTP_URL,
+                    get_url(env)
+          set_label labels, Google::Cloud::Trace::LabelKey::PID,
+                    ::Process.pid.to_s
+          set_label labels, Google::Cloud::Trace::LabelKey::TID,
+                    ::Thread.current.object_id.to_s
+        end
+
+        ##
+        # Configures stack and gae labels.
+        # @private
+        #
+        def set_extended_labels labels, capture_stack
+          if capture_stack
+            Google::Cloud::Trace::LabelKey.set_stack_trace labels,
+                                                           skip_frames: 3
+          end
+          if Google::Cloud::Core::Environment.gae?
+            set_label labels, Google::Cloud::Trace::LabelKey::GAE_APP_MODULE,
+                      Google::Cloud::Core::Environment.gae_module_id
+            set_label labels,
+                      Google::Cloud::Trace::LabelKey::GAE_APP_MODULE_VERSION,
+                      Google::Cloud::Core::Environment.gae_module_version
+          end
+        end
+
+        ##
+        # Sets the given label if the given value is a proper string.
+        #
+        # @private
+        # @param [Hash] labels The labels hash.
+        # @param [String] key The key of the label to set.
+        # @param [Object] value The value to set.
+        #
+        def set_label labels, key, value
+          labels[key] = value if value.is_a? ::String
+        end
+
+        ##
+        # Performs post-request tasks, including adding result-dependent
+        # labels to the root span, and adding trace context headers to the
+        # HTTP response.
+        #
+        # @private
+        # @param [Google::Cloud::Trace::TraceSpan] span The root span to
+        #     configure.
+        # @param [Array] result The Rack response.
+        #
+        def configure_result span, result
+          if result.is_a?(::Array) && result.size == 3
+            span.labels[Google::Cloud::Trace::LabelKey::HTTP_STATUS_CODE] =
+                result[0].to_s
+            result[1]["X-Cloud-Trace-Context"] =
+                span.trace.trace_context.to_string
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/notifications.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/notifications.rb
@@ -1,0 +1,115 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # Utility methods for configuring ActiveSupport notifications to generate
+      # spans in the current trace.
+      #
+      module Notifications
+        ##
+        # The default max length for label data.
+        DEFAULT_MAX_DATA_LENGTH = 1024
+
+        ##
+        # The default prefix for label keys
+        DEFAULT_LABEL_NAMESPACE = "/ruby/"
+
+        ##
+        # Stack truncation method that removes the ActiveSupport::Notifications
+        # calls from the top.
+        REMOVE_NOTIFICATION_FRAMEWORK =
+          lambda do |frame|
+            frame.absolute_path !~ %r{/lib/active_support/notifications}
+          end
+
+        ##
+        # Subscribes to the given event type or any type matching the given
+        # pattern. When an event is raised, a span is generated in the current
+        # thread's trace. The event payload is exposed as labels on the span.
+        # If there is no active trace for the current thread, then no span is
+        # generated.
+        #
+        # @param [String, Regex] type A specific type or pattern to select
+        #     notifications to listen for.
+        # @param [Integer] max_length The maximum length for label values.
+        #     If a label value exceeds this length, it is truncated.
+        #     If the length is nil, no truncation takes place.
+        # @param [String] label_namespace A string to prepend to all label
+        #     keys.
+        # @param [Boolean] capture_stack Whether traces should include the
+        #     call stack.
+        #
+        # @example
+        #
+        #   require "google/cloud/trace"
+        #   require "activerecord"
+        #
+        #   Google::Cloud::Trace::Notifications.instrument "sql.activerecord"
+        #
+        #   trace = Google::Cloud::Trace::Trace.new
+        #   Google::Cloud::Trace.set trace
+        #   ActiveRecord::Base.query "SHOW TABLES"
+        #
+        def self.instrument type,
+                            max_length: DEFAULT_MAX_DATA_LENGTH,
+                            label_namespace: DEFAULT_LABEL_NAMESPACE,
+                            capture_stack: false
+          require "active_support/notifications"
+          ActiveSupport::Notifications.subscribe(type) do |*args|
+            event = ActiveSupport::Notifications::Event.new(*args)
+            handle_notification_event event, max_length, label_namespace,
+                                      capture_stack
+          end
+        end
+
+        ##
+        # @private
+        def self.handle_notification_event event, maxlen, label_namespace,
+                                           capture_stack
+          cur_span = Google::Cloud::Trace.get
+          if cur_span && event.time && event.end
+            labels = payload_to_labels event, maxlen, label_namespace
+            if capture_stack
+              Google::Cloud::Trace::LabelKey.set_stack_trace \
+                labels,
+                skip_frames: 2,
+                truncate_stack: REMOVE_NOTIFICATION_FRAMEWORK
+            end
+            cur_span.create_span event.name,
+                                 start_time: event.time,
+                                 end_time: event.end,
+                                 labels: labels
+          end
+        end
+
+        ##
+        # @private
+        def self.payload_to_labels event, maxlen, label_namespace
+          labels = {}
+          event.payload.each do |k, v|
+            if v.is_a? ::String
+              v = v[0, maxlen-3] + "..." if maxlen && v.size > maxlen
+              labels["#{label_namespace}#{k}"] = v
+            end
+          end
+          labels
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/project.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/project.rb
@@ -1,0 +1,214 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/core/environment"
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # # Project
+      #
+      # Projects are top-level containers in Google Cloud Platform. They store
+      # information about billing and authorized users, and they control access
+      # to Stackdriver Trace resources. Each project has a friendly name and a
+      # unique ID. Projects can be created only in the [Google Developers
+      # Console](https://console.developers.google.com). See
+      # {Google::Cloud#trace}.
+      #
+      # @example
+      #   require "google/cloud/trace"
+      #
+      #   trace_client = Google::Cloud::Trace.new
+      #   traces = trace_client.list_traces Time.now - 3600, Time.now
+      #
+      # See Google::Cloud#trace
+      #
+      class Project
+        ##
+        # @private The Service object.
+        attr_accessor :service
+
+        ##
+        # @private Creates a new Project instance.
+        def initialize service
+          @service = service
+        end
+
+        ##
+        # The ID of the current project.
+        #
+        # @return [String] the Google Cloud project ID
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace_client = Google::Cloud::Trace.new(
+        #     project: "my-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
+        #
+        #   trace_client.project #=> "my-project"
+        #
+        def project
+          service.project
+        end
+
+        ##
+        # Create a new empty trace record for this project. Uses the current
+        # thread's TraceContext by default; otherwise you may provide a
+        # specific TraceContext.
+        #
+        # @param [Stackdriver::Core::TraceContext, nil] trace_context The
+        #     context within which to locate this trace (i.e. sets the trace ID
+        #     and the context parent span, if present.) If the context is set
+        #     explicitly to `nil`, a new trace with a new trace ID is created.
+        #     If no context is provided, the current thread's context is used.
+        # @return [Google::Cloud::Trace::TraceRecord] The new trace.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace_client = Google::Cloud::Trace.new(
+        #     project: "my-project",
+        #     keyfile: "/path/to/keyfile.json"
+        #   )
+        #
+        #   trace = trace_client.new_trace
+        #
+        def new_trace trace_context: :DEFAULT
+          if trace_context == :DEFAULT
+            trace_context = Stackdriver::Core::TraceContext.get
+          end
+          Google::Cloud::Trace::TraceRecord.new project, trace_context
+        end
+
+        ##
+        # Sends new traces to Stackdriver Trace or updates existing traces.
+        # If the ID of a trace that you send matches that of an existing trace,
+        # any fields in the existing trace and its spans are overwritten by the
+        # provided values, and any new fields provided are merged with the
+        # existing trace data. If the ID does not match, a new trace is created.
+        #
+        # @param [Google::Cloud::Trace::TraceRecord,
+        #     Array{Google::Cloud::Trace::TraceRecord}] traces Either a single
+        #     trace object or an array of trace objects.
+        # @return [Array{Google::Cloud::Trace::TraceRecord}] The traces written.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace_client = Google::Cloud::Trace.new
+        #
+        #   trace = trace_client.new_trace
+        #   trace.in_span "root_span" do
+        #     # Do stuff...
+        #   end
+        #
+        #   trace_client.patch_traces trace
+        #
+        def patch_traces traces
+          ensure_service!
+          service.patch_traces traces
+        end
+
+        ##
+        # Gets a single trace by its ID.
+        #
+        # @param [String] trace_id The ID of the trace to fetch.
+        # @return [Google::Cloud::Trace::TraceRecord, nil] The trace object, or
+        #     `nil` if there is no accessible trace with the given ID.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace_client = Google::Cloud::Trace.new
+        #
+        #   trace = trace_client.get_trace "1234567890abcdef1234567890abcdef"
+        #
+        def get_trace trace_id
+          ensure_service!
+          service.get_trace trace_id
+        end
+
+        ##
+        # Returns of a list of traces that match the specified conditions.
+        # You must provide a time interval. You may optionally provide a
+        # filter, an ordering, a view type.
+        # Results are paginated, and you may specify a page size. The result
+        # will come with a token you can pass back to retrieve the next page.
+        #
+        # @param [Time] start_time The start of the time interval (inclusive).
+        # @param [Time] end_time The end of the time interval (inclusive).
+        # @param [String] filter An optional filter.
+        # @param [String] order_by The optional sort order for returned traces.
+        #     May be `trace_id`, `name`, `duration`, or `start`. Any sort order
+        #     may also be reversed by appending `desc`; for example use
+        #     `start desc` to order traces from newest to oldest.
+        # @param [Symbol] view The optional type of view. Valid values are
+        #     `:MINIMAL`, `:ROOTSPAN`, and `:COMPLETE`. Default is `:MINIMAL`.
+        # @param [Integer] page_size The size of each page to return. Optional;
+        #     if omitted, the service will select a reasonable page size.
+        # @param [String] page_token A token indicating the page to return.
+        #     Each page of results includes proper token for specifying the
+        #     following page.
+        # @return [Google::Cloud::Trace::ResultSet] A page of results.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace_client = Google::Cloud::Trace.new
+        #
+        #   traces = trace_client.list_traces Time.now - 3600, Time.now
+        #   traces.each do |trace|
+        #     puts "Retrieved trace ID: #{trace.trace_id}"
+        #   end
+        #
+        def list_traces start_time, end_time,
+                        filter: nil,
+                        order_by: nil,
+                        view: nil,
+                        page_size: nil,
+                        page_token: nil
+          ensure_service!
+          service.list_traces project, start_time, end_time,
+                              filter: filter,
+                              order_by: order_by,
+                              view: view,
+                              page_size: page_size,
+                              page_token: page_token
+        end
+
+        ##
+        # @private Default project.
+        def self.default_project
+          ENV["TRACE_PROJECT"] ||
+            ENV["GOOGLE_CLOUD_PROJECT"] ||
+            ENV["GCLOUD_PROJECT"] ||
+            Google::Cloud::Core::Environment.project_id
+        end
+
+        protected
+
+        ##
+        # @private Raise an error unless an active connection to the service is
+        # available.
+        def ensure_service!
+          fail "Must have active connection to service" unless service
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -1,0 +1,207 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/core/environment"
+require "google/cloud/trace"
+
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # # Rails integration for Stackdriver Trace
+      #
+      # This Railtie is a drop-in Stackdriver Trace instrumentation plugin
+      # for Ruby on Rails applications. If present, it automatically
+      # instruments your Rails app to record performance traces and cause them
+      # to appear on your Stackdriver console.
+      #
+      # ## Installation
+      #
+      # To install this plugin, the gem `google-cloud-trace` must be in your
+      # Gemfile. You also must add the following line to your `application.rb`
+      # file:
+      #
+      # ```ruby
+      # require "google/cloud/trace/rails"
+      # ```
+      #
+      # If you include the `stackdriver` gem in your Gemfile, the above is done
+      # for you automatically, and you do not need to edit your
+      # `application.rb`.
+      #
+      # ## Configuration
+      #
+      # The following Rails configuration options are recognized.
+      #
+      # ```ruby
+      # config.google_cloud.use_trace = true | false
+      # ```
+      #
+      # Normally, tracing is activated when `RAILS_ENV` is set to `production`
+      # and credentials are available. You can override this and enable tracing
+      # in other environments by setting `use_trace` explicitly.
+      #
+      # ```ruby
+      # config.google_cloud.keyfile = "path/to/file"
+      # ```
+      #
+      # If your application is running on Google Cloud Platform, it will
+      # automatically use credentials available to your project. However, if
+      # you are running an application locally or on a different hosting
+      # provider, you may provide a path to your credentials file using this
+      # configuration.
+      #
+      # ```ruby
+      # config.google_cloud.project_id = "my-project-id"
+      # ```
+      #
+      # If your application is running on Google Cloud Platform, it will
+      # automatically select the project under which it is running. However, if
+      # you are running an application locally or on a different hosting
+      # provider, or if you want to log traces to a different project than you
+      # are using to host your application, you may provide the project ID.
+      #
+      # ```ruby
+      # config.google_cloud.trace.notifications = ["event1", "event2"]
+      # ```
+      #
+      # Provide a list of ActiveSupport events that you want recorded in your
+      # traces. By default, ActiveRecord queries, rendering, mailing, and file
+      # sending tasks are recorded, but you may provide an alternate list.
+      #
+      # ```ruby
+      # config.google_cloud.trace.max_data_length = 1024
+      # ```
+      #
+      # The maximum length of span properties recorded with ActiveSupport
+      # notification events. Any property value larger than this length is
+      # truncated.
+      #
+      class Railtie < ::Rails::Railtie
+        ##
+        # The default list of ActiveSupport notification types to include in
+        # traces.
+        #
+        DEFAULT_NOTIFICATIONS = [
+          "sql.active_record",
+          "render_template.action_view",
+          "send_file.action_controller",
+          "send_data.action_controller",
+          "deliver.action_mailer"
+        ].freeze
+
+        unless config.respond_to? :google_cloud
+          config.google_cloud = ActiveSupport::OrderedOptions.new
+        end
+        config.google_cloud.trace = ActiveSupport::OrderedOptions.new
+        config.google_cloud.trace.notifications = DEFAULT_NOTIFICATIONS.dup
+        config.google_cloud.trace.max_data_length =
+          Google::Cloud::Trace::Notifications::DEFAULT_MAX_DATA_LENGTH
+
+        initializer "Google.Cloud.Trace" do |app|
+          if Google::Cloud::Trace::Railtie.use_trace? app.config
+            Google::Cloud::Trace::Railtie.init_trace app
+          end
+        end
+
+        ##
+        # Determine whether to use Stackdriver Trace or not.
+        #
+        # Returns true if valid GCP project_id and keyfile are provided and
+        # either Rails is in "production" environment or
+        # config.google_cloud.use_trace is explicitly true. Otherwise false.
+        #
+        # @param [Rails::Railtie::Configuration] config The
+        #     Rails.application.config
+        #
+        # @return [Boolean] Whether to use Stackdriver Trace
+        #
+        def self.use_trace? config
+          gcp_config = config.google_cloud
+
+          # Return false if config.google_cloud.use_trace is
+          # explicitly false
+          return false if gcp_config.key?(:use_trace) &&
+                          !gcp_config.use_trace
+
+          # Try authenticate authorize client API. Return false if unable to
+          # authorize.
+          keyfile = gcp_config.trace.keyfile || gcp_config.keyfile
+          begin
+            Google::Cloud::Trace::Credentials.credentials_with_scope keyfile
+          rescue Exception => e
+            warn "Unable to initialize Google::Cloud::Trace due " \
+              "to authorization error: #{e.message}"
+            return false
+          end
+
+          if project_id(config).to_s.empty?
+            warn "Google::Cloud::Trace is not activated due to empty project_id"
+            return false
+          end
+
+          # Otherwise return true if Rails is running in production or
+          # config.google_cloud.use_trace is explicitly true
+          Rails.env.production? ||
+            (gcp_config.key?(:use_trace) && gcp_config.use_trace)
+        end
+
+        ##
+        # Return the effective project ID for this app, given a Rails config.
+        #
+        # @param [Rails::Railtie::Configuration] config The
+        #     Rails.application.config
+        # @return [String] The project ID, or nil if not found.
+        #
+        def self.project_id config
+          config.google_cloud.trace.project_id ||
+            config.google_cloud.project_id ||
+            ENV["TRACE_PROJECT"] ||
+            ENV["GOOGLE_CLOUD_PROJECT"] ||
+            Google::Cloud::Core::Environment.project_id
+        end
+
+        ##
+        # Initialize trace integration for Rails. Sets up the configuration,
+        # adds and configures middleware, and installs notifications.
+        #
+        # @private
+        #
+        def self.init_trace app
+          gcp_config = app.config.google_cloud
+          trace_config = gcp_config.trace
+          project_id = trace_config.project_id || gcp_config.project_id
+          keyfile = trace_config.keyfile || gcp_config.keyfile
+
+          tracer = Google::Cloud::Trace.new project: project_id,
+                                            keyfile: keyfile
+
+          app.middleware.insert_before \
+            Rack::Runtime,
+            Google::Cloud::Trace::Middleware,
+            service: tracer.service,
+            capture_stack: trace_config.capture_stack
+
+          trace_config.notifications.each do |type|
+            Google::Cloud::Trace::Notifications.instrument \
+              type,
+              max_length: trace_config.max_data_length,
+              capture_stack: trace_config.capture_stack
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/result_set.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/result_set.rb
@@ -1,0 +1,199 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # ResultSet represents the results of a `list_traces` request. It is
+      # an enumerable of the traces found, plus information about the request
+      # and a token to get the next page of results.
+      #
+      class ResultSet
+        include Enumerable
+
+        ##
+        # Create a new ResultSet given an enumerable of result Trace objects,
+        # a next page token (or nil if this is the last page), and all the
+        # query parameters.
+        #
+        # @private
+        #
+        def initialize service, project,
+                       results, next_page_token,
+                       start_time, end_time,
+                       filter: nil,
+                       order_by: nil,
+                       view: nil,
+                       page_size: nil,
+                       page_token: nil
+          @service = service
+          @project = project
+          @results = results
+          @next_page_token = next_page_token
+          @view = view
+          @page_size = page_size
+          @start_time = start_time
+          @end_time = end_time
+          @filter = filter
+          @order_by = order_by
+          @page_token = page_token
+        end
+
+        ##
+        # An `each` method that supports the Enumerable module. Iterates over
+        # the results and yields each, as a {Google::Cloud::Trace::TraceRecord}
+        # object, to the given block. If no block is provided, returns an
+        # Enumerator.
+        #
+        def each &block
+          @results.each(&block)
+        end
+
+        ##
+        # Returns the number of traces in this page of results.
+        #
+        # @return [Integer]
+        #
+        def size
+          @results.size
+        end
+
+        ##
+        # The trace service client that obtained this result set
+        # @private
+        attr_reader :service
+
+        ##
+        # The project ID string.
+        #
+        # @return [String]
+        #
+        attr_reader :project
+
+        ##
+        # The token to pass to `list_traces` to get the next page, or nil if
+        # this is the last page.
+        #
+        # @return [String, nil]
+        #
+        attr_reader :next_page_token
+
+        ##
+        # The `view` query parameter.
+        #
+        # @return [Symbol, nil]
+        #
+        attr_reader :view
+
+        ##
+        # The `page_size` query parameter.
+        #
+        # @return [Integer, nil]
+        #
+        attr_reader :page_size
+
+        ##
+        # The `start_time` query parameter.
+        #
+        # @return [Time, nil]
+        #
+        attr_reader :start_time
+
+        ##
+        # The `end_time` query parameter.
+        #
+        # @return [Time, nil]
+        #
+        attr_reader :end_time
+
+        ##
+        # The `filter` query parameter.
+        #
+        # @return [String, nil]
+        #
+        attr_reader :filter
+
+        ##
+        # The `order_by` query parameter.
+        #
+        # @return [String, nil]
+        #
+        attr_reader :order_by
+
+        ##
+        # The page token used to obtain this page of results.
+        #
+        # @return [String, nil]
+        #
+        attr_reader :page_token
+
+        ##
+        # Returns true if at least one more page of results can be retrieved.
+        #
+        # @return [Boolean]
+        #
+        def results_pending?
+          !next_page_token.nil?
+        end
+
+        ##
+        # Queries the service for the next page of results and returns a new
+        # ResultSet for that page. Returns `nil` if there are no more results.
+        #
+        # @return [Google::Cloud::Trace::ResultSet]
+        #
+        def next_page
+          return nil unless next_page?
+          service.list_traces \
+            project, start_time, end_time,
+            filter: filter,
+            order_by: order_by,
+            view: view,
+            page_size: page_size,
+            page_token: next_page_token
+        end
+
+        ##
+        # Create a new ResultSet given a Google::Gax::PagedEnumerable::Page,
+        # and all the query parameters.
+        #
+        # @private
+        #
+        def self.from_gax_page service, project_id,
+                               page, start_time, end_time,
+                               filter: nil,
+                               order_by: nil,
+                               view: nil,
+                               page_size: nil,
+                               page_token: nil
+          next_page_token = page.next_page_token
+          next_page_token = nil unless page.next_page_token?
+          results = page.map do |proto|
+            Google::Cloud::Trace::TraceRecord.from_proto proto
+          end
+          new service, project_id,
+              results, next_page_token,
+              start_time, end_time,
+              filter: filter,
+              order_by: order_by,
+              view: view,
+              page_size: page_size,
+              page_token: page_token
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/sampling.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/sampling.rb
@@ -1,0 +1,79 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # A sampler that enforces a certain QPS by delaying a minimum time
+      # between each sample.
+      #
+      class TimeSampler
+        ##
+        # Create a TimeSampler for the given QPS.
+        #
+        # @param [Number] qps Samples per second.
+        #
+        def initialize qps: 0.1
+          @delay_secs = 1.0 / qps
+          @last_time = ::Time.now.to_f - @delay_secs
+        end
+
+        ##
+        # Implements the sampler contract. Checks to see whether a sample
+        # should be taken at this time.
+        #
+        # @param [Hash] _data Context data (unused by this sampler).
+        # @return [Boolean] Whether to sample at this time.
+        #
+        def check _data = {}
+          time = ::Time.now.to_f
+          delays = (time - @last_time) / @delay_secs
+          if delays >= 2.0
+            @last_time = time - @delay_secs
+            true
+          elsif delays >= 1.0
+            @last_time += @delay_secs
+            true
+          else
+            false
+          end
+        end
+      end
+
+      @sampler = TimeSampler.new
+
+      ##
+      # Sets the global sampler.
+      #
+      # @param [#check] sampler The sampler, which must respond to the
+      #     `check` method, as defined for example in {TimeSampler#check}.
+      #
+      def self.sampler= sampler
+        @sampler = sampler
+      end
+
+      ##
+      # Checks whether a sample should be taken, using the global sampler.
+      #
+      # @param [Hash] data Optional context data.
+      # @return [Boolean] Whether to sample at this time.
+      #
+      def self.check_sampler data = {}
+        @sampler.check data
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/service.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/service.rb
@@ -1,0 +1,166 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/errors"
+require "google/cloud/trace/version"
+require "google/cloud/trace/v1"
+require "google/gax/errors"
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # Represents the connection to Trace, and exposes the API calls.
+      #
+      # @private
+      #
+      class Service
+        ##
+        # @private
+        attr_accessor :project
+
+        ##
+        # @private
+        attr_accessor :credentials
+
+        ##
+        # @private
+        attr_accessor :host
+
+        ##
+        # @private
+        attr_accessor :timeout
+
+        ##
+        # @private
+        attr_accessor :client_config
+
+        ##
+        # Creates a new Service instance.
+        def initialize project, credentials, host: nil, timeout: nil,
+                       client_config: nil
+          @project = project
+          @credentials = credentials
+          @host = host || V1::TraceServiceApi::SERVICE_ADDRESS
+          @timeout = timeout
+          @client_config = client_config || {}
+        end
+
+        def channel
+          require "grpc"
+          GRPC::Core::Channel.new host, nil, chan_creds
+        end
+
+        def chan_creds
+          return credentials if insecure?
+          require "grpc"
+          GRPC::Core::ChannelCredentials.new.compose \
+            GRPC::Core::CallCredentials.new credentials.client.updater_proc
+        end
+
+        def insecure?
+          credentials == :this_channel_is_insecure
+        end
+
+        def lowlevel_client
+          return mocked_lowlevel_client if mocked_lowlevel_client
+          @lowlevel_client ||= \
+            V1::TraceServiceApi.new(
+              service_path: host,
+              channel: channel,
+              timeout: timeout,
+              client_config: client_config,
+              app_name: "gcloud-ruby",
+              app_version: Google::Cloud::Trace::VERSION)
+        end
+        attr_accessor :mocked_lowlevel_client
+
+        ##
+        # Sends new traces to Stackdriver Trace or updates existing traces.
+        def patch_traces traces
+          traces = Array(traces)
+          traces_proto = Google::Devtools::Cloudtrace::V1::Traces.new
+          traces.each do |trace|
+            traces_proto.traces.push trace.to_proto
+          end
+          execute do
+            lowlevel_client.patch_traces @project, traces_proto
+          end
+          traces
+        end
+
+        ##
+        # Returns a trace given its ID
+        def get_trace trace_id
+          trace_proto = execute do
+            lowlevel_client.get_trace @project, trace_id
+          end
+          Google::Cloud::Trace::TraceRecord.from_proto trace_proto
+        end
+
+        ##
+        # Searches for traces matching the given criteria.
+        #
+        # rubocop:disable Metrics/MethodLength
+        def list_traces project_id, start_time, end_time,
+                        filter: nil,
+                        order_by: nil,
+                        view: nil,
+                        page_size: nil,
+                        page_token: nil
+          if page_token
+            call_opts = Google::Gax::CallOptions.new page_token: page_token
+          else
+            call_opts = Google::Gax::CallOptions.new
+          end
+          start_proto = Google::Cloud::Trace::Utils.time_to_proto start_time
+          end_proto = Google::Cloud::Trace::Utils.time_to_proto end_time
+          paged_enum = execute do
+            lowlevel_client.list_traces project_id,
+                                        view: view,
+                                        page_size: page_size,
+                                        start_time: start_proto,
+                                        end_time: end_proto,
+                                        filter: filter,
+                                        order_by: order_by,
+                                        options: call_opts
+          end
+          Google::Cloud::Trace::ResultSet.from_gax_page \
+            self, project_id,
+            paged_enum.page, start_time, end_time,
+            filter: filter,
+            order_by: order_by,
+            view: view,
+            page_size: page_size,
+            page_token: page_token
+        end
+
+        # @private
+        def inspect
+          "#{self.class}(#{@project})"
+        end
+
+        protected
+
+        def execute
+          yield
+        rescue Google::Gax::GaxError => e
+          # GaxError wraps BadStatus, but exposes it as #cause
+          raise Google::Cloud::Error.from_error(e.cause)
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/span.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/span.rb
@@ -1,0 +1,446 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "set"
+require "google/devtools/cloudtrace/v1/trace_pb"
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # Span represents a span in a trace record. Spans are contained in
+      # a trace and arranged in a forest. That is, each span may be a root span
+      # or have a parent span, and may have zero or more children.
+      #
+      class Span
+        ##
+        # The Trace object containing this span.
+        #
+        # @return [Google::Cloud::Trace::TraceRecord]
+        #
+        attr_reader :trace
+
+        ##
+        # The TraceSpan object representing this span's parent, or `nil` if
+        # this span is a root span.
+        #
+        # @return [Google::Cloud::Trace::Span, nil]
+        #
+        attr_reader :parent
+
+        ##
+        # The numeric ID of this span.
+        #
+        # @return [Integer]
+        #
+        attr_reader :span_id
+
+        ##
+        # The kind of this span.
+        #
+        # @return [Google::Cloud::Trace::SpanKind]
+        #
+        attr_accessor :kind
+
+        ##
+        # The name of this span.
+        #
+        # @return [String]
+        #
+        attr_accessor :name
+
+        ##
+        # The starting timestamp of this span in UTC, or `nil` if the
+        # starting timestamp has not yet been populated.
+        #
+        # @return [Time, nil]
+        #
+        attr_accessor :start_time
+
+        ##
+        # The ending timestamp of this span in UTC, or `nil` if the
+        # ending timestamp has not yet been populated.
+        #
+        # @return [Time, nil]
+        #
+        attr_accessor :end_time
+
+        ##
+        # The properties of this span.
+        #
+        # @return [Hash{String => String}]
+        #
+        attr_reader :labels
+
+        ##
+        # Create an empty Span object.
+        #
+        # @private
+        #
+        def initialize trace, id, parent, name, kind, start_time, end_time,
+                       labels
+          @trace = trace
+          @span_id = id
+          @parent = parent
+          @children = []
+          @name = name
+          @kind = kind
+          @start_time = start_time
+          @end_time = end_time
+          @labels = labels
+        end
+
+        ##
+        # Standard value equality check for this object.
+        #
+        # @param [Object] other
+        # @return [Boolean]
+        #
+        # rubocop:disable Metrics/AbcSize
+        def eql? other
+          other.is_a?(Google::Cloud::Trace::Span) &&
+            trace.trace_context == other.trace.trace_context &&
+            span_id == other.span_id &&
+            same_parent?(other) &&
+            same_children?(other) &&
+            kind == other.kind &&
+            name == other.name &&
+            start_time == other.start_time &&
+            end_time == other.end_time &&
+            labels == other.labels
+        end
+        alias_method :==, :eql?
+
+        ##
+        # Create a new Span object from a TraceSpan protobuf and insert it
+        # into the given trace.
+        #
+        # @param [Google::Devtools::Cloudtrace::V1::TraceSpan] span_proto The
+        #     span protobuf from the V1 gRPC Trace API.
+        # @param [Google::Cloud::Trace::TraceRecord] trace The trace object
+        #     to contain the span.
+        # @return [Google::Cloud::Trace::Span] A corresponding Span object.
+        #
+        def self.from_proto span_proto, trace
+          labels = {}
+          span_proto.labels.each { |k, v| labels[k] = v }
+          span_kind = SpanKind.get span_proto.kind
+          start_time =
+            Google::Cloud::Trace::Utils.proto_to_time span_proto.start_time
+          end_time =
+            Google::Cloud::Trace::Utils.proto_to_time span_proto.end_time
+          trace.create_span span_proto.name,
+                            parent_span_id: span_proto.parent_span_id.to_i,
+                            span_id: span_proto.span_id.to_i,
+                            kind: span_kind,
+                            start_time: start_time,
+                            end_time: end_time,
+                            labels: labels
+        end
+
+        ##
+        # Convert this Span object to an equivalent TraceSpan protobuf suitable
+        # for the V1 gRPC Trace API.
+        #
+        # @param [Integer] default_parent_id The parent span ID to use if the
+        #     span has no parent in the trace tree. Optional; defaults to 0.
+        # @return [Google::Devtools::Cloudtrace::V1::TraceSpan] The generated
+        #     protobuf.
+        #
+        def to_proto default_parent_id = 0
+          parent_span_id = parent ? parent.span_id.to_i : default_parent_id
+          start_proto = Google::Cloud::Trace::Utils.time_to_proto start_time
+          end_proto = Google::Cloud::Trace::Utils.time_to_proto end_time
+          Google::Devtools::Cloudtrace::V1::TraceSpan.new \
+            span_id: span_id.to_i,
+            kind: kind.to_sym,
+            name: name,
+            start_time: start_proto,
+            end_time: end_proto,
+            parent_span_id: parent_span_id,
+            labels: labels
+        end
+
+        ##
+        # Returns true if this span exists. A span exists until it has been
+        # removed from its trace.
+        #
+        # @return [Boolean]
+        #
+        def exists?
+          !@trace.nil?
+        end
+
+        ##
+        # Returns the trace context in effect within this span.
+        #
+        # @return [Stackdriver::Core::TraceContext]
+        #
+        def trace_context
+          ensure_exists!
+          trace.trace_context.with span_id: span_id
+        end
+
+        ##
+        # Returns the trace ID for this span.
+        #
+        # @return [String] The trace ID string.
+        #
+        def trace_id
+          ensure_exists!
+          trace.trace_id
+        end
+
+        ##
+        # Returns a list of children of this span.
+        #
+        # @return [Array{TraceSpan}] The children.
+        #
+        def children
+          ensure_exists!
+          @children.dup
+        end
+
+        ##
+        # Creates a new child span under this span.
+        #
+        # @param [String] name The name of the span.
+        # @param [Integer] span_id The numeric ID of the span, or nil to
+        #     generate a new random unique ID. Optional (defaults to nil).
+        # @param [SpanKind] kind The kind of span. Optional.
+        # @param [Time] start_time The starting timestamp, or nil if not yet
+        #     specified. Optional (defaults to nil).
+        # @param [Time] end_time The ending timestamp, or nil if not yet
+        #     specified. Optional (defaults to nil).
+        # @param [Hash{String=>String}] labels The span properties. Optional
+        #     (defaults to empty).
+        # @return [TraceSpan] The created span.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace = Google::Cloud::Trace.new trace_context
+        #   span = trace.create_span "root_span"
+        #   subspan = span.create_span "subspan"
+        #
+        def create_span name, span_id: nil, kind: SpanKind::UNSPECIFIED,
+                        start_time: nil, end_time: nil,
+                        labels: {}
+          ensure_exists!
+          span = trace.internal_create_span self, span_id, name, kind,
+                                            start_time, end_time, labels
+          @children << span
+          span
+        end
+
+        ##
+        # Creates a root span around the given block. Automatically populates
+        # the start and end timestamps. The span (with start time but not end
+        # time populated) is yielded to the block.
+        #
+        # @param [String] name The name of the span.
+        # @param [SpanKind] kind The kind of span. Optional.
+        # @param [Hash{String=>String}] labels The span properties. Optional
+        #     (defaults to empty).
+        # @return [TraceSpan] The created span.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace = Google::Cloud::Trace.new trace_context
+        #   trace.in_span "root_span" do |span|
+        #     # Do stuff...
+        #     span.in_span "subspan" do |subspan|
+        #       # Do subspan stuff...
+        #     end
+        #     # Do stuff...
+        #   end
+        #
+        def in_span name, kind: SpanKind::UNSPECIFIED, labels: {}
+          span = create_span name, kind: kind, labels: labels
+          span.start!
+          yield span
+        ensure
+          span.finish!
+        end
+
+        ##
+        # Sets the starting timestamp for this span to the current time.
+        # Asserts that the timestamp has not yet been set, and throws a
+        # RuntimeError if that is not the case.
+        # Also ensures that all ancestor spans have already started, and
+        # starts them if not.
+        #
+        def start!
+          fail "Span already started" if start_time
+          ensure_started
+        end
+
+        ##
+        # Sets the ending timestamp for this span to the current time.
+        # Asserts that the timestamp has not yet been set, and throws a
+        # RuntimeError if that is not the case.
+        # Also ensures that all descendant spans have also finished, and
+        # finishes them if not.
+        #
+        def finish!
+          fail "Span not yet started" unless start_time
+          fail "Span already finished" if end_time
+          ensure_finished
+        end
+
+        ##
+        # Sets the starting timestamp for this span to the current time, if
+        # it has not yet been set. Also ensures that all ancestor spans have
+        # also been started.
+        # Does nothing if the starting timestamp for this span is already set.
+        #
+        def ensure_started
+          ensure_exists!
+          unless start_time
+            self.start_time = ::Time.now.utc
+            parent.ensure_started if parent
+          end
+          self
+        end
+
+        ##
+        # Sets the ending timestamp for this span to the current time, if
+        # it has not yet been set. Also ensures that all descendant spans have
+        # also been finished.
+        # Does nothing if the ending timestamp for this span is already set.
+        #
+        def ensure_finished
+          ensure_exists!
+          unless end_time
+            self.end_time = ::Time.now.utc
+            @children.each(&:ensure_finished)
+          end
+          self
+        end
+
+        ##
+        # Deletes this span, and all descendant spans. After this completes,
+        # {Span#exists?} will return `false`.
+        #
+        def delete
+          ensure_exists!
+          @children.each(&:delete)
+          parent.remove_child(self) if parent
+          trace.remove_span(self)
+          @trace = nil
+          @parent = nil
+          self
+        end
+
+        ##
+        # Moves this span under a new parent, which must be part of the same
+        # trace. The entire tree under this span moves with it.
+        #
+        # @param [Google::Cloud::Trace::Span] new_parent The new parent.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace = Google::Cloud::Trace.new
+        #   root1 = trace.create_span "root_span_1"
+        #   root2 = trace.create_span "root_span_2"
+        #   subspan = root1.create_span "subspan"
+        #   subspan.move_under root2
+        #
+        def move_under new_parent
+          ensure_exists!
+          ensure_no_cycle! new_parent
+          if parent
+            parent.remove_child self
+          else
+            trace.remove_root self
+          end
+          if new_parent
+            new_parent.add_child self
+          else
+            trace.add_root self
+          end
+          @parent = new_parent
+          self
+        end
+
+        ##
+        # Add the given span to this span's child list.
+        #
+        # @private
+        #
+        def add_child child
+          @children << child
+        end
+
+        ##
+        # Remove the given span from this span's child list.
+        #
+        # @private
+        #
+        def remove_child child
+          @children.delete child
+        end
+
+        ##
+        # Ensure this span exists (i.e. has not been deleted) and throw a
+        # RuntimeError if not.
+        #
+        # @private
+        #
+        def ensure_exists!
+          fail "Span has been deleted" unless trace
+        end
+
+        ##
+        # Ensure moving this span under the given parent would not result
+        # in a cycle, and throw a RuntimeError if it would.
+        #
+        # @private
+        #
+        def ensure_no_cycle! new_parent
+          ptr = new_parent
+          until ptr.nil?
+            fail "Move would result in a cycle" if ptr.equal?(self)
+            ptr = ptr.parent
+          end
+        end
+
+        ##
+        # Returns true if this span has the same parent as the given other.
+        #
+        # @private
+        #
+        def same_parent? other
+          parent_id = parent ? parent.span_id : nil
+          other_parent_id = other.parent ? other.parent.span_id : nil
+          parent_id == other_parent_id
+        end
+
+        ##
+        # Returns true if this span has the same children as the given other.
+        #
+        # @private
+        #
+        def same_children? other
+          child_ids = @children.map(&:span_id)
+          other_child_ids = other.children.map(&:span_id)
+          ::Set.new(child_ids) == ::Set.new(other_child_ids)
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/span_kind.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/span_kind.rb
@@ -1,0 +1,80 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # SpanKind represents values for the "kind" field of span.
+      #
+      class SpanKind
+        @@mapping = {}
+
+        ##
+        # Create a new SpanKind.
+        #
+        # @private
+        #
+        def initialize name
+          @name = name
+          @@mapping[name] = self
+        end
+
+        ##
+        # The `:SPAN_KIND_UNSPECIFIED` value
+        #
+        UNSPECIFIED = new :SPAN_KIND_UNSPECIFIED
+
+        ##
+        # The `:RPC_SERVER` value
+        #
+        RPC_SERVER = new :RPC_SERVER
+
+        ##
+        # The `:RPC_CLIENT` value
+        #
+        RPC_CLIENT = new :RPC_CLIENT
+
+        ##
+        # Returns the symbolic representation of this SpanKind
+        #
+        # @return [Symbol] Symbol representation.
+        #
+        def to_sym
+          @name
+        end
+
+        ##
+        # Returns the string representation of this SpanKind
+        #
+        # @return [String] String representation.
+        #
+        def to_s
+          to_sym.to_s
+        end
+
+        ##
+        # Returns the SpanKind given a symbol or string representation.
+        #
+        # @param [String, Symbol] name The name of the SpanKind.
+        # @return [SpanKind] The SpanKind, or `nil` if not known.
+        #
+        def self.get name
+          @@mapping[name.to_sym]
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/trace_record.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/trace_record.rb
@@ -1,0 +1,308 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "date"
+require "google/devtools/cloudtrace/v1/trace_pb"
+require "stackdriver/core/trace_context"
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # Trace represents an entire trace record.
+      #
+      # A trace has an ID and contains a forest of spans. The trace object
+      # methods may be used to walk or manipulate the set of spans.
+      #
+      # @example
+      #   require "google/cloud/trace"
+      #
+      #   env = my_get_rack_environment
+      #   trace_context = Stackdriver::Core::TraceContext.parse_rack_env env
+      #
+      #   trace = Google::Cloud::Trace.new "my-project", trace_context
+      #   span = trace.create_span "root_span"
+      #   subspan = span.create_span "subspan"
+      #
+      #   trace_proto = trace.to_proto
+      #
+      class TraceRecord
+        ##
+        # Create an empty Trace object. If a trace context is provided, it is
+        # used to locate this trace within that context.
+        #
+        # @param [String] project The ID of the project containing this trace.
+        # @param [Stackdriver::Core::TraceContext] trace_context The context
+        #     within which to locate this trace (i.e. sets the trace ID and
+        #     the context parent span, if present.) If no context is provided,
+        #     a new trace with a new trace ID is created.
+        #
+        def initialize project, trace_context = nil, span_id_generator: nil
+          @project = project
+          @trace_context = trace_context || Stackdriver::Core::TraceContext.new
+          @root_spans = []
+          @spans_by_id = {}
+          @span_id_generator =
+            span_id_generator || ::Proc.new { rand(0xffffffffffffffff) + 1 }
+        end
+
+        ##
+        # Standard value equality check for this object.
+        #
+        # @param [Object] other Object to compare with
+        # @return [Boolean]
+        #
+        def eql? other
+          other.is_a?(Google::Cloud::Trace::TraceRecord) &&
+            trace_context == other.trace_context &&
+            @spans_by_id == other.instance_variable_get(:@spans_by_id)
+        end
+        alias_method :==, :eql?
+
+        ##
+        # Create a new Trace object from a trace protobuf.
+        #
+        # @param [Google::Devtools::Cloudtrace::V1::Trace] trace_proto The
+        #     trace protobuf from the V1 gRPC Trace API.
+        # @return [Trace, nil] A corresponding Trace object, or `nil` if the
+        #     proto does not represent an existing trace object.
+        #
+        def self.from_proto trace_proto
+          trace_id = trace_proto.trace_id.to_s
+          return nil if trace_id.empty?
+
+          tc = Stackdriver::Core::TraceContext.new trace_id: trace_id
+          trace = new trace_proto.project_id, tc
+          last_span_protos = []
+          span_protos = trace_proto.spans
+          until span_protos.size == last_span_protos.size
+            last_span_protos = span_protos
+            span_protos = trace.add_span_protos span_protos
+          end
+          trace
+        end
+
+        ##
+        # Convert this Trace object to an equivalent Trace protobuf suitable
+        # for the V1 gRPC Trace API.
+        #
+        # @return [Google::Devtools::Cloudtrace::V1::Trace] The generated
+        #     protobuf.
+        #
+        def to_proto
+          span_protos = @spans_by_id.values.map do |span|
+            span.to_proto trace_context.span_id.to_i
+          end
+          Google::Devtools::Cloudtrace::V1::Trace.new \
+            project_id: project,
+            trace_id: trace_id,
+            spans: span_protos
+        end
+
+        ##
+        # The project ID for this trace.
+        #
+        # @return [String]
+        #
+        attr_reader :project
+
+        ##
+        # The context for this trace.
+        #
+        # @return [Stackdriver::Core::TraceContext]
+        #
+        attr_reader :trace_context
+
+        ##
+        # The ID string for the trace.
+        #
+        # @return [String]
+        #
+        def trace_id
+          trace_context.trace_id
+        end
+
+        ##
+        # Returns an array of all spans in this trace, not in any particular
+        # order
+        #
+        # @return [Array{TraceSpan}]
+        #
+        def all_spans
+          @spans_by_id.values
+        end
+
+        ##
+        # Returns an array of all root spans in this trace, not in any
+        # particular order
+        #
+        # @return [Array{TraceSpan}]
+        #
+        def root_spans
+          @root_spans.dup
+        end
+
+        ##
+        # Creates a new span in this trace.
+        #
+        # @param [String] name The name of the span.
+        # @param [Integer] span_id The numeric ID of the span, or nil to
+        #     generate a new random unique ID. Optional (defaults to nil).
+        # @param [Integer] parent_span_id The span ID of the parent span, or 0
+        #     if this should be a new root span. Optional (defaults to 0).
+        # @param [SpanKind] kind The kind of span. Optional.
+        # @param [Time] start_time The starting timestamp, or nil if not yet
+        #     specified. Optional (defaults to nil).
+        # @param [Time] end_time The ending timestamp, or nil if not yet
+        #     specified. Optional (defaults to nil).
+        # @param [Hash{String=>String}] labels The span properties. Optional
+        #     (defaults to empty).
+        # @return [TraceSpan] The created span.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace = Google::Cloud::Trace.new trace_context
+        #   span = trace.create_span "root_span"
+        #
+        def create_span name, span_id: nil, parent_span_id: 0,
+                        kind: SpanKind::UNSPECIFIED,
+                        start_time: nil, end_time: nil,
+                        labels: {}
+          parent_span_id = parent_span_id.to_i
+          if parent_span_id == 0
+            internal_create_span nil, span_id, name, kind, start_time, end_time,
+                                 labels
+          else
+            @spans_by_id[parent_span_id].create_span name,
+                                                     span_id: span_id,
+                                                     kind: kind,
+                                                     start_time: start_time,
+                                                     end_time: end_time,
+                                                     labels: labels
+          end
+        end
+
+        ##
+        # Creates a root span around the given block. Automatically populates
+        # the start and end timestamps. The span (with start time but not end
+        # time populated) is yielded to the block.
+        #
+        # @param [String] name The name of the span.
+        # @param [SpanKind] kind The kind of span. Optional.
+        # @param [Hash{String=>String}] labels The span properties. Optional
+        #     (defaults to empty).
+        # @return [TraceSpan] The created span.
+        #
+        # @example
+        #   require "google/cloud/trace"
+        #
+        #   trace = Google::Cloud::Trace.new trace_context
+        #   trace.in_span "root_span" do |span|
+        #     # Do stuff...
+        #   end
+        #
+        def in_span name, kind: SpanKind::UNSPECIFIED, labels: {}
+          span = create_span name, kind: kind, labels: labels
+          span.start!
+          yield span
+        ensure
+          span.finish!
+        end
+
+        ##
+        # Internal implementation of span creation. Ensures that a span ID has
+        # been allocated, and that the span appears in the internal indexes.
+        #
+        # @private
+        #
+        def internal_create_span parent, span_id, name, kind, start_time,
+                                 end_time, labels
+          span_id = span_id.to_i
+          span_id = unique_span_id if span_id == 0
+          span = Google::Cloud::Trace::Span.new self, span_id, parent, name,
+                                                kind, start_time, end_time,
+                                                labels
+          @root_spans << span if parent.nil?
+          @spans_by_id[span_id] = span
+          span
+        end
+
+        ##
+        # Generates and returns a span ID that is unique in this trace.
+        #
+        # @private
+        #
+        def unique_span_id
+          loop do
+            id = @span_id_generator.call
+            return id if !@spans_by_id.include?(id) &&
+                         id != trace_context.span_id.to_i
+          end
+        end
+
+        ##
+        # Add the given span to the list of root spans.
+        #
+        # @private
+        #
+        def add_root span
+          @root_spans << span
+        end
+
+        ##
+        # Remove the given span from the list of root spans.
+        #
+        # @private
+        #
+        def remove_root span
+          @root_spans.delete span
+        end
+
+        ##
+        # Remove the given span from the list of spans overall.
+        #
+        # @private
+        #
+        def remove_span span
+          @root_spans.delete span
+          @spans_by_id.delete span.span_id
+        end
+
+        ##
+        # Given a list of span protobufs, for all spans whose parent is present
+        # in this trace already, convert that span to a `TraceSpan` object and
+        # add it into this trace. Returns the protos that have not yet been
+        # used. This method may be called repeatedly to populate a trace's
+        # span tree fully.
+        #
+        # @private
+        #
+        def add_span_protos span_protos
+          next_span_protos = []
+          span_protos.each do |span_proto|
+            parent_span_id = span_proto.parent_span_id.to_i
+            if parent_span_id == 0 || @spans_by_id.include?(parent_span_id)
+              Google::Cloud::Trace::Span.from_proto span_proto, self
+            else
+              next_span_protos << span_proto
+            end
+          end
+          next_span_protos
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -1,0 +1,46 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # Utils provides some internal utility methods for Trace.
+      #
+      # @private
+      #
+      module Utils
+        ##
+        # Convert a Ruby Time object to a timestamp proto.
+        #
+        # @private
+        #
+        def self.time_to_proto time
+          Google::Protobuf::Timestamp.new seconds: time.to_i,
+                                          nanos: time.nsec
+        end
+
+        ##
+        # Convert a Timestamp proto to a Ruby Time object.
+        #
+        # @private
+        #
+        def self.proto_to_time proto
+          Time.at(proto.seconds, Rational(proto.nanos, 1000))
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Trace
+      VERSION = "0.21.0".freeze
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/label_key_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/label_key_test.rb
@@ -1,0 +1,65 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Trace::LabelKey, :mock_trace do
+  describe ".set_stack_trace" do
+    it "generates a default stack trace" do
+      frames = [
+        stack_frame("/path/to/lib/mylib/stuff.rb", 90, "lib_method1"),
+        stack_frame("/path/to/app/myapp.rb", 1, "main"),
+      ]
+      Kernel.stub :caller_locations, frames do
+        labels = {}
+        Google::Cloud::Trace::LabelKey.set_stack_trace labels
+        labels["/stacktrace"].must_equal '{"stack_frame":[' \
+          '{"file_name":"/path/to/lib/mylib/stuff.rb",' \
+          '"line_number":90,"method_name":"lib_method1"},' \
+          '{"file_name":"/path/to/app/myapp.rb",' \
+          '"line_number":1,"method_name":"main"}' \
+          ']}'
+      end
+    end
+
+    it "applies truncation and filters" do
+      frames = [
+        stack_frame("/path/to/lib/active_support/notifications.rb",
+          123, "method1"),
+        stack_frame("/path/to/lib/active_support/notifications.rb",
+          456, "method2"),
+        stack_frame("/path/to/app/myapp.rb", 78, "app_method1"),
+        stack_frame("/path/to/lib/mylib/stuff.rb", 90, "lib_method1"),
+        stack_frame("/path/to/app/myapp.rb", 1, "main"),
+      ]
+      truncation_proc = ->(frame) {
+        frame.absolute_path !~ %r|/lib/active_support/notifications|
+      }
+      filter_proc = ->(frame) {
+        frame.absolute_path !~ %r|/lib/mylib|
+      }
+      Kernel.stub :caller_locations, frames do
+        labels = {}
+        Google::Cloud::Trace::LabelKey.set_stack_trace labels,
+          truncate_stack: truncation_proc, filter_stack: filter_proc
+        labels["/stacktrace"].must_equal '{"stack_frame":[' \
+          '{"file_name":"/path/to/app/myapp.rb",' \
+          '"line_number":78,"method_name":"app_method1"},' \
+          '{"file_name":"/path/to/app/myapp.rb",' \
+          '"line_number":1,"method_name":"main"}' \
+          ']}'
+      end
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
@@ -1,0 +1,198 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Trace::Middleware, :mock_trace do
+  let(:my_trace_id) { "0123456789abcdef0123456789abcdef" }
+  let(:my_span_id) { 12345 }
+  let(:hostname) { "my-app.appspot.com" }
+  let(:useragent) { "meowbrowser" }
+  let(:pid) { ::Process.pid.to_s }
+  let(:tid) { ::Thread.current.object_id.to_s }
+  let(:init_time) { ::Time.at 12345678 }
+  let(:start_time) { ::Time.at 12345679 }
+  let(:start_time_proto) { Google::Protobuf::Timestamp.new seconds: 12345679, nanos: 0 }
+  let(:my_path) { "/" }
+  let(:span_labels) {
+    {
+      Google::Cloud::Trace::LabelKey::AGENT => Google::Cloud::Trace::Middleware::AGENT_NAME,
+      Google::Cloud::Trace::LabelKey::HTTP_HOST => hostname,
+      Google::Cloud::Trace::LabelKey::HTTP_METHOD => "GET",
+      Google::Cloud::Trace::LabelKey::HTTP_CLIENT_PROTOCOL => "HTTP/1.1",
+      Google::Cloud::Trace::LabelKey::HTTP_USER_AGENT => useragent,
+      Google::Cloud::Trace::LabelKey::HTTP_URL => "http://#{hostname}#{my_path}",
+      Google::Cloud::Trace::LabelKey::PID => pid,
+      Google::Cloud::Trace::LabelKey::TID => tid,
+      Google::Cloud::Trace::LabelKey::HTTP_STATUS_CODE => "200"
+    }
+  }
+  let(:span_proto) {
+    Google::Devtools::Cloudtrace::V1::TraceSpan.new \
+      span_id: my_span_id,
+      name: my_path,
+      kind: :SPAN_KIND_UNSPECIFIED,
+      start_time: start_time_proto,
+      end_time: start_time_proto,
+      parent_span_id: 0,
+      labels: span_labels
+  }
+  let(:trace_proto) {
+    Google::Devtools::Cloudtrace::V1::Trace.new \
+      project_id: project,
+      trace_id: my_trace_id,
+      spans: [span_proto]
+  }
+  let(:traces_proto) {
+    traces_proto = Google::Devtools::Cloudtrace::V1::Traces.new
+    traces_proto.traces.push trace_proto
+    traces_proto
+  }
+
+  let(:sampler) {
+    ::Time.stub :now, init_time do
+      Google::Cloud::Trace::TimeSampler.new
+    end
+  }
+  let(:mock_span_id_generator) {
+    ::Proc.new { my_span_id }
+  }
+  let(:base_middleware) {
+    Google::Cloud::Trace::Middleware.new base_app,
+                                         sampler: sampler,
+                                         span_id_generator: mock_span_id_generator
+  }
+
+  def base_app(&block)
+    app = ::Struct.new(:block).new(block)
+    def app.call env
+      block ? block.call(env) : ["200", {}, "Hello, world!\n"]
+    end
+    app
+  end
+
+  def rack_env sample: nil,
+               span_id: my_span_id,
+               path: my_path
+    tc_header = my_trace_id
+    tc_header = "#{tc_header}/#{span_id}" if span_id
+    tc_header = "#{tc_header};o=1" if sample
+    {
+      "HTTP_X_CLOUD_TRACE_CONTEXT" => tc_header,
+      "PATH_INFO" => path,
+      "HTTP_HOST" => hostname,
+      "rack.url_scheme" => "http",
+      "REQUEST_METHOD" => "GET",
+      "SERVER_PROTOCOL" => "HTTP/1.1",
+      "HTTP_USER_AGENT" => useragent
+    }
+  end
+
+  describe ".get_trace_context" do
+    it "passes through the existing sampling decision" do
+      env = rack_env sample: true
+      tc = base_middleware.get_trace_context env
+
+      tc.trace_id.must_equal my_trace_id
+      tc.span_id.must_equal my_span_id
+      tc.sampled?.must_equal true
+      tc.capture_stack?.must_equal false
+      tc.new?.must_equal false
+    end
+
+    it "makes a new sampling decision" do
+      env = rack_env
+      middleware = base_middleware
+      tc = ::Time.stub :now, start_time do
+        middleware.get_trace_context env
+      end
+
+      tc.trace_id.must_equal my_trace_id
+      tc.span_id.must_equal my_span_id
+      tc.sampled?.must_equal true
+      tc.capture_stack?.must_equal false
+      tc.new?.must_equal false
+    end
+
+    it "honors path blacklist" do
+      env = rack_env path: "/_ah/health"
+      middleware = base_middleware
+      tc = ::Time.stub :now, start_time do
+        middleware.get_trace_context env
+      end
+
+      tc.trace_id.must_equal my_trace_id
+      tc.span_id.must_equal my_span_id
+      tc.sampled?.must_equal false
+      tc.capture_stack?.must_equal false
+      tc.new?.must_equal false
+    end
+  end
+
+  describe ".get_url" do
+    it "returns an URL without a query string" do
+      url = base_middleware.get_url rack_env
+      url.must_equal "http://#{hostname}#{my_path}"
+    end
+
+    it "returns an URL with a query string" do
+      env = rack_env.merge({"QUERY_STRING" => "foo=bar"})
+      url = base_middleware.get_url env
+      url.must_equal "http://#{hostname}#{my_path}?foo=bar"
+    end
+  end
+
+  describe ".call" do
+    it "sends a trace" do
+      mock = Minitest::Mock.new
+      mock.expect :patch_traces, nil, [project, traces_proto]
+      tracer.service.mocked_lowlevel_client = mock
+
+      env = rack_env sample: true, span_id: nil
+      middleware = Google::Cloud::Trace::Middleware.new \
+        base_app,
+        sampler: sampler,
+        service: tracer.service,
+        span_id_generator: mock_span_id_generator
+      result = ::Time.stub :now, start_time do
+        middleware.call env
+      end
+
+      mock.verify
+      result[1]["X-Cloud-Trace-Context"].must_equal "#{my_trace_id};o=1"
+    end
+
+    it "provides app access to the trace structure" do
+      mock = Minitest::Mock.new
+      mock.expect :patch_traces, nil, [project, traces_proto]
+      tracer.service.mocked_lowlevel_client = mock
+
+      env = rack_env sample: true, span_id: nil
+      myapp = ::Proc.new do |env|
+        Google::Cloud::Trace.get.span_id.must_equal my_span_id
+        ["200", {}, "Hello, world!\n"]
+      end
+      middleware = Google::Cloud::Trace::Middleware.new \
+        base_app(&myapp),
+        sampler: sampler,
+        service: tracer.service,
+        span_id_generator: mock_span_id_generator
+      result = ::Time.stub :now, start_time do
+        middleware.call env
+      end
+
+      mock.verify
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/notifications_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/notifications_test.rb
@@ -1,0 +1,64 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Trace::Notifications, :mock_trace do
+  let(:event_type) { "test_event_type" }
+
+  describe ".instrument" do
+    it "generates spans for events" do
+      Google::Cloud::Trace::Notifications.instrument event_type,
+                                                     capture_stack: true
+      frames = [
+        stack_frame("/path/to/lib/active_support/notifications.rb",
+          123, "method1"),
+        stack_frame("/path/to/lib/active_support/notifications.rb",
+          456, "method2"),
+        stack_frame("/path/to/app/myapp.rb", 78, "app_method1"),
+        stack_frame("/path/to/lib/mylib/stuff.rb", 90, "lib_method1"),
+        stack_frame("/path/to/app/myapp.rb", 1, "main"),
+      ]
+      trace = Google::Cloud::Trace::TraceRecord.new project
+      Google::Cloud::Trace.stub :get, trace do
+        Kernel.stub :caller_locations, frames do
+          ActiveSupport::Notifications.instrument event_type,
+                                                  foo: "barrr",
+                                                  whoops: "x" * 2000 do
+            # yada yada yada
+          end
+          ActiveSupport::Notifications.instrument "othertype", bar: "foooo" do
+            # yada yada yada
+          end
+        end
+      end
+      trace.all_spans.size.must_equal 1
+      span = trace.root_spans.first
+      span.name.must_equal event_type
+      expected_labels = {
+        "/ruby/foo" => "barrr",
+        "/ruby/whoops" => "x" * 1021 + "...",
+        "/stacktrace" => '{"stack_frame":[' \
+          '{"file_name":"/path/to/app/myapp.rb",' \
+          '"line_number":78,"method_name":"app_method1"},' \
+          '{"file_name":"/path/to/lib/mylib/stuff.rb",' \
+          '"line_number":90,"method_name":"lib_method1"},' \
+          '{"file_name":"/path/to/app/myapp.rb",' \
+          '"line_number":1,"method_name":"main"}' \
+          ']}'
+      }
+      span.labels.must_equal expected_labels
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/project_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/project_test.rb
@@ -1,0 +1,165 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Trace::Project, :mock_trace do
+  MockPagedEnum = ::Struct.new :page
+
+  let(:simple_trace_id) { "0123456789abcdef0123456789abcdef" }
+  let(:simple_span_id) { 54321 }
+  let(:simple_span_name) { "/path/to/resource" }
+  let(:simple_span_start) { Time.at 10001, 123 }
+  let(:simple_span_end) { Time.at 10002, 456 }
+  let(:simple_span_start_proto) { Google::Protobuf::Timestamp.new seconds: 10001, nanos: 123000 }
+  let(:simple_span_end_proto) { Google::Protobuf::Timestamp.new seconds: 10002, nanos: 456000 }
+  let(:simple_span_labels) { { "foo" => "bar" } }
+  let(:simple_span_proto) {
+    Google::Devtools::Cloudtrace::V1::TraceSpan.new \
+      span_id: simple_span_id,
+      kind: :RPC_SERVER,
+      name: simple_span_name,
+      start_time: simple_span_start_proto,
+      end_time: simple_span_end_proto,
+      parent_span_id: 0,
+      labels: simple_span_labels
+  }
+  let(:simple_trace_proto) {
+    Google::Devtools::Cloudtrace::V1::Trace.new \
+      project_id: project,
+      trace_id: simple_trace_id,
+      spans: [simple_span_proto]
+  }
+  let(:simple_traces_proto) {
+    traces_proto = Google::Devtools::Cloudtrace::V1::Traces.new
+    traces_proto.traces.push simple_trace_proto
+    traces_proto
+  }
+  let(:simple_trace_context) { Stackdriver::Core::TraceContext.new trace_id: simple_trace_id }
+  let(:simple_trace) {
+    trace = Google::Cloud::Trace::TraceRecord.new project, simple_trace_context
+    trace.create_span simple_span_name,
+                      span_id: simple_span_id,
+                      kind: Google::Cloud::Trace::SpanKind::RPC_SERVER,
+                      start_time: simple_span_start,
+                      end_time: simple_span_end,
+                      labels: simple_span_labels
+    trace
+  }
+
+  let(:second_trace_id) { "fedcba9876543210fedcba9876543210" }
+  let(:second_span_id) { 98765 }
+  let(:second_span_name) { "/path/to/resource" }
+  let(:second_span_start) { Time.at 10003, 123 }
+  let(:second_span_end) { Time.at 10004, 456 }
+  let(:second_span_start_proto) { Google::Protobuf::Timestamp.new seconds: 10003, nanos: 123000 }
+  let(:second_span_end_proto) { Google::Protobuf::Timestamp.new seconds: 10004, nanos: 456000 }
+  let(:second_span_labels) { { "foo" => "baz" } }
+  let(:second_span_proto) {
+    Google::Devtools::Cloudtrace::V1::TraceSpan.new \
+      span_id: second_span_id,
+      kind: :RPC_SERVER,
+      name: second_span_name,
+      start_time: second_span_start_proto,
+      end_time: second_span_end_proto,
+      parent_span_id: 0,
+      labels: second_span_labels
+  }
+  let(:second_trace_proto) {
+    Google::Devtools::Cloudtrace::V1::Trace.new \
+      project_id: project,
+      trace_id: second_trace_id,
+      spans: [second_span_proto]
+  }
+  let(:second_trace_context) { Stackdriver::Core::TraceContext.new trace_id: second_trace_id }
+  let(:second_trace) {
+    trace = Google::Cloud::Trace::TraceRecord.new project, second_trace_context
+    trace.create_span second_span_name,
+                      span_id: second_span_id,
+                      kind: Google::Cloud::Trace::SpanKind::RPC_SERVER,
+                      start_time: second_span_start,
+                      end_time: second_span_end,
+                      labels: second_span_labels
+    trace
+  }
+
+  let(:range_start_proto) { Google::Protobuf::Timestamp.new seconds: 10000, nanos: 0 }
+  let(:range_end_proto) { Google::Protobuf::Timestamp.new seconds: 10010, nanos: 0 }
+  let(:range_start) { Time.at 10000, 0 }
+  let(:range_end) { Time.at 10010, 0 }
+
+  let(:default_options) { Google::Gax::CallOptions.new }
+  let(:next_page_token) { "next" }
+  let(:gax_page) {
+    response = {
+      resource: [simple_trace_proto, second_trace_proto],
+      page_token: next_page_token
+    }
+    Google::Gax::PagedEnumerable::Page.new response, :page_token, :resource
+  }
+  let(:gax_paged_enum) {
+    MockPagedEnum.new gax_page
+  }
+
+  it "knows the project identifier" do
+    tracer.must_be_kind_of Google::Cloud::Trace::Project
+    tracer.project.must_equal project
+  end
+
+  it "gets a single trace" do
+    mock = Minitest::Mock.new
+    mock.expect :get_trace, simple_trace_proto, [project, simple_trace_id]
+    tracer.service.mocked_lowlevel_client = mock
+
+    actual_trace = tracer.get_trace simple_trace_id
+
+    mock.verify
+    actual_trace.must_equal simple_trace
+  end
+
+  it "lists traces" do
+    mock = Minitest::Mock.new
+    mock.expect :list_traces, gax_paged_enum,
+                [project,
+                  start_time: range_start_proto,
+                  end_time: range_end_proto,
+                  view: nil,
+                  page_size: nil,
+                  filter: nil,
+                  order_by: nil,
+                  options: default_options]
+    tracer.service.mocked_lowlevel_client = mock
+
+    actual_result = tracer.list_traces range_start, range_end
+
+    mock.verify
+    actual_result.must_be_kind_of Google::Cloud::Trace::ResultSet
+    actual_result.project.must_equal project
+    actual_result.next_page_token.must_equal next_page_token
+    actual_result.start_time.must_equal range_start
+    actual_result.end_time.must_equal range_end
+    actual_result.results_pending?.must_equal true
+    actual_result.to_a.must_equal [simple_trace, second_trace]
+  end
+
+  it "patches a trace" do
+    mock = Minitest::Mock.new
+    mock.expect :patch_traces, nil, [project, simple_traces_proto]
+    tracer.service.mocked_lowlevel_client = mock
+
+    tracer.patch_traces simple_trace
+
+    mock.verify
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/rails_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/rails_test.rb
@@ -1,0 +1,56 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "rails"
+require "rails/railtie"
+require "active_support/ordered_options"
+require "google/cloud/trace/rails"
+
+describe Google::Cloud::Trace::Railtie do
+  describe ".use_trace?" do
+    before do
+      @rails_config = ::ActiveSupport::OrderedOptions.new
+      @rails_config.google_cloud = ::ActiveSupport::OrderedOptions.new
+      @rails_config.google_cloud.trace = ::ActiveSupport::OrderedOptions.new
+    end
+
+    it "returns false if config.google_cloud.use_trace is explicitly false" do
+      @rails_config.google_cloud.use_trace = false
+
+      Google::Cloud::Trace::Railtie.use_trace?(@rails_config).must_equal false
+    end
+
+    it "returns false if can't find non-empty project_id" do
+      Google::Cloud::Trace::Credentials.stub :default, nil do
+        Google::Cloud::Trace::Project.stub :default_project, nil do
+          $stderr.stub :write, nil do
+            Google::Cloud::Trace::Railtie.use_trace?(@rails_config).must_equal false
+          end
+        end
+      end
+    end
+
+    it "returns true if config.google_cloud.use_trace is explicitly true even Rails is not in production" do
+      @rails_config.google_cloud.trace.project_id = "test-project"
+      @rails_config.google_cloud.use_trace = true
+
+      Google::Cloud::Trace::Credentials.stub :default, nil do
+        Rails.env.stub :production?, false do
+          Google::Cloud::Trace::Railtie.use_trace?(@rails_config).must_equal true
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/sampling_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/sampling_test.rb
@@ -1,0 +1,72 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Trace::TimeSampler do
+  let(:start_time) { ::Time.at(12345678) }
+
+  def sampler
+    ::Time.stub :now, start_time do
+      Google::Cloud::Trace::TimeSampler.new
+    end
+  end
+
+  describe ".check" do
+    it "samples the first time called" do
+      sam = Google::Cloud::Trace::TimeSampler.new
+      sam.check.must_equal true
+    end
+
+    it "doesn't sample when called too soon" do
+      sam = sampler
+      ::Time.stub :now, start_time - 1 do
+        sam.check.must_equal false
+      end
+    end
+
+    it "samples when called after a suitable delay" do
+      sam = sampler
+      ::Time.stub :now, start_time + 1 do
+        sam.check.must_equal true
+      end
+    end
+
+    it "advances last sampling time" do
+      sam = sampler
+      ::Time.stub :now, start_time + 3 do
+        sam.check.must_equal true
+      end
+      ::Time.stub :now, start_time + 9 do
+        sam.check.must_equal false
+      end
+      ::Time.stub :now, start_time + 11 do
+        sam.check.must_equal true
+      end
+    end
+
+    it "advances last sampling time after a large gap" do
+      sam = sampler
+      ::Time.stub :now, start_time + 30 do
+        sam.check.must_equal true
+      end
+      ::Time.stub :now, start_time + 31 do
+        sam.check.must_equal true
+      end
+      ::Time.stub :now, start_time + 32 do
+        sam.check.must_equal false
+      end
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
@@ -1,0 +1,248 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Trace::TraceRecord do
+  let(:my_trace_id) { "1234512345" }
+  let(:project_id) { "my-project" }
+  let(:my_trace_context) {
+    Stackdriver::Core::TraceContext.new trace_id: my_trace_id
+  }
+  let(:empty_trace) {
+    Google::Cloud::Trace::TraceRecord.new project_id, my_trace_context
+  }
+
+  it "initializes with a trace context" do
+    tc = Stackdriver::Core::TraceContext.new trace_id: my_trace_id,
+                                             span_id: 54321,
+                                             sampled: true,
+                                             capture_stack: false
+    trace = Google::Cloud::Trace::TraceRecord.new project_id, tc
+    trace.trace_context.must_equal tc
+    trace.trace_id.must_equal my_trace_id
+  end
+
+  it "initializes with no spans" do
+    trace = empty_trace
+
+    trace.all_spans.must_be_empty
+    trace.root_spans.must_be_empty
+  end
+
+  it "can create a new populated span" do
+    start_time = Time.at(1000)
+    end_time = Time.at(2000)
+    labels = {a: 1, b: 2}
+
+    trace = empty_trace
+    span = trace.create_span "aname",
+                             kind: Google::Cloud::Trace::SpanKind::RPC_SERVER,
+                             start_time: start_time, end_time: end_time,
+                             labels: labels
+
+    span.trace.must_equal trace
+    span.parent.must_be_nil
+    span.kind.must_equal Google::Cloud::Trace::SpanKind::RPC_SERVER
+    span.name.must_equal "aname"
+    span.start_time.must_equal start_time
+    span.end_time.must_equal end_time
+    span.labels.must_equal labels
+    span.children.must_be_empty
+    trace.all_spans.size.must_equal 1
+    trace.all_spans.must_include span
+    trace.root_spans.size.must_equal 1
+    trace.root_spans.must_include span
+  end
+
+  it "can create a new empty span" do
+    trace = empty_trace
+    span = trace.create_span ""
+
+    span.trace.must_equal trace
+    span.parent.must_be_nil
+    span.kind.must_equal Google::Cloud::Trace::SpanKind::UNSPECIFIED
+    span.name.must_be_empty
+    span.start_time.must_be_nil
+    span.end_time.must_be_nil
+    span.labels.must_be_empty
+    trace.all_spans.size.must_equal 1
+    trace.all_spans.must_include span
+    trace.root_spans.size.must_equal 1
+    trace.root_spans.must_include span
+  end
+
+  it "can create subspans" do
+    trace = empty_trace
+    span = trace.create_span "aname",
+                             kind: Google::Cloud::Trace::SpanKind::RPC_SERVER
+    subspan = span.create_span "bname",
+                               kind: Google::Cloud::Trace::SpanKind::RPC_CLIENT
+
+    subspan.trace.must_equal trace
+    subspan.parent.must_equal span
+    subspan.name.must_equal "bname"
+    subspan.kind.must_equal Google::Cloud::Trace::SpanKind::RPC_CLIENT
+    subspan.start_time.must_be_nil
+    subspan.end_time.must_be_nil
+    subspan.labels.must_be_empty
+    trace.all_spans.size.must_equal 2
+    trace.all_spans.must_include span
+    trace.all_spans.must_include subspan
+    trace.root_spans.size.must_equal 1
+    trace.root_spans.must_include span
+    span.children.size.must_equal 1
+    span.children.must_include subspan
+  end
+
+  it "can start and finish spans" do
+    trace = empty_trace
+    span = trace.create_span "aname"
+
+    span.start_time.must_be_nil
+    span.end_time.must_be_nil
+
+    pre_start_time = Time.now.utc
+    span.start!
+
+    span.start_time.must_be :>=, pre_start_time
+    span.end_time.must_be_nil
+
+    between_time = Time.now.utc
+    span.finish!
+    post_end_time = Time.now.utc
+
+    span.start_time.must_be :<=, between_time
+    span.end_time.must_be :>=, between_time
+    span.end_time.must_be :<=, post_end_time
+  end
+
+  it "can delete spans recursively" do
+    trace = empty_trace
+    span = trace.create_span "aname"
+    subspan = span.create_span "bname"
+    subsubspan = subspan.create_span "cname"
+    subspan.delete
+
+    subspan.exists?.must_equal false
+    subsubspan.exists?.must_equal false
+    span.children.must_be_empty
+    trace.all_spans.size.must_equal 1
+    trace.all_spans.must_include span
+    trace.root_spans.size.must_equal 1
+    trace.root_spans.must_include span
+  end
+
+  it "can move spans to a new parent" do
+    trace = empty_trace
+    span1 = trace.create_span "aname"
+    span2 = trace.create_span "bname"
+    subspan = span1.create_span "cname"
+
+    span1.children.must_include subspan
+    span2.children.must_be_empty
+    subspan.parent.must_equal span1
+
+    subspan.move_under span2
+
+    span1.children.must_be_empty
+    span2.children.must_include subspan
+    subspan.parent.must_equal span2
+  end
+
+  it "can create span trees using in_span" do
+    trace = empty_trace
+    sub1 = sub2 = nil
+    before_time = Time.now.utc
+    root1 = trace.in_span "aname" do |span|
+      sub1 = span.in_span("bname") { |s| s }
+      sub2 = span.in_span("cname") { |s| s }
+      span
+    end
+    root2 = trace.in_span("dname") { |span| span }
+    after_time = Time.now.utc
+
+    trace.all_spans.size.must_equal 4
+    trace.root_spans.size.must_equal 2
+
+    root1.children.size.must_equal 2
+    root1.children.must_include sub1
+    root1.children.must_include sub2
+    root2.children.must_be_empty
+
+    root1.start_time.must_be :>=, before_time
+    sub1.start_time.must_be :>=, root1.start_time
+    sub1.end_time.must_be :>=, sub1.start_time
+    sub2.start_time.must_be :>=, sub1.end_time
+    sub2.end_time.must_be :>=, sub2.start_time
+    root1.end_time.must_be :>=, sub2.end_time
+    root2.start_time.must_be :>=, root1.end_time
+    root2.end_time.must_be :>=, root2.start_time
+    after_time.must_be :>=, root2.end_time
+  end
+
+  it "converts to and from a protobuf" do
+    span_start = Time.at 10001, 123
+    span_start_p = Google::Protobuf::Timestamp.new seconds: 10001, nanos: 123000
+    sub_start = Time.at 10002, 456
+    sub_start_p = Google::Protobuf::Timestamp.new seconds: 10002, nanos: 456000
+    sub_end = Time.at 10003, 789
+    sub_end_p = Google::Protobuf::Timestamp.new seconds: 10003, nanos: 789000
+    span_end = Time.at 10004, 321
+    span_end_p = Google::Protobuf::Timestamp.new seconds: 10004, nanos: 321000
+    span_id = 314159
+    sub_id = 265359
+    span_name = "aname"
+    sub_name = "bname"
+    span_labels = { "foo" => "bar"}
+    sub_labels = { "foo" => "baz"}
+
+    trace = empty_trace
+    span = trace.create_span span_name,
+                             span_id: span_id,
+                             kind: Google::Cloud::Trace::SpanKind::RPC_SERVER,
+                             start_time: span_start, end_time: span_end,
+                             labels: span_labels
+    span.create_span sub_name,
+                     span_id: sub_id,
+                     kind: Google::Cloud::Trace::SpanKind::RPC_CLIENT,
+                     start_time: sub_start, end_time: sub_end,
+                     labels: sub_labels
+
+    proto = Google::Devtools::Cloudtrace::V1::Trace.new \
+      project_id: project_id,
+      trace_id: my_trace_id,
+      spans: [
+        Google::Devtools::Cloudtrace::V1::TraceSpan.new(
+          span_id: span_id,
+          kind: :RPC_SERVER,
+          name: span_name,
+          start_time: span_start_p,
+          end_time: span_end_p,
+          parent_span_id: 0,
+          labels: span_labels),
+        Google::Devtools::Cloudtrace::V1::TraceSpan.new(
+          span_id: sub_id,
+          kind: :RPC_CLIENT,
+          name: sub_name,
+          start_time: sub_start_p,
+          end_time: sub_end_p,
+          parent_span_id: span_id,
+          labels: sub_labels)
+      ]
+
+    trace.to_proto.must_equal proto
+    Google::Cloud::Trace::TraceRecord.from_proto(proto).must_equal trace
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/utils_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/utils_test.rb
@@ -1,0 +1,34 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Trace::Utils do
+  let(:secs) { 1234567890 }
+  let(:nsecs) { 987654321 }
+  let(:time_proto) {
+    Google::Protobuf::Timestamp.new seconds: secs, nanos: nsecs
+  }
+  let(:time_obj) {
+    Time.at(secs, Rational(nsecs, 1000))
+  }
+
+  it "converts time objects to protos" do
+    Google::Cloud::Trace::Utils.time_to_proto(time_obj).must_equal time_proto
+  end
+
+  it "converts time protos to objects" do
+    Google::Cloud::Trace::Utils.proto_to_time(time_proto).must_equal time_obj
+  end
+end

--- a/google-cloud-trace/test/helper.rb
+++ b/google-cloud-trace/test/helper.rb
@@ -1,0 +1,68 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gem "minitest"
+require "minitest/autorun"
+require "minitest/focus"
+require "minitest/rg"
+require "ostruct"
+require "json"
+require "base64"
+require "google/cloud/trace"
+require "grpc"
+
+##
+# Monkey-Patch CallOptions to support Mocks
+class Google::Gax::CallOptions
+  ##
+  # Minitest Mock depends on === to match same-value objects.
+  # By default, CallOptions objects do not match with ===.
+  # Therefore, we must add this capability.
+  def === other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout === other.timeout &&
+      retry_options === other.retry_options &&
+      page_token === other.page_token &&
+      kwargs === other.kwargs
+  end
+  def == other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout == other.timeout &&
+      retry_options == other.retry_options &&
+      page_token == other.page_token &&
+      kwargs == other.kwargs
+  end
+end
+
+class MockTrace < Minitest::Spec
+  MockFrame = ::Struct.new :absolute_path, :lineno, :label
+
+  def stack_frame absolute_path, lineno, label
+    MockFrame.new absolute_path, lineno, label
+  end
+
+  let(:project) { "test-project" }
+  let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
+  let(:tracer) { Google::Cloud::Trace::Project.new(Google::Cloud::Trace::Service.new(project, credentials)) }
+
+
+  # Register this spec type for when :mock_trace is used.
+  register_spec_type(self) do |desc, *addl|
+    addl.include? :mock_trace
+  end
+
+  def project_path
+    "projects/#{project}"
+  end
+end


### PR DESCRIPTION
This implements application instrumentation for Trace. This is similar to what we've done for logging and debugging: a middleware and a railtie that causes a running app to report performance traces automatically.

Note that this PR also includes a full veneer for the Trace V1 API. This is because the Trace protos weren't conducive to idiomatic Ruby analysis and manipulation, and had to be wrapped in order to make the instrumentation process make sense. There are only three calls in the API, so this wasn't a big deal.

A few to-do items remain, which will be addressed in separate PRs:

* There is a temporary hack in middleware.rb to work around a current trace service bug. The trace team tells me this should be fixed in a few days, so I should be able to remove this hack before we release the gem.
* Acceptance tests are not yet written.

Also note: This PR is set to be merged into a feature branch because it depends on the as-yet-unreleased stackdriver-core gem.