### PR TITLE
Make CircleCI use latest rubygems

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,11 @@ dependencies:
   pre:
     # The following three commands install 2.0.0
     - rvm get stable
+    - gem update --system
+    - rvm-exec 2.2.5 gem update --system
+    - rvm-exec 2.3.1 gem update --system
     - rvm install 2.0.0-p648
+    - rvm-exec 2.0.0-p648 gem update --system
     - rvm-exec 2.0.0-p648 gem install bundler
 
   override:


### PR DESCRIPTION
We've seen a handful of errors that look like they come from old rubygems.
Add rubygems update to the ruby dependencies.