### PR TITLE
Refactor core protobuf conversion methods

### DIFF
--- a/google-cloud-core/test/google/cloud/core/grpc_utils/hash_to_struct_test.rb
+++ b/google-cloud-core/test/google/cloud/core/grpc_utils/hash_to_struct_test.rb
@@ -1,0 +1,185 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "google/cloud/core/grpc_utils"
+
+describe Google::Cloud::Core::GRPCUtils, :hash_to_struct do
+  it "converts empty hash" do
+    hash = {}
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.must_be :empty?
+  end
+
+  it "converts simple hash" do
+    hash = { "foo" => "bar" }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+    bar_value = struct.fields["foo"]
+    bar_value.must_be_kind_of Google::Protobuf::Value
+    bar_value.kind.must_equal :string_value
+    bar_value.string_value.must_equal "bar"
+  end
+
+  it "converts simple hash of symbols" do
+    hash = { foo: :bar }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+    bar_value = struct.fields["foo"]
+    bar_value.must_be_kind_of Google::Protobuf::Value
+    bar_value.kind.must_equal :string_value
+    bar_value.string_value.must_equal "bar"
+  end
+
+  it "converts hash with nil value" do
+    hash = { "foo" => nil }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+    nil_value = struct.fields["foo"]
+    nil_value.must_be_kind_of Google::Protobuf::Value
+    nil_value.kind.must_equal :null_value
+    nil_value.null_value.must_equal :NULL_VALUE
+  end
+
+  it "converts hash with int value" do
+    hash = { "foo" => 123 }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+    int_value = struct.fields["foo"]
+    int_value.must_be_kind_of Google::Protobuf::Value
+    int_value.kind.must_equal :number_value
+    int_value.number_value.must_equal 123.0
+  end
+
+  it "converts hash with float value" do
+    hash = { "foo" => 456.789 }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+    float_value = struct.fields["foo"]
+    float_value.must_be_kind_of Google::Protobuf::Value
+    float_value.kind.must_equal :number_value
+    float_value.number_value.must_equal 456.789
+  end
+
+  it "converts hash with true value" do
+    hash = { "foo" => true }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+    true_value = struct.fields["foo"]
+    true_value.must_be_kind_of Google::Protobuf::Value
+    true_value.kind.must_equal :bool_value
+    true_value.bool_value.must_equal true
+  end
+
+  it "converts hash with false value" do
+    hash = { "foo" => false }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+    false_value = struct.fields["foo"]
+    false_value.must_be_kind_of Google::Protobuf::Value
+    false_value.kind.must_equal :bool_value
+    false_value.bool_value.must_equal false
+  end
+
+  it "converts hash with hash value" do
+    hash = { "foo" => { bar: :baz } }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+    hash_value = struct.fields["foo"]
+    hash_value.must_be_kind_of Google::Protobuf::Value
+    hash_value.kind.must_equal :struct_value
+    hash_value.struct_value.fields.must_be_kind_of Google::Protobuf::Map
+    hash_value.struct_value.fields["bar"].must_be_kind_of Google::Protobuf::Value
+    hash_value.struct_value.fields["bar"].kind.must_equal :string_value
+    hash_value.struct_value.fields["bar"].string_value.must_equal "baz"
+  end
+
+  it "converts hash with array value" do
+    hash = { "foo" => ["hello", "world"] }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+    array_value = struct.fields["foo"]
+    array_value.must_be_kind_of Google::Protobuf::Value
+    array_value.kind.must_equal :list_value
+    array_value.list_value.must_be_kind_of Google::Protobuf::ListValue
+    array_value.list_value.values.wont_be :empty?
+    array_value.list_value.values.first.must_equal Google::Protobuf::Value.new(string_value: "hello")
+    array_value.list_value.values.last.must_equal Google::Protobuf::Value.new(string_value: "world")
+  end
+
+  it "converts complex hash" do
+    hash = { foo: nil, bar: true, baz: :bif, pi: 3.14, meta: { foo: :bar }, msg: ["hello", "world"] }
+    struct = Google::Cloud::Core::GRPCUtils.hash_to_struct hash
+    struct.must_be_kind_of Google::Protobuf::Struct
+    struct.fields.must_be_kind_of Google::Protobuf::Map
+    struct.fields.keys.wont_be :empty?
+
+    nil_value = struct.fields["foo"]
+    nil_value.must_be_kind_of Google::Protobuf::Value
+    nil_value.kind.must_equal :null_value
+    nil_value.null_value.must_equal :NULL_VALUE
+
+    true_value = struct.fields["bar"]
+    true_value.must_be_kind_of Google::Protobuf::Value
+    true_value.kind.must_equal :bool_value
+    true_value.bool_value.must_equal true
+
+    string_value = struct.fields["baz"]
+    string_value.must_be_kind_of Google::Protobuf::Value
+    string_value.kind.must_equal :string_value
+    string_value.string_value.must_equal "bif"
+
+    num_value = struct.fields["pi"]
+    num_value.must_be_kind_of Google::Protobuf::Value
+    num_value.kind.must_equal :number_value
+    num_value.number_value.must_equal 3.14
+
+    hash_value = struct.fields["meta"]
+    hash_value.must_be_kind_of Google::Protobuf::Value
+    hash_value.kind.must_equal :struct_value
+    hash_value.struct_value.fields.must_be_kind_of Google::Protobuf::Map
+    hash_value.struct_value.fields["foo"].must_be_kind_of Google::Protobuf::Value
+    hash_value.struct_value.fields["foo"].kind.must_equal :string_value
+    hash_value.struct_value.fields["foo"].string_value.must_equal "bar"
+
+    array_value = struct.fields["msg"]
+    array_value.must_be_kind_of Google::Protobuf::Value
+    array_value.kind.must_equal :list_value
+    array_value.list_value.must_be_kind_of Google::Protobuf::ListValue
+    array_value.list_value.values.wont_be :empty?
+    array_value.list_value.values.first.must_equal Google::Protobuf::Value.new(string_value: "hello")
+    array_value.list_value.values.last.must_equal Google::Protobuf::Value.new(string_value: "world")
+  end
+end

