### PR TITLE
Improve Logging::Railtie activation warning messages

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -104,15 +104,15 @@ module Google
             Google::Cloud::Logging::Credentials.credentials_with_scope keyfile
           rescue Exception => e
             warn "Unable to initialize Google::Cloud::Logging due " \
-              "to authorization error: #{e.message}"
+              "to authorization error: #{e.message}\nFallback to default logger"
             return false
           end
 
           project_id = gcp_config.logging.project_id || gcp_config.project_id ||
                        Google::Cloud::Logging::Project.default_project
           if project_id.to_s.empty?
-            warn "Unable to initialize Google::Cloud::Logging with empty " \
-              "project_id"
+            warn "Google::Cloud::Logging is not activated due to empty " \
+              "project_id; fallback to default logger"
             return false
           end
 

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -103,8 +103,9 @@ module Google
           begin
             Google::Cloud::Logging::Credentials.credentials_with_scope keyfile
           rescue Exception => e
-            warn "Unable to initialize Google::Cloud::Logging due " \
-              "to authorization error: #{e.message}\nFalling back to default logger"
+            warn "Google::Cloud::Logging is not activated due to " \
+              "authorization error: #{e.message}\nFalling back to default " \
+              "logger"
             return false
           end
 
@@ -117,9 +118,8 @@ module Google
           end
 
           # Otherwise default to true if Rails is running in production or
-          # config.stackdriver.use_logging is explicitly true
-          Rails.env.production? ||
-            (gcp_config.key?(:use_logging) && gcp_config.use_logging)
+          # config.stackdriver.use_logging is true
+          Rails.env.production? || gcp_config.use_logging
         end
       end
     end

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -104,7 +104,7 @@ module Google
             Google::Cloud::Logging::Credentials.credentials_with_scope keyfile
           rescue Exception => e
             warn "Unable to initialize Google::Cloud::Logging due " \
-              "to authorization error: #{e.message}\nFallback to default logger"
+              "to authorization error: #{e.message}\nFalling back to default logger"
             return false
           end
 
@@ -112,7 +112,7 @@ module Google
                        Google::Cloud::Logging::Project.default_project
           if project_id.to_s.empty?
             warn "Google::Cloud::Logging is not activated due to empty " \
-              "project_id; fallback to default logger"
+              "project_id; falling back to default logger"
             return false
           end
 


### PR DESCRIPTION
Improve the Google::Cloud::Logging::Railtie activation warning messages. So they don't get confused as error message. See #1095 for example.

Also, the new Google::Cloud::Trace::Railtie warning messages changed the wording a little bit. So I'm also updating the warning message in Logging::Railtie to match that, so they are consistent.

[close #1095 ]