### PR TITLE
Basic acceptance tests for google-cloud-trace

### DIFF
--- a/google-cloud-trace/.rubocop.yml
+++ b/google-cloud-trace/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "google-cloud-trace.gemspec"
     - "lib/google/devtools/**/*"
     - "Rakefile"

--- a/google-cloud-trace/acceptance/trace/trace_test.rb
+++ b/google-cloud-trace/acceptance/trace/trace_test.rb
@@ -1,0 +1,59 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "trace_helper"
+
+describe Google::Cloud::Trace, :trace do
+  describe "API client" do
+    it "writes a trace and reads it back" do
+      orig_trace = simple_trace
+      tracer.patch_traces orig_trace
+      trace = wait_until do
+        tracer.get_trace orig_trace.trace_id
+      end
+      trace.must_equal orig_trace
+    end
+
+    it "writes traces and lists them" do
+      start_time = Time.now.utc - 2
+      trace1 = simple_trace
+      sleep 0.01
+      trace2 = simple_trace
+      sleep 0.01
+      trace3 = simple_trace
+      end_time = Time.now.utc + 1
+      tracer.patch_traces [trace1, trace2, trace3]
+      all_results = wait_until do
+        res = tracer.list_traces start_time, end_time,
+                                 view: :COMPLETE,
+                                 filter: simple_span_name,
+                                 order_by: "start",
+                                 page_size: 4
+        res.size == 3 ? res : nil
+      end
+      all_results.to_a.must_equal [trace1, trace2, trace3]
+      all_results.results_pending?.must_equal false
+      page1 = tracer.list_traces start_time, end_time,
+                                 view: :COMPLETE,
+                                 filter: simple_span_name,
+                                 order_by: "start",
+                                 page_size: 2
+      page1.to_a.must_equal [trace1, trace2]
+      page1.results_pending?.must_equal true
+      page2 = page1.next_page
+      page2.to_a.must_equal [trace3]
+      page2.results_pending?.must_equal false
+    end
+  end
+end

--- a/google-cloud-trace/acceptance/trace_helper.rb
+++ b/google-cloud-trace/acceptance/trace_helper.rb
@@ -1,0 +1,72 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gem "minitest"
+require "minitest/autorun"
+require "minitest/focus"
+require "minitest/rg"
+require "google/cloud/trace"
+
+# Create shared trace object so we don't create new for each test
+$tracer = Google::Cloud::Trace.new
+
+module Acceptance
+  class TraceTest < Minitest::Test
+    MAX_DELAY = 5
+
+    attr_accessor :tracer
+
+    ##
+    # Setup project based on available ENV variables
+    def setup
+      @tracer = $tracer
+      @test_id = format "%032x", rand(0x100000000000000000000000000000000)
+      refute_nil @tracer, "You do not have an active tracer to run the tests."
+      super
+    end
+
+    # Add spec DSL
+    extend Minitest::Spec::DSL
+
+    let(:simple_span_name) { "/path/to/#{@test_id}" }
+    let(:simple_span_labels) { { "foo" => "bar" } }
+
+    def simple_trace
+      tc = Stackdriver::Core::TraceContext.new.with is_new: false
+      trace = tracer.new_trace trace_context: tc
+      now = Time.now.utc
+      trace.create_span simple_span_name,
+                        start_time: now - 1,
+                        end_time: now,
+                        labels: simple_span_labels
+      trace
+    end
+
+    def wait_until
+      delay = 0
+      while delay <= MAX_DELAY
+        sleep delay
+        result = yield
+        return result if result
+        delay += 1
+      end
+      nil
+    end
+
+    # Register this spec type for when :trace is used.
+    register_spec_type(self) do |desc, *addl|
+      addl.include? :trace
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/result_set.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/result_set.rb
@@ -156,7 +156,7 @@ module Google
         # @return [Google::Cloud::Trace::ResultSet]
         #
         def next_page
-          return nil unless next_page?
+          return nil unless results_pending?
           service.list_traces \
             project, start_time, end_time,
             filter: filter,

--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -38,7 +38,7 @@ module Google
         # @private
         #
         def self.proto_to_time proto
-          Time.at(proto.seconds, Rational(proto.nanos, 1000))
+          Time.at(proto.seconds, Rational(proto.nanos, 1000)).utc
         end
       end
     end


### PR DESCRIPTION
Acceptance tests for the veneer trace veneer calls. Also fixes two bugs in the instrumentation code.

To merge into the stackdriver-core-dependencies branch along with other code that is dependent on the release of the stackdriver-core gem.