### PR TITLE
Refactor GRPCUtils

### DIFF
--- a/google-cloud-core/lib/google/cloud/core/grpc_utils.rb
+++ b/google-cloud-core/lib/google/cloud/core/grpc_utils.rb
@@ -23,68 +23,75 @@ module Google
       # @private Conversion to/from GRPC objects.
       module GRPCUtils
         ##
-        # @private Convert a Hash to a Google::Protobuf::Struct.
-        def self.hash_to_struct hash
-          # TODO: ArgumentError if hash is not a Hash
-          Google::Protobuf::Struct.new fields:
-            Hash[hash.map { |k, v| [String(k), object_to_value(v)] }]
-        end
+        # @private GRPC conversion methods.
+        module ClassMethods
+          ##
+          # @private Convert a Hash to a Google::Protobuf::Struct.
+          def hash_to_struct hash
+            # TODO: ArgumentError if hash is not a Hash
+            Google::Protobuf::Struct.new fields:
+              Hash[hash.map { |k, v| [String(k), object_to_value(v)] }]
+          end
 
-        ##
-        # @private Convert a Google::Protobuf::Struct to a Hash.
-        def self.struct_to_hash struct
-          # TODO: ArgumentError if struct is not a Google::Protobuf::Struct
-          Hash[struct.fields.map { |k, v| [k, value_to_object(v)] }]
-        end
+          ##
+          # @private Convert a Google::Protobuf::Struct to a Hash.
+          def struct_to_hash struct
+            # TODO: ArgumentError if struct is not a Google::Protobuf::Struct
+            Hash[struct.fields.map { |k, v| [k, value_to_object(v)] }]
+          end
 
-        ##
-        # @private Convert a Google::Protobuf::Value to an Object.
-        def self.value_to_object value
-          # TODO: ArgumentError if struct is not a Google::Protobuf::Value
-          if value.null_value
-            nil
-          elsif value.number_value
-            value.number_value
-          elsif value.struct_value
-            struct_to_hash value.struct_value
-          elsif value.list_value
-            value.list_value.values.map { |v| value_to_object(v) }
-          elsif !value.bool_value.nil? # Make sure its a bool, not nil
-            value.bool_value
-          else
-            nil # just in case
+          ##
+          # @private Convert a Google::Protobuf::Value to an Object.
+          def value_to_object value
+            # TODO: ArgumentError if struct is not a Google::Protobuf::Value
+            if value.null_value
+              nil
+            elsif value.number_value
+              value.number_value
+            elsif value.struct_value
+              struct_to_hash value.struct_value
+            elsif value.list_value
+              value.list_value.values.map { |v| value_to_object(v) }
+            elsif !value.bool_value.nil? # Make sure its a bool, not nil
+              value.bool_value
+            else
+              nil # just in case
+            end
+          end
+
+          ##
+          # @private Convert an Object to a Google::Protobuf::Value.
+          def object_to_value obj
+            case obj
+            when String then Google::Protobuf::Value.new string_value: obj
+            when Array then Google::Protobuf::ListValue.new(values:
+              obj.map { |o| object_to_value(o) })
+            when Hash then Google::Protobuf::Value.new struct_value:
+              hash_to_struct(obj)
+            when Numeric then Google::Protobuf::Value.new number_value: obj
+            when TrueClass then Google::Protobuf::Value.new bool_value: true
+            when FalseClass then Google::Protobuf::Value.new bool_value: false
+            when NilClass then Google::Protobuf::Value.new null_value:
+              :NULL_VALUE
+            else
+              # Could raise ArgumentError here, or could convert to a string
+              Google::Protobuf::Value.new string_value: obj.to_s
+            end
+          end
+
+          ##
+          # @private Convert a Google::Protobuf::Map to a Hash
+          def map_to_hash map
+            if map.respond_to? :to_h
+              map.to_h
+            else
+              # Enumerable doesn't have to_h on ruby 2.0...
+              Hash[map.to_a]
+            end
           end
         end
 
