### PR TITLE
Extend trace test timeout to 65 seconds

### DIFF
--- a/google-cloud-trace/acceptance/trace_helper.rb
+++ b/google-cloud-trace/acceptance/trace_helper.rb
@@ -24,7 +24,7 @@ $tracer = Google::Cloud::Trace.new
 module Acceptance
   class TraceTest < Minitest::Test
     MIN_DELAY = 2
-    MAX_DELAY = 8
+    MAX_DELAY = 11
 
     attr_accessor :tracer
 


### PR DESCRIPTION
The current trace acceptance tests have timeout at 35 seconds, but the Circle CI builds are still intermittently failing due to timeouts. So we can further bump the timeout to 65 seconds.