### PR TITLE
Remove google-cloud-logger's dependency on orderedhash gem

### DIFF
--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 0.21.1"
   gem.add_dependency "stackdriver-core", "~> 0.21.0"
   gem.add_dependency "google-gax", "~> 0.8.0"
-  gem.add_dependency "orderedhash", "= 0.0.6"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -14,7 +14,6 @@
 
 
 require "logger"
-require "orderedhash"
 
 module Google
   module Cloud
@@ -90,7 +89,7 @@ module Google
         end
 
         ##
-        # A OrderedHash of Thread IDs to Stackdriver request trace ID. The
+        # A Hash of Thread IDs to Stackdriver request trace ID. The
         # Stackdriver trace ID is a shared request identifier across all
         # Stackdriver services.
         #
@@ -142,7 +141,7 @@ module Google
           @resource = resource
           @labels = labels
           @level = 0 # DEBUG is the default behavior
-          @request_info = OrderedHash.new
+          @request_info = {}
           @closed = false
           # Unused, but present for API compatibility
           @formatter = ::Logger::Formatter.new


### PR DESCRIPTION
I used OrderedHash gem in google-cloud-logger previously because I needed a hash implementation that can preserve insert order. It turns out Ruby's built-in Hash class is able to do that already since 1.9. So we can remove the dependency on the OrderedHash gem and use the built-in Hash class directly.

[close #1243]