-        ##
-        # @private Convert an Object to a Google::Protobuf::Value.
-        def self.object_to_value obj
-          case obj
-          when String then Google::Protobuf::Value.new string_value: obj
-          when Array then Google::Protobuf::ListValue.new(values:
-            obj.map { |o| object_to_value(o) })
-          when Hash then Google::Protobuf::Value.new struct_value:
-            hash_to_struct(obj)
-          when Numeric then Google::Protobuf::Value.new number_value: obj
-          when TrueClass then Google::Protobuf::Value.new bool_value: true
-          when FalseClass then Google::Protobuf::Value.new bool_value: false
-          when NilClass then Google::Protobuf::Value.new null_value: :NULL_VALUE
-          else
-            # We could raise ArgumentError here, or we could convert to a string
-            Google::Protobuf::Value.new string_value: obj.to_s
-          end
-        end
-
-        ##
-        # @private Convert a Google::Protobuf::Map to a Hash
-        def self.map_to_hash map
-          if map.respond_to? :to_h
-            map.to_h
-          else
-            # Enumerable doesn't have to_h on ruby 2.0...
-            Hash[map.to_a]
-          end
-        end
+        extend ClassMethods
       end
     end
   end

--- a/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
@@ -63,14 +63,14 @@ module Google
 
         # @private byte array as a string
         def to_grpc
-          Core::GRPCUtils.decode_bytes(@cursor)
+          GRPCUtils.decode_bytes(@cursor)
         end
 
         # @private byte array as a string
         def self.from_grpc grpc
           grpc = String grpc
           return nil if grpc.empty?
-          new Core::GRPCUtils.encode_bytes(grpc)
+          new GRPCUtils.encode_bytes(grpc)
         end
       end
     end

--- a/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
@@ -131,7 +131,7 @@ module Google
             if gql_query_param.parameter_type == :cursor
               [name, Cursor.from_grpc(gql_query_param.cursor)]
             else
-              [name, Core::GRPCUtils.from_value(gql_query_param.value)]
+              [name, GRPCUtils.from_value(gql_query_param.value)]
             end
           end]
           bindings.freeze
@@ -164,7 +164,7 @@ module Google
             else
               @grpc.named_bindings[name.to_s] = \
                 Google::Datastore::V1::GqlQueryParameter.new(
-                  value: Core::GRPCUtils.to_value(value))
+                  value: GRPCUtils.to_value(value))
             end
           end
         end
@@ -181,7 +181,7 @@ module Google
             if gql_query_param.parameter_type == :cursor
               Cursor.from_grpc gql_query_param.cursor
             else
-              Core::GRPCUtils.from_value gql_query_param.value
+              GRPCUtils.from_value gql_query_param.value
             end
           end
           bindings.freeze
@@ -213,7 +213,7 @@ module Google
             else
               @grpc.positional_bindings << \
                 Google::Datastore::V1::GqlQueryParameter.new(
-                  value: Core::GRPCUtils.to_value(value))
+                  value: GRPCUtils.to_value(value))
             end
           end
         end

--- a/google-cloud-datastore/lib/google/cloud/datastore/grpc_utils.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/grpc_utils.rb
@@ -20,11 +20,12 @@ require "base64"
 
 module Google
   module Cloud
-    module Core
+    module Datastore
       ##
       # @private Conversion to/from Datastore GRPC objects.
       # This file adds Datastore methods to Core::GRPCUtils.
       module GRPCUtils
+        extend Google::Cloud::Core::GRPCUtils::ClassMethods
         # rubocop:disable all
 
         PROP_FILTER_OPS = { "<"            => :LESS_THAN,

--- a/google-cloud-datastore/lib/google/cloud/datastore/properties.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/properties.rb
@@ -73,15 +73,15 @@ module Google
         alias_method :to_hash, :to_h
 
         def to_grpc
-          Hash[@hash.map { |(k, v)| [k.to_s, Core::GRPCUtils.to_value(v)] }]
+          Hash[@hash.map { |(k, v)| [k.to_s, GRPCUtils.to_value(v)] }]
         end
 
         def self.from_grpc grpc_map
           # For some reason Google::Protobuf::Map#map isn't returning the value.
           # It returns nil every time. COnvert to Hash to get actual objects.
-          grpc_hash = Core::GRPCUtils.map_to_hash grpc_map
+          grpc_hash = GRPCUtils.map_to_hash grpc_map
           grpc_array = grpc_hash.map do |(k, v)|
-            [k.to_s, Core::GRPCUtils.from_value(v)]
+            [k.to_s, GRPCUtils.from_value(v)]
           end
           new Hash[grpc_array]
         end
@@ -97,7 +97,7 @@ module Google
         end
 
         # rubocop:disable all
-        # Disabled rubocop because this needs to match Core::GRPCUtils.to_value
+        # Disabled rubocop because this needs to match GRPCUtils.to_value
 
         ##
         # Ensures the value is a type that can be persisted,

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -177,8 +177,8 @@ module Google
               property_filter: Google::Datastore::V1::PropertyFilter.new(
                 property: Google::Datastore::V1::PropertyReference.new(
                   name: name),
-                op: Core::GRPCUtils.to_prop_filter_op(operator),
-                value: Core::GRPCUtils.to_value(value)
+                op: GRPCUtils.to_prop_filter_op(operator),
+                value: GRPCUtils.to_value(value)
               )
             )
 
