### PR TITLE
Update toc.json for GAPIC docs 

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -5,6 +5,7 @@
   "markdown": "ruby",
   "titleDelimiter": "::",
   "defaultModule": "google-cloud",
+  "matchServiceTitle": true,
   "content": "json",
   "home": "home.html",
   "package": {

--- a/google-cloud-datastore/docs/toc.json
+++ b/google-cloud-datastore/docs/toc.json
@@ -48,52 +48,20 @@
         {
           "title": "Key",
           "type": "google/cloud/datastore/key"
-        }
-      ]
-    },
-    {
-      "title": "Datastore::V1",
-      "type": "google/cloud/datastore/v1/datastoreclient",
-      "nav": [
-        {
-          "title": "DatastoreClient",
-          "type": "google/cloud/datastore/v1/datastoreclient"
         },
         {
-          "title": "BoolValue",
-          "type": "google/protobuf/boolvalue"
-        },
-        {
-          "title": "BytesValue",
-          "type": "google/protobuf/bytesvalue"
-        },
-        {
-          "title": "DoubleValue",
-          "type": "google/protobuf/doublevalue"
-        },
-        {
-          "title": "FloatValue",
-          "type": "google/protobuf/floatvalue"
-        },
-        {
-          "title": "Int32Value",
-          "type": "google/protobuf/int32value"
-        },
-        {
-          "title": "Int64Value",
-          "type": "google/protobuf/int64value"
-        },
-        {
-          "title": "StringValue",
-          "type": "google/protobuf/stringvalue"
-        },
-        {
-          "title": "UInt32Value",
-          "type": "google/protobuf/uint32value"
-        },
-        {
-          "title": "UInt64Value",
-          "type": "google/protobuf/uint64value"
+          "title": "V1",
+          "type": "google/cloud/datastore/v1",
+          "nav": [
+            {
+              "title": "DatastoreClient",
+              "type": "google/cloud/datastore/v1/datastoreclient"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/datastore/v1"
+            }
+          ]
         }
       ]
     }

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
@@ -14,6 +14,43 @@
 
 module Google
   module Datastore
+    ##
+    # The `Google::Datastore::V1` module provides the following types:
+    #
+    # Class | Description
+    # ----- | -----------
+    # {Google::Datastore::V1::AllocateIdsRequest} | The request for Datastore::AllocateIds.
+    # {Google::Datastore::V1::AllocateIdsResponse} | The response for Datastore::AllocateIds.
+    # {Google::Datastore::V1::BeginTransactionRequest} | The request for Datastore::BeginTransaction.
+    # {Google::Datastore::V1::BeginTransactionResponse} | The response for Datastore::BeginTransaction.
+    # {Google::Datastore::V1::CommitRequest} | The request for Datastore::Commit.
+    # {Google::Datastore::V1::CommitResponse} | The response for Datastore::Commit.
+    # {Google::Datastore::V1::CompositeFilter} | A filter that merges multiple other filters.
+    # {Google::Datastore::V1::Entity} | A Datastore data object.
+    # {Google::Datastore::V1::EntityResult} | The result of fetching an entity from Datastore.
+    # {Google::Datastore::V1::Filter} | A holder for any type of filter.
+    # {Google::Datastore::V1::GqlQuery} | A query in the GQL grammar.
+    # {Google::Datastore::V1::GqlQueryParameter} | A binding parameter for a GQL query.
+    # {Google::Datastore::V1::Key} | A unique identifier for an entity.
+    # {Google::Datastore::V1::KindExpression} | A representation of a kind.
+    # {Google::Datastore::V1::LookupRequest} | The request for Datastore::Lookup.
+    # {Google::Datastore::V1::LookupResponse} | The response for Datastore::Lookup.
+    # {Google::Datastore::V1::Mutation} | A mutation to apply to an entity.
+    # {Google::Datastore::V1::MutationResult} | The result of applying a mutation.
+    # {Google::Datastore::V1::PartitionId} | A partition ID identifies a grouping of entities.
+    # {Google::Datastore::V1::Projection} | A representation of a property in a projection.
+    # {Google::Datastore::V1::PropertyFilter} | A filter on a specific property.
+    # {Google::Datastore::V1::PropertyOrder} | The desired order for a specific property.
+    # {Google::Datastore::V1::PropertyReference} | A property relative to the kind expressions.
+    # {Google::Datastore::V1::Query} | A query for entities.
+    # {Google::Datastore::V1::QueryResultBatch} | A batch of results produced by a query.
+    # {Google::Datastore::V1::ReadOptions} | The options shared by read requests.
+    # {Google::Datastore::V1::RollbackRequest} | The request for Datastore::Rollback.
+    # {Google::Datastore::V1::RollbackResponse} | The response for Datastore::Rollback.
+    # {Google::Datastore::V1::RunQueryRequest} | The request for Datastore::RunQuery.
+    # {Google::Datastore::V1::RunQueryResponse} | The response for Datastore::RunQuery.
+    # {Google::Datastore::V1::Value} | Holds any of the supported value types and associated metadata.
+    #
     module V1
       # The request for Datastore::Lookup.
       # @!attribute [rw] project_id

