### PR TITLE
Add doctest support for Google::Cloud.speech

### DIFF
--- a/google-cloud-speech/support/doctest_helper.rb
+++ b/google-cloud-speech/support/doctest_helper.rb
@@ -116,6 +116,10 @@ YARD::Doctest.configure do |doctest|
     mock_speech
   end
 
+  doctest.before "Google::Cloud.speech" do
+    mock_speech
+  end
+
   doctest.before "Google::Cloud::Speech" do
     mock_speech
   end


### PR DESCRIPTION
Add missing doctest configuration. Fixes occasional errors in speech doctest.