@@ -331,7 +331,7 @@ module Google
           if cursor.is_a? Cursor
             @grpc.start_cursor = cursor.to_grpc
           elsif cursor.is_a? String
-            @grpc.start_cursor = Core::GRPCUtils.decode_bytes cursor
+            @grpc.start_cursor = GRPCUtils.decode_bytes cursor
           else
             fail ArgumentError, "Can't set a cursor using a #{cursor.class}."
           end

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     Google::Datastore::V1::RunQueryResponse.new(
       batch: Google::Datastore::V1::QueryResultBatch.new(
         entity_results: run_query_res_entities,
-        end_cursor: Google::Cloud::Core::GRPCUtils.decode_bytes(query_cursor)
+        end_cursor: Google::Cloud::Datastore::GRPCUtils.decode_bytes(query_cursor)
       )
     )
   end
@@ -47,7 +47,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
         Google::Datastore::V1::EntityResult.new(
           entity: Google::Datastore::V1::Entity.new(
             key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc,
-            properties: { "name" => Google::Cloud::Core::GRPCUtils.to_value("thingamajig") }
+            properties: { "name" => Google::Cloud::Datastore::GRPCUtils.to_value("thingamajig") }
           )
         )
       end

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
     grpc = Google::Datastore::V1::Entity.new
     grpc.key = Google::Datastore::V1::Key.new
     grpc.key.path << Google::Datastore::V1::Key::PathElement.new(kind: "User", id: 123456)
-    grpc.properties["name"] = Google::Cloud::Core::GRPCUtils.to_value "User McNumber"
+    grpc.properties["name"] = Google::Cloud::Datastore::GRPCUtils.to_value "User McNumber"
 
     entity_from_grpc = Google::Cloud::Datastore::Entity.from_grpc grpc
     entity_from_grpc.exclude_from_indexes?("name").must_equal false
@@ -38,7 +38,7 @@ describe Google::Cloud::Datastore::Entity, :exclude_from_indexes, :mock_datastor
     grpc = Google::Datastore::V1::Entity.new
     grpc.key = Google::Datastore::V1::Key.new
     grpc.key.path << Google::Datastore::V1::Key::PathElement.new(kind: "User", id: 123456)
-    grpc.properties["tags"] = Google::Cloud::Core::GRPCUtils.to_value ["ruby", "code"]
+    grpc.properties["tags"] = Google::Cloud::Datastore::GRPCUtils.to_value ["ruby", "code"]
 
     entity_from_grpc = Google::Cloud::Datastore::Entity.from_grpc grpc
     entity_from_grpc.exclude_from_indexes?("tags").must_equal [false, false]

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
@@ -80,9 +80,9 @@ describe Google::Cloud::Datastore::Entity, :mock_datastore do
     grpc.key.path << Google::Datastore::V1::Key::PathElement.new
     grpc.key.path.first.kind = "User"
     grpc.key.path.first.id = 123456
