### PR TITLE
Update Error Reporting, Monitoring, and Trace docs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -315,6 +315,19 @@ namespace :jsondoc do
           mkdir_p gh_pages + "json/google-cloud/#{version}/google/protobuf", verbose: true
           cp Dir["#{src}/google/protobuf/*.json"], gh_pages + "json/google-cloud/#{version}/google/protobuf/", verbose: true
         end
+
+        # Copy GAPIC directories with names that do not match gem namespace
+        # google-cloud-error_reporting
+        if gem == "google-cloud-error_reporting" && Dir.exists?("#{src}/google/devtools")
+          mkdir_p gh_pages + "json/google-cloud/#{version}/google/devtools", verbose: true
+          if Dir.exists? "#{src}/google/devtools/clouderrorreporting"
+            # Copy the gem's subdir in devtools
+            header_2 "Copying  #{gem_shortname} jsondoc for devtools"
+            cp_r Dir["#{src}/google/devtools/clouderrorreporting"],
+                 gh_pages + "json/google-cloud/#{version}/google/devtools/", verbose: true
+          end
+          # TODO: copy devtools/cloudtrace for google-cloud-trace when adding it to google-cloud
+        end
       end
 
       # Copy the contents of google/cloud/ for the gem. This also gets the core error files.

--- a/google-cloud-error_reporting/.yardopts
+++ b/google-cloud-error_reporting/.yardopts
@@ -1,5 +1,7 @@
 --no-private
 --title=Stackdriver Error Reporting
+--exclude lib/google/devtools/clouderrorreporting/v1beta1
+--markup markdown
 
 ./lib/**/*.rb
 -