--- a/google-cloud-core/test/google/cloud/core/grpc_utils/object_to_value_test.rb
+++ b/google-cloud-core/test/google/cloud/core/grpc_utils/object_to_value_test.rb
@@ -1,0 +1,56 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "google/cloud/core/grpc_utils"
+
+describe Google::Cloud::Core::GRPCUtils, :object_to_value do
+  let(:nil_value) { Google::Protobuf::Value.new null_value: :NULL_VALUE }
+  let(:true_value) { Google::Protobuf::Value.new bool_value: true }
+  let(:string_value) { Google::Protobuf::Value.new string_value: "bif" }
+  let(:num_value) { Google::Protobuf::Value.new number_value: 3.14 }
+  let(:struct_value) { Google::Protobuf::Value.new struct_value: Google::Protobuf::Struct.new(fields: { "foo" => Google::Protobuf::Value.new(string_value: "bar") }) }
+  let(:list_value) { Google::Protobuf::Value.new list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "hello"),  Google::Protobuf::Value.new(string_value: "world") ]) }
+
+  it "converts nil object" do
+    value = Google::Cloud::Core::GRPCUtils.object_to_value nil
+    value.must_equal nil_value
+  end
+
+  it "converts true object" do
+    value = Google::Cloud::Core::GRPCUtils.object_to_value true
+    value.must_equal true_value
+  end
+
+  it "converts string object" do
+    value = Google::Cloud::Core::GRPCUtils.object_to_value "bif"
+    value.must_equal string_value
+  end
+
+  it "converts num object" do
+    value = Google::Cloud::Core::GRPCUtils.object_to_value 3.14
+    value.must_equal num_value
+  end
+
+  it "converts struct object" do
+    value = Google::Cloud::Core::GRPCUtils.object_to_value({ "foo" => "bar" })
+    value.must_equal struct_value
+  end
+
+  it "converts list object" do
+    value = Google::Cloud::Core::GRPCUtils.object_to_value ["hello", "world"]
+    value.must_equal list_value
+  end
+end

