### PR TITLE
Add File#rotate

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -228,6 +228,28 @@ module Google
     #                    encryption_key: key
     # ```
     #
+    # Use {Google::Cloud::Storage::File#rotate} to rotate customer-supplied
+    # encryption keys.
+    #
+    # ```ruby
+    # require "google/cloud/storage"
+    #
+    # storage = Google::Cloud::Storage.new
+    # bucket = storage.bucket "my-todo-app"
+    #
+    # # Old key was stored securely for later use.
+    # old_key = "y\x03\"\x0E\xB6\xD3\x9B\x0E\xAB*\x19\xFAv\xDEY\xBEI..."
+    #
+    # file = bucket.file "path/to/my-file.ext", encryption_key: old_key
+    #
+    # # Key generation shown for example purposes only. Write your own.
+    # cipher = OpenSSL::Cipher.new "aes-256-cfb"
+    # cipher.encrypt
+    # new_key = cipher.random_key
+    #
+    # file.rotate encryption_key: old_key, new_encryption_key: new_key
+    # ```
+    #
     # ## Downloading a File
     #
     # Files can be downloaded to the local file system. (See

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -471,6 +471,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::File#rotate" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, OpenStruct.new(done: true, resource: file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "path/to/my-file.ext", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Storage::File#delete" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket"]


### PR DESCRIPTION
This PR provides a method for rotating customer-supplied encryption keys that is similar to [`rotate_encryption_key`](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/storage/cloud-client/encryption.py#L96) in google-cloud-python.

It does *not* expose the full options list of [`objects.rewrite`](https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite). I feel that should be discussed in a follow-up issue and pull request, since it may make sense to change `File#copy` to use `objects.rewrite` and expose the full power of `objects.rewrite`, including callbacks/controls for multiple requests.  

[closes #730]