--- a/google-cloud-logging/docs/toc.json
+++ b/google-cloud-logging/docs/toc.json
@@ -57,36 +57,28 @@
         {
           "title": "Railtie",
           "type": "google/cloud/logging/railtie"
-        }
-      ]
-    },
-    {
-      "title": "Logging::V2",
-      "type": "google/cloud/logging/v2/loggingservicev2client",
-      "nav": [
-        {
-          "title": "ConfigServiceV2Client",
-          "type": "google/cloud/logging/v2/configservicev2client"
         },
         {
-          "title": "LoggingServiceV2Client",
-          "type": "google/cloud/logging/v2/loggingservicev2client"
-        },
-        {
-          "title": "MetricsServiceV2Client",
-          "type": "google/cloud/logging/v2/metricsservicev2client"
-        },
-        {
-          "title": "Any",
-          "type": "google/protobuf/any"
-        },
-        {
-          "title": "Duration",
-          "type": "google/protobuf/duration"
-        },
-        {
-          "title": "Timestamp",
-          "type": "google/protobuf/timestamp"
+          "title": "V2",
+          "type": "google/cloud/logging/v2",
+          "nav": [
+            {
+              "title": "ConfigServiceV2Client",
+              "type": "google/cloud/logging/v2/configservicev2client"
+            },
+            {
+              "title": "LoggingServiceV2Client",
+              "type": "google/cloud/logging/v2/loggingservicev2client"
+            },
+            {
+              "title": "MetricsServiceV2Client",
+              "type": "google/cloud/logging/v2/metricsservicev2client"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/logging/v2"
+            }
+          ]
         }
       ]
     }

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
@@ -14,6 +14,35 @@
 
 module Google
   module Logging