--- a/google-cloud-core/test/google/cloud/core/grpc_utils/struct_to_hash_test.rb
+++ b/google-cloud-core/test/google/cloud/core/grpc_utils/struct_to_hash_test.rb
@@ -1,0 +1,48 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "google/cloud/core/grpc_utils"
+
+describe Google::Cloud::Core::GRPCUtils, :struct_to_hash do
+  let(:struct) do
+    Google::Protobuf::Struct.new(fields: {
+      "foo"  => Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+      "bar"  => Google::Protobuf::Value.new(bool_value: true),
+      "baz"  => Google::Protobuf::Value.new(string_value: "bif"),
+      "pi"   => Google::Protobuf::Value.new(number_value: 3.14),
+      "meta" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "foo" => Google::Protobuf::Value.new(string_value: "bar") })),
+      "msg"  => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "hello"), Google::Protobuf::Value.new(string_value: "world")]))
+    })
+  end
+
+  it "converts empty struct" do
+    hash = Google::Cloud::Core::GRPCUtils.struct_to_hash Google::Protobuf::Struct.new
+    hash.must_be_kind_of Hash
+    hash.must_be :empty?
+  end
+
+  it "converts complex struct" do
+    hash = Google::Cloud::Core::GRPCUtils.struct_to_hash struct
+    hash.must_be_kind_of Hash
+    hash.wont_be :empty?
+    hash["foo"].must_equal nil
+    hash["bar"].must_equal true
+    hash["baz"].must_equal "bif"
+    hash["pi"].must_equal 3.14
+    hash["meta"].must_equal({ "foo" => "bar" })
+    hash["msg"].must_equal ["hello", "world"]
+  end
+end

--- a/google-cloud-core/test/google/cloud/core/grpc_utils/value_to_object_test.rb
+++ b/google-cloud-core/test/google/cloud/core/grpc_utils/value_to_object_test.rb
@@ -1,0 +1,56 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "google/cloud/core/grpc_utils"
+
+describe Google::Cloud::Core::GRPCUtils, :value_to_object do
+  let(:nil_value) { Google::Protobuf::Value.new null_value: :NULL_VALUE }
+  let(:true_value) { Google::Protobuf::Value.new bool_value: true }
+  let(:string_value) { Google::Protobuf::Value.new string_value: "bif" }
+  let(:num_value) { Google::Protobuf::Value.new number_value: 3.14 }
+  let(:struct_value) { Google::Protobuf::Value.new struct_value: Google::Protobuf::Struct.new(fields: { "foo" => Google::Protobuf::Value.new(string_value: "bar") }) }
+  let(:list_value) { Google::Protobuf::Value.new list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "hello"),  Google::Protobuf::Value.new(string_value: "world") ]) }
+
+  it "converts nil value" do
+    obj = Google::Cloud::Core::GRPCUtils.value_to_object nil_value
+    obj.must_equal nil
+  end
+
+  it "converts true value" do
+    obj = Google::Cloud::Core::GRPCUtils.value_to_object true_value
+    obj.must_equal true
+  end
+
+  it "converts string value" do
+    obj = Google::Cloud::Core::GRPCUtils.value_to_object string_value
+    obj.must_equal "bif"
+  end
+
+  it "converts num value" do
+    obj = Google::Cloud::Core::GRPCUtils.value_to_object num_value
+    obj.must_equal 3.14
+  end
+
+  it "converts struct value" do
+    obj = Google::Cloud::Core::GRPCUtils.value_to_object struct_value
+    obj.must_equal({ "foo" => "bar" })
+  end
+
+  it "converts list value" do
+    obj = Google::Cloud::Core::GRPCUtils.value_to_object list_value
+    obj.must_equal ["hello", "world"]
+  end
+end


### PR DESCRIPTION
Sort to match the type order of the Value protobufs.
Use the kind attribute that is used in the oneof definition.