### PR TITLE
Removed unnecessary require "digest/sha2" in Cloud Storage Documentation & Test

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -14,7 +14,6 @@
 
 require "storage_helper"
 require "net/http"
-require "digest/sha2"
 
 describe Google::Cloud::Storage::File, :storage do
   let :bucket do

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -210,7 +210,6 @@ module Google
     #
     # ```ruby
     # require "google/cloud/storage"
-    # require "digest/sha2"
     #
     # storage = Google::Cloud::Storage.new
     # bucket = storage.bucket "my-todo-app"

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -540,7 +540,6 @@ module Google
         #
         # @example Providing a customer-supplied encryption key:
         #   require "google/cloud/storage"
-        #   require "digest/sha2"
         #
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-bucket"


### PR DESCRIPTION
Hi everyone,

After removing the [`encryption_key_sha256`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/1109) parameter, I found an unnecessary `require "digest/sha2"` statement in the following locations in the _google-cloud-ruby_ documentation [1][2]. I also found it in an acceptance test where it should have been removed. I did test the acceptance test locally after the change was made.

This PR will clean that up. Thanks for reading. 

[1] https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/v0.23.0/google/cloud/storage
[2] https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/v0.23.0/google/cloud/storage/bucket
