### PR TITLE
Support for Per-Object Storage Class

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -247,6 +247,18 @@ describe Google::Cloud::Storage::File, :storage do
     uploaded.metadata["title"].must_equal meta[:metadata][:title]
   end
 
+  it "should create and update storage_class" do
+    uploaded = bucket.create_file files[:logo][:path], "CloudLogo-storage_class.png", storage_class: :nearline
+
+    uploaded.storage_class.must_equal "NEARLINE"
+    uploaded.storage_class = :dra
+    uploaded.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+
+    retrieved1 = bucket.file "CloudLogo-storage_class.png"
+
+    retrieved1.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+  end
+
   it "should copy an existing file" do
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo"
     copied = try_with_backoff "copying existing file" do

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -231,7 +231,7 @@ module Google
         #   Values include `:multi_regional`, `:regional`, `:nearline`,
         #   `:coldline`, `:standard`, and `:dra` (Durable Reduced
         #   Availability), as well as the strings returned by
-        #   Bucket#storage_class. For more information, see [Storage
+        #   {Bucket#storage_class}. For more information, see [Storage
         #   Classes](https://cloud.google.com/storage/docs/storage-classes). The
         #   default value is `:standard`, which is equivalent to
         #   `:multi_regional` or `:regional` depending on the bucket's location
@@ -306,6 +306,7 @@ module Google
         end
 
         def storage_class_for str
+          return nil if str.nil?
           { "durable_reduced_availability" => "DURABLE_REDUCED_AVAILABILITY",
             "dra" => "DURABLE_REDUCED_AVAILABILITY",
             "durable" => "DURABLE_REDUCED_AVAILABILITY",
@@ -313,7 +314,7 @@ module Google
             "coldline" => "COLDLINE",
             "multi_regional" => "MULTI_REGIONAL",
             "regional" => "REGIONAL",
-            "standard" => "STANDARD" }[str.to_s.downcase]
+            "standard" => "STANDARD" }[str.to_s.downcase] || str.to_s
         end
       end
     end

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -171,12 +171,13 @@ module Google
                         cache_control: nil, content_disposition: nil,
                         content_encoding: nil, content_language: nil,
                         content_type: nil, crc32c: nil, md5: nil, metadata: nil,
-                        key: nil
+                        storage_class: nil, key: nil
           file_obj = Google::Apis::StorageV1::Object.new \
             cache_control: cache_control, content_type: content_type,
             content_disposition: content_disposition, md5_hash: md5,
             content_encoding: content_encoding, crc32c: crc32c,
-            content_language: content_language, metadata: metadata
+            content_language: content_language, metadata: metadata,
+            storage_class: storage_class
           content_type ||= mime_type_for(Pathname(source).to_path)
           execute do
             service.insert_object \
@@ -228,6 +229,17 @@ module Google
               source_generation: options[:generation],
               rewrite_token: options[:token],
               options: options
+          end
+        end
+
+        ## Rewrite a file from source bucket/object to a
+        # destination bucket/object.
+        def update_file_storage_class bucket_name, file_path, storage_class
+          execute do
+            service.rewrite_object \
+              bucket_name, file_path,
+              bucket_name, file_path,
+              Google::Apis::StorageV1::Object.new(storage_class: storage_class)
           end
         end
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -231,7 +231,8 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
         content_disposition: "attachment; filename=filename.ext",
         content_encoding: "gzip",
         content_language: "en",
-        content_type: "image/png"
+        content_type: "image/png",
+        storage_class: "NEARLINE"
       }
 
       mock = Minitest::Mock.new
@@ -727,12 +728,14 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
   def empty_file_gapi cache_control: nil, content_disposition: nil,
                       content_encoding: nil, content_language: nil,
-                      content_type: nil, crc32c: nil, md5: nil, metadata: nil
+                      content_type: nil, crc32c: nil, md5: nil, metadata: nil,
+                      storage_class: nil
     Google::Apis::StorageV1::Object.new(
       cache_control: cache_control, content_type: content_type,
       content_disposition: content_disposition, md5_hash: md5,
       content_encoding: content_encoding, crc32c: crc32c,
-      content_language: content_language, metadata: metadata)
+      content_language: content_language, metadata: metadata,
+      storage_class: storage_class)
   end
 
   def find_file_gapi bucket=nil, name = nil


### PR DESCRIPTION
Support Per-Object Storage Class (POSC) on File creation, and File update.

Files are created with a custom POSC using the `storage_class` method argument:

```ruby
require "google/cloud/storage"

storage = Google::Cloud::Storage.new
bucket = storage.bucket "my-todo-app"

bucket.storage_class #=> "STANDARD"

bucket.create_file "/var/todo-app/avatars/heidi/400x400.png",
                   "avatars/heidi/400x400.png",
                   storage_class: :regional
```

Existing files can modify their POSC using the `storage_class=` method:

```ruby
require "google/cloud/storage"

storage = Google::Cloud::Storage.new
bucket = storage.bucket "my-todo-app"

file = bucket.file "avatars/heidi/400x400.png"

file.storage_class #=> "REGIONAL"

# Update POSC
file.storage_class = "NEARLINE"
```

/cc @jskeet @omaray @danoscarmike 