### PR TITLE
Adding UNNEST to named paramter @words in bigquery snippet

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -166,7 +166,7 @@ module Google
     #
     # sql = "SELECT word, SUM(word_count) AS word_count " \
     #       "FROM `bigquery-public-data.samples.shakespeare`" \
-    #       "WHERE word IN (@words) GROUP BY word"
+    #       "WHERE word IN UNNEST(@words) GROUP BY word"
     # data = bigquery.query sql, params: { words: ['me', 'I', 'you'] }
     # ```
     #


### PR DESCRIPTION
This purpose of this PR is to fix issue #1185. The BigQuery snippet for using named query parameters didn't work properly without using `UNNEST`. 

Thanks @quartzmo!
