### PR TITLE
Jsondoc TOC fixes

### DIFF
--- a/lib/gcloud/jsondoc/generator.rb
+++ b/lib/gcloud/jsondoc/generator.rb
@@ -107,9 +107,8 @@ module Gcloud
       end
 
       def short_description description
-        first_sentence_regex = /\A(.+?)(\. |\z)/
-        result = description.match(first_sentence_regex)
-        description = result[0].rstrip if result
+        result = description.split(/\.(?=[\W])/)
+        description = result[0] + "." if result.size > 1
         description
       end
     end

--- a/lib/gcloud/jsondoc/generator.rb
+++ b/lib/gcloud/jsondoc/generator.rb
@@ -17,7 +17,7 @@ module Gcloud
       #   source links, instead of the relative execution path. Optional
       # @param [Hash, nil] generate A hash configuration for types that need to
       #   be generated, such as TOCs. Optional
-      def initialize registry, source_path = nil, generate: generate
+      def initialize registry, source_path = nil, generate: nil
         @registry = registry
         @docs = []
         @types = []

--- a/lib/gcloud/jsondoc/generator.rb
+++ b/lib/gcloud/jsondoc/generator.rb
@@ -69,27 +69,27 @@ module Gcloud
       end
 
       def generate_docs
-        @generate[:documents].each do |doc|
-          unless doc[:type] == "toc"
+        @generate[:documents].each do |g_config|
+          unless g_config[:type] == "toc"
             fail "documents type 'toc' not found. Only TOC-type docs are currently supported."
           end
 
-          modules = doc[:modules].map do |m|
+          modules = g_config[:modules].map do |m|
             # There appears to be an issue with duplicates, so create a hash to
             # ensure only one type for each id is returned.
-            matched_types = @types.each_with_object({}) do |type, memo|
-              if matching_type? type, m[:include], m[:exclude]
-                json = type.jbuilder.attributes!
+            matched_types = @docs.each_with_object({}) do |doc, memo|
+              if matching_type? doc, m[:include], m[:exclude]
+                json = doc.jbuilder.attributes!
                 memo[json["id"]] = OpenStruct.new(
                   id: json["id"],
-                  name: type.title,
+                  name: doc.title,
                   description: short_description(json["description"])
                 )
               end
             end
             OpenStruct.new title: m[:title], types: matched_types.values
           end
-          generated_doc = GeneratedTocDoc.new doc[:title], modules
+          generated_doc = GeneratedTocDoc.new g_config[:title], modules
           @docs << generated_doc
           @types << generated_doc
         end

--- a/test/fixtures/included_module/included_classes.rb
+++ b/test/fixtures/included_module/included_classes.rb
@@ -17,10 +17,91 @@ module IncludedModule
     end
   end
 
-  ##
-  # Entities not found as +ResultType.KEY_ONLY+ entities. The order of results
-  # in this field is undefined and has no relation to the order of the keys
-  # in the input.
-  class ClassB
+  # +Any+ contains an arbitrary serialized protocol buffer message along with a
+  # URL that describes the type of the serialized message.
+  #
+  # Protobuf library provides support to pack/unpack Any values in the form
+  # of utility functions or additional generated methods of the Any type.
+  #
+  # Example 1: Pack and unpack a message in C++.
+  #
+  #     Foo foo = ...;
+  #     Any any;
+  #     any.PackFrom(foo);
+  #     ...
+  #     if (any.UnpackTo(&foo)) {
+  #       ...
+  #     }
+  #
+  # Example 2: Pack and unpack a message in Java.
+  #
+  #     Foo foo = ...;
+  #     Any any = Any.pack(foo);
+  #     ...
+  #     if (any.is(Foo.class)) {
+  #       foo = any.unpack(Foo.class);
+  #     }
+  #
+  # The pack methods provided by protobuf library will by default use
+  # 'type.googleapis.com/full.type.name' as the type URL and the unpack
+  # methods only use the fully qualified type name after the last '/'
+  # in the type URL, for example "foo.bar.com/x/y.z" will yield type
+  # name "y.z".
+  #
+  #
+  # = JSON
+  #
+  # The JSON representation of an +Any+ value uses the regular
+  # representation of the deserialized, embedded message, with an
+  # additional field +@type+ which contains the type URL. Example:
+  #
+  #     package google.profile;
+  #     message Person {
+  #       string first_name = 1;
+  #       string last_name = 2;
+  #     }
+  #
+  #     {
+  #       "@type": "type.googleapis.com/google.profile.Person",
+  #       "firstName": <string>,
+  #       "lastName": <string>
+  #     }
+  #
+  # If the embedded message type is well-known and has a custom JSON
+  # representation, that representation will be embedded adding a field
+  # +value+ which holds the custom JSON in addition to the +@type+
+  # field. Example (for message Google::Protobuf::Duration):
+  #
+  #     {
+  #       "@type": "type.googleapis.com/google.protobuf.Duration",
+  #       "value": "1.212s"
+  #     }
+  # @!attribute [rw] type_url
+  #   @return [String]
+  #     A URL/resource name whose content describes the type of the
+  #     serialized protocol buffer message.
+  #
+  #     For URLs which use the schema +http+, +https+, or no schema, the
+  #     following restrictions and interpretations apply:
+  #
+  #     * If no schema is provided, +https+ is assumed.
+  #     * The last segment of the URL's path must represent the fully
+  #       qualified name of the type (as in +path/google.protobuf.Duration+).
+  #       The name should be in a canonical form (e.g., leading "." is
+  #       not accepted).
+  #     * An HTTP GET on the URL must yield a Google::Protobuf::Type
+  #       value in binary format, or produce an error.
+  #     * Applications are allowed to cache lookup results based on the
+  #       URL, or have them precompiled into a binary to avoid any
+  #       lookup. Therefore, binary compatibility needs to be preserved
+  #       on changes to types. (Use versioned type names to manage
+  #       breaking changes.)
+  #
+  #     Schemas other than +http+, +https+ (or the empty schema) might be
+  #     used with implementation specific semantics.
+  # @!attribute [rw] value
+  #   @return [String]
+  #     Must be a valid serialized protocol buffer of the above specified type.
+  class Any
   end
 end

