### PR TITLE
Upgrade google-gax dependency

### DIFF
--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.21.0"
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.21.0"
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.21.0"
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 0.21.1"
   gem.add_dependency "stackdriver-core", "~> 0.21.0"
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
   gem.add_dependency "orderedhash", "= 0.0.6"
 
   gem.add_development_dependency "minitest", "~> 5.9"

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
 
   gem.add_development_dependency "rubocop", "<= 0.35.1"
 end

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.21.0"
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.8"
 
   gem.add_development_dependency "minitest", "~> 5.9"

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.21.0"
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.8"
 
   gem.add_development_dependency "minitest", "~> 5.9"

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.21.0"
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -22,8 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 0.21.1"
   gem.add_dependency "stackdriver-core", "~> 0.21.0"
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 0.21.0"
-  gem.add_dependency "google-gax", "~> 0.7.1"
-  gem.add_dependency "googleapis-common-protos", "~> 1.3.5"
+  gem.add_dependency "google-gax", "~> 0.8.0"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"


### PR DESCRIPTION
Upgrade google-gax dependency to use the 0.8.x releases. Remove explicit dependency on googleapis-common-protos, since google-gax already declares this dependency.