### PR TITLE
Require standard logger from cloud logger because it is now used internally

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+require "logger"
 require "orderedhash"
 
 module Google


### PR DESCRIPTION
@hxiong388 Whoops, sorry. This is why the daily integration tests have been failing.