### PR TITLE
Datastore acceptance test backoff

### DIFF
--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -279,14 +279,17 @@ describe "Datastore", :datastore do
     query = Google::Cloud::Datastore::Query.new.kind("Person").
       where("linkedTo", "=", person.key)
 
-    entities = dataset.run query
-    entities.count.must_equal 1
+    try_with_backoff "query by key" do
+      entities = dataset.run query
+      fail "retry query by key" unless entities.count == 1
+      entities.count.must_equal 1
 
-    entity = entities.first
-    entity["fullName"].must_equal      person["fullName"]
-    entity["linkedTo"].kind.must_equal person["linkedTo"].kind
-    entity["linkedTo"].id.must_equal   person["linkedTo"].id
-    entity["linkedTo"].name.must_equal person["linkedTo"].name
+      entity = entities.first
+      entity["fullName"].must_equal      person["fullName"]
+      entity["linkedTo"].kind.must_equal person["linkedTo"].kind
+      entity["linkedTo"].id.must_equal   person["linkedTo"].id
+      entity["linkedTo"].name.must_equal person["linkedTo"].name
+    end
   end
 
   describe "querying the datastore" do

--- a/google-cloud-datastore/acceptance/datastore_helper.rb
+++ b/google-cloud-datastore/acceptance/datastore_helper.rb
@@ -66,5 +66,19 @@ module Acceptance
       end
       reporter.record result
     end
+
+    def try_with_backoff msg = nil, limit: 10
+      count = 0
+      loop do
+        begin
+          return yield
+        rescue => e
+          raise e if count >= limit
+          count += 1
+          puts "Retry (#{count}): #{msg}"
+          sleep count
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Add `try_with_backoff` to Datastore acceptance tests. This one test has failed several times on CircleCI. We think CircleCI might be too fast, and this test is failing because of Datastore's eventual consistency. Using `try_with_backoff` should help this test be more reliable.