### PR TITLE
Add yard-doctest testing to Vision

### DIFF
--- a/google-cloud-vision/.rubocop.yml
+++ b/google-cloud-vision/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - "acceptance/**/*"
+    - "support/**/*"
     - "google-cloud-vision.gemspec"
     - "Rakefile"
     - "lib/google/cloud/vision/v1.rb"

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -66,8 +66,9 @@ namespace :acceptance do
 end
 
 desc "Run yard-doctest example tests."
-task :doctest do
-  puts "The google-cloud-vision gem does not have doctest tests."
+task doctest: :yard do
+  sh "bundle exec yard config -a autoload_plugins yard-doctest"
+  sh "bundle exec yard doctest"
 end
 
 desc "Start an interactive shell."

--- a/google-cloud-vision/lib/google/cloud/vision.rb
+++ b/google-cloud-vision/lib/google/cloud/vision.rb
@@ -92,9 +92,9 @@ module Google
     #
     # face.features.to_h.count #=> 9
     # face.features.eyes.left.pupil
-    # #=> #<Landmark (x: 190.41544, y: 84.4557, z: -1.3682901)>
+    # #<Landmark (x: 190.41544, y: 84.4557, z: -1.3682901)>
     # face.features.chin.center
-    # #=> #<Landmark (x: 233.21977, y: 189.47475, z: 19.487228)>
+    # #<Landmark (x: 233.21977, y: 189.47475, z: 19.487228)>
     # ```
     #
     # To run multiple features on an image in a single request, pass the image

--- a/google-cloud-vision/lib/google/cloud/vision/annotate.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotate.rb
@@ -37,14 +37,14 @@ module Google
       #   face_image = vision.image "path/to/face.jpg"
       #   landmark_image = vision.image "path/to/landmark.jpg"
       #
-      #   annotation = vision.annotate do |annotate|
+      #   annotations = vision.annotate do |annotate|
       #      annotate.annotate face_image, faces: true, labels: true
       #      annotate.annotate landmark_image, landmarks: true
       #   end
       #
-      #   annotation.faces.count #=> 1
-      #   annotation.labels.count #=> 4
-      #   annotation.landmarks.count #=> 1
+      #   annotations[0].faces.count #=> 1
+      #   annotations[0].labels.count #=> 4
+      #   annotations[1].landmarks.count #=> 1
       #
       class Annotate
         # @private

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
@@ -29,7 +29,7 @@ module Google
         #
         # @see https://developers.google.com/knowledge-graph/ Knowledge Graph
         #
-        # @example
+        # @example In landmark detection:
         #   require "google/cloud/vision"
         #
         #   vision = Google::Cloud::Vision.new
@@ -37,11 +37,11 @@ module Google
         #   image = vision.image "path/to/landmark.jpg"
         #
         #   landmark = image.landmark
-        #   landmark.score #=> 0.91912264
+        #   landmark.score #=> 0.9191226363182068
         #   landmark.description #=> "Mount Rushmore"
         #   landmark.mid #=> "/m/019dvv"
         #
-        # @example
+        # @example In logo detection:
         #   require "google/cloud/vision"
         #
         #   vision = Google::Cloud::Vision.new
@@ -49,24 +49,24 @@ module Google
         #   image = vision.image "path/to/logo.jpg"
         #
         #   logo = image.logo
-        #   logo.score #=> 0.70057315
+        #   logo.score #=> 0.7005731463432312
         #   logo.description #=> "Google"
         #   logo.mid #=> "/m/0b34hf"
         #
-        # @example
+        # @example In label detection:
         #   require "google/cloud/vision"
         #
         #   vision = Google::Cloud::Vision.new
         #
-        #   image = vision.image "path/to/face.jpg"
+        #   image = vision.image "path/to/landmark.jpg"
         #
         #   labels = image.labels
         #   labels.count #=> 4
         #
         #   label = labels.first
-        #   label.score #=> 0.9481349
-        #   label.description #=> "person"
-        #   label.mid #=> "/m/01g317"
+        #   label.score #=> 0.9481348991394043
+        #   label.description #=> "stone carving"
+        #   label.mid #=> "/m/02wtjj"
         #
         class Entity
           ##

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
@@ -34,7 +34,7 @@ module Google
         #   image = vision.image "path/to/face.jpg"
         #
         #   face = image.face