-    grpc.properties["name"] = Google::Cloud::Core::GRPCUtils.to_value "User McNumber"
-    grpc.properties["email"] = Google::Cloud::Core::GRPCUtils.to_value "number@example.net"
-    grpc.properties["avatar"] = Google::Cloud::Core::GRPCUtils.to_value nil
+    grpc.properties["name"] = Google::Cloud::Datastore::GRPCUtils.to_value "User McNumber"
+    grpc.properties["email"] = Google::Cloud::Datastore::GRPCUtils.to_value "number@example.net"
+    grpc.properties["avatar"] = Google::Cloud::Datastore::GRPCUtils.to_value nil
 
     entity_from_grpc = Google::Cloud::Datastore::Entity.from_grpc grpc
 
@@ -162,8 +162,8 @@ describe Google::Cloud::Datastore::Entity, :mock_datastore do
     grpc = Google::Datastore::V1::Entity.new
     grpc.key = Google::Datastore::V1::Key.new
     grpc.key.path << Google::Datastore::V1::Key::PathElement.new(kind: "User", id: 123456)
-    grpc.properties["name"] = Google::Cloud::Core::GRPCUtils.to_value "User McNumber"
-    grpc.properties["email"] = Google::Cloud::Core::GRPCUtils.to_value "number@example.net"
+    grpc.properties["name"] = Google::Cloud::Datastore::GRPCUtils.to_value "User McNumber"
+    grpc.properties["email"] = Google::Cloud::Datastore::GRPCUtils.to_value "number@example.net"
 
     entity_from_grpc = Google::Cloud::Datastore::Entity.from_grpc grpc
 

--- a/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
         Google::Datastore::V1::EntityResult.new(
           entity: Google::Datastore::V1::Entity.new(
             key: Google::Cloud::Datastore::Key.new("ds-test", "thingie#{i}").to_grpc,
-            properties: { "name" => Google::Cloud::Core::GRPCUtils.to_value("thingamajig") }
+            properties: { "name" => Google::Cloud::Datastore::GRPCUtils.to_value("thingamajig") }
           )
         )
       end,
@@ -41,7 +41,7 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
         Google::Datastore::V1::EntityResult.new(
           entity: Google::Datastore::V1::Entity.new(
             key: Google::Cloud::Datastore::Key.new("ds-test", "thingie#{i}").to_grpc,
-            properties: { "name" => Google::Cloud::Core::GRPCUtils.to_value("thingamajig") }
+            properties: { "name" => Google::Cloud::Datastore::GRPCUtils.to_value("thingamajig") }
           )
         )
       end,
@@ -56,7 +56,7 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
         Google::Datastore::V1::EntityResult.new(
           entity: Google::Datastore::V1::Entity.new(
             key: Google::Cloud::Datastore::Key.new("ds-test", "thingie#{i}").to_grpc,
-            properties: { "name" => Google::Cloud::Core::GRPCUtils.to_value("thingamajig") }
+            properties: { "name" => Google::Cloud::Datastore::GRPCUtils.to_value("thingamajig") }
           )
         )
       end

--- a/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
@@ -28,13 +28,13 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
 
   it "decodes empty value" do
     value = Google::Datastore::V1::Value.new
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_equal nil
   end
 
   it "encodes a string" do
     raw = "hello, i am a string"
-    value = Google::Cloud::Core::GRPCUtils.to_value raw
+    value = Google::Cloud::Datastore::GRPCUtils.to_value raw
     value.value_type.must_equal :string_value
     value.string_value.must_equal raw
   end
@@ -43,12 +43,12 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     str = "ohai, i am also a string"
     value = Google::Datastore::V1::Value.new
     value.string_value = str
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_equal str
   end
 
   it "encodes nil" do
-    value = Google::Cloud::Core::GRPCUtils.to_value nil
+    value = Google::Cloud::Datastore::GRPCUtils.to_value nil
     value.value_type.must_equal :null_value
     value.null_value.must_equal :NULL_VALUE
   end
@@ -56,12 +56,12 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
   it "decodes NULL" do
     value = Google::Datastore::V1::Value.new
     value.null_value = :NULL_VALUE
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_equal nil
   end
 
   it "encodes true" do
-    value = Google::Cloud::Core::GRPCUtils.to_value true
+    value = Google::Cloud::Datastore::GRPCUtils.to_value true
     value.value_type.must_equal :boolean_value
     value.boolean_value.must_equal true
   end
@@ -69,12 +69,12 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
   it "decodes true" do
     value = Google::Datastore::V1::Value.new
     value.boolean_value = true
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_equal true
   end
 
   it "encodes false" do
