### PR TITLE
Rename to_ and from_proto to to_ and from_grpc for trace models

### DIFF
--- a/google-cloud-trace/lib/google/cloud/trace/result_set.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/result_set.rb
@@ -182,7 +182,7 @@ module Google
           next_page_token = page.next_page_token
           next_page_token = nil unless page.next_page_token?
           results = page.map do |proto|
-            Google::Cloud::Trace::TraceRecord.from_proto proto
+            Google::Cloud::Trace::TraceRecord.from_grpc proto
           end
           new service, project_id,
               results, next_page_token,

--- a/google-cloud-trace/lib/google/cloud/trace/service.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/service.rb
@@ -125,8 +125,8 @@ module Google
           else
             call_opts = Google::Gax::CallOptions.new
           end
-          start_proto = Google::Cloud::Trace::Utils.time_to_proto start_time
-          end_proto = Google::Cloud::Trace::Utils.time_to_proto end_time
+          start_proto = Google::Cloud::Trace::Utils.time_to_grpc start_time
+          end_proto = Google::Cloud::Trace::Utils.time_to_grpc end_time
           paged_enum = execute do
             lowlevel_client.list_traces project_id,
                                         view: view,

--- a/google-cloud-trace/lib/google/cloud/trace/service.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/service.rb
@@ -93,7 +93,7 @@ module Google
           traces = Array(traces)
           traces_proto = Google::Devtools::Cloudtrace::V1::Traces.new
           traces.each do |trace|
-            traces_proto.traces.push trace.to_proto
+            traces_proto.traces.push trace.to_grpc
           end
           execute do
             lowlevel_client.patch_traces @project, traces_proto
@@ -107,7 +107,7 @@ module Google
           trace_proto = execute do
             lowlevel_client.get_trace @project, trace_id
           end
-          Google::Cloud::Trace::TraceRecord.from_proto trace_proto
+          Google::Cloud::Trace::TraceRecord.from_grpc trace_proto
         end
 
         ##

--- a/google-cloud-trace/lib/google/cloud/trace/span.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/span.rb
@@ -152,9 +152,9 @@ module Google
           span_proto.labels.each { |k, v| labels[k] = v }
           span_kind = SpanKind.get span_proto.kind
           start_time =
-            Google::Cloud::Trace::Utils.proto_to_time span_proto.start_time
+            Google::Cloud::Trace::Utils.grpc_to_time span_proto.start_time
           end_time =
-            Google::Cloud::Trace::Utils.proto_to_time span_proto.end_time
+            Google::Cloud::Trace::Utils.grpc_to_time span_proto.end_time
           trace.create_span span_proto.name,
                             parent_span_id: span_proto.parent_span_id.to_i,
                             span_id: span_proto.span_id.to_i,
@@ -174,8 +174,8 @@ module Google
         #     protobuf.
         #
         def to_grpc default_parent_id = 0
-          start_proto = Google::Cloud::Trace::Utils.time_to_proto start_time
-          end_proto = Google::Cloud::Trace::Utils.time_to_proto end_time
+          start_proto = Google::Cloud::Trace::Utils.time_to_grpc start_time
+          end_proto = Google::Cloud::Trace::Utils.time_to_grpc end_time
           Google::Devtools::Cloudtrace::V1::TraceSpan.new \
             span_id: span_id.to_i,
             kind: kind.to_sym,

--- a/google-cloud-trace/lib/google/cloud/trace/span.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/span.rb
@@ -147,7 +147,7 @@ module Google
         #     to contain the span.
         # @return [Google::Cloud::Trace::Span] A corresponding Span object.
         #
-        def self.from_proto span_proto, trace
+        def self.from_grpc span_proto, trace
           labels = {}
           span_proto.labels.each { |k, v| labels[k] = v }
           span_kind = SpanKind.get span_proto.kind
@@ -173,7 +173,7 @@ module Google
         # @return [Google::Devtools::Cloudtrace::V1::TraceSpan] The generated
         #     protobuf.
         #
-        def to_proto default_parent_id = 0
+        def to_grpc default_parent_id = 0
           start_proto = Google::Cloud::Trace::Utils.time_to_proto start_time
           end_proto = Google::Cloud::Trace::Utils.time_to_proto end_time
           Google::Devtools::Cloudtrace::V1::TraceSpan.new \