-        #   face.confidence #=> 0.86162376
+        #   face.confidence #=> 0.8616237640380859
         #
         class Face
           ##
@@ -137,9 +137,9 @@ module Google
           #   image = vision.image "path/to/face.jpg"
           #   face = image.face
           #
-          #   face.angles.roll #=> -5.1492119
-          #   face.angles.yaw #=> -4.0695682
-          #   face.angles.pitch #=> -13.083284
+          #   face.angles.roll #=> -5.149211883544922
+          #   face.angles.yaw #=> -4.069568157196045
+          #   face.angles.pitch #=> -13.083284378051758
           #
           class Angles
             ##
@@ -239,7 +239,9 @@ module Google
           #   face = image.face
           #
           #   face.bounds.face.count #=> 4
-          #   face.bounds.face.first #=> #<Vertex (x: 153, y: 34)>
+          #   vertex = face.bounds.face.first
+          #   vertex.x #=> 28
+          #   vertex.y #=> 40
           #
           class Bounds
             ##
@@ -339,9 +341,9 @@ module Google
           #
           #   face.features.to_h.count #=> 9
           #   face.features.eyes.left.pupil
-          #   #=> #<Landmark (x: 190.41544, y: 84.4557, z: -1.3682901)>
+          #   #<Landmark (x: 190.41544, y: 84.4557, z: -1.3682901)>
           #   face.features.chin.center
-          #   #=> #<Landmark (x: 233.21977, y: 189.47475, z: 19.487228)>
+          #   #<Landmark (x: 233.21977, y: 189.47475, z: 19.487228)>
           #
           class Features
             ##
@@ -384,7 +386,7 @@ module Google
             #   face = image.face
             #
             #   face.features["RIGHT_EAR_TRAGION"]
-            #   #=> #<Landmark (x: 303.81198, y: 88.5782, z: 77.719193)>
+            #   #<Landmark (x: 303.81198, y: 88.5782, z: 77.719193)>
             #
             def [] landmark_type
               landmark = Array(@grpc.landmarks).detect do |l|
@@ -544,9 +546,9 @@ module Google
             #
             #   face.features.to_h.count #=> 9
             #   face.features.eyes.left.pupil
-            #   #=> #<Landmark (x: 190.41544, y: 84.4557, z: -1.3682901)>
+            #   #<Landmark (x: 190.41544, y: 84.4557, z: -1.3682901)>
             #   face.features.chin.center
-            #   #=> #<Landmark (x: 233.21977, y: 189.47475, z: 19.487228)>
+            #   #<Landmark (x: 233.21977, y: 189.47475, z: 19.487228)>
             #
             class Landmark
               ##
@@ -575,7 +577,7 @@ module Google
               #   image = vision.image "path/to/face.jpg"
               #   face = image.face
               #
-              #   face.features.forehead.type #=> "FOREHEAD_GLABELLA"
+              #   face.features.forehead.type #=> :FOREHEAD_GLABELLA
               #
               def type
                 @grpc.type
@@ -673,7 +675,7 @@ module Google
             #   chin = face.features.chin
             #
             #   chin.center
-            #   #=> #<Landmark (x: 233.21977, y: 189.47475, z: 19.487228)>
+            #   #<Landmark (x: 233.21977, y: 189.47475, z: 19.487228)>
             #
             class Chin
               attr_reader :left, :center, :right
@@ -743,7 +745,7 @@ module Google
             #
             #   ears = face.features.ears
             #   ears.right
-            #   #=> #<Landmark (x: 303.81198, y: 88.5782, z: 77.719193)>
+            #   #<Landmark (x: 303.81198, y: 88.5782, z: 77.719193)>
             #
             class Ears
               attr_reader :left, :right
@@ -813,7 +815,7 @@ module Google
             #
             #   right_eyebrow = eyebrows.right
             #   right_eyebrow.top
