### PR TITLE
Fix bug: The default retry for Datastore does not work at all

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client_config.json
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client_config.json
@@ -2,13 +2,11 @@
   "interfaces": {
     "google.datastore.v1.Datastore": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {


### PR DESCRIPTION
We have started to use Datastore for our project which has about 100 req/s and 700 million entries.
Soon we noticed a high error rate over 0.3% for fetching data.

This was the error trace:

```
Google::Cloud::UnavailableError
14:{"created":"@1486867211.150038818",
"description":"Secure read failed",
"file":"src/core/lib/security/transport/secure_endpoint.c",
"file_line":157,
"grpc_status":14,
"referenced_errors":[{"created":"@1486867211.149993825","description":"EOF","file":"src/core/lib/iomgr/tcp_posix.c","file_line":235}]}
```

```
Google::Gax::RetryError
GaxError Exception occurred in retry method that was not classified as transient, caused by 14:
{"created":"@1486867211.150038818",
"description":"Secure read failed",
"file":"src/core/lib/security/transport/secure_endpoint.c",
"file_line":157,
"grpc_status":14,
"referenced_errors":[{"created":"@1486867211.149993825","description":"EOF","file":"src/core/lib/iomgr/tcp_posix.c","file_line":235}]}
```

I found it curious what `retry method that was not classified as transient` means because `UnavailableError` should be retried.
Reading the code, I found a misconfiguration of the default `client_config`.

[Here](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb#L109) you pass the [default json configuration](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client_config.json) to Google::Gax.

But in the code of Google::Gax, [here](https://github.com/googleapis/gax-ruby/blob/master/lib/google/gax/settings.rb#L490),  the `retry_codes_def` is not used.

In the [comment of Google::Gax](https://github.com/googleapis/gax-ruby/blob/master/lib/google/gax/settings.rb#L403), we can see the differently structured JSON file from that of this repository (There is no `retry_codes_def` !!).

But in the [other comment of Google::Gax](https://github.com/googleapis/gax-ruby/blob/master/lib/google/gax/settings.rb#L334) still has word `+retry_codes_def+` .

I have no idea which library or comment is correct, but I’ve patched to google-cloud-datastore gem(this repository) and now confirmed that retry is working well. Our server’s error rates went down to 0.0%

I use
google-cloud-datastore 0.23
and 
google-gax 0.6.0

Maybe am I using wrong version's combination?

If this pull request is correct, I think we have to rewrite all default client_config.json for other services too.

related to this issue maybe? https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/723#issuecomment-257442519
