### PR TITLE
Try to make trace acceptance tests less flaky by retrying more

### DIFF
--- a/google-cloud-trace/acceptance/trace/trace_test.rb
+++ b/google-cloud-trace/acceptance/trace/trace_test.rb
@@ -44,11 +44,14 @@ describe Google::Cloud::Trace, :trace do
       end
       all_results.to_a.must_equal [trace1, trace2, trace3]
       all_results.results_pending?.must_equal false
-      page1 = tracer.list_traces start_time, end_time,
+      page1 = wait_until do
+        res = tracer.list_traces start_time, end_time,
                                  view: :COMPLETE,
                                  filter: simple_span_name,
                                  order_by: "start",
                                  page_size: 2
+        res.to_a == [trace1, trace2] ? res : nil
+      end
       page1.to_a.must_equal [trace1, trace2]
       page1.results_pending?.must_equal true
       page2 = page1.next_page

--- a/google-cloud-trace/acceptance/trace_helper.rb
+++ b/google-cloud-trace/acceptance/trace_helper.rb
@@ -24,7 +24,7 @@ $tracer = Google::Cloud::Trace.new
 module Acceptance
   class TraceTest < Minitest::Test
     MIN_DELAY = 2
-    MAX_DELAY = 5
+    MAX_DELAY = 8
 
     attr_accessor :tracer
 


### PR DESCRIPTION
This adds about 20 more seconds worth of retries for trace acceptance tests. It also adds a retry on the paged list test. It didn't have it previously, because the previous test (non-paged) already retried, so I was assuming that all the indexes would be in place by the time it was done. However, I've seen cases where the first test succeeds but the second yields the wrong results. (That seems to imply that the index building is also subject to replication, and any particular request won't necessarily succeed even if a different request has already succeeded.) So I'm adding a retry for the second test too, just to try to stabilize it further.