-            #   #=> #<Landmark (x: 256.3194, y: 58.222664, z: -17.299419)>
+            #   #<Landmark (x: 256.3194, y: 58.222664, z: -17.299419)>
             #
             class Eyebrows
               attr_reader :left, :right
@@ -884,7 +886,7 @@ module Google
             #
             #   right_eyebrow = eyebrows.right
             #   right_eyebrow.top
-            #   #=> #<Landmark (x: 256.3194, y: 58.222664, z: -17.299419)>
+            #   #<Landmark (x: 256.3194, y: 58.222664, z: -17.299419)>
             #
             class Eyebrow
               attr_reader :left, :top, :right
@@ -956,7 +958,7 @@ module Google
             #
             #   right_eye = eyes.right
             #   right_eye.pupil
-            #   #=> #<Landmark (x: 256.63464, y: 79.641411, z: -6.0731235)>
+            #   #<Landmark (x: 256.63464, y: 79.641411, z: -6.0731235)>
             #
             class Eyes
               attr_reader :left, :right
@@ -1029,7 +1031,7 @@ module Google
             #   right_eye = face.features.eyes.right
             #
             #   right_eye.pupil
-            #   #=> #<Landmark (x: 256.63464, y: 79.641411, z: -6.0731235)>
+            #   #<Landmark (x: 256.63464, y: 79.641411, z: -6.0731235)>
             #
             class Eye
               attr_reader :left, :bottom, :center, :pupil, :top, :right
@@ -1102,7 +1104,7 @@ module Google
             #   lips = face.features.lips
             #
             #   lips.top
-            #   #=> #<Landmark (x: 228.54768, y: 143.2952, z: -5.6550336)>
+            #   #<Landmark (x: 228.54768, y: 143.2952, z: -5.6550336)>
             #
             class Lips
               attr_reader :top, :bottom
@@ -1175,7 +1177,7 @@ module Google
             #   mouth = face.features.mouth
             #
             #   mouth.center
-            #   #=> #<Landmark (x: 228.53499, y: 150.29066, z: 1.1069832)>
+            #   #<Landmark (x: 228.53499, y: 150.29066, z: 1.1069832)>
             #
             class Mouth
               attr_reader :left, :center, :right
@@ -1249,7 +1251,7 @@ module Google
             #   nose = face.features.nose
             #
             #   nose.tip
-            #   #=> #<Landmark (x: 225.23511, y: 122.47372, z: -25.817825)>
+            #   #<Landmark (x: 225.23511, y: 122.47372, z: -25.817825)>
             #
             class Nose
               attr_reader :left, :bottom, :tip, :top, :right
@@ -1320,7 +1322,7 @@ module Google
           #
           #   face.likelihood.to_h.count #=> 7
           #   face.likelihood.sorrow? #=> false
-          #   face.likelihood.sorrow #=> "VERY_UNLIKELY"
+          #   face.likelihood.sorrow #=> :VERY_UNLIKELY
           #
           class Likelihood
             POSITIVE_RATINGS = %i(POSSIBLE LIKELY VERY_LIKELY)

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
@@ -112,8 +112,8 @@ module Google
           #   color.blue #=> 20.0
           #   color.rgb #=> "f7ec14"
           #   color.alpha #=> 1.0
-          #   color.score #=> 0.20301804
-          #   color.pixel_fraction #=> 0.0072649573
+          #   color.score #=> 0.20301803946495056
+          #   color.pixel_fraction #=> 0.007264957297593355
           #
           class Color
             ##

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
@@ -35,7 +35,7 @@ module Google
         #
         #   safe_search = image.safe_search
         #   safe_search.spoof? #=> false
-        #   safe_search.spoof #=> "VERY_UNLIKELY"
+        #   safe_search.spoof #=> :VERY_UNLIKELY
         #
         class SafeSearch
           POSITIVE_RATINGS = %i(POSSIBLE LIKELY VERY_LIKELY)

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
@@ -35,7 +35,7 @@ module Google
         #   text.locale #=> "en"
         #   text.words.count #=> 28
         #   text.text
-        #   #=> "Google Cloud Client for Ruby an idiomatic, intuitive... "
+        #   # "Google Cloud Client for Ruby an idiomatic, intuitive... "
         #
         class Text
           ##