+    ##
+    # The `Google::Logging::V2` module provides the following types:
+    #
+    # Class | Description
+    # ----- | -----------
+    # {Google::Logging::V2::CreateLogMetricRequest} | The parameters to CreateLogMetric.
+    # {Google::Logging::V2::CreateSinkRequest} | The parameters to CreateSink.
+    # {Google::Logging::V2::DeleteLogMetricRequest} | The parameters to DeleteLogMetric.
+    # {Google::Logging::V2::DeleteLogRequest} | The parameters to DeleteLog.
+    # {Google::Logging::V2::DeleteSinkRequest} | The parameters to DeleteSink.
+    # {Google::Logging::V2::GetLogMetricRequest} | The parameters to GetLogMetric.
+    # {Google::Logging::V2::GetSinkRequest} | The parameters to GetSink.
+    # {Google::Logging::V2::ListLogEntriesRequest} | The parameters to ListLogEntries.
+    # {Google::Logging::V2::ListLogEntriesResponse} | Result returned from ListLogEntries.
+    # {Google::Logging::V2::ListLogMetricsRequest} | The parameters to ListLogMetrics.
+    # {Google::Logging::V2::ListLogMetricsResponse} | Result returned from ListLogMetrics.
+    # {Google::Logging::V2::ListMonitoredResourceDescriptorsRequest} | The parameters to ListMonitoredResourceDescriptors
+    # {Google::Logging::V2::ListMonitoredResourceDescriptorsResponse} | Result returned from ListMonitoredResourceDescriptors.
+    # {Google::Logging::V2::ListSinksRequest} | The parameters to ListSinks.
+    # {Google::Logging::V2::ListSinksResponse} | Result returned from ListSinks.
+    # {Google::Logging::V2::LogEntry} | An individual entry in a log.
+    # {Google::Logging::V2::LogEntryOperation} | Additional information about a potentially long-running operation with which a log entry is associated.
+    # {Google::Logging::V2::LogMetric} | Describes a logs-based metric.
+    # {Google::Logging::V2::LogSink} | Describes a sink used to export log entries outside of Stackdriver Logging.
+    # {Google::Logging::V2::UpdateLogMetricRequest} | The parameters to UpdateLogMetric.
+    # {Google::Logging::V2::UpdateSinkRequest} | The parameters to UpdateSink.
+    # {Google::Logging::V2::WriteLogEntriesRequest} | The parameters to WriteLogEntries.
+    # {Google::Logging::V2::WriteLogEntriesResponse} | Result returned from WriteLogEntries.
+    #
     module V2
       # The parameters to DeleteLog.
       # @!attribute [rw] log_name

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -84,52 +84,20 @@
         {
           "title": "Key",
           "type": "google/cloud/datastore/key"
-        }
-      ]
-    },
-    {
-      "title": "Datastore::V1",
-      "type": "google/cloud/datastore/v1/datastoreclient",
-      "nav": [
-        {
-          "title": "DatastoreClient",
-          "type": "google/cloud/datastore/v1/datastoreclient"
         },
         {
-          "title": "BoolValue",
-          "type": "google/protobuf/boolvalue"
-        },
-        {
-          "title": "BytesValue",
-          "type": "google/protobuf/bytesvalue"
-        },
-        {
-          "title": "DoubleValue",
-          "type": "google/protobuf/doublevalue"
-        },
-        {
-          "title": "FloatValue",
-          "type": "google/protobuf/floatvalue"
-        },
-        {
-          "title": "Int32Value",
-          "type": "google/protobuf/int32value"
-        },
-        {
-          "title": "Int64Value",
-          "type": "google/protobuf/int64value"
-        },
-        {
-          "title": "StringValue",
-          "type": "google/protobuf/stringvalue"
-        },
-        {
-          "title": "UInt32Value",
-          "type": "google/protobuf/uint32value"
-        },
-        {
-          "title": "UInt64Value",
-          "type": "google/protobuf/uint64value"
+          "title": "V1",
+          "type": "google/cloud/datastore/v1",
+          "nav": [
+            {
+              "title": "DatastoreClient",
+              "type": "google/cloud/datastore/v1/datastoreclient"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/datastore/v1"
+            }
+          ]
         }
       ]
     },
@@ -200,36 +168,28 @@
         {
           "title": "Railtie",
           "type": "google/cloud/logging/railtie"
-        }
-      ]
-    },
-    {
-      "title": "Logging::V2",
-      "type": "google/cloud/logging/v2/loggingservicev2client",
-      "nav": [
-        {
-          "title": "ConfigServiceV2Client",
-          "type": "google/cloud/logging/v2/configservicev2client"
         },
         {
-          "title": "LoggingServiceV2Client",
-          "type": "google/cloud/logging/v2/loggingservicev2client"
-        },
-        {
-          "title": "MetricsServiceV2Client",
-          "type": "google/cloud/logging/v2/metricsservicev2client"
-        },
-        {
-          "title": "Any",
-          "type": "google/protobuf/any"
-        },
-        {
-          "title": "Duration",
-          "type": "google/protobuf/duration"
-        },
-        {
-          "title": "Timestamp",
-          "type": "google/protobuf/timestamp"
+          "title": "V2",
+          "type": "google/cloud/logging/v2",
+          "nav": [
+            {
+              "title": "ConfigServiceV2Client",
+              "type": "google/cloud/logging/v2/configservicev2client"
+            },
+            {
+              "title": "LoggingServiceV2Client",
+              "type": "google/cloud/logging/v2/loggingservicev2client"
+            },
+            {
+              "title": "MetricsServiceV2Client",
+              "type": "google/cloud/logging/v2/metricsservicev2client"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/logging/v2"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
This PR moves GAPIC items under Datastore and Logging services in the left nav of the gh-pages site. It enables a flag in `manifest.json` to use new focus support provided by GoogleCloudPlatform/gcloud-common#213. It also provides links in the pages shown for "Data Types" as discussed in GoogleCloudPlatform/gcloud-common#207.

[closes #1141]