### PR TITLE
Add emulator host param to Pub/Sub

### DIFF
--- a/google-cloud-datastore/test/google/cloud/datastore_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore_test.rb
@@ -166,5 +166,40 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "uses DATASTORE_EMULATOR_HOST environment variable" do
+      emulator_host = "localhost:4567"
+      emulator_check = ->(name) { (name == "DATASTORE_EMULATOR_HOST") ? emulator_host : nil }
+      # Clear all environment variables, except DATASTORE_EMULATOR_HOST
+      ENV.stub :[], emulator_check do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
+          Google::Cloud::Datastore::Credentials.stub :default, default_credentials do
+            datastore = Google::Cloud::Datastore.new
+            datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
+            datastore.project.must_equal "project-id"
+            datastore.service.credentials.must_equal :this_channel_is_insecure
+            datastore.service.host.must_equal emulator_host
+          end
+        end
+      end
+    end
+
+    it "allows emulator_host to be set" do
+      emulator_host = "localhost:4567"
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
+          Google::Cloud::Datastore::Credentials.stub :default, default_credentials do
+            datastore = Google::Cloud::Datastore.new emulator_host: emulator_host
+            datastore.must_be_kind_of Google::Cloud::Datastore::Dataset
+            datastore.project.must_equal "project-id"
+            datastore.service.credentials.must_equal :this_channel_is_insecure
+            datastore.service.host.must_equal emulator_host
+          end
+        end
+      end
+    end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -166,5 +166,40 @@ describe Google::Cloud do
         end
       end
     end
+
+    it "uses PUBSUB_EMULATOR_HOST environment variable" do
+      emulator_host = "localhost:4567"
+      emulator_check = ->(name) { (name == "PUBSUB_EMULATOR_HOST") ? emulator_host : nil }
+      # Clear all environment variables, except PUBSUB_EMULATOR_HOST
+      ENV.stub :[], emulator_check do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
+          Google::Cloud::Pubsub::Credentials.stub :default, default_credentials do
+            pubsub = Google::Cloud::Pubsub.new
+            pubsub.must_be_kind_of Google::Cloud::Pubsub::Project
+            pubsub.project.must_equal "project-id"
+            pubsub.service.credentials.must_equal :this_channel_is_insecure
+            pubsub.service.host.must_equal emulator_host
+          end
+        end
+      end
+    end
+
+    it "allows emulator_host to be set" do
+      emulator_host = "localhost:4567"
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Get project_id from Google Compute Engine
+        Google::Cloud::Core::Environment.stub :project_id, "project-id" do
+          Google::Cloud::Pubsub::Credentials.stub :default, default_credentials do
+            pubsub = Google::Cloud::Pubsub.new emulator_host: emulator_host
+            pubsub.must_be_kind_of Google::Cloud::Pubsub::Project
+            pubsub.project.must_equal "project-id"
+            pubsub.service.credentials.must_equal :this_channel_is_insecure
+            pubsub.service.host.must_equal emulator_host
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Add the `emulator_host` param and tests to Pub/Sub. This param was added to Datastore in #1220. Also backfill Datastore `emulator_host` tests.