### PR TITLE
Datastore.new accepts emulator_host params

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -545,6 +545,8 @@ module Google
       # @param [Integer] timeout Default timeout to use in requests. Optional.
       # @param [Hash] client_config A hash of values to override the default
       #   behavior of the API client. See Google::Gax::CallSettings. Optional.
+      # @param [String] emulator_host Datastore emulator host. Optional.
+      #   If the param is nil, ENV["DATASTORE_EMULATOR_HOST"] will be used.
       #
       # @return [Google::Cloud::Datastore::Dataset]
       #
@@ -566,16 +568,17 @@ module Google
       #   datastore.save task
       #
       def self.new project: nil, keyfile: nil, scope: nil, timeout: nil,
-                   client_config: nil
+                   client_config: nil, emulator_host: nil
         project ||= Google::Cloud::Datastore::Dataset.default_project
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
 
-        if ENV["DATASTORE_EMULATOR_HOST"]
+        emulator_host ||= ENV["DATASTORE_EMULATOR_HOST"]
+        if emulator_host
           return Google::Cloud::Datastore::Dataset.new(
             Google::Cloud::Datastore::Service.new(
               project, :this_channel_is_insecure,
-              host: ENV["DATASTORE_EMULATOR_HOST"],
+              host: emulator_host,
               client_config: client_config))
         end
         credentials = credentials_with_scope keyfile, scope


### PR DESCRIPTION
For the local development or test purpose, I always use [Datastore Emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator).

The pain point to use it is we have to set the environmental variables like below before we start ruby server.

`ENV["DATASTORE_EMULATOR_HOST"]`

If the ruby (especially rails) development, those configuration should be included in the files like `settings.yaml`, etc.
We set project name params in such files but only the `emulator host` should in  environmental variables. 

Sometimes our team members start development without `ENV["DATASTORE_EMULATOR_HOST"]` and they write and read data remotely from the local computer. This is big accident.

So I believe we should accept `emulator_host` params just like `project` params in the `Datastore.new` method.
