### PR TITLE
Trace sampler interface is now just a Proc

### DIFF
--- a/google-cloud-trace/docs/toc.json
+++ b/google-cloud-trace/docs/toc.json
@@ -47,6 +47,10 @@
           "type": "google/cloud/trace/resultset"
         },
         {
+          "title": "Sampling",
+          "type": "google/cloud/trace/sampling"
+        },
+        {
           "title": "Span",
           "type": "google/cloud/trace/span"
         },

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -26,6 +26,7 @@ require "google/cloud/trace/sampling"
 require "google/cloud/trace/service"
 require "google/cloud/trace/span"
 require "google/cloud/trace/span_kind"
+require "google/cloud/trace/time_sampler"
 require "google/cloud/trace/trace_record"
 require "google/cloud/trace/utils"
 
@@ -68,6 +69,11 @@ module Google
     # to the "Trace" section. It also integrates with Google App Engine
     # Flexible and Google Container Engine to provide additional information
     # for applications hosted in those environments.
+    #
+    # Note that not all requests will have traces. By default, the library will
+    # sample about one trace every ten seconds per Ruby process, to prevent
+    # heavily used applications from reporting too much data. See
+    # {Google::Cloud::Trace::Sampling} for more details.
     #
     # ### Using instrumentation with Ruby on Rails
     #

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -107,8 +107,8 @@ module Google
         #     Default is DEFAULT_PATH_BLACKLIST.
         # @param [Boolean] capture_stack Whether to capture stack traces for
         #     each span. Default is false.
-        # @param [#check] sampler A sampler to use, or nil to use the default.
-        #     See {Google::Cloud::Trace.sampler=}
+        # @param [Proc] sampler A sampler to use, or nil to use the default.
+        #     See {Google::Cloud::Trace::Sampling}
         #
         def initialize app,
                        service: nil,
@@ -167,10 +167,9 @@ module Google
               path = get_path env
               if @path_blacklist.find { |p| p === path }
                 sampled = false
-              elsif @sampler
-                sampled = @sampler.check {}
               else
-                sampled = Google::Cloud::Trace.check_sampler
+                sampler = @sampler || Google::Cloud::Trace::Sampling.sampler
+                sampled = sampler.call {}
               end
               tc = Stackdriver::Core::TraceContext.new \
                 trace_id: tc.trace_id,

--- a/google-cloud-trace/lib/google/cloud/trace/time_sampler.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/time_sampler.rb
@@ -1,0 +1,58 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # A sampler that enforces a certain QPS by delaying a minimum time
+      # between each sample.
+      #
+      # See {Google::Cloud::Trace::Sampling} for more information.
+      #
+      class TimeSampler
+        ##
+        # Create a TimeSampler for the given QPS.
+        #
+        # @param [Number] qps Samples per second.
+        #
+        def initialize qps: 0.1
+          @delay_secs = 1.0 / qps
+          @last_time = ::Time.now.to_f - @delay_secs
+        end
+
+        ##
+        # Implements the sampler contract. Checks to see whether a sample
+        # should be taken at this time.
+        #
+        # @param [Hash] _data Context data (unused by this sampler).
+        # @return [Boolean] Whether to sample at this time.
+        #
+        def call _data = {}
+          time = ::Time.now.to_f
+          delays = (time - @last_time) / @delay_secs
+          if delays >= 2.0
+            @last_time = time - @delay_secs
+            true
+          elsif delays >= 1.0
+            @last_time += @delay_secs
+            true
+          else
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/time_sampler_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/time_sampler_test.rb
@@ -23,49 +23,49 @@ describe Google::Cloud::Trace::TimeSampler do
     end
   end
 
-  describe ".check" do
+  describe ".call" do
     it "samples the first time called" do
       sam = Google::Cloud::Trace::TimeSampler.new
-      sam.check.must_equal true
+      sam.call.must_equal true
     end
 
     it "doesn't sample when called too soon" do
       sam = sampler
       ::Time.stub :now, start_time - 1 do
-        sam.check.must_equal false
+        sam.call.must_equal false
       end
     end
 
     it "samples when called after a suitable delay" do
       sam = sampler
       ::Time.stub :now, start_time + 1 do
-        sam.check.must_equal true
+        sam.call.must_equal true
       end
     end
 
     it "advances last sampling time" do
       sam = sampler
       ::Time.stub :now, start_time + 3 do
-        sam.check.must_equal true
+        sam.call.must_equal true
       end
       ::Time.stub :now, start_time + 9 do
-        sam.check.must_equal false
+        sam.call.must_equal false
       end
       ::Time.stub :now, start_time + 11 do
-        sam.check.must_equal true
+        sam.call.must_equal true
       end
     end
 
     it "advances last sampling time after a large gap" do
       sam = sampler
       ::Time.stub :now, start_time + 30 do
-        sam.check.must_equal true
+        sam.call.must_equal true
       end
       ::Time.stub :now, start_time + 31 do
-        sam.check.must_equal true
+        sam.call.must_equal true
       end
       ::Time.stub :now, start_time + 32 do
-        sam.check.must_equal false
+        sam.call.must_equal false
       end
     end
   end


### PR DESCRIPTION
Overall, clean up interfaces and documentation around sampling. Specifically:

* Change the method on the sampler interface from `check` to `call` so a Proc can be used. Sorry for that annoyance; I've been writing too much Java these past couple years.
* Move `TimeSampler` class into a separate `time_sampler.rb` file.
* Move the global sampler attribute into a `Google::Cloud::Trace::Sampling` module and make it an attribute like it should be.
* Clarify documentation around sampling, by including a section in the main `Google::Cloud::Trace` guide and using the new `Google::Cloud::Trace::Sampling` module to document details.