### PR TITLE
Jsondoc tables

### DIFF
--- a/gcloud-jsondoc.gemspec
+++ b/gcloud-jsondoc.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test)/}) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'yard', "~> 0.8"
+  s.add_dependency 'yard', "~> 0.9"
   s.add_dependency 'kramdown', "~> 1.9"
   s.add_dependency 'jbuilder', "~> 2.3.0"
 

--- a/lib/gcloud/jsondoc/markup_helper.rb
+++ b/lib/gcloud/jsondoc/markup_helper.rb
@@ -9,7 +9,8 @@ module Gcloud
 
       def md s, multi_paragraph = false
         html = Kramdown::Document.new(s.to_s, input: "GFM", hard_wrap: false).to_html.strip
-        html = add_anchor_link_directives(html)
+        html = add_anchor_link_directives html
+        html = add_css html
         html = unwrap_paragraph(html) unless multi_paragraph
         html = resolve_links(html) if html # in YARD's HtmlHelper
         html
@@ -27,6 +28,11 @@ module Gcloud
 
       def unwrap_paragraph html
         html.sub(/\A<p>/, "").sub(/<\/p>\z/, "")
+      end
+
+      def add_css html
+        # Add the `table` class for correct style in Angular app.
+        html.sub("<table>", "<table class=\"table\">")
       end
 
       # API expected by HtmlHelper; overrides BaseHelper#linkify (not included)

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -21,6 +21,21 @@ describe Gcloud::Jsondoc, :jsondoc_spec, :class do
       expected_html = <<EOT
 <p>You can use MyClass for almost anything.</p>
 
+<table class="table">
+  <thead>
+    <tr>
+      <th>Class</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Integer</td>
+      <td>A numeric class.</td>
+    </tr>
+  </tbody>
+</table>
+
 <ul>
   <li><a data-anchor=\"first-subheading\" href=\"#first-subheading\">First subheading</a></li>
   <li><a data-anchor=\"second-subheading\" href=\"#second-subheading\">Second subheading</a></li>
@@ -35,7 +50,7 @@ describe Gcloud::Jsondoc, :jsondoc_spec, :class do
 <p>Second usage description</p>
 EOT
       @doc["description"].must_equal expected_html.sub(/\n\Z/, "") # strip heredoc newline
-      @doc["source"].must_equal "test/fixtures/my_module/my_class.rb#L16"
+      @doc["source"].must_equal "test/fixtures/my_module/my_class.rb#L20"
     end
 
     it "should exclude exclude @private and protected methods" do
@@ -50,7 +65,7 @@ EOT
         method["name"].must_equal "example_instance_method"
         method["type"].must_equal "instance"
         method["description"].must_equal "<p>Accepts many arguments for testing this library. Has no relation to\n<a data-custom-type=\"mymodule/myclass\" data-method=\"other_instance_method-instance\">#other_instance_method</a>. Also accepts a block if a block is given.</p>\n\n<p>Do not call this method until you have read all of its documentation.</p>"
-        method["source"].must_equal "test/fixtures/my_module/my_class.rb#L62"
+        method["source"].must_equal "test/fixtures/my_module/my_class.rb#L66"
       end
 
       it "must have method examples" do

--- a/test/fixtures/my_module/my_class.rb
+++ b/test/fixtures/my_module/my_class.rb
@@ -2,6 +2,10 @@ module MyModule
   ##
   # You can use MyClass for almost anything.
   #
+  # Class | Description
+  # ----- | -----------
+  # Integer | A numeric class.
+  #
   # * [First subheading](#first-subheading)
   # * [Second subheading](#second-subheading)
   #


### PR DESCRIPTION
Add the `table` class to markdown tables for correct style in Angular app.

@swcloud This fixes the table style issue in the "Data Types" page.