### PR TITLE
Add regex-based matching for left nav, include GAPIC Pub/Sub code

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -5,7 +5,6 @@
   "markdown": "ruby",
   "titleDelimiter": "::",
   "defaultModule": "google-cloud",
-  "matchServiceTitle": true,
   "content": "json",
   "home": "home.html",
   "package": {

--- a/google-cloud-core/docs/toc.json
+++ b/google-cloud-core/docs/toc.json
@@ -32,6 +32,7 @@
     {
       "title": "Core",
       "type": "google/cloud/error",
+      "patterns": ["google\/cloud\/\\w*error$"],
       "nav": [
         {
           "title": "AbortedError",
@@ -52,10 +53,6 @@
         {
           "title": "DeadlineExceededError",
           "type": "google/cloud/deadlineexceedederror"
-        },
-        {
-          "title": "Errors",
-          "type": "google/cloud/error"
         },
         {
           "title": "FailedPreconditionError",
@@ -96,14 +93,6 @@
         {
           "title": "UnknownError",
           "type": "google/cloud/unknownerror"
-        },
-        {
-          "title": "Errors",
-          "type": "google/cloud/error"
-        },
-        {
-          "title": "Errors",
-          "type": "google/cloud/error"
         }
       ]
     }

--- a/google-cloud-datastore/docs/toc.json
+++ b/google-cloud-datastore/docs/toc.json
@@ -32,6 +32,7 @@
     {
       "title": "Datastore",
       "type": "google/cloud/datastore",
+      "patterns": ["\/datastore"],
       "nav": [
         {
           "title": "Dataset",
@@ -52,6 +53,7 @@
         {
           "title": "V1",
           "type": "google/cloud/datastore/v1",
+          "patterns": ["\/datastore\/v1"],
           "nav": [
             {
               "title": "DatastoreClient",

--- a/google-cloud-language/docs/toc.json
+++ b/google-cloud-language/docs/toc.json
@@ -32,20 +32,21 @@
     {
       "title": "Natural Language",
       "type": "google/cloud/language",
-        "nav": [
-          {
-            "title": "Project",
-            "type": "google/cloud/language/project"
-          },
-          {
-            "title": "Document",
-            "type": "google/cloud/language/document"
-          },
-          {
-            "title": "Annotation",
-            "type": "google/cloud/language/annotation"
-          }
-        ]
+      "patterns": ["\/language"],
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/language/project"
+        },
+        {
+          "title": "Document",
+          "type": "google/cloud/language/document"
+        },
+        {
+          "title": "Annotation",
+          "type": "google/cloud/language/annotation"
+        }
+      ]
     }
   ]
 }

--- a/google-cloud-logging/docs/toc.json
+++ b/google-cloud-logging/docs/toc.json
@@ -37,6 +37,7 @@
     {
       "title": "Logging",
       "type": "google/cloud/logging",
+      "patterns": ["\/logging"],
       "nav": [
         {
           "title": "Project",
@@ -61,6 +62,7 @@
         {
           "title": "V2",
           "type": "google/cloud/logging/v2",
+          "patterns": ["\/logging\/v2"],
           "nav": [
             {
               "title": "ConfigServiceV2Client",

--- a/google-cloud-pubsub/.yardopts
+++ b/google-cloud-pubsub/.yardopts
@@ -1,9 +1,6 @@
 --no-private
 --title=Google Cloud Pub/Sub
---exclude lib/google/pubsub
---exclude lib/google/iam
---exclude lib/google/cloud/pubsub/v1
---exclude lib/google/cloud/pubsub/v1.rb
+--exclude lib/google/pubsub/v1
 --markup markdown
 
 ./lib/**/*.rb

--- a/google-cloud-pubsub/docs/toc.json
+++ b/google-cloud-pubsub/docs/toc.json
@@ -32,6 +32,7 @@
     {
       "title": "PubSub",
       "type": "google/cloud/pubsub",
+      "patterns": ["\/pubsub"],
       "nav": [
         {
           "title": "Project",
@@ -44,6 +45,25 @@
         {
           "title": "Subscription",
           "type": "google/cloud/pubsub/subscription"
+        },
+        {
+          "title": "V1",
+          "type": "google/cloud/pubsub/v1",
+          "patterns": ["\/pubsub\/v1"],
+          "nav": [
+            {
+              "title": "PublisherApi",
+              "type": "google/cloud/pubsub/v1/publisherapi"
+            },
+            {
+              "title": "SubscriberApi",
+              "type": "google/cloud/pubsub/v1/subscriberapi"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/pubsub/v1"
+            }
+          ]
         }
       ]
     }

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
@@ -14,6 +14,34 @@
 
 module Google
   module Pubsub
+    ##
+    # The `Google::Pubsub::V1` module provides the following types:
+    #
+    # Class | Description
+    # ----- | -----------
+    # {Google::Pubsub::V1::AcknowledgeRequest} | Request for the Acknowledge method.
+    # {Google::Pubsub::V1::DeleteSubscriptionRequest} | Request for the DeleteSubscription method.
+    # {Google::Pubsub::V1::DeleteTopicRequest} | Request for the DeleteTopic method.
+    # {Google::Pubsub::V1::GetSubscriptionRequest} | Request for the GetSubscription method.
+    # {Google::Pubsub::V1::GetTopicRequest} | Request for the GetTopic method.
+    # {Google::Pubsub::V1::ListSubscriptionsRequest} | Request for the ListSubscriptions method.
+    # {Google::Pubsub::V1::ListSubscriptionsResponse} | Response for the ListSubscriptions method.
+    # {Google::Pubsub::V1::ListTopicsRequest} | Request for the ListTopics method.
+    # {Google::Pubsub::V1::ListTopicsResponse} | Response for the ListTopics method.
+    # {Google::Pubsub::V1::ListTopicSubscriptionsRequest} | Request for the ListTopicSubscriptions method.
+    # {Google::Pubsub::V1::ListTopicSubscriptionsResponse} | Response for the ListTopicSubscriptions method.
+    # {Google::Pubsub::V1::ModifyAckDeadlineRequest} | Request for the ModifyAckDeadline method.
+    # {Google::Pubsub::V1::ModifyPushConfigRequest} | Request for the ModifyPushConfig method.
+    # {Google::Pubsub::V1::PublishRequest} | Request for the Publish method.
+    # {Google::Pubsub::V1::PublishResponse} | Response for the Publish method.
+    # {Google::Pubsub::V1::PubsubMessage} | A message data and its attributes.
+    # {Google::Pubsub::V1::PullRequest} | Request for the Pull method.
+    # {Google::Pubsub::V1::PullResponse} | Response for the Pull method.
+    # {Google::Pubsub::V1::PushConfig} | Configuration for a push delivery endpoint.
+    # {Google::Pubsub::V1::ReceivedMessage} | A message and its corresponding acknowledgment ID.
+    # {Google::Pubsub::V1::Subscription} | A subscription resource.
+    # {Google::Pubsub::V1::Topic} | A topic resource.
+    #
     module V1
       # A topic resource.
       # @!attribute [rw] name

--- a/google-cloud-resource_manager/docs/toc.json
+++ b/google-cloud-resource_manager/docs/toc.json
@@ -32,6 +32,7 @@
     {
       "title": "Resource Manager",
       "type": "google/cloud/resourcemanager",
+      "patterns": ["\/resourcemanager"],
       "nav": [
         {
           "title": "Manager",

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -308,6 +308,7 @@
     {
       "title": "Resource Manager",
       "type": "google/cloud/resourcemanager",
+      "patterns": ["\/resourcemanager"],
       "nav": [
         {
           "title": "Manager",

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -207,6 +207,7 @@
     {
       "title": "Logging",
       "type": "google/cloud/logging",
+      "patterns": ["\/logging"],
       "nav": [
         {
           "title": "Project",
@@ -231,6 +232,7 @@
         {
           "title": "V2",
           "type": "google/cloud/logging/v2",
+          "patterns": ["\/logging\/v2"],
           "nav": [
             {
               "title": "ConfigServiceV2Client",

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -125,6 +125,7 @@
     {
       "title": "Datastore",
       "type": "google/cloud/datastore",
+      "patterns": ["\/datastore"],
       "nav": [
         {
           "title": "Dataset",
@@ -145,6 +146,7 @@
         {
           "title": "V1",
           "type": "google/cloud/datastore/v1",
+          "patterns": ["\/datastore\/v1"],
           "nav": [
             {
               "title": "DatastoreClient",

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -58,6 +58,7 @@
     {
       "title": "Core",
       "type": "google/cloud/error",
+      "patterns": ["google\/cloud\/\\w*error$"],
       "nav": [
         {
           "title": "AbortedError",
@@ -78,10 +79,6 @@
         {
           "title": "DeadlineExceededError",
           "type": "google/cloud/deadlineexceedederror"
-        },
-        {
-          "title": "Errors",
-          "type": "google/cloud/error"
         },
         {
           "title": "FailedPreconditionError",
@@ -122,14 +119,6 @@
         {
           "title": "UnknownError",
           "type": "google/cloud/unknownerror"
-        },
-        {
-          "title": "Errors",
-          "type": "google/cloud/error"
-        },
-        {
-          "title": "Errors",
-          "type": "google/cloud/error"
         }
       ]
     },

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -290,6 +290,7 @@
     {
       "title": "PubSub",
       "type": "google/cloud/pubsub",
+      "patterns": ["\/pubsub"],
       "nav": [
         {
           "title": "Project",
@@ -302,6 +303,25 @@
         {
           "title": "Subscription",
           "type": "google/cloud/pubsub/subscription"
+        },
+        {
+          "title": "V1",
+          "type": "google/cloud/pubsub/v1",
+          "patterns": ["\/pubsub\/v1"],
+          "nav": [
+            {
+              "title": "PublisherApi",
+              "type": "google/cloud/pubsub/v1/publisherapi"
+            },
+            {
+              "title": "SubscriberApi",
+              "type": "google/cloud/pubsub/v1/subscriberapi"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/pubsub/v1"
+            }
+          ]
         }
       ]
     },

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -257,6 +257,7 @@
     {
       "title": "Natural Language",
       "type": "google/cloud/language",
+      "patterns": ["\/language"],
       "nav": [
         {
           "title": "Project",


### PR DESCRIPTION
This PR provides the following gh-pages docs changes:

* Replaces `matchServiceTitle` in `manifest.json` with `patterns` in `toc.json`. This supports multi-word service titles (e.g., 'Natural Language') when the name in the package path is different (e.g., `google/cloud/language`).

* Fixes the broken link to Core in the left nav

* Adds GAPIC Pub/Sub code to the docs.

[fixes #1184, fixes #1142, closes #1074]

NOTICE: DO NOT MERGE. This PR is on hold pending the merge of GoogleCloudPlatform/gcloud-common#217.