### PR TITLE
Generate TOC pages in jsondoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,20 @@ require "gcloud/jsondoc"
 registry = YARD::Registry.load! ".yardoc"
 
 toc_config = {
-  types: [
+  documents: [
     {
+      type: "toc",
       title: "Google::Datastore::V1::DataTypes",
-      toc: { package: "Google::Datastore::V1", include: "google/datastore/v1/" }
+      modules: [
+        {
+          title: "Google::Protobuf",
+          include: ["google/protobuf"]
+        },
+        {
+          title: "Google::Datastore::V1",
+          include: ["google/datastore/v1"]
+        }
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ generator = Gcloud::Jsondoc::Generator.new registry
 generator.write_to "jsondoc"
 ```
 
-Note: If the source code lives in a sub-directory of the main repo, as it
+#### Setting a different path to source code
+
+If the source code lives in a sub-directory of the main repo, as it
 currently does for `google-cloud-*` gems, be sure to provide the subdirectory
 name to the `Generator` initializer:
 
@@ -48,6 +50,31 @@ generator.write_to "jsondoc"
 
 Without this configuration, the `source` URLs for the code on GitHub will be
 incorrect. You don't need it if `lib` is in the repo root.
+
+#### Generating a TOC resource (page)
+
+You can generate a resource (page) for the Angular site app with a special
+description containing a TOC table for select classes/modules. The `package`
+property will be used for the headline of the description. The `include`
+property is a regex matched to jsondoc filepaths:
+
+```ruby
+require "gcloud/jsondoc"
+
+registry = YARD::Registry.load! ".yardoc"
+
+toc_config = {
+  types: [
+    {
+      title: "Google::Datastore::V1::DataTypes",
+      toc: { package: "Google::Datastore::V1", include: "google/datastore/v1/" }
+    }
+  ]
+}
+
+generator = Gcloud::Jsondoc::Generator.new registry, nil, generate: toc_config
+generator.write_to "jsondoc"
+```
 
 ### To test documentation examples
 

--- a/gcloud-jsondoc.gemspec
+++ b/gcloud-jsondoc.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-autotest", "~> 1.0"
+  s.add_development_dependency "minitest-focus", "~> 1.1"
   s.add_development_dependency "activesupport", "~> 4.0"
 end

--- a/lib/gcloud/jsondoc/generated_toc_doc.rb
+++ b/lib/gcloud/jsondoc/generated_toc_doc.rb
@@ -13,7 +13,7 @@ module Gcloud
                   :methods, :subtree, :descendants, :types, :types_subtree,
                   :source_path
 
-      def initialize title, package, included
+      def initialize title, modules
         @name = title.split("::").last
         @title = title
         @full_name = @title.gsub("::", "/").downcase
@@ -24,8 +24,7 @@ module Gcloud
         @types = [self]
         @types_subtree = @types
         @source_path = ""
-        @package = package
-        @included = included
+        @modules = modules
         build!
       end
 
@@ -46,7 +45,8 @@ module Gcloud
 
       def description_template
 <<EOT
-<p>The <code><%= @package %></code> module provides the following types:</p>
+<% @modules.each do |m| -%>
+<h4><%= m.title %></h4>
 
 <table class="table">
   <thead>
@@ -56,15 +56,15 @@ module Gcloud
     </tr>
   </thead>
   <tbody>
-<% @included.each_pair do |k,v| %>
+<% m.types.each do |t| %>
     <tr>
-      <td><a data-custom-type="<%= v["id"] %>"><%= k %></a></td>
-      <td><%= md(v["description"].split("\n")[0].split(". ")[0]) %></td>
+      <td><a data-custom-type="<%= t.id %>"><%= t.name %></a></td>
+      <td><%= unwrap_paragraph t.description %></td>
     </tr>
-<% end -%>
-
+<% end %>
   </tbody>
 </table>
+<% end %>
 EOT
       end
     end

--- a/lib/gcloud/jsondoc/generated_toc_doc.rb
+++ b/lib/gcloud/jsondoc/generated_toc_doc.rb
@@ -1,0 +1,72 @@
+require "gcloud/jsondoc/markup_helper"
+require "gcloud/jsondoc/json_helper"
+require "gcloud/jsondoc/method"
+require "erb"
+
+module Gcloud
+  module Jsondoc
+    class GeneratedTocDoc < Doc
+      include Gcloud::Jsondoc::MarkupHelper, JsonHelper
+
+      # object is API defined by YARD's HtmlHelper
+      attr_reader :name, :title, :full_name, :filepath, :jbuilder, :object,
+                  :methods, :subtree, :descendants, :types, :types_subtree,
+                  :source_path
+
+      def initialize title, package, included
+        @name = title.split("::").last
+        @title = title
+        @full_name = @title.gsub("::", "/").downcase
+        @filepath = "#{@full_name}.json"
+        @source_path = source_path
+        @subtree = [self]
+        @descendants = []
+        @types = [self]
+        @types_subtree = @types
+        @source_path = ""
+        @package = package
+        @included = included
+        build!
+      end
+
+      def build!
+        @jbuilder = Jbuilder.new do |json|
+          json.id @full_name
+          json.name @name
+          json.title @title.split "::"
+          json.description ERB.new(description_template, nil, '-').result(binding)
+          json.source ""
+          json.resources []
+          json.examples []
+          json.methods []
+        end
+      end
+
+      protected
+
+      def description_template
+<<EOT
+<p>The <code><%= @package %></code> module provides the following types:</p>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Class</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+<% @included.each_pair do |k,v| %>
+    <tr>
+      <td><a data-custom-type="<%= v["id"] %>"><%= k %></a></td>
+      <td><%= md(v["description"].split("\n")[0].split(". ")[0]) %></td>
+    </tr>
+<% end -%>
+
+  </tbody>
+</table>
+EOT
+      end
+    end
+  end
+end

--- a/lib/gcloud/jsondoc/generator.rb
+++ b/lib/gcloud/jsondoc/generator.rb
@@ -1,5 +1,7 @@
+require "json"
 require "jbuilder"
 require "gcloud/jsondoc/doc"
+require "gcloud/jsondoc/generated_toc_doc"
 
 module Gcloud
   module Jsondoc
@@ -11,10 +13,16 @@ module Gcloud
       #
       # @param [YARD::Registry] registry The YARD registry instance containing
       #   the source code objects
-      def initialize registry, source_path = nil
+      # @param [String, nil] source_path The filesystem path to be used for
+      #   source links, instead of the relative execution path. Optional
+      # @param [Hash, nil] generate A hash configuration for types that need to
+      #   be generated, such as TOCs. Optional
+      def initialize registry, source_path = nil, generate: generate
         @registry = registry
         @docs = []
+        @types = []
         @source_path = source_path
+        @generate = generate
       end
 
       def write_to base_path
@@ -35,7 +43,6 @@ module Gcloud
           end
         end
         types_path = Pathname.new(base_path).join "types.json"
-        puts types_path.to_path
         File.write types_path, types_builder.target!
       end
 
@@ -46,15 +53,36 @@ module Gcloud
         modules.each do |object|
           @docs += Doc.new(object, @source_path).subtree
         end
+        set_types
+        generate_docs if @generate
         @registry.clear
       end
+
+      protected
 
       ##
       # Returns a flat list from @docs that can be used to produce `types.json`.
       def set_types
-        @types = []
         docs.each do |doc|
           @types += doc.types_subtree
+        end
+      end
+
+      def generate_docs
+        @generate[:types].each do |gtype|
+          if gtype[:toc]
+            included = @types.each_with_object({}) do |type, memo|
+              if Regexp.new(gtype[:toc][:include]).match(type.filepath) &&
+                !type.object.docstring.empty?
+                memo[type.title] = type.jbuilder.attributes!
+              end
+            end
+            generated_doc = GeneratedTocDoc.new gtype[:title], gtype[:toc][:package], included
+            @docs << generated_doc
+            @types << generated_doc
+          else
+            fail "Property :toc not found. Only TOC-type docs are supported."
+          end
         end
       end
     end

--- a/lib/gcloud/jsondoc/version.rb
+++ b/lib/gcloud/jsondoc/version.rb
@@ -1,5 +1,5 @@
 module Gcloud
   module Jsondoc
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/test/fixtures/included_module/included_classes.rb
+++ b/test/fixtures/included_module/included_classes.rb
@@ -1,0 +1,15 @@
+module IncludedModule
+  ##
+  # When mode is +TRANSACTIONAL+, mutations affecting a single entity are
+  # applied in order. The following sequences of mutations affecting a single
+  # entity are not permitted in a single +Commit+ request.
+  class ClassA
+  end
+
+  ##
+  # Entities not found as +ResultType.KEY_ONLY+ entities. The order of results
+  # in this field is undefined and has no relation to the order of the keys
+  # in the input.
+  class ClassB
+  end
+end

--- a/test/fixtures/included_module/nested/class_a.rb
+++ b/test/fixtures/included_module/nested/class_a.rb
@@ -1,0 +1,8 @@
+module IncludedModule
+  module Nested
+    ##
+    # The response for Datastore::RunQuery.
+    class ClassA
+    end
+  end
+end

--- a/test/fixtures/included_module_2/included_classes.rb
+++ b/test/fixtures/included_module_2/included_classes.rb
@@ -1,0 +1,15 @@
+module IncludedModule2
+  ##
+  # When mode is +TRANSACTIONAL+, mutations affecting a single entity are
+  # applied in order. The following sequences of mutations affecting a single
+  # entity are not permitted in a single +Commit+ request.
+  class ClassA
+  end
+
+  ##
+  # Entities not found as +ResultType.KEY_ONLY+ entities. The order of results
+  # in this field is undefined and has no relation to the order of the keys
+  # in the input.
+  class ClassB
+  end
+end

--- a/test/fixtures/included_module_2/nested/class_a.rb
+++ b/test/fixtures/included_module_2/nested/class_a.rb
@@ -1,0 +1,8 @@
+module IncludedModule2
+  module Nested
+    ##
+    # The response for Datastore::RunQuery.
+    class ClassA
+    end
+  end
+end

--- a/test/generated_toc_doc_test.rb
+++ b/test/generated_toc_doc_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+describe Gcloud::Jsondoc, :generated_toc_doc do
+  let(:registry) { YARD::Registry.load(["test/fixtures/**/*.rb"], true) }
+  let(:generate) do
+    { types: [{title: "Google::Datastore::V1::DataTypes", toc: {package: "Google::Datastore::V1", include: "includedmodule/"}}] }
+  end
+  let(:generator) do
+    generator = Gcloud::Jsondoc::Generator.new registry, nil, generate: generate
+    generator.build!
+    generator
+  end
+  let(:docs) { generator.docs }
+
+  it "must generate a TOC doc as directed in the generate option" do
+    toc = docs.last
+    toc.must_be_kind_of Gcloud::Jsondoc::GeneratedTocDoc
+    toc.filepath.must_equal "google/datastore/v1/datatypes.json"
+    toc_json = toc.jbuilder.attributes!
+    toc_json["id"].must_equal "google/datastore/v1/datatypes"
+    toc_json["name"].must_equal "DataTypes"
+    toc_json["title"].must_equal ["Google","Datastore","V1","DataTypes"]
+    toc_json["source"].must_equal ""
+    toc_json["resources"].must_equal []
+    toc_json["examples"].must_equal []
+    toc_json["methods"].must_equal []
+    expected_html = <<EOT
+<p>The <code>Google::Datastore::V1</code> module provides the following types:</p>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Class</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+    <tr>
+      <td><a data-custom-type=\"includedmodule/classa\">IncludedModule::ClassA</a></td>
+      <td><p>When mode is +TRANSACTIONAL+, mutations affecting a single entity are
+applied in order.</td>
+    </tr>
+
+    <tr>
+      <td><a data-custom-type=\"includedmodule/classb\">IncludedModule::ClassB</a></td>
+      <td><p>Entities not found as +ResultType.KEY_ONLY+ entities.</td>
+    </tr>
+
+    <tr>
+      <td><a data-custom-type=\"includedmodule/nested/classa\">IncludedModule::Nested::ClassA</a></td>
+      <td><p>The response for Datastore::RunQuery.</p>.</td>
+    </tr>
+
+  </tbody>
+</table>
+EOT
+    toc_json["description"].must_equal expected_html
+  end
+end

--- a/test/generated_toc_doc_test.rb
+++ b/test/generated_toc_doc_test.rb
@@ -3,7 +3,25 @@ require 'test_helper'
 describe Gcloud::Jsondoc, :generated_toc_doc do
   let(:registry) { YARD::Registry.load(["test/fixtures/**/*.rb"], true) }
   let(:generate) do
-    { types: [{title: "Google::Datastore::V1::DataTypes", toc: {package: "Google::Datastore::V1", include: "includedmodule/"}}] }
+    {
+      documents: [
+        {
+          type: "toc",
+          title: "Google::Datastore::V1::DataTypes",
+          modules: [
+            {
+              title: "IncludedModule",
+              include: ["includedmodule/"]
+            },
+            {
+              title: "IncludedModule2",
+              include: ["includedmodule2/"],
+              exclude: ["includedmodule2/nested"]
+            }
+          ]
+        }
+      ]
+    }
   end
   let(:generator) do
     generator = Gcloud::Jsondoc::Generator.new registry, nil, generate: generate
@@ -25,7 +43,7 @@ describe Gcloud::Jsondoc, :generated_toc_doc do
     toc_json["examples"].must_equal []
     toc_json["methods"].must_equal []
     expected_html = <<EOT
-<p>The <code>Google::Datastore::V1</code> module provides the following types:</p>
+<h4>IncludedModule</h4>
 
 <table class="table">
   <thead>
@@ -38,22 +56,49 @@ describe Gcloud::Jsondoc, :generated_toc_doc do
 
     <tr>
       <td><a data-custom-type=\"includedmodule/classa\">IncludedModule::ClassA</a></td>
-      <td><p>When mode is +TRANSACTIONAL+, mutations affecting a single entity are
-applied in order.</td>
+      <td>When mode is +TRANSACTIONAL+, mutations affecting a single entity are
+applied in order. The following sequences of mutations affecting a single
+entity are not permitted in a single +Commit+ request.</td>
     </tr>
 
     <tr>
       <td><a data-custom-type=\"includedmodule/classb\">IncludedModule::ClassB</a></td>
-      <td><p>Entities not found as +ResultType.KEY_ONLY+ entities.</td>
+      <td>Entities not found as +ResultType.KEY_ONLY+ entities.</td>
     </tr>
 
     <tr>
       <td><a data-custom-type=\"includedmodule/nested/classa\">IncludedModule::Nested::ClassA</a></td>
-      <td><p>The response for Datastore::RunQuery.</p>.</td>
+      <td>The response for Datastore::RunQuery.</td>
     </tr>
 
   </tbody>
 </table>
+<h4>IncludedModule2</h4>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Class</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+
+    <tr>
+      <td><a data-custom-type=\"includedmodule2/classa\">IncludedModule2::ClassA</a></td>
+      <td>When mode is +TRANSACTIONAL+, mutations affecting a single entity are
+applied in order. The following sequences of mutations affecting a single
+entity are not permitted in a single +Commit+ request.</td>
+    </tr>
+
+    <tr>
+      <td><a data-custom-type=\"includedmodule2/classb\">IncludedModule2::ClassB</a></td>
+      <td>Entities not found as +ResultType.KEY_ONLY+ entities.</td>
+    </tr>
+
+  </tbody>
+</table>
+
 EOT
     toc_json["description"].must_equal expected_html
   end

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -5,10 +5,21 @@ describe Gcloud::Jsondoc, :generator do
   let(:source_path) { "my-module-subdir" }
   let(:generate) do
     {
-      types: [
+      documents: [
         {
+          type: "toc",
           title: "Google::Datastore::V1::DataTypes",
-          toc: { package: "Google::Datastore::V1", include: "includedmodule/" }
+          modules: [
+            {
+              title: "IncludedModule",
+              include: ["includedmodule/"]
+            },
+            {
+              title: "IncludedModule2",
+              include: ["includedmodule2/"],
+              exclude: ["includedmodule2/nested"]
+            }
+          ]
         }
       ]
     }
@@ -29,7 +40,7 @@ describe Gcloud::Jsondoc, :generator do
 
   it "must have all docs" do
     docs.must_be_kind_of Array
-    docs.size.must_equal 11
+    docs.size.must_equal 16
     docs[0].full_name.must_equal "mymodule"
     docs[0].name.must_equal "MyModule"
     docs[0].filepath.must_equal "mymodule.json"
@@ -37,7 +48,7 @@ describe Gcloud::Jsondoc, :generator do
 
   it "must have all types" do
     types.must_be_kind_of Array
-    types.size.must_equal 28
+    types.size.must_equal 36
     types[0].full_name.must_equal "mymodule"
     types[0].name.must_equal "MyModule"
     types[0].filepath.must_equal "mymodule.json"

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -3,10 +3,19 @@ require 'test_helper'
 describe Gcloud::Jsondoc, :generator do
   let(:registry) { YARD::Registry.load(["test/fixtures/**/*.rb"], true) }
   let(:source_path) { "my-module-subdir" }
+  let(:generate) do
+    {
+      types: [
+        {
+          title: "Google::Datastore::V1::DataTypes",
+          toc: { package: "Google::Datastore::V1", include: "includedmodule/" }
+        }
+      ]
+    }
+  end
   let(:generator) do
-    generator = Gcloud::Jsondoc::Generator.new registry
+    generator = Gcloud::Jsondoc::Generator.new registry, nil, generate: generate
     generator.build!
-    generator.set_types
     generator
   end
   let(:docs) { generator.docs }
@@ -20,7 +29,7 @@ describe Gcloud::Jsondoc, :generator do
 
   it "must have all docs" do
     docs.must_be_kind_of Array
-    docs.size.must_equal 5
+    docs.size.must_equal 11
     docs[0].full_name.must_equal "mymodule"
     docs[0].name.must_equal "MyModule"
     docs[0].filepath.must_equal "mymodule.json"
@@ -28,7 +37,7 @@ describe Gcloud::Jsondoc, :generator do
 
   it "must have all types" do
     types.must_be_kind_of Array
-    types.size.must_equal 19
+    types.size.must_equal 28
     types[0].full_name.must_equal "mymodule"
     types[0].name.must_equal "MyModule"
     types[0].filepath.must_equal "mymodule.json"
@@ -40,5 +49,19 @@ describe Gcloud::Jsondoc, :generator do
       doc_json["id"].must_equal "mymodule"
       doc_json["source"].must_equal "my-module-subdir/test/fixtures/my_module.rb#L15"
     end
+  end
+
+  it "must generate a TOC doc as directed in the generate option" do
+    toc = docs.last
+    toc.filepath.must_equal "google/datastore/v1/datatypes.json"
+    toc_json = toc.jbuilder.attributes!
+    toc_json["id"].must_equal "google/datastore/v1/datatypes"
+    toc_json["name"].must_equal "DataTypes"
+    toc_json["title"].must_equal ["Google","Datastore","V1","DataTypes"]
+  end
+
+  it "must generate a TOC type as directed in the generate option" do
+    toc = types.last
+    toc.filepath.must_equal "google/datastore/v1/datatypes.json"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'gcloud/jsondoc'
 
-require 'minitest/autorun'
+gem "minitest"
+require "minitest/autorun"
+require "minitest/focus"


### PR DESCRIPTION
See update to README, below, for description of this feature.

[refs #1180]

Updated screenshot of generated TOC for Datastore. Note that although multiple tables with different titles *can* be used (as below), all of the listed types could also be shown in a single table.

![datatypes-2](https://cloud.githubusercontent.com/assets/205445/22841889/8646ea1c-ef90-11e6-876d-3556155f23eb.png)