@@ -148,7 +148,9 @@ module Google
           #   word = words.first
           #   word.text #=> "Google"
           #   word.bounds.count #=> 4
-          #   word.bounds.first #=> #<Vertex (x: 13, y: 8)>
+          #   vertex = word.bounds.first
+          #   vertex.x #=> 13
+          #   vertex.y #=> 8
           #
           class Word
             ##

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
@@ -37,8 +37,8 @@ module Google
         #
         #   text.bounds.count #=> 4
         #   vertex = text.bounds.first
-        #   vertex.x #=> 13
-        #   vertex.y #=> 8
+        #   vertex.x #=> 1
+        #   vertex.y #=> 0
         #
         class Vertex
           attr_reader :x, :y

--- a/google-cloud-vision/lib/google/cloud/vision/image.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/image.rb
@@ -103,7 +103,9 @@ module Google
         #
         #   face = faces.first
         #   face.bounds.face.count #=> 4
-        #   face.bounds.face.first #=> #<Vertex (x: 153, y: 34)>
+        #   vertex = face.bounds.face.first
+        #   vertex.x #=> 28
+        #   vertex.y #=> 40
         #
         def faces max_results = Google::Cloud::Vision.default_max_faces
           ensure_vision!
@@ -140,7 +142,7 @@ module Google
         #   landmarks = image.landmarks
         #
         #   landmark = landmarks.first
-        #   landmark.score #=> 0.91912264
+        #   landmark.score #=> 0.9191226363182068
         #   landmark.description #=> "Mount Rushmore"
         #   landmark.mid #=> "/m/019dvv"
         #
@@ -179,7 +181,7 @@ module Google
         #   logos = image.logos
         #
         #   logo = logos.first
-        #   logo.score #=> 0.70057315
+        #   logo.score #=> 0.7005731463432312
         #   logo.description #=> "Google"
         #   logo.mid #=> "/m/0b34hf"
         #
@@ -213,15 +215,15 @@ module Google
         #   require "google/cloud/vision"
         #
         #   vision = Google::Cloud::Vision.new
-        #   image = vision.image "path/to/face.jpg"
+        #   image = vision.image "path/to/landmark.jpg"
         #
         #   labels = image.labels
         #
         #   labels.count #=> 4
         #   label = labels.first
-        #   label.score #=> 0.9481349
-        #   label.description #=> "person"
-        #   label.mid #=> "/m/01g317"
+        #   label.score #=> 0.9481348991394043
+        #   label.description #=> "stone carving"
+        #   label.mid #=> "/m/02wtjj"
         #
         def labels max_results = Google::Cloud::Vision.default_max_labels
           ensure_vision!
@@ -254,11 +256,10 @@ module Google
         #
         #   text = image.text
         #
-        #   text = image.text
         #   text.locale #=> "en"
         #   text.words.count #=> 28
         #   text.text
-        #   #=> "Google Cloud Client for Ruby an idiomatic, intuitive... "
+        #   # "Google Cloud Client for Ruby an idiomatic, intuitive... "
         #
         def text
           ensure_vision!
@@ -282,7 +283,7 @@ module Google
         #   safe_search = image.safe_search
         #
         #   safe_search.spoof? #=> false
-        #   safe_search.spoof #=> "VERY_UNLIKELY"
+        #   safe_search.spoof #=> :VERY_UNLIKELY
         #
         def safe_search
           ensure_vision!

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -42,8 +42,8 @@ module Google
       #   annotation = vision.annotate image, labels: true
       #
       #   annotation.labels.map &:description
-      #   #=> ["stone carving", "ancient history", "statue", "sculpture",
-      #   #=>  "monument", "landmark"]
+      #   # ["stone carving", "ancient history", "statue", "sculpture",
+      #   #  "monument", "landmark"]
       #
       # See Google::Cloud#vision
       class Project
@@ -196,8 +196,8 @@ module Google
         #   annotation = vision.annotate image, labels: true
         #
         #   annotation.labels.map &:description