-    value = Google::Cloud::Core::GRPCUtils.to_value false
+    value = Google::Cloud::Datastore::GRPCUtils.to_value false
     value.value_type.must_equal :boolean_value
     value.boolean_value.must_equal false
   end
@@ -82,13 +82,13 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
   it "decodes false" do
     value = Google::Datastore::V1::Value.new
     value.boolean_value = false
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_equal false
   end
 
   it "encodes integer" do
     raw = 1234
-    value = Google::Cloud::Core::GRPCUtils.to_value raw
+    value = Google::Cloud::Datastore::GRPCUtils.to_value raw
     value.value_type.must_equal :integer_value
     value.integer_value.must_equal raw
   end
@@ -97,13 +97,13 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     num = 1234
     value = Google::Datastore::V1::Value.new
     value.integer_value = num
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_equal num
   end
 
   it "encodes float" do
     raw = 12.34
-    value = Google::Cloud::Core::GRPCUtils.to_value raw
+    value = Google::Cloud::Datastore::GRPCUtils.to_value raw
     value.value_type.must_equal :double_value
     value.double_value.must_equal raw
   end
@@ -112,13 +112,13 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     num = 12.34
     value = Google::Datastore::V1::Value.new
     value.double_value = num
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_equal num
   end
 
   it "encodes Key" do
     key = Google::Cloud::Datastore::Key.new "Thing", 123
-    value = Google::Cloud::Core::GRPCUtils.to_value key
+    value = Google::Cloud::Datastore::GRPCUtils.to_value key
     value.value_type.must_equal :key_value
     value.key_value.must_equal key.to_grpc
   end
@@ -127,7 +127,7 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     key = Google::Cloud::Datastore::Key.new "Thing", 123
     value = Google::Datastore::V1::Value.new
     value.key_value = key.to_grpc
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     assert_kind_of Google::Cloud::Datastore::Key, raw
     refute_kind_of Google::Datastore::V1::Key, raw
     raw.to_grpc.must_equal key.to_grpc
@@ -137,7 +137,7 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     entity = Google::Cloud::Datastore::Entity.new
     entity.key = Google::Cloud::Datastore::Key.new "Thing", 123
     entity["name"] = "Thing 1"
-    value = Google::Cloud::Core::GRPCUtils.to_value entity
+    value = Google::Cloud::Datastore::GRPCUtils.to_value entity
     value.value_type.must_equal :entity_value
     value.entity_value.properties.must_equal entity.to_grpc.properties
     value.entity_value.key.must_be :nil? # embedded entities can't have keys
@@ -149,7 +149,7 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     entity["name"] = "Thing 1"
     value = Google::Datastore::V1::Value.new
     value.entity_value = entity.to_grpc
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     assert_kind_of Google::Cloud::Datastore::Entity, raw
     refute_kind_of Google::Datastore::V1::Entity, raw
     raw_grpc = raw.to_grpc
@@ -159,7 +159,7 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
 
   it "encodes Array" do
     array = ["string", 123, true]
-    value = Google::Cloud::Core::GRPCUtils.to_value array
+    value = Google::Cloud::Datastore::GRPCUtils.to_value array
     value.value_type.must_equal :array_value
     value.array_value.must_equal Google::Datastore::V1::ArrayValue.new(
       values: [Google::Datastore::V1::Value.new(string_value: "string"),
@@ -175,7 +175,7 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
                 Google::Datastore::V1::Value.new.tap { |v| v.integer_value = 123 },
                 Google::Datastore::V1::Value.new.tap { |v| v.boolean_value = true }]
     )
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     assert_kind_of Array, raw
     raw.count.must_equal 3
     raw[0].must_equal "string"
@@ -184,21 +184,21 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
   end
 
   it "encodes Time" do
-    value = Google::Cloud::Core::GRPCUtils.to_value time_obj
+    value = Google::Cloud::Datastore::GRPCUtils.to_value time_obj
     value.value_type.must_equal :timestamp_value
     value.timestamp_value.must_equal time_grpc
   end
 
   it "encodes Date" do
     date_obj = time_obj.to_date