--- a/google-cloud-error_reporting/docs/toc.json
+++ b/google-cloud-error_reporting/docs/toc.json
@@ -8,24 +8,44 @@
   ],
   "services": [
     {
-      "title": "ReportErrorsServiceApi",
-      "type": "google/cloud/errorreporting/v1beta1/reporterrorsserviceapi"
-    },
-    {
-      "title": "ErrorStatsServiceApi",
-      "type": "google/cloud/errorreporting/v1beta1/errorstatsserviceapi"
-    },
-    {
-      "title": "ErrorGroupServiceApi",
-      "type": "google/cloud/errorreporting/v1beta1/errorgroupserviceapi"
-    },
-    {
-      "title": "Middleware",
-      "type": "google/cloud/errorreporting/middleware"
-    },
-    {
-      "title": "Railtie",
-      "type": "google/cloud/errorreporting/railtie"
+      "title": "Error Reporting",
+      "type": "google/cloud/errorreporting",
+      "patterns": ["\/errorreporting", "\/clouderrorreporting"],
+      "nav": [
+
+        {
+          "title": "Middleware",
+          "type": "google/cloud/errorreporting/middleware"
+        },
+        {
+          "title": "Railtie",
+          "type": "google/cloud/errorreporting/railtie"
+        },
+        {
+          "title": "V1Beta1",
+          "type": "google/cloud/errorreporting/v1beta1",
+          "patterns": ["\/errorreporting\/v1beta1", "\/clouderrorreporting"],
+          "nav": [
+            {
+              "title": "ReportErrorsServiceApi",
+              "type": "google/cloud/errorreporting/v1beta1/reporterrorsserviceapi"
+            },
+            {
+              "title": "ErrorStatsServiceApi",
+              "type": "google/cloud/errorreporting/v1beta1/errorstatsserviceapi"
+            },
+            {
+              "title": "ErrorGroupServiceApi",
+              "type": "google/cloud/errorreporting/v1beta1/errorgroupserviceapi"
+            },
+            {
+              "title": "Data Types",
+              "patterns": ["\/clouderrorreporting\/v1beta1"],
+              "type": "google/devtools/clouderrorreporting/v1beta1"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
@@ -15,6 +15,34 @@
 module Google
   module Devtools
     module Clouderrorreporting
+      ##
+      # The `Google::Devtools::Clouderrorreporting::V1beta1` module provides the following types:
+      #
+      # Class | Description
+      # ----- | -----------
+      # {Google::Devtools::Clouderrorreporting::V1beta1::DeleteEventsRequest} | Deletes all events in the project.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::DeleteEventsResponse} | Response message for deleting error events.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorContext} | A description of the context in which an error occurred.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorEvent} | An error event which is returned by the Error Reporting system.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroup} | Description of a group of similar error events.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroupOrder} | A sorting order of error groups.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroupStats} | Data extracted for a specific group based on certain filter criteria.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::HttpRequestContext} | HTTP request data that is related to a reported error.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ListEventsRequest} | Specifies a set of error events to return.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ListEventsResponse} | Contains a set of requested error events.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ListGroupStatsRequest} | Specifies a set of {Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroupStats} to return.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ListGroupStatsResponse} | Contains a set of requested error group stats.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::QueryTimeRange} | Requests might be rejected or the resulting timed count durations might be adjusted for lower durations.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ReportedErrorEvent} | An error event which is reported to the Error Reporting system.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ReportErrorEventRequest} | A request for reporting an individual error event.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ReportErrorEventResponse} | Response for reporting an individual error event.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ServiceContext} | Describes a running service that sends errors.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::ServiceContextFilter} | Specifies criteria for filtering a subset of service contexts.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::SourceLocation} | Indicates a location in the source code of the service for which errors are reported.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::TimedCount} | The number of errors in a given time period.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::TimedCountAlignment} | Specifies how the time periods of error group counts are aligned.
+      # {Google::Devtools::Clouderrorreporting::V1beta1::TrackingIssue} | Information related to tracking the progress on resolving the error.
+      #
       module V1beta1
         # Description of a group of similar error events.
         # @!attribute [rw] name

--- a/google-cloud-monitoring/.yardopts
+++ b/google-cloud-monitoring/.yardopts
@@ -1,5 +1,7 @@
 --no-private
 --title=Stackdriver Monitoring
+--exclude lib/google/monitoring/v3
+--markup markdown
 
 ./lib/**/*.rb
 -

--- a/google-cloud-monitoring/docs/toc.json
+++ b/google-cloud-monitoring/docs/toc.json
@@ -2,12 +2,30 @@
   "guides": [],
   "services": [
     {
-      "title": "GroupServiceApi",
-      "type": "google/cloud/monitoring/v3/groupserviceapi"
-    },
-    {
-      "title": "MetricServiceApi",
-      "type": "google/cloud/monitoring/v3/metricserviceapi"
+      "title": "Monitoring",
+      "type": "google/cloud/monitoring",
+      "patterns": ["\/monitoring"],
+      "nav": [
+        {
+          "title": "V3",
+          "type": "google/cloud/monitoring/v3",
+          "patterns": ["\/monitoring\/v3"],
+          "nav": [
+            {
+              "title": "GroupServiceApi",
+              "type": "google/cloud/monitoring/v3/groupserviceapi"
+            },
+            {
+              "title": "MetricServiceApi",
+              "type": "google/cloud/monitoring/v3/metricserviceapi"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/monitoring/v3"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
@@ -14,6 +14,17 @@
 
 module Google
   module Monitoring
+    ##
+    # The `Google::Monitoring::V3` module provides the following types:
+    #
+    # Class | Description
+    # ----- | -----------
+    # {Google::Monitoring::V3::Group} | The description of a dynamic collection of monitored resources.
+    # {Google::Monitoring::V3::Point} | A single data point in a time series.
+    # {Google::Monitoring::V3::TimeInterval} | A time interval extending just after a start time through an end time.
+    # {Google::Monitoring::V3::TimeSeries} | A collection of data points that describes the time-varying values of a metric.
+    # {Google::Monitoring::V3::TypedValue} | A single strongly-typed value.
+    #
     module V3
       # A single strongly-typed value.
       # @!attribute [rw] bool_value

--- a/google-cloud-trace/.yardopts
+++ b/google-cloud-trace/.yardopts
@@ -1,5 +1,6 @@
 --no-private
 --title=Stackdriver Trace
+--exclude lib/google/devtools/cloudtrace/v1
 --markup markdown
 
 ./lib/**/*.rb

--- a/google-cloud-trace/docs/toc.json
+++ b/google-cloud-trace/docs/toc.json
@@ -35,13 +35,14 @@
   ],
   "services": [
     {
-      "title": "Google::Cloud",
-      "type": "google/cloud"
-    },
-    {
-      "title": "Google::Cloud::Trace",
+      "title": "Trace",
       "type": "google/cloud/trace",
+      "patterns": ["\/trace", "\/cloudtrace"],
       "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/trace/project"
+        },
         {
           "title": "LabelKey",
           "type": "google/cloud/trace/labelkey"
@@ -53,10 +54,6 @@
         {
           "title": "Notifications",
           "type": "google/cloud/trace/notifications"
-        },
-        {
-          "title": "Project",
-          "type": "google/cloud/trace/project"
         },
         {
           "title": "Railtie",
@@ -81,12 +78,24 @@
         {
           "title": "TraceRecord",
           "type": "google/cloud/trace/tracerecord"
+        },
+        {
+          "title": "V1",
+          "type": "google/cloud/trace/v1",
+          "patterns": ["\/trace\/v1", "\/cloudtrace"],
+          "nav": [
+            {
+              "title": "TraceServiceApi",
+              "type": "google/cloud/trace/v1/traceserviceapi"
+            },
+            {
+              "title": "Data Types",
+              "patterns": ["\/cloudtrace\/v1"],
+              "type": "google/devtools/cloudtrace/v1"
+            }
+          ]
         }
       ]
-    },
-    {
-      "title": "Low-Level API",
-      "type": "google/cloud/trace/v1/traceserviceapi"
     }
   ]
 }

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
@@ -15,6 +15,18 @@
 module Google
   module Devtools
     module Cloudtrace
+      ##
+      # The `Google::Devtools::Cloudtrace::V1` module provides the following types:
+      #
+      # Class | Description
+      # ----- | -----------
+      # {Google::Devtools::Cloudtrace::V1::GetTraceRequest} | The request message for the GetTrace method.
+      # {Google::Devtools::Cloudtrace::V1::ListTracesRequest} | The request message for the ListTraces method.
+      # {Google::Devtools::Cloudtrace::V1::ListTracesResponse} | The response message for the ListTraces method.
+      # {Google::Devtools::Cloudtrace::V1::PatchTracesRequest} | The request message for the PatchTraces method.
+      # {Google::Devtools::Cloudtrace::V1::Trace} | A trace describes how long it takes for an application to perform an operation.
+      # {Google::Devtools::Cloudtrace::V1::Traces} | List of new or updated traces.
+      # {Google::Devtools::Cloudtrace::V1::TraceSpan} | A span represents a single timed event within a trace.
       module V1
         # A trace describes how long it takes for an application to perform an
         # operation. It consists of a set of spans, each of which represent a single

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -289,15 +289,27 @@
     },
     {
       "title": "Monitoring",
-      "type": "google/cloud/monitoring/v3",
+      "type": "google/cloud/monitoring",
+      "patterns": ["\/monitoring"],
       "nav": [
         {
-          "title": "GroupServiceApi",
-          "type": "google/cloud/monitoring/v3/groupserviceapi"
-        },
-        {
-          "title": "MetricServiceApi",
-          "type": "google/cloud/monitoring/v3/metricserviceapi"
+          "title": "V3",
+          "type": "google/cloud/monitoring/v3",
+          "patterns": ["\/monitoring\/v3"],
+          "nav": [
+            {
+              "title": "GroupServiceApi",
+              "type": "google/cloud/monitoring/v3/groupserviceapi"
+            },
+            {
+              "title": "MetricServiceApi",
+              "type": "google/cloud/monitoring/v3/metricserviceapi"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/monitoring/v3"
+            }
+          ]
         }
       ]
     },

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -180,20 +180,10 @@
     },
     {
       "title": "Error Reporting",
-      "type": "google/cloud/errorreporting/v1beta1",
+      "type": "google/cloud/errorreporting",
+      "patterns": ["\/errorreporting", "\/clouderrorreporting"],
       "nav": [
-        {
-          "title": "ReportErrorsServiceApi",
-          "type": "google/cloud/errorreporting/v1beta1/reporterrorsserviceapi"
-        },
-        {
-          "title": "ErrorStatsServiceApi",
-          "type": "google/cloud/errorreporting/v1beta1/errorstatsserviceapi"
-        },
-        {
-          "title": "ErrorGroupServiceApi",
-          "type": "google/cloud/errorreporting/v1beta1/errorgroupserviceapi"
-        },
+
         {
           "title": "Middleware",
           "type": "google/cloud/errorreporting/middleware"
@@ -201,6 +191,30 @@
         {
           "title": "Railtie",
           "type": "google/cloud/errorreporting/railtie"
+        },
+        {
+          "title": "V1Beta1",
+          "type": "google/cloud/errorreporting/v1beta1",
+          "patterns": ["\/errorreporting\/v1beta1", "\/clouderrorreporting"],
+          "nav": [
+            {
+              "title": "ReportErrorsServiceApi",
+              "type": "google/cloud/errorreporting/v1beta1/reporterrorsserviceapi"
+            },
+            {
+              "title": "ErrorStatsServiceApi",
+              "type": "google/cloud/errorreporting/v1beta1/errorstatsserviceapi"
+            },
+            {
+              "title": "ErrorGroupServiceApi",
+              "type": "google/cloud/errorreporting/v1beta1/errorgroupserviceapi"
+            },
+            {
+              "title": "Data Types",
+              "patterns": ["\/clouderrorreporting\/v1beta1"],
+              "type": "google/devtools/clouderrorreporting/v1beta1"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
This PR:

* Includes GAPIC types in JSON docs
* Updates TOCs with the design for GAPIC types in GoogleCloudPlatform/gcloud-common/issues/207
* Adds hand-authored tables of GAPIC "Data Types" per the design for GAPIC types in GoogleCloudPlatform/gcloud-common/issues/207

/cc @omaray 