-        #   #=> ["stone carving", "ancient history", "statue", "sculpture",
-        #   #=>  "monument", "landmark"]
+        #   # ["stone carving", "ancient history", "statue", "sculpture",
+        #   #  "monument", "landmark"]
         #
         # @example With multiple images:
         #   require "google/cloud/vision"
@@ -242,7 +242,7 @@ module Google
         #   annotation = vision.annotate image, labels: 3
         #
         #   annotation.labels.map &:description
-        #   #=> ["stone carving", "ancient history", "statue"]
+        #   # ["stone carving", "ancient history", "statue"]
         #
         def annotate *images, faces: false, landmarks: false, logos: false,
                      labels: false, text: false, safe_search: false,

--- a/google-cloud-vision/support/doctest_helper.rb
+++ b/google-cloud-vision/support/doctest_helper.rb
@@ -1,0 +1,634 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/storage"
+require "google/cloud/vision"
+
+##
+# Monkey-Patch CallOptions to support Mocks
+class Google::Gax::CallOptions
+  ##
+  # Minitest Mock depends on === to match same-value objects.
+  # By default, CallOptions objects do not match with ===.
+  # Therefore, we must add this capability.
+  def === other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout === other.timeout &&
+      retry_options === other.retry_options &&
+      page_token === other.page_token &&
+      kwargs === other.kwargs
+  end
+  def == other
+    return false unless other.is_a? Google::Gax::CallOptions
+    timeout == other.timeout &&
+      retry_options == other.retry_options &&
+      page_token == other.page_token &&
+      kwargs == other.kwargs
+  end
+end
+
+class File
+  def self.file? f
+    true
+  end
+  def self.readable? f
+    true
+  end
+  def self.read *args
+    "fake file data"
+  end
+  def self.open *args
+    # Examples use file paths such as "path/to/face.jpg"
+    return StringIO.new("fake image data") if args[0] =~ /path\/to\//
+    new *args
+  end
+end
+
+class MicrophoneInput
+  def self.read size
+    "1,2,3"
+  end
+end
+
+module Google
+  module Cloud
+    module Vision
+      def self.stub_new
+        define_singleton_method :new do |*args|
+          yield *args
+        end
+      end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
+    end
+    module Storage
+      def self.stub_new
+        define_singleton_method :new do |*args|
+          yield *args
+        end
+      end
+      # Create default unmocked methods that will raise if ever called
+      def self.new *args
+        raise "This code example is not yet mocked"
+      end
+    end
+  end
+end
+
+def mock_vision
+  Google::Cloud::Vision.stub_new do |*args|
+    credentials = OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {}))
+    vision = Google::Cloud::Vision::Project.new(Google::Cloud::Vision::Service.new("my-todo-project", credentials))
+
+    vision.service.mocked_service = Minitest::Mock.new
+    if block_given?
+      yield vision.service.mocked_service
+    end
+    vision
+  end
+end
+
+def mock_storage
+  Google::Cloud::Storage.stub_new do |*args|
+    credentials = OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {}))
+    storage = Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new("my-todo-project", credentials))
+
+    storage.service.mocked_service = Minitest::Mock.new
+    yield storage.service.mocked_service
+    storage
+  end
+end
+
+YARD::Doctest.configure do |doctest|
+  # Current mocking does not support testing GAPIC layer. (Auth failures occur.)
+  doctest.skip "Google::Cloud::Vision::V1"
+
+  # Skip all aliases, since tests would be exact duplicates
+  doctest.skip "Google::Cloud::Vision::Project#mark"
+  doctest.skip "Google::Cloud::Vision::Project#detect"
+  doctest.skip "Google::Cloud::Vision::Annotation::Face::Angles#pan"
+  doctest.skip "Google::Cloud::Vision::Annotation::Face::Angles#tilt"
+
+  doctest.before "Google::Cloud#vision" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, landmarks_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud.vision" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, landmarks_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, faces_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision.new" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, landmarks_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision.default_max" do
+    # Reset all defaults to 100, since some examples change them to 5
+    Google::Cloud::Vision.default_max_faces = 100
+    Google::Cloud::Vision.default_max_labels = 100
+    Google::Cloud::Vision.default_max_landmarks = 100
+    Google::Cloud::Vision.default_max_logos = 100
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, labels_resp, annotate_args
+    end
+  end
+
+  # Project
+
+  doctest.before "Google::Cloud::Vision::Project" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, faces_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Project#annotate" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, faces_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Project#annotate@With multiple images:" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, labels_resp(2, 4, 6), annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Project#annotate@With multiple images and configurations passed in a block:" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, multi_resp, annotate_args
+    end
+  end
+
+  # Image
+
+  doctest.before "Google::Cloud::Vision::Image" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, text_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Image#faces" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, faces_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Image#landmarks" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, landmarks_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Image#logos" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, logos_resp(1, 5), annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Image#labels" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, labels_resp(1, 4), annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Image#text" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, text_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Image#safe_search" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, safe_search_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Image#properties" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, properties_resp, annotate_args
+    end
+  end
+
+  # Annotate
+
+  doctest.before "Google::Cloud::Vision::Annotate" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, multi_resp, annotate_args
+    end
+  end
+
+  # Annotation
+
+  doctest.before "Google::Cloud::Vision::Annotation" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, faces_labels_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation#landmark" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, landmarks_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation#logo" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, logos_resp(1, 1), annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation#label" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, labels_resp(1, 1), annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation#text" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, text_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation#safe_search" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, safe_search_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation#properties" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, properties_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation::Face" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, faces_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation::Entity@In landmark detection:" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, landmarks_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation::Entity@In logo detection:" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, logos_resp(1, 5), annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation::Entity@In label detection:" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, labels_resp(1, 4), annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation::Text" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, text_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation::SafeSearch" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, safe_search_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation::Vertex" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, text_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Annotation::Properties" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, properties_resp, annotate_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Vision::Location" do
+    mock_vision do |mock|
+      mock.expect :batch_annotate_images, landmarks_resp, annotate_args
+    end
+  end
+end
+
+# Fixture helpers
+
+
+
+def default_headers
+  { "google-cloud-resource-prefix" => "projects/my-project-id" }
+end
+
+def default_options
+  Google::Gax::CallOptions.new kwargs: default_headers
+end
+
+def annotate_args
+  [Array,Hash]
+end
+
+def faces_resp
+  Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
+    responses: [
+      Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+        face_annotations: [
+          face_annotation_response
+        ]
+      )
+    ]
+  )
+end
+
+def landmarks_resp
+  Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
+    responses: [
+      Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+        landmark_annotations: [
+          landmark_annotation_response
+        ]
+      )
+    ]
+  )
+end
+
+def logos_resp images_count = 1, *logos_counts
+  responses = images_count.times.map do
+    Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+      logo_annotations: logo_annotation_response(logos_counts.shift || 1)
+    )
+  end
+  Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(responses: responses)
+end
+
+def labels_resp images_count = 1, *labels_counts
+  responses = images_count.times.map do
+    Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+      label_annotations: label_annotation_response(labels_counts.shift || 1)
+    )
+  end
+  Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(responses: responses)
+end
+
+def text_resp
+  Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
+    responses: [
+      Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+        text_annotations: text_annotation_responses
+      )
+    ]
+  )
+end
+
+def safe_search_resp
+  Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
+    responses: [
+      Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+        safe_search_annotation: safe_search_annotation_response
+      )
+    ]
+  )
+end
+
+def properties_resp
+  Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
+    responses: [
+      Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+        image_properties_annotation: properties_annotation_response
+      )
+    ]
+  )
+end
+
+def faces_labels_resp
+  Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
+    responses: [
+      Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+        face_annotations: [
+          face_annotation_response
+        ],
+        label_annotations: label_annotation_response(4)
+      )
+    ]
+  )
+end
+
+def multi_resp
+  Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.new(
+    responses: [
+      Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+        face_annotations: [
+          face_annotation_response
+        ],
+        label_annotations: label_annotation_response(4)
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+        landmark_annotations: [
+          landmark_annotation_response
+        ]
+      ),
+      Google::Cloud::Vision::V1::AnnotateImageResponse.new(
+        text_annotations: text_annotation_responses
+      )
+    ]
+  )
+end
+
+def recognition_config
+  Google::Cloud::Speech::V1::RecognitionConfig.new encoding: :LINEAR16, sample_rate: 16000
+end
+
+def bounding_poly
+  Google::Cloud::Vision::V1::BoundingPoly.new(
+    vertices: [
+      Google::Cloud::Vision::V1::Vertex.new(x: 1, y: 0),
+      Google::Cloud::Vision::V1::Vertex.new(x: 295, y: 0),
+      Google::Cloud::Vision::V1::Vertex.new(x: 295, y: 301),
+      Google::Cloud::Vision::V1::Vertex.new(x: 1, y: 301)
+    ]
+  )
+end
+
+def face_annotation_response
+  Google::Cloud::Vision::V1::FaceAnnotation.new(
+    bounding_poly: bounding_poly,
+    fd_bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(
+      vertices: [
+        Google::Cloud::Vision::V1::Vertex.new(x: 28, y: 40),
+        Google::Cloud::Vision::V1::Vertex.new(x: 250, y: 40),
+        Google::Cloud::Vision::V1::Vertex.new(x: 250, y: 262),
+        Google::Cloud::Vision::V1::Vertex.new(x: 28, y: 262)
+      ]
+    ),
+    landmarks: [
+      Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :LEFT_EYE, position: Google::Cloud::Vision::V1::Position.new(x: 83.707092, y: 128.34, z: -0.00013388535)),
+      Google::Cloud::Vision::V1::FaceAnnotation::Landmark.new(type: :FOREHEAD_GLABELLA, position: Google::Cloud::Vision::V1::Position.new(x: 126.53813, y: 93.812057, z: -18.863352))
+    ],
+    roll_angle: -5.1492119,
+    pan_angle: -4.0695682,
+    tilt_angle: -13.083284,
+    detection_confidence: 0.86162376,
+    landmarking_confidence: 34.489909,
+    joy_likelihood:           :VERY_UNLIKELY,
+    sorrow_likelihood:        :VERY_UNLIKELY,
+    anger_likelihood:         :VERY_UNLIKELY,
+    surprise_likelihood:      :VERY_UNLIKELY,
+    under_exposed_likelihood: :VERY_UNLIKELY,
+    blurred_likelihood:       :VERY_UNLIKELY,
+    headwear_likelihood:      :VERY_UNLIKELY,
+  )
+end
+
+def landmark_annotation_response
+  Google::Cloud::Vision::V1::EntityAnnotation.new(
+    mid: "/m/019dvv",
+    description: "Mount Rushmore",
+    score: 0.91912264,
+    bounding_poly: bounding_poly,
+    locations: [
+      Google::Cloud::Vision::V1::LocationInfo.new(
+        lat_lng: Google::Type::LatLng.new(latitude: 43.878264, longitude: -103.45700740814209)
+      )
+   ]
+  )
+end
+
+def logo_annotation_response count = 1
+  count.times.map do
+    Google::Cloud::Vision::V1::EntityAnnotation.new(
+      mid: "/m/0b34hf",
+      description: "Google",
+      score: 0.70057315,
+      bounding_poly: bounding_poly
+    )
+  end
+end
+
+def label_annotation_response count = 1
+  count.times.map do
+    Google::Cloud::Vision::V1::EntityAnnotation.new(
+      mid: "/m/02wtjj",
+      description: "stone carving",
+      score: 0.9481349
+    )
+  end
+end
+
+def text_annotation_response
+  Google::Cloud::Vision::V1::EntityAnnotation.new(
+    locale: "en",
+    description: "Google Cloud Client for Ruby an idiomatic, intuitive, and\nnatural way for Ruby developers to integrate with Google Cloud\nPlatform services, like Cloud Datastore and Cloud Storage.\n",
+    bounding_poly: bounding_poly
+  )
+end
+
+def text_annotation_responses
+  [ text_annotation_response,
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Google", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 53, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 53, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Cloud", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 59, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 89, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 89, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 59, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Client", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 96, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 128, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 128, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 96, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Library", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 132, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 170, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 170, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 132, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "for", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 175, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 191, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 191, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 175, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Ruby", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 195, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 221, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 221, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 195, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "an", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 236, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 245, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 245, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 236, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "idiomatic,", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 250, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 307, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 307, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 250, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "intuitive,", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 311, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 360, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 360, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 311, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "and", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 363, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 385, y: 8), Google::Cloud::Vision::V1::Vertex.new(x: 385, y: 23), Google::Cloud::Vision::V1::Vertex.new(x: 363, y: 23)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "natural", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 52, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 52, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "way", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 56, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 77, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 77, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 56, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "for", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 82, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 98, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 98, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 82, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Ruby", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 102, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 130, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 130, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 102, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "developers", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 135, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 196, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 196, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 135, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "to", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 201, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 212, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 212, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 201, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "integrate", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 215, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 265, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 265, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 215, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "with", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 270, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 293, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 293, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 270, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Google", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 299, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 339, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 339, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 299, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Cloud", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 345, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 376, y: 33), Google::Cloud::Vision::V1::Vertex.new(x: 376, y: 49), Google::Cloud::Vision::V1::Vertex.new(x: 345, y: 49)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Platform", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 59, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 59, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 13, y: 74)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "services,", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 67, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 117, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 117, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 67, y: 74)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "like", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 121, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 138, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 138, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 121, y: 74)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Cloud", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 145, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 177, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 177, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 145, y: 74)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Datastore", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 181, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 236, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 236, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 181, y: 74)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "and", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 242, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 260, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 260, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 242, y: 74)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Cloud", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 267, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 298, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 298, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 267, y: 74)])),
+    Google::Cloud::Vision::V1::EntityAnnotation.new(description: "Storage.", bounding_poly: Google::Cloud::Vision::V1::BoundingPoly.new(vertices: [Google::Cloud::Vision::V1::Vertex.new(x: 304, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 351, y: 59), Google::Cloud::Vision::V1::Vertex.new(x: 351, y: 74), Google::Cloud::Vision::V1::Vertex.new(x: 304, y: 74)]))
+  ]
+end
+
+
+
+def safe_search_annotation_response
+  Google::Cloud::Vision::V1::SafeSearchAnnotation.new(
+    adult:    :VERY_UNLIKELY,
+    spoof:    :VERY_UNLIKELY,
+    medical:  :POSSIBLE,
+    violence: :LIKELY
+  )
+end
+
+def properties_annotation_response
+  Google::Cloud::Vision::V1::ImageProperties.new(
+    dominant_colors: Google::Cloud::Vision::V1::DominantColorsAnnotation.new(
+      colors: [
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 247, green: 236, blue: 20),
+                           score: 0.20301804,
+                           pixel_fraction: 0.0072649573),
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 0, green: 0, blue: 0),
+                           score: 0.09256918,
+                           pixel_fraction: 0.19258064),
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 255, green: 255, blue: 255),
+                           score: 0.1002003,
+                           pixel_fraction: 0.022258064),
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 3, green: 4, blue: 254),
+                           score: 0.089072376,
+                           pixel_fraction: 0.054516129),
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 168, green: 215, blue: 255),
+                           score: 0.019252902,
+                           pixel_fraction: 0.0070967744),
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 127, green: 177, blue: 255),
+                           score: 0.017626688,
+                           pixel_fraction: 0.0045161289),
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 178, green: 223, blue: 255),
+                           score: 0.015010362,
+                           pixel_fraction: 0.0022580645),
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 172, green: 224, blue: 255),
+                           score: 0.0049617039,
+                           pixel_fraction: 0.0012903226),
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 160, green: 218, blue: 255),
+                           score: 0.0027604031,
+                           pixel_fraction: 0.0022580645),
+        Google::Cloud::Vision::V1::ColorInfo.new(color: Google::Type::Color.new(red: 156, green: 214, blue: 255),
+                           score: 0.00096750073,
+                           pixel_fraction: 0.00064516132)
+      ]
+    )
+  )
+end


### PR DESCRIPTION
This PR adds yard-doctest testing and mock setup to Vision. It updates a number examples for compatibility with yard-doctest. It also fixes a couple of errors that existed in the examples.

[refs #226]