### PR TITLE
Remove orphaned span hack from middleware, and fix conversion of orphaned spans from protos

### DIFF
--- a/google-cloud-trace/acceptance/trace_helper.rb
+++ b/google-cloud-trace/acceptance/trace_helper.rb
@@ -43,7 +43,7 @@ module Acceptance
     let(:simple_span_labels) { { "foo" => "bar" } }
 
     def simple_trace
-      tc = Stackdriver::Core::TraceContext.new.with is_new: false
+      tc = Stackdriver::Core::TraceContext.new.with is_new: false, span_id: 123
       trace = tracer.new_trace trace_context: tc
       now = Time.now.utc
       trace.create_span simple_span_name,

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -161,12 +161,6 @@ module Google
         #
         def create_trace env
           trace_context = get_trace_context env
-
-          # TEMP: Drop the context parent span because a bug is preventing
-          # such traces from appearing in Flex apps. We expect this bug to
-          # be fixed around 2016.12.16, so re-check around that time.
-          trace_context = trace_context.with span_id: nil
-
           Google::Cloud::Trace::TraceRecord.new \
             @service.project,
             trace_context,


### PR DESCRIPTION
This removes a temporary hack in middleware.rb that worked around a bug in the trace backend where it failed to index traces with orphaned spans (i.e. spans whose parent isn't present in the trace). These traces sometimes happen when running on the App Engine Flexible beta because the front end load balancer doesn't always report the root span. The backend bug was fixed on 2016.12.16.

This also fixes a bug I found while testing the above. Converting a trace protobuf with an orphaned span to a TraceRecord failed because the algorithm didn't take orphans into account.