### PR TITLE
Generate GAPIC Data Types docs TOCs

### DIFF
--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -99,7 +99,29 @@ task :jsondoc => :yard do
   require "gcloud/jsondoc"
 
   registry = YARD::Registry.load! ".yardoc"
-  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-datastore"
+
+  toc_config = {
+    documents: [
+      {
+        type: "toc",
+        title: "Google::Datastore::V1::DataTypes",
+        modules: [
+          {
+            title: "Google::Datastore::V1",
+            include: ["google/datastore/v1"]
+          },
+          {
+            title: "Google::Protobuf",
+            include: ["google/protobuf"]
+          }
+        ]
+      }
+    ]
+  }
+
+  generator = Gcloud::Jsondoc::Generator.new registry,
+                                             "google-cloud-datastore",
+                                             generate: toc_config
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-datastore/docs/toc.json
+++ b/google-cloud-datastore/docs/toc.json
@@ -32,7 +32,7 @@
     {
       "title": "Datastore",
       "type": "google/cloud/datastore",
-      "patterns": ["\/datastore"],
+      "patterns": ["\/datastore", "google\/protobuf"],
       "nav": [
         {
           "title": "Dataset",
@@ -53,7 +53,7 @@
         {
           "title": "V1",
           "type": "google/cloud/datastore/v1",
-          "patterns": ["\/datastore\/v1"],
+          "patterns": ["\/datastore\/v1", "google\/protobuf"],
           "nav": [
             {
               "title": "DatastoreClient",
@@ -61,7 +61,7 @@
             },
             {
               "title": "Data Types",
-              "type": "google/datastore/v1"
+              "type": "google/datastore/v1/datatypes"
             }
           ]
         }

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
@@ -14,43 +14,6 @@
 
 module Google
   module Datastore
-    ##
-    # The `Google::Datastore::V1` module provides the following types:
-    #
-    # Class | Description
-    # ----- | -----------
-    # {Google::Datastore::V1::AllocateIdsRequest} | The request for Datastore::AllocateIds.
-    # {Google::Datastore::V1::AllocateIdsResponse} | The response for Datastore::AllocateIds.
-    # {Google::Datastore::V1::BeginTransactionRequest} | The request for Datastore::BeginTransaction.
-    # {Google::Datastore::V1::BeginTransactionResponse} | The response for Datastore::BeginTransaction.
-    # {Google::Datastore::V1::CommitRequest} | The request for Datastore::Commit.
-    # {Google::Datastore::V1::CommitResponse} | The response for Datastore::Commit.
-    # {Google::Datastore::V1::CompositeFilter} | A filter that merges multiple other filters.
-    # {Google::Datastore::V1::Entity} | A Datastore data object.
-    # {Google::Datastore::V1::EntityResult} | The result of fetching an entity from Datastore.
-    # {Google::Datastore::V1::Filter} | A holder for any type of filter.
-    # {Google::Datastore::V1::GqlQuery} | A query in the GQL grammar.
-    # {Google::Datastore::V1::GqlQueryParameter} | A binding parameter for a GQL query.
-    # {Google::Datastore::V1::Key} | A unique identifier for an entity.
-    # {Google::Datastore::V1::KindExpression} | A representation of a kind.
-    # {Google::Datastore::V1::LookupRequest} | The request for Datastore::Lookup.
-    # {Google::Datastore::V1::LookupResponse} | The response for Datastore::Lookup.
-    # {Google::Datastore::V1::Mutation} | A mutation to apply to an entity.
-    # {Google::Datastore::V1::MutationResult} | The result of applying a mutation.
-    # {Google::Datastore::V1::PartitionId} | A partition ID identifies a grouping of entities.
-    # {Google::Datastore::V1::Projection} | A representation of a property in a projection.
-    # {Google::Datastore::V1::PropertyFilter} | A filter on a specific property.
-    # {Google::Datastore::V1::PropertyOrder} | The desired order for a specific property.
-    # {Google::Datastore::V1::PropertyReference} | A property relative to the kind expressions.
-    # {Google::Datastore::V1::Query} | A query for entities.
-    # {Google::Datastore::V1::QueryResultBatch} | A batch of results produced by a query.
-    # {Google::Datastore::V1::ReadOptions} | The options shared by read requests.
-    # {Google::Datastore::V1::RollbackRequest} | The request for Datastore::Rollback.
-    # {Google::Datastore::V1::RollbackResponse} | The response for Datastore::Rollback.
-    # {Google::Datastore::V1::RunQueryRequest} | The request for Datastore::RunQuery.
-    # {Google::Datastore::V1::RunQueryResponse} | The response for Datastore::RunQuery.
-    # {Google::Datastore::V1::Value} | Holds any of the supported value types and associated metadata.
-    #
     module V1
       # The request for Datastore::Lookup.
       # @!attribute [rw] project_id

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -103,7 +103,29 @@ task :jsondoc => :yard do
   require "gcloud/jsondoc"
 
   registry = YARD::Registry.load! ".yardoc"
-  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-error_reporting"
+
+  toc_config = {
+    documents: [
+      {
+        type: "toc",
+        title: "Google::Devtools::Clouderrorreporting::V1beta1::DataTypes",
+        modules: [
+          {
+            title: "Google::Devtools::Clouderrorreporting::V1beta1",
+            include: ["google/devtools/clouderrorreporting/v1beta1"]
+          },
+          {
+            title: "Google::Protobuf",
+            include: ["google/protobuf"]
+          }
+        ]
+      }
+    ]
+  }
+
+  generator = Gcloud::Jsondoc::Generator.new registry,
+                                             "google-cloud-error_reporting",
+                                             generate: toc_config
   generator.write_to "jsondoc"
   cp ["docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-error_reporting/docs/toc.json
+++ b/google-cloud-error_reporting/docs/toc.json
@@ -10,7 +10,7 @@
     {
       "title": "Error Reporting",
       "type": "google/cloud/errorreporting",
-      "patterns": ["\/errorreporting", "\/clouderrorreporting"],
+      "patterns": ["\/errorreporting", "\/clouderrorreporting", "google\/protobuf"],
       "nav": [
 
         {
@@ -24,7 +24,7 @@
         {
           "title": "V1Beta1",
           "type": "google/cloud/errorreporting/v1beta1",
-          "patterns": ["\/errorreporting\/v1beta1", "\/clouderrorreporting"],
+          "patterns": ["\/errorreporting\/v1beta1", "\/clouderrorreporting", "google\/protobuf"],
           "nav": [
             {
               "title": "ReportErrorsServiceClient",
@@ -40,8 +40,7 @@
             },
             {
               "title": "Data Types",
-              "patterns": ["\/clouderrorreporting\/v1beta1"],
-              "type": "google/devtools/clouderrorreporting/v1beta1"
+              "type": "google/devtools/clouderrorreporting/v1beta1/datatypes"
             }
           ]
         }

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
@@ -15,34 +15,6 @@
 module Google
   module Devtools
     module Clouderrorreporting
-      ##
-      # The `Google::Devtools::Clouderrorreporting::V1beta1` module provides the following types:
-      #
-      # Class | Description
-      # ----- | -----------
-      # {Google::Devtools::Clouderrorreporting::V1beta1::DeleteEventsRequest} | Deletes all events in the project.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::DeleteEventsResponse} | Response message for deleting error events.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorContext} | A description of the context in which an error occurred.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorEvent} | An error event which is returned by the Error Reporting system.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroup} | Description of a group of similar error events.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroupOrder} | A sorting order of error groups.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroupStats} | Data extracted for a specific group based on certain filter criteria.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::HttpRequestContext} | HTTP request data that is related to a reported error.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ListEventsRequest} | Specifies a set of error events to return.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ListEventsResponse} | Contains a set of requested error events.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ListGroupStatsRequest} | Specifies a set of {Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroupStats} to return.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ListGroupStatsResponse} | Contains a set of requested error group stats.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::QueryTimeRange} | Requests might be rejected or the resulting timed count durations might be adjusted for lower durations.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ReportedErrorEvent} | An error event which is reported to the Error Reporting system.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ReportErrorEventRequest} | A request for reporting an individual error event.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ReportErrorEventResponse} | Response for reporting an individual error event.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ServiceContext} | Describes a running service that sends errors.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::ServiceContextFilter} | Specifies criteria for filtering a subset of service contexts.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::SourceLocation} | Indicates a location in the source code of the service for which errors are reported.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::TimedCount} | The number of errors in a given time period.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::TimedCountAlignment} | Specifies how the time periods of error group counts are aligned.
-      # {Google::Devtools::Clouderrorreporting::V1beta1::TrackingIssue} | Information related to tracking the progress on resolving the error.
-      #
       module V1beta1
         # Description of a group of similar error events.
         # @!attribute [rw] name

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -95,7 +95,25 @@ task :jsondoc => :yard do
   require "gcloud/jsondoc"
 
   registry = YARD::Registry.load! ".yardoc"
-  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-language"
+
+  toc_config = {
+    documents: [
+      {
+        type: "toc",
+        title: "Google::Cloud::Language::V1::DataTypes",
+        modules: [
+          {
+            title: "Google::Cloud::Language::V1",
+            include: ["google/cloud/language/v1"]
+          }
+        ]
+      }
+    ]
+  }
+
+  generator = Gcloud::Jsondoc::Generator.new registry,
+                                             "google-cloud-language",
+                                             generate: toc_config
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-language/docs/toc.json
+++ b/google-cloud-language/docs/toc.json
@@ -54,6 +54,10 @@
             {
               "title": "LanguageServiceClient",
               "type": "google/cloud/language/v1/languageserviceclient"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/cloud/language/v1/datatypes"
             }
           ]
         }

--- a/google-cloud-language/lib/google/cloud/language/v1/doc/google/cloud/language/v1/language_service.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/doc/google/cloud/language/v1/language_service.rb
@@ -15,29 +15,6 @@
 module Google
   module Cloud
     module Language
-      ##
-      # The `Google::Cloud::Language::V1` module provides the following types:
-      #
-      # Class | Description
-      # ----- | -----------
-      # {Google::Cloud::Language::V1::AnalyzeEntitiesRequest} | The entity analysis request message.
-      # {Google::Cloud::Language::V1::AnalyzeEntitiesResponse} | The entity analysis response message.
-      # {Google::Cloud::Language::V1::AnalyzeSentimentRequest} | The sentiment analysis request message.
-      # {Google::Cloud::Language::V1::AnalyzeSentimentResponse} | The sentiment analysis response message.
-      # {Google::Cloud::Language::V1::AnalyzeSyntaxRequest} | The syntax analysis request message.
-      # {Google::Cloud::Language::V1::AnalyzeSyntaxResponse} | The syntax analysis response message.
-      # {Google::Cloud::Language::V1::AnnotateTextRequest} | The request message for the text annotation API, which can perform multiple analysis types (sentiment, entities, and syntax) in one call.
-      # {Google::Cloud::Language::V1::AnnotateTextRequest::Features} | All available features for sentiment, syntax, and semantic analysis.
-      # {Google::Cloud::Language::V1::DependencyEdge} | Represents dependency parse tree information for a token.
-      # {Google::Cloud::Language::V1::EncodingType} | Represents the text encoding that the caller uses to process the output.
-      # {Google::Cloud::Language::V1::Entity} | Represents a phrase in the text that is a known entity, such as a person, an organization, or location.
-      # {Google::Cloud::Language::V1::EntityMention} | Represents a mention for an entity in the text.
-      # {Google::Cloud::Language::V1::PartOfSpeech} | Represents part of speech information for a token.
-      # {Google::Cloud::Language::V1::Sentence} | Represents a sentence in the input document.
-      # {Google::Cloud::Language::V1::Sentiment} | Represents the feeling associated with the entire text or entities in the text.
-      # {Google::Cloud::Language::V1::TextSpan} | Represents an output piece of text.
-      # {Google::Cloud::Language::V1::Token} | Represents the smallest syntactic building block of the text.
-      #
       module V1
         # ================================================================ #
         #

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -149,7 +149,37 @@ task :jsondoc => :yard do
   require "gcloud/jsondoc"
 
   registry = YARD::Registry.load! ".yardoc"
-  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-logging"
+
+  toc_config = {
+    documents: [
+      {
+        type: "toc",
+        title: "Google::Logging::V2::DataTypes",
+        modules: [
+          {
+            title: "Google::Logging::V2",
+            include: ["google/logging/v2"]
+          },
+          {
+            title: "Google::Logging::Type",
+            include: ["google/logging/type"]
+          },
+          {
+            title: "Google::Api",
+            include: ["google/api"]
+          },
+          {
+            title: "Google::Protobuf",
+            include: ["google/protobuf"]
+          }
+        ]
+      }
+    ]
+  }
+
+  generator = Gcloud::Jsondoc::Generator.new registry,
+                                             "google-cloud-logging",
+                                             generate: toc_config
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-logging/docs/toc.json
+++ b/google-cloud-logging/docs/toc.json
@@ -37,7 +37,7 @@
     {
       "title": "Logging",
       "type": "google/cloud/logging",
-      "patterns": ["\/logging"],
+      "patterns": ["\/logging", "google\/api", "google\/protobuf"],
       "nav": [
         {
           "title": "Project",
@@ -62,7 +62,7 @@
         {
           "title": "V2",
           "type": "google/cloud/logging/v2",
-          "patterns": ["\/logging\/v2"],
+          "patterns": ["\/logging\/v2", "\/logging\/type", "google\/api", "google\/protobuf"],
           "nav": [
             {
               "title": "ConfigServiceV2Client",
@@ -78,7 +78,7 @@
             },
             {
               "title": "Data Types",
-              "type": "google/logging/v2"
+              "type": "google/logging/v2/datatypes"
             }
           ]
         }

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
@@ -14,35 +14,6 @@
 
 module Google
   module Logging
-    ##
-    # The `Google::Logging::V2` module provides the following types:
-    #
-    # Class | Description
-    # ----- | -----------
-    # {Google::Logging::V2::CreateLogMetricRequest} | The parameters to CreateLogMetric.
-    # {Google::Logging::V2::CreateSinkRequest} | The parameters to CreateSink.
-    # {Google::Logging::V2::DeleteLogMetricRequest} | The parameters to DeleteLogMetric.
-    # {Google::Logging::V2::DeleteLogRequest} | The parameters to DeleteLog.
-    # {Google::Logging::V2::DeleteSinkRequest} | The parameters to DeleteSink.
-    # {Google::Logging::V2::GetLogMetricRequest} | The parameters to GetLogMetric.
-    # {Google::Logging::V2::GetSinkRequest} | The parameters to GetSink.
-    # {Google::Logging::V2::ListLogEntriesRequest} | The parameters to ListLogEntries.
-    # {Google::Logging::V2::ListLogEntriesResponse} | Result returned from ListLogEntries.
-    # {Google::Logging::V2::ListLogMetricsRequest} | The parameters to ListLogMetrics.
-    # {Google::Logging::V2::ListLogMetricsResponse} | Result returned from ListLogMetrics.
-    # {Google::Logging::V2::ListMonitoredResourceDescriptorsRequest} | The parameters to ListMonitoredResourceDescriptors
-    # {Google::Logging::V2::ListMonitoredResourceDescriptorsResponse} | Result returned from ListMonitoredResourceDescriptors.
-    # {Google::Logging::V2::ListSinksRequest} | The parameters to ListSinks.
-    # {Google::Logging::V2::ListSinksResponse} | Result returned from ListSinks.
-    # {Google::Logging::V2::LogEntry} | An individual entry in a log.
-    # {Google::Logging::V2::LogEntryOperation} | Additional information about a potentially long-running operation with which a log entry is associated.
-    # {Google::Logging::V2::LogMetric} | Describes a logs-based metric.
-    # {Google::Logging::V2::LogSink} | Describes a sink used to export log entries outside of Stackdriver Logging.
-    # {Google::Logging::V2::UpdateLogMetricRequest} | The parameters to UpdateLogMetric.
-    # {Google::Logging::V2::UpdateSinkRequest} | The parameters to UpdateSink.
-    # {Google::Logging::V2::WriteLogEntriesRequest} | The parameters to WriteLogEntries.
-    # {Google::Logging::V2::WriteLogEntriesResponse} | Result returned from WriteLogEntries.
-    #
     module V2
       # The parameters to DeleteLog.
       # @!attribute [rw] log_name

--- a/google-cloud-monitoring/Rakefile
+++ b/google-cloud-monitoring/Rakefile
@@ -66,7 +66,33 @@ task :jsondoc => :yard do
   require "gcloud/jsondoc"
 
   registry = YARD::Registry.load! ".yardoc"
-  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-monitoring"
+
+  toc_config = {
+    documents: [
+      {
+        type: "toc",
+        title: "Google::Monitoring::V3::DataTypes",
+        modules: [
+          {
+            title: "Google::Monitoring::V3",
+            include: ["google/monitoring/v3"]
+          },
+          {
+            title: "Google::Api",
+            include: ["google/api"]
+          },
+          {
+            title: "Google::Protobuf",
+            include: ["google/protobuf"]
+          }
+        ]
+      }
+    ]
+  }
+
+  generator = Gcloud::Jsondoc::Generator.new registry,
+                                             "google-cloud-monitoring",
+                                             generate: toc_config
   generator.write_to "jsondoc"
   cp ["docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-monitoring/docs/toc.json
+++ b/google-cloud-monitoring/docs/toc.json
@@ -4,12 +4,12 @@
     {
       "title": "Monitoring",
       "type": "google/cloud/monitoring",
-      "patterns": ["\/monitoring"],
+      "patterns": ["\/monitoring", "google\/api", "google\/protobuf"],
       "nav": [
         {
           "title": "V3",
           "type": "google/cloud/monitoring/v3",
-          "patterns": ["\/monitoring\/v3"],
+          "patterns": ["\/monitoring\/v3", "google\/api", "google\/protobuf"],
           "nav": [
             {
               "title": "GroupServiceClient",
@@ -21,7 +21,7 @@
             },
             {
               "title": "Data Types",
-              "type": "google/monitoring/v3"
+              "type": "google/monitoring/v3/datatypes"
             }
           ]
         }

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
@@ -14,17 +14,6 @@
 
 module Google
   module Monitoring
-    ##
-    # The `Google::Monitoring::V3` module provides the following types:
-    #
-    # Class | Description
-    # ----- | -----------
-    # {Google::Monitoring::V3::Group} | The description of a dynamic collection of monitored resources.
-    # {Google::Monitoring::V3::Point} | A single data point in a time series.
-    # {Google::Monitoring::V3::TimeInterval} | A time interval extending just after a start time through an end time.
-    # {Google::Monitoring::V3::TimeSeries} | A collection of data points that describes the time-varying values of a metric.
-    # {Google::Monitoring::V3::TypedValue} | A single strongly-typed value.
-    #
     module V3
       # A single strongly-typed value.
       # @!attribute [rw] bool_value

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -118,7 +118,29 @@ task :jsondoc => :yard do
   require "gcloud/jsondoc"
 
   registry = YARD::Registry.load! ".yardoc"
-  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-pubsub"
+
+  toc_config = {
+    documents: [
+      {
+        type: "toc",
+        title: "Google::Pubsub::V1::DataTypes",
+        modules: [
+          {
+            title: "Google::Pubsub::V1",
+            include: ["google/pubsub/v1"]
+          },
+          {
+            title: "Google::Protobuf",
+            include: ["google/protobuf"]
+          }
+        ]
+      }
+    ]
+  }
+
+  generator = Gcloud::Jsondoc::Generator.new registry,
+                                             "google-cloud-pubsub",
+                                             generate: toc_config
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-pubsub/docs/toc.json
+++ b/google-cloud-pubsub/docs/toc.json
@@ -32,7 +32,7 @@
     {
       "title": "PubSub",
       "type": "google/cloud/pubsub",
-      "patterns": ["\/pubsub"],
+      "patterns": ["\/pubsub", "google\/protobuf"],
       "nav": [
         {
           "title": "Project",
@@ -49,7 +49,7 @@
         {
           "title": "V1",
           "type": "google/cloud/pubsub/v1",
-          "patterns": ["\/pubsub\/v1"],
+          "patterns": ["\/pubsub\/v1", "google\/protobuf"],
           "nav": [
             {
               "title": "PublisherClient",
@@ -61,7 +61,7 @@
             },
             {
               "title": "Data Types",
-              "type": "google/pubsub/v1"
+              "type": "google/pubsub/v1/datatypes"
             }
           ]
         }

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
@@ -14,36 +14,6 @@
 
 module Google
   module Pubsub
-    ##
-    # The `Google::Pubsub::V1` module provides the following types:
-    #
-    # Class | Description
-    # ----- | -----------
-    # {Google::Pubsub::V1::AcknowledgeRequest} | Request for the Acknowledge method.
-    # {Google::Pubsub::V1::DeleteSubscriptionRequest} | Request for the DeleteSubscription method.
-    # {Google::Pubsub::V1::DeleteTopicRequest} | Request for the DeleteTopic method.
-    # {Google::Pubsub::V1::GetSubscriptionRequest} | Request for the GetSubscription method.
-    # {Google::Pubsub::V1::GetTopicRequest} | Request for the GetTopic method.
-    # {Google::Pubsub::V1::ListSubscriptionsRequest} | Request for the ListSubscriptions method.
-    # {Google::Pubsub::V1::ListSubscriptionsResponse} | Response for the ListSubscriptions method.
-    # {Google::Pubsub::V1::ListTopicsRequest} | Request for the ListTopics method.
-    # {Google::Pubsub::V1::ListTopicsResponse} | Response for the ListTopics method.
-    # {Google::Pubsub::V1::ListTopicSubscriptionsRequest} | Request for the ListTopicSubscriptions method.
-    # {Google::Pubsub::V1::ListTopicSubscriptionsResponse} | Response for the ListTopicSubscriptions method.
-    # {Google::Pubsub::V1::ModifyAckDeadlineRequest} | Request for the ModifyAckDeadline method.
-    # {Google::Pubsub::V1::ModifyPushConfigRequest} | Request for the ModifyPushConfig method.
-    # {Google::Pubsub::V1::PublishRequest} | Request for the Publish method.
-    # {Google::Pubsub::V1::PublishResponse} | Response for the Publish method.
-    # {Google::Pubsub::V1::PubsubMessage} | A message data and its attributes.
-    # {Google::Pubsub::V1::PullRequest} | Request for the Pull method.
-    # {Google::Pubsub::V1::PullResponse} | Response for the Pull method.
-    # {Google::Pubsub::V1::PushConfig} | Configuration for a push delivery endpoint.
-    # {Google::Pubsub::V1::ReceivedMessage} | A message and its corresponding acknowledgment ID.
-    # {Google::Pubsub::V1::StreamingPullRequest} | Request for the StreamingPull streaming RPC method.
-    # {Google::Pubsub::V1::StreamingPullResponse} | Response for the StreamingPull streaming RPC method.
-    # {Google::Pubsub::V1::Subscription} | A subscription resource.
-    # {Google::Pubsub::V1::Topic} | A topic resource.
-    #
     module V1
       # A topic resource.
       # @!attribute [rw] name

--- a/google-cloud-spanner/.yardopts
+++ b/google-cloud-spanner/.yardopts
@@ -1,9 +1,7 @@
 --no-private
 --title=Google Cloud Spanner
 --exclude lib/google/spanner
---exclude lib/google/cloud/spanner/admin/database/v1
 --exclude lib/google/cloud/spanner/admin/database/v1.rb
---exclude lib/google/cloud/spanner/admin/instance/v1
 --exclude lib/google/cloud/spanner/admin/instance/v1.rb
 --markup markdown
 

--- a/google-cloud-spanner/.yardopts
+++ b/google-cloud-spanner/.yardopts
@@ -1,8 +1,6 @@
 --no-private
 --title=Google Cloud Spanner
 --exclude lib/google/spanner
---exclude lib/google/cloud/spanner/v1
---exclude lib/google/cloud/spanner/v1.rb
 --exclude lib/google/cloud/spanner/admin/database/v1
 --exclude lib/google/cloud/spanner/admin/database/v1.rb
 --exclude lib/google/cloud/spanner/admin/instance/v1

--- a/google-cloud-spanner/Rakefile
+++ b/google-cloud-spanner/Rakefile
@@ -128,7 +128,29 @@ task :jsondoc => :yard do
   require "gcloud/jsondoc"
 
   registry = YARD::Registry.load! ".yardoc"
-  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-spanner"
+
+  toc_config = {
+    documents: [
+      {
+        type: "toc",
+        title: "Google::Spanner::V1::DataTypes",
+        modules: [
+          {
+            title: "Google::Spanner::V1",
+            include: ["google/spanner/v1"]
+          },
+          {
+            title: "Google::Protobuf",
+            include: ["google/protobuf"]
+          }
+        ]
+      }
+    ]
+  }
+
+  generator = Gcloud::Jsondoc::Generator.new registry,
+                                             "google-cloud-spanner",
+                                             generate: toc_config
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-spanner/Rakefile
+++ b/google-cloud-spanner/Rakefile
@@ -140,8 +140,24 @@ task :jsondoc => :yard do
             include: ["google/spanner/v1"]
           },
           {
+            title: "Google::Spanner::Admin::Instance::V1",
+            include: ["google/spanner/admin/instance/v1"]
+          },
+          {
+            title: "Google::Spanner::Admin::Database::V1",
+            include: ["google/spanner/admin/database/v1"]
+          },
+          {
+            title: "Google::Iam::V1",
+            include: ["google/iam/v1"]
+          },
+          {
             title: "Google::Protobuf",
             include: ["google/protobuf"]
+          },
+          {
+            title: "Google::Rpc",
+            include: ["google/rpc"]
           }
         ]
       }

--- a/google-cloud-spanner/docs/toc.json
+++ b/google-cloud-spanner/docs/toc.json
@@ -32,16 +32,24 @@
     {
       "title": "Spanner",
       "type": "google/cloud/spanner",
-      "patterns": ["\/spanner", "google\/protobuf"],
+      "patterns": ["\/spanner", "\/spanner\/v1", "\/spanner\/admin\/instance\/v1", "\/spanner\/admin\/database\/v1", "google\/iam", "google\/protobuf", "google\/rpc"],
       "nav": [
         {
           "title": "V1",
           "type": "google/cloud/spanner/v1",
-          "patterns": ["\/spanner\/v1", "google\/protobuf"],
+          "patterns": ["\/spanner\/v1", "\/spanner\/admin\/instance\/v1", "\/spanner\/admin\/database\/v1", "google\/iam", "google\/protobuf", "google\/rpc"],
           "nav": [
             {
               "title": "SpannerClient",
               "type": "google/cloud/spanner/v1/spannerclient"
+            },
+            {
+              "title": "InstanceAdminClient",
+              "type": "google/cloud/spanner/admin/instance/v1/instanceadminclient"
+            },
+            {
+              "title": "DatabaseAdminClient",
+              "type": "google/cloud/spanner/admin/database/v1/databaseadminclient"
             },
             {
               "title": "Data Types",

--- a/google-cloud-spanner/docs/toc.json
+++ b/google-cloud-spanner/docs/toc.json
@@ -31,7 +31,25 @@
   "services": [
     {
       "title": "Spanner",
-      "type": "google/cloud/spanner"
+      "type": "google/cloud/spanner",
+      "patterns": ["\/spanner", "google\/protobuf"],
+      "nav": [
+        {
+          "title": "V1",
+          "type": "google/cloud/spanner/v1",
+          "patterns": ["\/spanner\/v1", "google\/protobuf"],
+          "nav": [
+            {
+              "title": "SpannerClient",
+              "type": "google/cloud/spanner/v1/spannerclient"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/spanner/v1/datatypes"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -107,7 +107,29 @@ task :jsondoc => :yard do
   require "gcloud/jsondoc"
 
   registry = YARD::Registry.load! ".yardoc"
-  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-trace"
+
+  toc_config = {
+    documents: [
+      {
+        type: "toc",
+        title: "Google::Devtools::Cloudtrace::V1::DataTypes",
+        modules: [
+          {
+            title: "Google::Devtools::Cloudtrace::V1",
+            include: ["google/devtools/cloudtrace/v1"]
+          },
+          {
+            title: "Google::Protobuf",
+            include: ["google/protobuf"]
+          }
+        ]
+      }
+    ]
+  }
+
+  generator = Gcloud::Jsondoc::Generator.new registry,
+                                             "google-cloud-trace",
+                                             generate: toc_config
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-trace/docs/toc.json
+++ b/google-cloud-trace/docs/toc.json
@@ -37,7 +37,7 @@
     {
       "title": "Trace",
       "type": "google/cloud/trace",
-      "patterns": ["\/trace", "\/cloudtrace"],
+      "patterns": ["\/trace", "\/cloudtrace", "google\/protobuf"],
       "nav": [
         {
           "title": "Project",
@@ -82,7 +82,7 @@
         {
           "title": "V1",
           "type": "google/cloud/trace/v1",
-          "patterns": ["\/trace\/v1", "\/cloudtrace"],
+          "patterns": ["\/trace\/v1", "\/cloudtrace", "google\/protobuf"],
           "nav": [
             {
               "title": "TraceServiceClient",
@@ -90,8 +90,7 @@
             },
             {
               "title": "Data Types",
-              "patterns": ["\/cloudtrace\/v1"],
-              "type": "google/devtools/cloudtrace/v1"
+              "type": "google/devtools/cloudtrace/v1/datatypes"
             }
           ]
         }

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
@@ -15,18 +15,6 @@
 module Google
   module Devtools
     module Cloudtrace
-      ##
-      # The `Google::Devtools::Cloudtrace::V1` module provides the following types:
-      #
-      # Class | Description
-      # ----- | -----------
-      # {Google::Devtools::Cloudtrace::V1::GetTraceRequest} | The request message for the GetTrace method.
-      # {Google::Devtools::Cloudtrace::V1::ListTracesRequest} | The request message for the ListTraces method.
-      # {Google::Devtools::Cloudtrace::V1::ListTracesResponse} | The response message for the ListTraces method.
-      # {Google::Devtools::Cloudtrace::V1::PatchTracesRequest} | The request message for the PatchTraces method.
-      # {Google::Devtools::Cloudtrace::V1::Trace} | A trace describes how long it takes for an application to perform an operation.
-      # {Google::Devtools::Cloudtrace::V1::Traces} | List of new or updated traces.
-      # {Google::Devtools::Cloudtrace::V1::TraceSpan} | A span represents a single timed event within a trace.
       module V1
         # A trace describes how long it takes for an application to perform an
         # operation. It consists of a set of spans, each of which represent a single

--- a/google-cloud-vision/.yardopts
+++ b/google-cloud-vision/.yardopts
@@ -1,6 +1,5 @@
 --no-private
 --title=Google Cloud Vision
---exclude lib/google/cloud/vision/v1
 --exclude lib/google/cloud/vision/v1.rb
 --markup markdown
 

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -96,7 +96,37 @@ task :jsondoc => :yard do
   require "gcloud/jsondoc"
 
   registry = YARD::Registry.load! ".yardoc"
-  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-vision"
+
+  toc_config = {
+    documents: [
+      {
+        type: "toc",
+        title: "Google::Cloud::Vision::V1::DataTypes",
+        modules: [
+          {
+            title: "Google::Cloud::Vision::V1",
+            include: ["google/cloud/vision/v1"]
+          },
+          {
+            title: "Google::Protobuf",
+            include: ["google/protobuf"]
+          },
+          {
+            title: "Google::Rpc",
+            include: ["google/rpc"]
+          },
+          {
+            title: "Google::Type",
+            include: ["google/type"]
+          }
+        ]
+      }
+    ]
+  }
+
+  generator = Gcloud::Jsondoc::Generator.new registry,
+                                             "google-cloud-vision",
+                                             generate: toc_config
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-vision/docs/toc.json
+++ b/google-cloud-vision/docs/toc.json
@@ -32,6 +32,7 @@
     {
       "title": "Vision",
       "type": "google/cloud/vision",
+      "patterns": ["\/cloud\/vision", "google\/protobuf", "google\/rpc", "google\/type"],
       "nav": [
         {
           "title": "Project",
@@ -44,6 +45,21 @@
         {
           "title": "Annotation",
           "type": "google/cloud/vision/annotation"
+        },
+        {
+          "title": "V1",
+          "type": "google/cloud/vision/v1",
+          "patterns": ["\/cloud\/vision\/v1", "google\/protobuf", "google\/rpc", "google\/type"],
+          "nav": [
+            {
+              "title": "ImageAnnotatorClient",
+              "type": "google/cloud/vision/v1/imageannotatorclient"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/cloud/vision/v1/datatypes"
+            }
+          ]
         }
       ]
     }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -321,7 +321,7 @@
             },
             {
               "title": "Data Types",
-              "type": "google/monitoring/v3"
+              "type": "google/monitoring/v3/datatypes"
             }
           ]
         }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -504,6 +504,7 @@
     {
       "title": "Vision",
       "type": "google/cloud/vision",
+      "patterns": ["\/cloud\/vision"],
       "nav": [
         {
           "title": "Project",
@@ -516,6 +517,21 @@
         {
           "title": "Annotation",
           "type": "google/cloud/vision/annotation"
+        },
+        {
+          "title": "V1",
+          "type": "google/cloud/vision/v1",
+          "patterns": ["\/cloud\/vision\/v1"],
+          "nav": [
+            {
+              "title": "ImageAnnotatorClient",
+              "type": "google/cloud/vision/v1/imageannotatorclient"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/cloud/vision/v1/datatypes"
+            }
+          ]
         }
       ]
     }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -359,7 +359,7 @@
             },
             {
               "title": "Data Types",
-              "type": "google/pubsub/v1"
+              "type": "google/pubsub/v1/datatypes"
             }
           ]
         }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -211,8 +211,7 @@
             },
             {
               "title": "Data Types",
-              "patterns": ["\/clouderrorreporting\/v1beta1"],
-              "type": "google/devtools/clouderrorreporting/v1beta1"
+              "type": "google/devtools/clouderrorreporting/v1beta1/datatypes"
             }
           ]
         }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -292,6 +292,10 @@
             {
               "title": "LanguageServiceClient",
               "type": "google/cloud/language/v1/languageserviceclient"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/cloud/language/v1/datatypes"
             }
           ]
         }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -154,7 +154,7 @@
             },
             {
               "title": "Data Types",
-              "type": "google/datastore/v1"
+              "type": "google/datastore/v1/datatypes"
             }
           ]
         }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -261,7 +261,7 @@
             },
             {
               "title": "Data Types",
-              "type": "google/logging/v2"
+              "type": "google/logging/v2/datatypes"
             }
           ]
         }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -477,7 +477,7 @@
             {
               "title": "Data Types",
               "patterns": ["\/cloudtrace\/v1"],
-              "type": "google/devtools/cloudtrace/v1"
+              "type": "google/devtools/cloudtrace/v1/datatypes"
             }
           ]
         }


### PR DESCRIPTION
Replace hand-written "Data Types" TOCs (as specified in GoogleCloudPlatform/gcloud-common/issues/207) in GAPIC code with generated jsondoc files.

Add GAPIC docs to Vision.

[closes #1180, closes #1206]

- [x] Datastore
- [x] Error Reporting
- [x] Language
- [x] Logging
- [x] Monitoring 
- [x] Pub/Sub
- [x] Spanner
- [x] Trace
- [x] Vision 