### PR TITLE
Update product name Translate API to Cloud Translation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ file.copy backup, file.name
 - [google-cloud-translate README](google-cloud-translate/README.md)
 - [google-cloud-translate API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/master/google/cloud/translate)
 - [google-cloud-translate on RubyGems](https://rubygems.org/gems/google-cloud-translate)
-- [Google Cloud Translation API documentation](https://cloud.google.com/translate/docs)
+- [Google Cloud Translation API documentation](https://cloud.google.com/translation/docs)
 
 #### Quick Start
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This client supports the following Google Cloud Platform services at an [Alpha](
 * [Cloud Pub/Sub](#cloud-pubsub-alpha) (Alpha)
 * [Cloud Resource Manager](#cloud-resource-manager-alpha) (Alpha)
 * [Cloud Speech API](#cloud-speech-api-alpha) (Alpha)
-* [Translate API](#translate-api-alpha) (Alpha)
+* [Cloud Translation API](#translate-api-alpha) (Alpha)
 * [Cloud Vision API](#cloud-vision-api-alpha) (Alpha)
 
 The support for each service is distributed as a separate gem. However, for your convenience, the `google-cloud` gem lets you install the entire collection.
@@ -373,12 +373,12 @@ backup = storage.bucket "task-attachment-backups"
 file.copy backup, file.name
 ```
 
-### Translate API (Alpha)
+### Cloud Translation API (Alpha)
 
 - [google-cloud-translate README](google-cloud-translate/README.md)
 - [google-cloud-translate API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/master/google/cloud/translate)
 - [google-cloud-translate on RubyGems](https://rubygems.org/gems/google-cloud-translate)
-- [Google Translate API documentation](https://cloud.google.com/translate/docs)
+- [Google Cloud Translation API documentation](https://cloud.google.com/translate/docs)
 
 #### Quick Start
 

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -32,7 +32,7 @@ module Google
     # API with the Google Cloud Speech API and extract insights from audio
     # conversations. Use with Vision API OCR to understand scanned documents.
     # Extract entities and understand sentiments in multiple languages by
-    # translating text first with Translate API.
+    # translating text first with Cloud Translation API.
     #
     # The Google Cloud Natural Language API is currently a beta release, and
     # might be changed in backward-incompatible ways. It is not subject to any

--- a/google-cloud-translate/.yardopts
+++ b/google-cloud-translate/.yardopts
@@ -1,5 +1,5 @@
 --no-private
---title=Google Cloud Translate
+--title=Google Cloud Translation API
 --markup markdown
 
 ./lib/**/*.rb

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -1,12 +1,12 @@
 # google-cloud-translate
 
-[Google Translate](https://cloud.google.com/translate/) ([docs](https://cloud.google.com/translate/docs)) provides a simple, programmatic interface for translating an arbitrary string into any supported language. It is highly responsive, so websites and applications can integrate with Translate API for fast, dynamic translation of source text. Language detection is also available in cases where the source language is unknown.
+[Google Cloud Translation API](https://cloud.google.com/translate/) ([docs](https://cloud.google.com/translate/docs)) provides a simple, programmatic interface for translating an arbitrary string into any supported language. It is highly responsive, so websites and applications can integrate with Translation API for fast, dynamic translation of source text. Language detection is also available in cases where the source language is unknown.
 
-Translate API supports more than ninety different languages, from Afrikaans to Zulu. Used in combination, this enables translation between thousands of language pairs. Also, you can send in HTML and receive HTML with translated text back. You don't need to extract your source text or reassemble the translated content.
+Translation API supports more than one hundred different languages, from Afrikaans to Zulu. Used in combination, this enables translation between thousands of language pairs. Also, you can send in HTML and receive HTML with translated text back. You don't need to extract your source text or reassemble the translated content.
 
 - [google-cloud-translate API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/master/google/cloud/translate)
 - [google-cloud-translate on RubyGems](https://rubygems.org/gems/google-cloud-translate)
-- [Google Translate documentation](https://cloud.google.com/translate/docs)
+- [Google Cloud Translation API documentation](https://cloud.google.com/translate/docs)
 
 ## Quick Start
 
@@ -16,7 +16,7 @@ $ gem install google-cloud-translate
 
 ## Authentication
 
-Like other Cloud Platform services, Google Translate API supports
+Like other Cloud Platform services, Google Cloud Translation API supports
 authentication using a project ID and OAuth 2.0 credentials. In addition,
 it supports authentication using a public API access key. (If both the API
 key and the project and OAuth 2.0 credentials are provided, the API key

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -1,12 +1,12 @@
 # google-cloud-translate
 
-[Google Cloud Translation API](https://cloud.google.com/translate/) ([docs](https://cloud.google.com/translate/docs)) provides a simple, programmatic interface for translating an arbitrary string into any supported language. It is highly responsive, so websites and applications can integrate with Translation API for fast, dynamic translation of source text. Language detection is also available in cases where the source language is unknown.
+[Google Cloud Translation API](https://cloud.google.com/translation/) ([docs](https://cloud.google.com/translation/docs)) provides a simple, programmatic interface for translating an arbitrary string into any supported language. It is highly responsive, so websites and applications can integrate with Translation API for fast, dynamic translation of source text. Language detection is also available in cases where the source language is unknown.
 
 Translation API supports more than one hundred different languages, from Afrikaans to Zulu. Used in combination, this enables translation between thousands of language pairs. Also, you can send in HTML and receive HTML with translated text back. You don't need to extract your source text or reassemble the translated content.
 
 - [google-cloud-translate API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/master/google/cloud/translate)
 - [google-cloud-translate on RubyGems](https://rubygems.org/gems/google-cloud-translate)
-- [Google Cloud Translation API documentation](https://cloud.google.com/translate/docs)
+- [Google Cloud Translation API documentation](https://cloud.google.com/translation/docs)
 
 ## Quick Start
 

--- a/google-cloud-translate/acceptance/translate_helper.rb
+++ b/google-cloud-translate/acceptance/translate_helper.rb
@@ -23,13 +23,13 @@ $translate = Google::Cloud.new.translate retries: 10
 
 module Acceptance
   ##
-  # Test class for running against a Translate instance.
+  # Test class for running against a Translation API instance.
   # Ensures that there is an active connection for the tests to use.
   #
   # This class can be used with the spec DSL.
   # To do so, add :translate to describe:
   #
-  #   describe "My Translate Test", :translate do
+  #   describe "My Translation API Test", :translate do
   #     it "does a thing" do
   #       your.code.must_be :thing?
   #     end

--- a/google-cloud-translate/docs/authentication.md
+++ b/google-cloud-translate/docs/authentication.md
@@ -6,7 +6,7 @@ Like other Cloud Platform services, Google Cloud Translation API supports authen
 
 ### Using an API access key
 
-Follow the general instructions at [Identifying your application to Google](https://cloud.google.com/translate/v2/using_rest#auth), and the specific instructions for [Server keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
+Follow the general instructions for obtaining an authorization token using your service account at [Translation API Quickstart](https://cloud.google.com/translation/docs/getting-started).
 
 **API key** is discovered in the following order:
 

--- a/google-cloud-translate/docs/authentication.md
+++ b/google-cloud-translate/docs/authentication.md
@@ -2,7 +2,7 @@
 
 With `google-cloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
 
-Like other Cloud Platform services, Google Translate API supports authentication using a project ID and OAuth 2.0 credentials. In addition, it supports authentication using a public API access key. (If both the API key and the project and OAuth 2.0 credentials are provided, the API key will be used.)
+Like other Cloud Platform services, Google Cloud Translation API supports authentication using a project ID and OAuth 2.0 credentials. In addition, it supports authentication using a public API access key. (If both the API key and the project and OAuth 2.0 credentials are provided, the API key will be used.)
 
 ### Using an API access key
 

--- a/google-cloud-translate/docs/toc.json
+++ b/google-cloud-translate/docs/toc.json
@@ -30,7 +30,7 @@
   ],
   "services": [
     {
-      "title": "Translate",
+      "title": "Translation",
       "type": "google/cloud/translate",
       "nav": [
         {

--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Mike Moore", "Chris Smith"]
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
-  gem.description   = "google-cloud-translate is the official library for Google Translate API."
-  gem.summary       = "API Client library for Google Translate API"
+  gem.description   = "google-cloud-translate is the official library for Google Cloud Translation API."
+  gem.summary       = "API Client library for Google Cloud Translation API"
   gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
   gem.license       = "Apache-2.0"
 

--- a/google-cloud-translate/lib/google-cloud-translate.rb
+++ b/google-cloud-translate/lib/google-cloud-translate.rb
@@ -24,10 +24,10 @@ require "google/cloud"
 module Google
   module Cloud
     ##
-    # Creates a new object for connecting to the Translate service.
-    # Each call creates a new connection.
+    # Creates a new object for connecting to the Cloud Translation API. Each
+    # call creates a new connection.
     #
-    # Like other Cloud Platform services, Google Translate API supports
+    # Like other Cloud Platform services, Google Cloud Translation API supports
     # authentication using a project ID and OAuth 2.0 credentials. In addition,
     # it supports authentication using a public API access key. (If both the API
     # key and the project and OAuth 2.0 credentials are provided, the API key
@@ -77,10 +77,10 @@ module Google
     end
 
     ##
-    # Creates a new object for connecting to the Translate service.
-    # Each call creates a new connection.
+    # Creates a new object for connecting to the Cloud Translation API. Each
+    # call creates a new connection.
     #
-    # Like other Cloud Platform services, Google Translate API supports
+    # Like other Cloud Platform services, Google Cloud Translation API supports
     # authentication using a project ID and OAuth 2.0 credentials. In addition,
     # it supports authentication using a public API access key. (If both the API
     # key and the project and OAuth 2.0 credentials are provided, the API key
@@ -88,8 +88,8 @@ module Google
     # [Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/guides/authentication).
     #
     # @param [String] key a public API access key (not an OAuth 2.0 token)
-    # @param [String] project Project identifier for the Translate service you
-    #   are connecting to.
+    # @param [String] project Identifier for the Cloud Translation API project
+    #   to which you are connecting.
     # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
     #   file path the file must be readable.
     # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the

--- a/google-cloud-translate/lib/google/cloud/translate.rb
+++ b/google-cloud-translate/lib/google/cloud/translate.rb
@@ -19,16 +19,16 @@ require "google/cloud/translate/api"
 module Google
   module Cloud
     ##
-    # # Google Translate API
+    # # Google Cloud Translation API
     #
-    # [Google Translate API](https://cloud.google.com/translate/) provides a
-    # simple, programmatic interface for translating an arbitrary string into
-    # any supported language. It is highly responsive, so websites and
-    # applications can integrate with Translate API for fast, dynamic
+    # [Google Cloud Translation API](https://cloud.google.com/translate/)
+    # provides a simple, programmatic interface for translating an arbitrary
+    # string into any supported language. It is highly responsive, so websites
+    # and applications can integrate with Translation API for fast, dynamic
     # translation of source text. Language detection is also available in cases
     # where the source language is unknown.
     #
-    # Translate API supports more than ninety different languages, from
+    # Translation API supports more than one hundred different languages, from
     # Afrikaans to Zulu. Used in combination, this enables translation between
     # thousands of language pairs. Also, you can send in HTML and receive HTML
     # with translated text back. You don't need to extract your source text or
@@ -47,7 +47,7 @@ module Google
     #
     # ## Authenticating
     #
-    # Like other Cloud Platform services, Google Translate API supports
+    # Like other Cloud Platform services, Google Cloud Translation API supports
     # authentication using a project ID and OAuth 2.0 credentials. In addition,
     # it supports authentication using a public API access key. (If both the API
     # key and the project and OAuth 2.0 credentials are provided, the API key
@@ -79,7 +79,7 @@ module Google
     #
     # You may want to use the `from` option to specify the language of the
     # source text, as the following example illustrates. (Single words do not
-    # give Translate API much to work with.)
+    # give Translation API much to work with.)
     #
     # ```ruby
     # require "google/cloud/translate"
@@ -130,8 +130,8 @@ module Google
     # ## Detecting languages
     #
     # You can use {Google::Cloud::Translate::Api#detect} to see which language
-    # the Translate API ranks as the most likely source language for a text. The
-    # `confidence` score is a float value between `0` and `1`.
+    # the Translation API ranks as the most likely source language for a text.
+    # The `confidence` score is a float value between `0` and `1`.
     #
     # ```ruby
     # require "google/cloud/translate"
@@ -165,7 +165,7 @@ module Google
     #
     # ## Listing supported languages
     #
-    # Translate API adds new languages frequently. You can use
+    # Translation API adds new languages frequently. You can use
     # {Google::Cloud::Translate::Api#languages} to query the list of supported
     # languages.
     #
@@ -218,19 +218,19 @@ module Google
     #
     module Translate
       ##
-      # Creates a new object for connecting to the Translate service.
-      # Each call creates a new connection.
+      # Creates a new object for connecting to Cloud Translation API. Each call
+      # creates a new connection.
       #
-      # Like other Cloud Platform services, Google Translate API supports
-      # authentication using a project ID and OAuth 2.0 credentials. In
+      # Like other Cloud Platform services, Google Cloud Translation API
+      # supports authentication using a project ID and OAuth 2.0 credentials. In
       # addition, it supports authentication using a public API access key. (If
       # both the API key and the project and OAuth 2.0 credentials are provided,
       # the API key will be used.) Instructions and configuration options are
       # covered in the [Authentication
       # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/guides/authentication).
       #
-      # @param [String] project Project identifier for the Translate service you
-      #   are connecting to.
+      # @param [String] project Identifier for the Cloud Translation API project
+      #   to which you are connecting.
       # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
       #   file path the file must be readable.
       # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling

--- a/google-cloud-translate/lib/google/cloud/translate.rb
+++ b/google-cloud-translate/lib/google/cloud/translate.rb
@@ -21,7 +21,7 @@ module Google
     ##
     # # Google Cloud Translation API
     #
-    # [Google Cloud Translation API](https://cloud.google.com/translate/)
+    # [Google Cloud Translation API](https://cloud.google.com/translation/)
     # provides a simple, programmatic interface for translating an arbitrary
     # string into any supported language. It is highly responsive, so websites
     # and applications can integrate with Translation API for fast, dynamic

--- a/google-cloud-translate/lib/google/cloud/translate/api.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/api.rb
@@ -32,7 +32,7 @@ module Google
       # with translated text back. You don't need to extract your source text or
       # reassemble the translated content.
       #
-      # @see https://cloud.google.com/translation/docs/getting_started
+      # @see https://cloud.google.com/translation/docs/getting-started
       #   Cloud Translation API Quickstart
       #
       # @example
@@ -91,7 +91,7 @@ module Google
         ##
         # Returns text translations from one language to another.
         #
-        # @see https://cloud.google.com/translate/v2/using_rest#Translate
+        # @see https://cloud.google.com/translation/docs/translating-text#Translate
         #   Translating Text
         #
         # @param [String] text The text or texts to translate.
@@ -199,8 +199,8 @@ module Google
         # Detect the most likely language or languages of a text or multiple
         # texts.
         #
-        # @see https://cloud.google.com/translate/v2/using_rest#detect-language
-        #   Detect Language
+        # @see https://cloud.google.com/translation/docs/detecting-language
+        #   Detecting Language
         #
         # @param [String] text The text or texts upon which language detection
         #   should be performed.
@@ -242,8 +242,8 @@ module Google
         # List the languages supported by the API. These are the languages to
         # and from which text can be translated.
         #
-        # @see https://cloud.google.com/translate/v2/using_rest#supported-languages
-        #   Discover Supported Languages
+        # @see https://cloud.google.com/translation/docs/discovering-supported-languages
+        #   Discovering Supported Languages
         #
         # @param [String] language The language and collation in which the names
         #   of the languages are returned. If this is `nil` then no names are

--- a/google-cloud-translate/lib/google/cloud/translate/api.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/api.rb
@@ -25,15 +25,15 @@ module Google
       ##
       # # Api
       #
-      # Represents top-level access to the Google Translate API. Translate API
-      # supports more than ninety different languages, from Afrikaans to Zulu.
-      # Used in combination, this enables translation between thousands of
-      # language pairs. Also, you can send in HTML and receive HTML with
-      # translated text back. You don't need to extract your source text or
+      # Represents top-level access to the Google Cloud Translation API.
+      # Translation API supports more than one hundred different languages, from
+      # Afrikaans to Zulu. Used in combination, this enables translation between
+      # thousands of language pairs. Also, you can send in HTML and receive HTML
+      # with translated text back. You don't need to extract your source text or
       # reassemble the translated content.
       #
-      # @see https://cloud.google.com/translate/v2/getting_started Translate API
-      #   Getting Started
+      # @see https://cloud.google.com/translation/docs/getting_started
+      #   Cloud Translation API Quickstart
       #
       # @example
       #   require "google/cloud/translate"
@@ -55,7 +55,7 @@ module Google
         attr_accessor :service
 
         ##
-        # @private Creates a new Translate Api instance.
+        # @private Creates a new Api instance.
         #
         # See {Google::Cloud.translate}
         def initialize service
@@ -63,7 +63,7 @@ module Google
         end
 
         ##
-        # The Translate project connected to.
+        # The Cloud Translation API project connected to.
         #
         # @example
         #   require "google/cloud/translate"
@@ -92,7 +92,7 @@ module Google
         # Returns text translations from one language to another.
         #
         # @see https://cloud.google.com/translate/v2/using_rest#Translate
-        #   Translate Text
+        #   Translating Text
         #
         # @param [String] text The text or texts to translate.
         # @param [String] to The target language into which the text should be
@@ -104,8 +104,8 @@ module Google
         #   639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
         #   language code. This is optional.
         # @param [String] format The format of the text. Possible values include
-        #   `:text` and `:html`. This is optional. The Translate API default is
-        #   `:html`.
+        #   `:text` and `:html`. This is optional. The Translation API default
+        #   is `:html`.
         # @param [String] model The model used by the service to perform the
         #   translation. The neural machine translation model (`nmt`) is billed
         #   as a premium edition feature. If this is set to `base`, then the

--- a/google-cloud-translate/lib/google/cloud/translate/credentials.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/credentials.rb
@@ -19,7 +19,7 @@ module Google
   module Cloud
     module Translate
       ##
-      # @private Represents the OAuth 2.0 signing logic for Translate.
+      # @private Represents the OAuth 2.0 signing logic for Translation API.
       class Credentials < Google::Cloud::Credentials
         SCOPE = ["https://www.googleapis.com/auth/cloud-platform"]
         PATH_ENV_VARS = %w(TRANSLATE_KEYFILE GOOGLE_CLOUD_KEYFILE

--- a/google-cloud-translate/lib/google/cloud/translate/detection.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/detection.rb
@@ -22,8 +22,8 @@ module Google
       # Represents a detect language query result. Returned by
       # {Google::Cloud::Translate::Api#detect}.
       #
-      # @see https://cloud.google.com/translate/v2/using_rest#detect-language
-      #   Detect Language
+      # @see https://cloud.google.com/translation/docs/detecting-language
+      #   Detecting Language
       #
       # @example
       #   require "google/cloud/translate"

--- a/google-cloud-translate/lib/google/cloud/translate/language.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/language.rb
@@ -22,8 +22,8 @@ module Google
       # Represents a supported languages query result. Returned by
       # {Google::Cloud::Translate::Api#languages}.
       #
-      # @see https://cloud.google.com/translate/v2/using_rest#supported-languages
-      #   Discover Supported Languages
+      # @see https://cloud.google.com/translation/docs/discovering-supported-languages
+      #   Discovering Supported Languages
       #
       # @example
       #   require "google/cloud/translate"

--- a/google-cloud-translate/lib/google/cloud/translate/service.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/service.rb
@@ -23,7 +23,7 @@ module Google
     module Translate
       ##
       # @private
-      # Represents the Translate REST service, exposing the API calls.
+      # Represents the Translation API REST service, exposing the API calls.
       class Service #:nodoc:
         API_VERSION = "v2"
         API_URL = "https://translation.googleapis.com"

--- a/google-cloud-translate/lib/google/cloud/translate/translation.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/translation.rb
@@ -22,7 +22,7 @@ module Google
       # Represents a translation query result. Returned by
       # {Google::Cloud::Translate::Api#translate}.
       #
-      # @see https://cloud.google.com/translate/v2/using_rest#Translate
+      # @see https://cloud.google.com/translation/docs/translating-text#Translate
       #   Translating Text
       #
       # @example

--- a/google-cloud-translate/lib/google/cloud/translate/translation.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/translation.rb
@@ -23,7 +23,7 @@ module Google
       # {Google::Cloud::Translate::Api#translate}.
       #
       # @see https://cloud.google.com/translate/v2/using_rest#Translate
-      #   Translate Text
+      #   Translating Text
       #
       # @example
       #   require "google/cloud/translate"
@@ -99,11 +99,11 @@ module Google
 
         ##
         # Determines if the source language was detected by the Google Cloud
-        # Translate API.
+        # Cloud Translation API.
         #
         # @return [Boolean] `true` if the source language was detected by the
-        #   Translate service, `false` if the source language was provided in
-        #   the request
+        #   Cloud Translation API, `false` if the source language was provided
+        #   in the request
         def detected?
           @detected
         end

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/image_annotator.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/image_annotator.rb
@@ -397,7 +397,7 @@ module Google
         #     significant hindrance if the hint is wrong). Text detection returns an
         #     error if one or more of the specified languages is not one of the
         #     {supported
-        #     languages}[https://cloud.google.com/translate/v2/translate-reference#supported_languages].
+        #     languages}[https://cloud.google.com/translation/docs/languages].
         class ImageContext; end
 
         # Request for performing Google Cloud Vision API tasks over a user-provided

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -338,7 +338,7 @@
       ]
     },
     {
-      "title": "Translate",
+      "title": "Translation",
       "type": "google/cloud/translate",
       "nav": [
         {


### PR DESCRIPTION
This PR updates the product name Translate API to Cloud Translation API.

Specifically, it updates the following:

* "Translate API" to "Google Cloud Translation API", "Cloud Translation API", or "Translation API" in guide docs, code docs, README, and similar
* Package title "Translate" to "Translation" in left nav of gh-pages site
* `cloud.google.com/translate/` to `cloud.google.com/translation/` in links (`/translation/` currently forwards to `/translate/`, but my expectation is that this will change)
* broken links to new URLs
* "more than ninety different languages" to "more than one hundred different languages"


This PR does NOT update:

* The product name "Translate API" in historical entries in CHANGELOGs.
* The package and gem name
* Any code object names, such as the module name `Translate` or factory methods named `translate`
* Any sample code, including variables named `translate` (I feel it is best to wait change examples at the same time as the code, in order to stay in sync with cloud.google.com samples, and thus reduce churn for GoogleCloudPlatform/ruby-docs-samples#136)

[closes #1112, refs #1135]