### PR TITLE
Update Spanner acceptance tests

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/instance_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/instance_test.rb
@@ -16,8 +16,8 @@ require "spanner_helper"
 
 describe "Spanner Instances", :spanner do
   it "creates, updates, and deletes an instance" do
-    instance_id = "#{$spanner_prefix}-crud"
-    name = "gcloud-ruby Empty Instance"
+    instance_id = "#{$spanner_prefix}-empty"
+    name = "#{$spanner_prefix} Empty"
     config = "regional-us-central1"
 
     spanner.instance(instance_id).must_be :nil?


### PR DESCRIPTION
Turns out the instance id and name needs to be unique in a project.
Give the instance being created in the acceptance tests a unique name.
This will a failure when two acceptance tests are being run concurrently.