-    value = Google::Cloud::Core::GRPCUtils.to_value date_obj
+    value = Google::Cloud::Datastore::GRPCUtils.to_value date_obj
     value.value_type.must_equal :timestamp_value
     value.timestamp_value.must_equal Google::Protobuf::Timestamp.new(seconds: date_obj.to_time.to_i)
   end
 
   it "encodes DateTime" do
     datetime_obj = time_obj.to_datetime
-    value = Google::Cloud::Core::GRPCUtils.to_value datetime_obj
+    value = Google::Cloud::Datastore::GRPCUtils.to_value datetime_obj
     value.value_type.must_equal :timestamp_value
     value.timestamp_value.must_equal time_grpc
   end
@@ -206,20 +206,20 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
   it "decodes timestamp" do
     value = Google::Datastore::V1::Value.new
     value.timestamp_value = time_grpc
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_equal time_obj
   end
 
   it "encodes IO as blob" do
     raw = File.open "acceptance/data/CloudPlatform_128px_Retina.png", "rb"
-    value = Google::Cloud::Core::GRPCUtils.to_value raw
+    value = Google::Cloud::Datastore::GRPCUtils.to_value raw
     value.value_type.must_equal :blob_value
     value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
   end
 
   it "encodes StringIO as blob" do
     raw = StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
-    value = Google::Cloud::Core::GRPCUtils.to_value raw
+    value = Google::Cloud::Datastore::GRPCUtils.to_value raw
     value.value_type.must_equal :blob_value
     value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
   end