--- a/test/fixtures/included_module/included_classes.rb
+++ b/test/fixtures/included_module/included_classes.rb
@@ -4,6 +4,17 @@ module IncludedModule
   # applied in order. The following sequences of mutations affecting a single
   # entity are not permitted in a single +Commit+ request.
   class ClassA
+
+    ##
+    # Returns length of `str.to_s`.
+    #
+    # @param [Object] items a variable-length argument list
+    #
+    # @return [Integer] the length of the string from `to_s`
+    #
+    def an_instance_method *items
+      items.length
+    end
   end
 
   ##

--- a/test/generated_toc_doc_test.rb
+++ b/test/generated_toc_doc_test.rb
@@ -57,13 +57,13 @@ describe Gcloud::Jsondoc, :generated_toc_doc do
     <tr>
       <td><a data-custom-type=\"includedmodule/classa\">IncludedModule::ClassA</a></td>
       <td>When mode is +TRANSACTIONAL+, mutations affecting a single entity are
-applied in order. The following sequences of mutations affecting a single
-entity are not permitted in a single +Commit+ request.</td>
+applied in order.</td>
     </tr>
 
     <tr>
-      <td><a data-custom-type=\"includedmodule/classb\">IncludedModule::ClassB</a></td>
-      <td>Entities not found as +ResultType.KEY_ONLY+ entities.</td>
+      <td><a data-custom-type=\"includedmodule/any\">IncludedModule::Any</a></td>
+      <td>+Any+ contains an arbitrary serialized protocol buffer message along with a
+URL that describes the type of the serialized message.</td>
     </tr>
 
     <tr>
@@ -87,8 +87,7 @@ entity are not permitted in a single +Commit+ request.</td>
     <tr>
       <td><a data-custom-type=\"includedmodule2/classa\">IncludedModule2::ClassA</a></td>
       <td>When mode is +TRANSACTIONAL+, mutations affecting a single entity are
-applied in order. The following sequences of mutations affecting a single
-entity are not permitted in a single +Commit+ request.</td>
+applied in order.</td>
     </tr>
 
     <tr>

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -48,7 +48,7 @@ describe Gcloud::Jsondoc, :generator do
 
   it "must have all types" do
     types.must_be_kind_of Array
-    types.size.must_equal 36
+    types.size.must_equal 38
     types[0].full_name.must_equal "mymodule"
     types[0].name.must_equal "MyModule"
     types[0].filepath.must_equal "mymodule.json"

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -48,7 +48,7 @@ describe Gcloud::Jsondoc, :generator do
 
   it "must have all types" do
     types.must_be_kind_of Array
-    types.size.must_equal 38
+    types.size.must_equal 46
     types[0].full_name.must_equal "mymodule"
     types[0].name.must_equal "MyModule"
     types[0].filepath.must_equal "mymodule.json"


### PR DESCRIPTION
Fixes a build error introduced by #1224 as well as two other issues in the generation of TOC types for the gh-pages site.