### PR TITLE
Change Document#url? to Document#gcs_url?

### DIFF
--- a/google-cloud-language/lib/google/cloud/language/document.rb
+++ b/google-cloud-language/lib/google/cloud/language/document.rb
@@ -74,12 +74,6 @@ module Google
           @grpc.source == :gcs_content_uri
         end
 
-        def url?
-          puts "The method Document#url? is deprecated. " \
-          "Use Document#gcs_url? instead."
-          gcs_url?
-        end
-        
         ##
         # @private The source of the document's content.
         #

--- a/google-cloud-language/lib/google/cloud/language/document.rb
+++ b/google-cloud-language/lib/google/cloud/language/document.rb
@@ -70,10 +70,16 @@ module Google
         ##
         # @private Whether the document source is a Google Cloud Storage URI.
         #
-        def url?
+        def gcs_url?
           @grpc.source == :gcs_content_uri
         end
 
+        def url?
+          puts "The method Document#url? is deprecated. " \
+          "Use Document#gcs_url? instead."
+          gcs_url?
+        end
+        
         ##
         # @private The source of the document's content.
         #

--- a/google-cloud-language/test/google/cloud/language/document_test.rb
+++ b/google-cloud-language/test/google/cloud/language/document_test.rb
@@ -55,7 +55,7 @@ describe Google::Cloud::Language::Document, :mock_language do
 
     # These are private methods
     doc.must_be :content?
-    doc.wont_be :url?
+    doc.wont_be :gcs_url?
     doc.must_be :text?
     doc.wont_be :html?
   end
@@ -65,7 +65,7 @@ describe Google::Cloud::Language::Document, :mock_language do
     doc.must_be_kind_of Google::Cloud::Language::Document
 
     # These are private methods
-    doc.must_be :url?
+    doc.must_be :gcs_url?
     doc.wont_be :content?
     doc.must_be :text?
     doc.wont_be :html?
@@ -76,7 +76,7 @@ describe Google::Cloud::Language::Document, :mock_language do
     doc.must_be_kind_of Google::Cloud::Language::Document
 
     # These are private methods
-    doc.must_be :url?
+    doc.must_be :gcs_url?
     doc.wont_be :content?
     doc.must_be :html?
     doc.wont_be :text?
@@ -87,7 +87,7 @@ describe Google::Cloud::Language::Document, :mock_language do
     doc.must_be_kind_of Google::Cloud::Language::Document
 
     # These are private methods
-    doc.must_be :url?
+    doc.must_be :gcs_url?
     doc.wont_be :content?
     doc.must_be :html?
     doc.wont_be :text?

--- a/google-cloud-language/test/google/cloud/language/project/document_test.rb
+++ b/google-cloud-language/test/google/cloud/language/project/document_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Language::Project, :document, :mock_language do
     doc = language.document "Hello world!"
     doc.must_be_kind_of Google::Cloud::Language::Document
     doc.must_be :content? # private method
-    doc.wont_be :url? # private method
+    doc.wont_be :gcs_url? # private method
     doc.must_be :text? # private method
     doc.wont_be :html? # private method
     doc.source.must_equal "Hello world!" # private method
@@ -28,7 +28,7 @@ describe Google::Cloud::Language::Project, :document, :mock_language do
   it "builds a document from URL" do
     doc = language.document "gs://bucket/path.txt"
     doc.must_be_kind_of Google::Cloud::Language::Document
-    doc.must_be :url? # private method
+    doc.must_be :gcs_url? # private method
     doc.wont_be :content? # private method
     doc.must_be :text? # private method
     doc.wont_be :html? # private method
@@ -39,7 +39,7 @@ describe Google::Cloud::Language::Project, :document, :mock_language do
     fake = OpenStruct.new to_gs_url: "gs://bucket/path.txt"
     doc = language.document fake
     doc.must_be_kind_of Google::Cloud::Language::Document
-    doc.must_be :url? # private method
+    doc.must_be :gcs_url? # private method
     doc.wont_be :content? # private method
     doc.must_be :text? # private method
     doc.wont_be :html? # private method
@@ -49,7 +49,7 @@ describe Google::Cloud::Language::Project, :document, :mock_language do
   it "sets the format of the URL when provided" do
     doc = language.document "gs://bucket/path.ext", format: :html
     doc.must_be_kind_of Google::Cloud::Language::Document
-    doc.must_be :url? # private method
+    doc.must_be :gcs_url? # private method
     doc.wont_be :content? # private method
     doc.must_be :html? # private method
     doc.wont_be :text? # private method
@@ -59,7 +59,7 @@ describe Google::Cloud::Language::Project, :document, :mock_language do
   it "derives HTML format if the URL ends in .html" do
     doc = language.document "gs://bucket/path.html"
     doc.must_be_kind_of Google::Cloud::Language::Document
-    doc.must_be :url? # private method
+    doc.must_be :gcs_url? # private method
     doc.wont_be :content? # private method
     doc.must_be :html? # private method
     doc.wont_be :text? # private method


### PR DESCRIPTION
Got some internal feedback from the language team to change this method name because url? is misleading.