@@ -229,7 +229,7 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
     raw.binmode
     raw.write(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     raw.rewind
-    value = Google::Cloud::Core::GRPCUtils.to_value raw
+    value = Google::Cloud::Datastore::GRPCUtils.to_value raw
     value.value_type.must_equal :blob_value
     value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
   end
@@ -237,14 +237,14 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
   it "decodes blob to StringIO" do
     value = Google::Datastore::V1::Value.new
     value.blob_value = File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_be_kind_of StringIO
     raw.read.must_equal StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")).read
   end
 
   it "encodes location hash" do
     latlng_obj = {latitude: 37.4220041, longitude: -122.0862462}
-    value = Google::Cloud::Core::GRPCUtils.to_value latlng_obj
+    value = Google::Cloud::Datastore::GRPCUtils.to_value latlng_obj
     value.value_type.must_equal :geo_point_value
     value.geo_point_value.must_equal Google::Type::LatLng.new(latitude: 37.4220041, longitude: -122.0862462)
   end
@@ -252,7 +252,7 @@ describe Google::Cloud::Datastore::Properties, :mock_datastore do
   it "decodes geo_point" do
     value = Google::Datastore::V1::Value.new
     value.geo_point_value = Google::Type::LatLng.new(latitude: 37.4220041, longitude: -122.0862462)
-    raw = Google::Cloud::Core::GRPCUtils.from_value value
+    raw = Google::Cloud::Datastore::GRPCUtils.from_value value
     raw.must_equal({latitude: 37.4220041, longitude: -122.0862462})
   end
 end

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Datastore::Dataset::QueryResults, :mock_datastore do
     Google::Datastore::V1::RunQueryResponse.new(
       batch: Google::Datastore::V1::QueryResultBatch.new(
         entity_results: run_query_res_entities,
-        end_cursor: Google::Cloud::Core::GRPCUtils.decode_bytes(query_cursor)
+        end_cursor: Google::Cloud::Datastore::GRPCUtils.decode_bytes(query_cursor)
       )
     )
   end

--- a/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
     new_filter = grpc.filter.composite_filter.filters.first
     new_filter.property_filter.property.name.must_equal "completed"
     new_filter.property_filter.op.must_equal :EQUAL
-    Google::Cloud::Core::GRPCUtils.from_value(new_filter.property_filter.value).must_equal true
+    Google::Cloud::Datastore::GRPCUtils.from_value(new_filter.property_filter.value).must_equal true
 
     # Add a second filter and generate new grpcbuf
     # Use the filter alias to add the second filter
@@ -59,14 +59,14 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
     first_filter.composite_filter.must_be :nil?
     first_filter.property_filter.property.name.must_equal "completed"
     first_filter.property_filter.op.must_equal :EQUAL
-    Google::Cloud::Core::GRPCUtils.from_value(first_filter.property_filter.value).must_equal true
+    Google::Cloud::Datastore::GRPCUtils.from_value(first_filter.property_filter.value).must_equal true
 
     second_filter = grpc.filter.composite_filter.filters.last
     second_filter.property_filter.wont_be :nil?
     second_filter.composite_filter.must_be :nil?
     second_filter.property_filter.property.name.must_equal "due"
     second_filter.property_filter.op.must_equal :GREATER_THAN
-    Google::Cloud::Core::GRPCUtils.from_value(second_filter.property_filter.value).must_equal Time.new(2014, 1, 1, 0, 0, 0, 0)
+    Google::Cloud::Datastore::GRPCUtils.from_value(second_filter.property_filter.value).must_equal Time.new(2014, 1, 1, 0, 0, 0, 0)
   end
 
   it "can order results" do
@@ -200,7 +200,7 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
     ancestor_filter = grpc.filter.composite_filter.filters.first
     ancestor_filter.property_filter.property.name.must_equal "__key__"
     ancestor_filter.property_filter.op.must_equal :HAS_ANCESTOR
-    key = Google::Cloud::Core::GRPCUtils.from_value(ancestor_filter.property_filter.value)
+    key = Google::Cloud::Datastore::GRPCUtils.from_value(ancestor_filter.property_filter.value)
     key.kind.must_equal ancestor_key.kind
     key.id.must_equal   ancestor_key.id
     key.name.must_equal ancestor_key.name
@@ -218,7 +218,7 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
     ancestor_filter = grpc.filter.composite_filter.filters.first
     ancestor_filter.property_filter.property.name.must_equal "__key__"
     ancestor_filter.property_filter.op.must_equal :HAS_ANCESTOR
-    key = Google::Cloud::Core::GRPCUtils.from_value(ancestor_filter.property_filter.value)
+    key = Google::Cloud::Datastore::GRPCUtils.from_value(ancestor_filter.property_filter.value)
     key.kind.must_equal ancestor_key.kind
     key.id.must_equal   ancestor_key.id
     key.name.must_equal ancestor_key.name
@@ -244,7 +244,7 @@ describe Google::Cloud::Datastore::Query, :mock_datastore do
     filter = grpc.filter.composite_filter.filters.first
     filter.property_filter.property.name.must_equal "completed"
     filter.property_filter.op.must_equal :EQUAL
-    Google::Cloud::Core::GRPCUtils.from_value(filter.property_filter.value).must_equal true
+    Google::Cloud::Datastore::GRPCUtils.from_value(filter.property_filter.value).must_equal true
 
     grpc.distinct_on.wont_be :empty?
     grpc.distinct_on.count.must_equal 1

--- a/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
         Google::Datastore::V1::EntityResult.new(
           entity: Google::Datastore::V1::Entity.new(
             key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc,
-            properties: { "name" => Google::Cloud::Core::GRPCUtils.to_value("thingamajig") }
+            properties: { "name" => Google::Cloud::Datastore::GRPCUtils.to_value("thingamajig") }
           )
         )
       end
@@ -51,7 +51,7 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
     Google::Datastore::V1::RunQueryResponse.new(
       batch: Google::Datastore::V1::QueryResultBatch.new(
         entity_results: run_query_res_entities,
-        end_cursor: Google::Cloud::Core::GRPCUtils.decode_bytes(query_cursor)
+        end_cursor: Google::Cloud::Datastore::GRPCUtils.decode_bytes(query_cursor)
       )
     )
   end


### PR DESCRIPTION
Refactor the Core GRPCUtils module it make it easier to reuse. The helper methods have been moved to the `Google::Cloud::Core::GRPCUtils::ClassMethods` module so they can be included elsewhere.
Existing code using `Google::Cloud::Core::GRPCUtils` is unaffected.

A new module, `Google::Cloud::Datastore::GRPCUtils` has also been added. This ensures that Datastore does not pollute Core's `GRPCUtils` module, so the code won't behave differently for other services depending on whether Datastore is loaded or not. This also hides `Google::Cloud::Core` from showing up [on rubydocs.info](http://www.rubydoc.info/gems/google-cloud-datastore/Google/Cloud/Core).