### PR TITLE
Logger object understands all attributes supported by the stdlib Logger

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -56,6 +56,7 @@ module Google
         ##
         # The Google Cloud log_name to write the log entry with.
         attr_reader :log_name
+        alias_method :progname, :log_name
 
         ##
         # The Google Cloud resource to write the log entry with.
@@ -64,6 +65,22 @@ module Google
         ##
         # The Google Cloud labels to write the log entry with.
         attr_reader :labels
+
+        ##
+        # The logging severity threshold (e.g. `Logger::INFO`)
+        attr_reader :level
+        alias_method :sev_threshold, :level
+
+        ##
+        # This logger does not use a formatter, but it provides a default
+        # Logger::Formatter for API compatibility with the standard Logger.
+        attr_accessor :formatter
+
+        ##
+        # This logger treats progname as an alias for log_name.
+        def progname= name
+          @log_name = name
+        end
 
         ##
         # A OrderedHash of Thread IDs to Stackdriver request trace ID. The
@@ -119,6 +136,7 @@ module Google
           @labels = labels
           @level = 0 # DEBUG is the default behavior
           @request_info = OrderedHash.new
+          @formatter = ::Logger::Formatter.new
         end
 
         ##

--- a/google-cloud-logging/test/google/cloud/logging/sink_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/sink_test.rb
@@ -28,8 +28,8 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
     sink.writer_identity.must_equal  "roles/owner"
     sink.start_at.must_be_close_to   Time.at(sink_hash["start_time"]["seconds"], sink_hash["start_time"]["nanos"]/1000.0)
     sink.start_time.must_be_close_to Time.at(sink_hash["start_time"]["seconds"], sink_hash["start_time"]["nanos"]/1000.0)
-    sink.end_at.must_equal           nil
-    sink.end_time.must_equal         nil
+    sink.end_at.must_be_nil
+    sink.end_time.must_be_nil
   end
 
   it "can set different sink format versions" do
@@ -52,14 +52,14 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
 
     sink.start_at.must_be_close_to   time
     sink.start_time.must_be_close_to time
-    sink.end_at.must_equal           nil
-    sink.end_time.must_equal         nil
+    sink.end_at.must_be_nil
+    sink.end_time.must_be_nil
 
     sink.start_time = nil
     sink.end_time   = time
 
-    sink.start_at.must_equal     nil
-    sink.start_time.must_equal   nil
+    sink.start_at.must_be_nil
+    sink.start_time.must_be_nil
     sink.end_at.must_be_close_to   time
     sink.end_time.must_be_close_to time
 
@@ -68,14 +68,14 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
 
     sink.start_at.must_be_close_to   time
     sink.start_time.must_be_close_to time
-    sink.end_at.must_equal           nil
-    sink.end_time.must_equal         nil
+    sink.end_at.must_be_nil
+    sink.end_time.must_be_nil
 
     sink.start_at = nil
     sink.end_at   = time
 
-    sink.start_at.must_equal     nil
-    sink.start_time.must_equal   nil
+    sink.start_at.must_be_nil
+    sink.start_time.must_be_nil
     sink.end_at.must_be_close_to   time
     sink.end_time.must_be_close_to time
   end

--- a/google-cloud-logging/test/google/cloud/logging_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging_test.rb
@@ -19,11 +19,11 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.logging" do
       gcloud = Google::Cloud.new
       stubbed_logging = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
-        project.must_equal nil
-        keyfile.must_equal nil
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        client_config.must_be :nil?
+        project.must_be_nil
+        keyfile.must_be_nil
+        scope.must_be_nil
+        timeout.must_be_nil
+        client_config.must_be_nil
         "logging-project-object-empty"
       }
       Google::Cloud.stub :logging, stubbed_logging do
@@ -37,9 +37,9 @@ describe Google::Cloud do
       stubbed_logging = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        client_config.must_be :nil?
+        scope.must_be_nil
+        timeout.must_be_nil
+        client_config.must_be_nil
         "logging-project-object"
       }
       Google::Cloud.stub :logging, stubbed_logging do
@@ -87,14 +87,14 @@ describe Google::Cloud do
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
         keyfile.must_equal "path/to/keyfile.json"
-        scope.must_equal nil
+        scope.must_be_nil
         "logging-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "logging-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
+        timeout.must_be_nil
+        client_config.must_be_nil
         OpenStruct.new project: project
       }
 
@@ -138,14 +138,14 @@ describe Google::Cloud do
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
         keyfile.must_equal "path/to/keyfile.json"
-        scope.must_equal nil
+        scope.must_be_nil
         "logging-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "logging-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
+        timeout.must_be_nil
+        client_config.must_be_nil
         OpenStruct.new project: project
       }
 


### PR DESCRIPTION
Currently, methods that are defined by `attr_reader` and `attr_accessor` in the standard Ruby `Logger` class, are missing from `Google::Cloud::Logging::Logger`. In some cases, these attributes are meaningless (e.g. the `formatter` attribute) while in other cases they represent missing functionality (e.g. currently there is a setter for `sev_threshold` but the getter is missing.)

The missing methods caused a few use cases to break when external code assumed that the logger conforms fully to the standard API. For example, if this logger is used as the Rails logger, `rails server` would crash in development mode because the Rails server script assumes the Rails logger has a formatter.

This PR restores all missing attribute-driven methods in the logger class. It also provides tests for attributes, and fixes some minitest warnings.