### PR TITLE
Exclude spanner from google-cloud docs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -272,7 +272,7 @@ namespace :jsondoc do
       mkdir_p gh_pages + "json/google-cloud/#{version}/google/cloud/"
     end
 
-    excluded = ["gcloud", "google-cloud", "stackdriver", "stackdriver-core"]
+    excluded = ["gcloud", "google-cloud", "stackdriver", "stackdriver-core", "google-cloud-spanner"]
     gems.each do |gem|
       next if excluded.include? gem
 


### PR DESCRIPTION
Fixes broken build caused by jsondoc:google-cloud expectation
that every gem has a most recent version.