--- a/google-cloud-trace/lib/google/cloud/trace/trace_record.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/trace_record.rb
@@ -36,7 +36,7 @@ module Google
       #   span = trace.create_span "root_span"
       #   subspan = span.create_span "subspan"
       #
-      #   trace_proto = trace.to_proto
+      #   trace_proto = trace.to_grpc
       #
       class TraceRecord
         ##
@@ -79,7 +79,7 @@ module Google
         # @return [Trace, nil] A corresponding Trace object, or `nil` if the
         #     proto does not represent an existing trace object.
         #
-        def self.from_proto trace_proto
+        def self.from_grpc trace_proto
           trace_id = trace_proto.trace_id.to_s
           return nil if trace_id.empty?
 
@@ -105,9 +105,9 @@ module Google
         # @return [Google::Devtools::Cloudtrace::V1::Trace] The generated
         #     protobuf.
         #
-        def to_proto
+        def to_grpc
           span_protos = @spans_by_id.values.map do |span|
-            span.to_proto trace_context.span_id.to_i
+            span.to_grpc trace_context.span_id.to_i
           end
           Google::Devtools::Cloudtrace::V1::Trace.new \
             project_id: project,
@@ -320,7 +320,7 @@ module Google
           new_span_ids = ::Set.new
           span_protos.each do |span_proto|
             if parent_span_ids.include? span_proto.parent_span_id
-              Google::Cloud::Trace::Span.from_proto span_proto, self
+              Google::Cloud::Trace::Span.from_grpc span_proto, self
               new_span_ids.add span_proto.span_id
             end
           end

--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -23,22 +23,22 @@ module Google
       #
       module Utils
         ##
-        # Convert a Ruby Time object to a timestamp proto.
+        # Convert a Ruby Time object to a timestamp proto object.
         #
         # @private
         #
-        def self.time_to_proto time
+        def self.time_to_grpc time
           Google::Protobuf::Timestamp.new seconds: time.to_i,
                                           nanos: time.nsec
         end
 
         ##
-        # Convert a Timestamp proto to a Ruby Time object.
+        # Convert a Timestamp proto object to a Ruby Time object.
         #
         # @private
         #
-        def self.proto_to_time proto
-          Time.at(proto.seconds, Rational(proto.nanos, 1000)).utc
+        def self.grpc_to_time grpc
+          Time.at(grpc.seconds, Rational(grpc.nanos, 1000)).utc
         end
       end
     end

--- a/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
@@ -242,8 +242,8 @@ describe Google::Cloud::Trace::TraceRecord do
           labels: sub_labels)
       ]
 
-    trace.to_proto.must_equal proto
-    Google::Cloud::Trace::TraceRecord.from_proto(proto).must_equal trace
+    trace.to_grpc.must_equal proto
+    Google::Cloud::Trace::TraceRecord.from_grpc(proto).must_equal trace
   end
 
   it "converts to and from a protobuf with an orphaned span" do
@@ -298,7 +298,7 @@ describe Google::Cloud::Trace::TraceRecord do
           labels: sub_labels)
       ]
 
-    trace.to_proto.must_equal proto
-    Google::Cloud::Trace::TraceRecord.from_proto(proto).must_equal trace
+    trace.to_grpc.must_equal proto
+    Google::Cloud::Trace::TraceRecord.from_grpc(proto).must_equal trace
   end
 end

--- a/google-cloud-trace/test/google/cloud/trace/utils_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/utils_test.rb
@@ -24,11 +24,11 @@ describe Google::Cloud::Trace::Utils do
     Time.at(secs, Rational(nsecs, 1000))
   }
 
-  it "converts time objects to protos" do
-    Google::Cloud::Trace::Utils.time_to_proto(time_obj).must_equal time_proto
+  it "converts time objects to proto objects" do
+    Google::Cloud::Trace::Utils.time_to_grpc(time_obj).must_equal time_proto
   end
 
-  it "converts time protos to objects" do
-    Google::Cloud::Trace::Utils.proto_to_time(time_proto).must_equal time_obj
+  it "converts proto objects to time objects" do
+    Google::Cloud::Trace::Utils.grpc_to_time(time_proto).must_equal time_obj
   end
 end


### PR DESCRIPTION
It looks like the other ruby client libraries name these methods `to_grpc` and `from_grpc`, so @dazuma is changing these method names to match.

@hxiong388 PTAL.