### PR TITLE
Create google-cloud-env gem

### DIFF
--- a/google-cloud-env/.autotest
+++ b/google-cloud-env/.autotest
@@ -1,0 +1,15 @@
+# -*- ruby -*-
+
+require "autotest/suffix"
+
+# Autotest.add_hook :initialize do |at|
+#   at.clear_mappings
+#
+#   at.add_mapping %r%^lib/(.*)\.rb$% do |_, m|
+#     at.files_matching %r%^test/#{m[1]}.*_test.rb$%
+#   end
+#
+#   at.add_mapping %r%^test/.*_test\.rb$% do |filename, _|
+#     filename
+#   end
+# end

--- a/google-cloud-env/.gitignore
+++ b/google-cloud-env/.gitignore
@@ -1,0 +1,16 @@
+Gemfile.lock
+keyfile.json
+coverage/*
+doc/*
+pkg/*
+html/*
+jsondoc/*
+
+# Ignore vagrant directory
+.vagrant
+
+# Ignore YARD stuffs
+.yardoc
+
+# directories left by gh-pages
+_site/*

--- a/google-cloud-env/.rubocop.yml
+++ b/google-cloud-env/.rubocop.yml
@@ -1,0 +1,41 @@
+AllCops:
+  Exclude:
+    - "google-cloud-env.gemspec"
+    - "Rakefile"
+    - "test/**/*"
+
+Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/MethodDefParentheses:
+  EnforcedStyle: require_no_parentheses
+Style/NumericLiterals:
+  Enabled: false
+Style/SpaceAroundOperators:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Style/EmptyLines:
+  Enabled: false
+Style/EmptyElse:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Max: 10
+Metrics/PerceivedComplexity:
+  Max: 10
+Metrics/AbcSize:
+  Max: 25
+Metrics/MethodLength:
+  Max: 20
+Metrics/ParameterLists:
+  Enabled: false
+Style/RescueModifier:
+  Enabled: false
+Style/ClassVars:
+  Enabled: false
+Style/TrivialAccessors:
+  Enabled: false
+Style/FileName:
+  Enabled: false # for lib/google-cloud-env.rb file

--- a/google-cloud-env/.yardopts
+++ b/google-cloud-env/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--title=Google Cloud Env
+--markup markdown
+
+./lib/**/*.rb
+-
+README.md

--- a/google-cloud-env/CHANGELOG.md
+++ b/google-cloud-env/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "rake", "~> 11.0"
+gem "gcloud-jsondoc",
+    git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
+    branch: "gcloud-jsondoc"
+
+# TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
+# so pinning to 2.1 for now.
+gem "rainbow", "~> 2.1.0"

--- a/google-cloud-env/LICENSE
+++ b/google-cloud-env/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/google-cloud-env/README.md
+++ b/google-cloud-env/README.md
@@ -1,0 +1,32 @@
+# google-cloud-env
+
+This library provides information on the application hosting environment for apps running on Google Cloud Platform.
+
+- [google-cloud-env API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-env/master/google/cloud/env)
+
+## Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+## Versioning
+
+This library follows [Semantic Versioning](http://semver.org/).
+
+It is currently in major version zero (0.y.z), which means that anything may change at any time and the public API should not be considered stable.
+
+## Contributing
+
+Contributions to this library are always welcome and highly encouraged.
+
+See the [Contributing Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/contributing) for more information on how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. See [Code of Conduct](../CODE_OF_CONDUCT.md) for more information.
+
+## License
+
+This library is licensed under Apache 2.0. Full license text is available in [LICENSE](LICENSE).
+
+## Support
+
+Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-env/Rakefile
+++ b/google-cloud-env/Rakefile
@@ -1,0 +1,106 @@
+require "bundler/setup"
+require "bundler/gem_tasks"
+
+require "rubocop/rake_task"
+RuboCop::RakeTask.new
+
+desc "Run tests."
+task :test do
+  $LOAD_PATH.unshift "lib", "test"
+  Dir.glob("test/**/*_test.rb").each { |file| require_relative file }
+end
+
+namespace :test do
+  desc "Run tests with coverage."
+  task :coverage do
+    require "simplecov"
+    SimpleCov.start do
+      command_name "google-cloud-env"
+      track_files "lib/**/*.rb"
+      add_filter "test/"
+    end
+
+    Rake::Task["test"].invoke
+  end
+end
+
+desc "Run acceptance tests."
+task :acceptance do
+  puts "The google-cloud-env gem does not have acceptance tests."
+end
+
+namespace :acceptance do
+  desc "Run acceptance cleanup."
+  task :cleanup do
+  end
+end
+
+desc "Run yard-doctest example tests."
+task :doctest do
+  puts "The google-cloud-env gem does not have doctest tests."
+end
+
+desc "Start an interactive shell."
+task :console do
+  require "irb"
+  require "irb/completion"
+  require "pp"
+
+  $LOAD_PATH.unshift "lib"
+
+  require "google-cloud-env"
+
+  ARGV.clear
+  IRB.start
+end
+
+require "yard"
+require "yard/rake/yardoc_task"
+YARD::Rake::YardocTask.new
+
+desc "Generates JSON output from google-cloud-env .yardoc"
+task :jsondoc => :yard do
+  require "rubygems"
+  require "gcloud/jsondoc"
+
+  registry = YARD::Registry.load! ".yardoc"
+  generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-env"
+  generator.write_to "jsondoc"
+  cp ["docs/toc.json"], "jsondoc", verbose: true
+end
+
+desc "Run the CI build"
+task :ci do
+  header "BUILDING google-cloud-env"
+  header "google-cloud-env rubocop", "*"
+  sh "bundle exec rake rubocop"
+  header "google-cloud-env jsondoc", "*"
+  sh "bundle exec rake jsondoc"
+  header "google-cloud-env doctest", "*"
+  sh "bundle exec rake doctest"
+  header "google-cloud-env test", "*"
+  sh "bundle exec rake test"
+end
+namespace :ci do
+  desc "Run the CI build, with acceptance tests."
+  task :acceptance do
+    Rake::Task["ci"].invoke
+    header "google-cloud-env acceptance", "*"
+    sh "bundle exec rake acceptance -v"
+  end
+  task :a do
+    # This is a handy shortcut to save typing
+    Rake::Task["ci:acceptance"].invoke
+  end
+end
+
+task :default => :test
+
+def header str, token = "#"
+  line_length = str.length + 8
+  puts ""
+  puts token * line_length
+  puts "#{token * 3} #{str} #{token * 3}"
+  puts token * line_length
+  puts ""
+end

--- a/google-cloud-env/docs/toc.json
+++ b/google-cloud-env/docs/toc.json
@@ -1,0 +1,22 @@
+{
+  "guides": [
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Google Cloud Env",
+      "type": "google/cloud/env"
+    }
+  ]
+}

--- a/google-cloud-env/google-cloud-env.gemspec
+++ b/google-cloud-env/google-cloud-env.gemspec
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path("../lib/google/cloud/env/version", __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.name          = "google-cloud-env"
+  gem.version       = Google::Cloud::Env::VERSION
+
+  gem.authors       = ["Daniel Azuma"]
+  gem.email         = ["dazuma@google.com"]
+  gem.description   = "google-cloud-env provides information on the Google Cloud Platform hosting environment. Applications can use this library to determine hosting context information such as the project ID, whether App Engine is running, what tags are set on the VM instance, and much more."
+  gem.summary       = "Google Cloud Platform hosting environment information."
+  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.license       = "Apache-2.0"
+
+  gem.files         = `git ls-files -- lib/*`.split("\n") +
+                      ["README.md", "LICENSE", ".yardopts"]
+  gem.require_paths = ["lib"]
+
+  gem.required_ruby_version = ">= 2.0.0"
+
+  gem.add_dependency "faraday", "~> 0.11"
+
+  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest-autotest", "~> 1.0"
+  gem.add_development_dependency "minitest-focus", "~> 1.1"
+  gem.add_development_dependency "minitest-rg", "~> 5.2"
+  gem.add_development_dependency "autotest-suffix", "~> 1.1"
+  gem.add_development_dependency "rubocop", "<= 0.35.1"
+  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "<= 0.1.8"
+end

--- a/google-cloud-env/lib/google-cloud-env.rb
+++ b/google-cloud-env/lib/google-cloud-env.rb
@@ -1,0 +1,17 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/env"
+require "google/cloud/env/version"

--- a/google-cloud-env/lib/google/cloud/env.rb
+++ b/google-cloud-env/lib/google/cloud/env.rb
@@ -1,0 +1,366 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "faraday"
+require "json"
+
+
+module Google
+  module Cloud
+    ##
+    # # Google Cloud hosting environment
+    #
+    # This library provides access to information about the application's
+    # hosting environment if it is running on Google Cloud Platform. You may
+    # use this library to determine which Google Cloud product is hosting your
+    # application (e.g. app engine, container engine), information about the
+    # Google Cloud project hosting the application, information about the
+    # virtual machine instance, authentication information, and so forth.
+    #
+    # ## Usage
+    #
+    # Obtain an instance of the environment info with:
+    #
+    #     require "google/cloud/env"
+    #     env = Google::Cloud.env
+    #
+    # Then you can interrogate any fields using methods on the object.
+    #
+    #     if env.app_engine?
+    #       # App engine specific logic
+    #     end
+    #
+    # Any item that does not apply to the current environment will return nil.
+    # For example:
+    #
+    #     unless env.app_engine?
+    #       service = env.app_engine_service_id  # => nil
+    #     end
+    #
+    class Env
+      # @private Base (host) URL for the metadata server.
+      METADATA_HOST = "http://169.254.169.254".freeze
+
+      # @private URL path for v1 of the metadata service.
+      METADATA_PATH_BASE = "/computeMetadata/v1".freeze
+
+      # @private URL path for metadata server root.
+      METADATA_ROOT_PATH = "/".freeze
+
+      ##
+      # Create a new instance of the environment information.
+      # Most client should not need to call this directly. Obtain a singleton
+      # instance of the information from `Google::Cloud.env`. This constructor
+      # is provided for internal testing and allows mocking of the data.
+      #
+      # @param [Hash] env Mock environment variables.
+      # @param [Faraday::Connection] connection Faraday connection to use.
+      #
+      def initialize env: nil, connection: nil
+        @metadata_cache = {}
+        @env = env || ::ENV
+        @connection = connection ||
+                      ::Faraday.new(url: METADATA_HOST,
+                                    request: { timeout: 0.1 })
+      end
+
+      ##
+      # Determine whether the application is running on Google App Engine.
+      #
+      # @return [Boolean]
+      #
+      def app_engine?
+        env["GAE_INSTANCE"] ? true : false
+      end
+
+      ##
+      # Determine whether the application is running on Google Container Engine.
+      #
+      # @return [Boolean]
+      #
+      def container_engine?
+        container_engine_cluster_name ? true : false
+      end
+
+      ##
+      # Determine whether the application is running on Google Cloud Shell.
+      #
+      # @return [Boolean]
+      #
+      def cloud_shell?
+        env["DEVSHELL_GCLOUD_CONFIG"] ? true : false
+      end
+
+      ##
+      # Determine whether the application is running on Google Compute Engine.
+      #
+      # Note that most other products (e.g. App Engine, Container Engine,
+      # Cloud Shell) themselves use Compute Engine under the hood, so this
+      # method will return true for all the above products. If you want to
+      # determine whether the application is running on a "raw" Compute Engine
+      # VM without using a higher level hosting product, use
+      # {Env#raw_compute_engine?}.
+      #
+      # @return [Boolean]
+      #
+      def compute_engine?
+        metadata?
+      end
+
+      ##
+      # Determine whether the application is running on "raw" Google Compute
+      # Engine without using a higher level hosting product such as App
+      # Engine or Container Engine.
+      #
+      # @return [Boolean]
+      #
+      def raw_compute_engine?
+        !app_engine? && !cloud_shell? && metadata? && !container_engine?
+      end
+
+      ##
+      # Returns the unique string ID of the project hosting the application,
+      # or `nil` if the application is not running on Google Cloud.
+      #
+      # @return [String,nil]
+      #
+      def project_id
+        env["GCLOUD_PROJECT"] || env["DEVSHELL_PROJECT_ID"] ||
+          lookup_metadata("project", "project-id")
+      end
+
+      ##
+      # Returns the unique numeric ID of the project hosting the application,
+      # or `nil` if the application is not running on Google Cloud.
+      #
+      # Caveat: this method does not work and returns `nil` on CloudShell.
+      #
+      # @return [Integer,nil]
+      #
+      def numeric_project_id
+        # CloudShell's metadata server seems to run in a dummy project.
+        # We can get the user's normal project ID via environment variables,
+        # but the numeric ID from the metadata service is not correct. So
+        # disable this for CloudShell to avoid confusion.
+        return nil if cloud_shell?
+
+        result = lookup_metadata "project", "numeric-project-id"
+        result.nil? ? nil : result.to_i
+      end
+
+      ##
+      # Returns the name of the VM instance hosting the application, or `nil`
+      # if the application is not running on Google Cloud.
+      #
+      # @return [String,nil]
+      #
+      def instance_name
+        env["GAE_INSTANCE"] || lookup_metadata("instance", "name")
+      end
+
+      ##
+      # Returns the description field (which may be the empty string) of the
+      # VM instance hosting the application, or `nil` if the application is
+      # not running on Google Cloud.
+      #
+      # @return [String,nil]
+      #
+      def instance_description
+        lookup_metadata "instance", "description"
+      end
+
+      ##
+      # Returns the zone (for example "`us-central1-c`") in which the instance
+      # hosting the application lives. Returns `nil` if the application is
+      # not running on Google Cloud.
+      #
+      # @return [String,nil]
+      #
+      def instance_zone
+        result = lookup_metadata "instance", "zone"
+        result.nil? ? nil : result.split("/").last
+      end
+
+      ##
+      # Returns the machine type of the VM instance hosting the application,
+      # or `nil` if the application is not running on Google Cloud.
+      #
+      # @return [String,nil]
+      #
+      def instance_machine_type
+        result = lookup_metadata "instance", "machine-type"
+        result.nil? ? nil : result.split("/").last
+      end
+
+      ##
+      # Returns an array (which may be empty) of all tags set on the VM
+      # instance hosting the  application, or `nil` if the application is not
+      # running on Google Cloud.
+      #
+      # @return [Array<String>,nil]
+      #
+      def instance_tags
+        result = lookup_metadata "instance", "tags"
+        result.nil? ? nil : JSON.parse(result)
+      end
+
+      ##
+      # Returns an array (which may be empty) of all attribute keys present
+      # for the VM instance hosting the  application, or `nil` if the
+      # application is not running on Google Cloud.
+      #
+      # @return [Array<String>,nil]
+      #
+      def instance_attribute_keys
+        result = lookup_metadata "instance", "attributes/"
+        result.nil? ? nil : result.split
+      end
+
+      ##
+      # Returns the value of the given instance attribute for the VM instance
+      # hosting the application, or `nil` if the given key does not exist or
+      # application is not running on Google Cloud.
+      #
+      # @param [String] key Attribute key to look up.
+      # @return [String,nil]
+      #
+      def instance_attribute key
+        lookup_metadata "instance", "attributes/#{key}"
+      end
+
+      ##
+      # Returns the name of the running App Engine service, or `nil` if the
+      # current code is not running in App Engine.
+      #
+      # @return [String,nil]
+      #
+      def app_engine_service_id
+        env["GAE_SERVICE"]
+      end
+
+      ##
+      # Returns the version of the running App Engine service, or `nil` if the
+      # current code is not running in App Engine.
+      #
+      # @return [String,nil]
+      #
+      def app_engine_service_version
+        env["GAE_VERSION"]
+      end
+
+      ##
+      # Returns the amount of memory reserved for the current App Engine
+      # instance, or `nil` if the current code is not running in App Engine.
+      #
+      # @return [Integer,nil]
+      #
+      def app_engine_memory_mb
+        result = env["GAE_MEMORY_MB"]
+        result.nil? ? nil : result.to_i
+      end
+
+      ##
+      # Returns the name of the Container Engine cluster hosting the
+      # application, or `nil` if the current code is not running in
+      # Container Engine.
+      #
+      # @return [String,nil]
+      #
+      def container_engine_cluster_name
+        instance_attribute "cluster-name"
+      end
+
+      ##
+      # Returns the name of the Container Engine namespace hosting the
+      # application, or `nil` if the current code is not running in
+      # Container Engine.
+      #
+      # @return [String,nil]
+      #
+      def container_engine_namespace_id
+        env["GKE_NAMESPACE_ID"]
+      end
+
+      ##
+      # Determine whether the Google Compute Engine Metadata Service is running.
+      #
+      # @return [Boolean]
+      #
+      def metadata?
+        unless metadata_cache.include?(METADATA_ROOT_PATH)
+          begin
+            resp = connection.get METADATA_ROOT_PATH
+            metadata_cache[METADATA_ROOT_PATH] = \
+              resp.status == 200 && resp.headers["Metadata-Flavor"] == "Google"
+          rescue ::Faraday::TimeoutError, ::Faraday::ConnectionFailed
+            metadata_cache[METADATA_ROOT_PATH] = false
+          end
+        end
+        metadata_cache[METADATA_ROOT_PATH]
+      end
+
+      ##
+      # Retrieve info from the Google Compute Engine Metadata Service.
+      # Returns `nil` if the Metadata Service is not running or the given
+      # data is not present.
+      #
+      # @param [String] type Type of metadata to look up. Currently supported
+      #     values are "project" and "instance".
+      # @param [String] entry Metadata entry path to look up.
+      # @return [String,nil]
+      #
+      def lookup_metadata type, entry
+        path = "#{METADATA_PATH_BASE}/#{type}/#{entry}"
+        if !metadata_cache.include?(path) && metadata?
+          begin
+            resp = connection.get path do |req|
+              req.headers = { "Metadata-Flavor" => "Google" }
+            end
+            metadata_cache[path] = resp.status == 200 ? resp.body.strip : nil
+          rescue ::Faraday::TimeoutError, ::Faraday::ConnectionFailed
+            metadata_cache[path] = nil
+          end
+        end
+        metadata_cache[path]
+      end
+
+      ##
+      # Returns the global instance of {Google::Cloud::Env}.
+      #
+      # @return [Google::Cloud::Env]
+      #
+      def self.get
+        ::Google::Cloud.env
+      end
+
+      private
+
+      attr_reader :connection
+      attr_reader :env
+      attr_reader :metadata_cache
+    end
+
+    @env = Env.new
+
+    ##
+    # Returns the global instance of {Google::Cloud::Env}.
+    #
+    # @return [Google::Cloud::Env]
+    #
+    def self.env
+      @env
+    end
+  end
+end

--- a/google-cloud-env/lib/google/cloud/env/version.rb
+++ b/google-cloud-env/lib/google/cloud/env/version.rb
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    class Env
+      VERSION = "0.1.0".freeze
+    end
+  end
+end

--- a/google-cloud-env/test/google/cloud/env_test.rb
+++ b/google-cloud-env/test/google/cloud/env_test.rb
@@ -1,0 +1,231 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "google/cloud/env"
+
+
+describe Google::Cloud::Env do
+  let(:instance_name) { "instance-a1b2" }
+  let(:instance_description) { "" }
+  let(:instance_zone) { "us-west99-z" }
+  let(:instance_machine_type) { "z9999-really-really-huge" }
+  let(:instance_tags) { ["erlang", "elixir"] }
+  let(:project_id) { "my-project-123" }
+  let(:numeric_project_id) { 1234567890 }
+  let(:gae_service) { "default" }
+  let(:gae_version) { "20170214t123456" }
+  let(:gae_memory_mb) { 640 }
+  let(:gke_cluster) { "my-cluster" }
+  let(:gke_namespace) { "my-namespace" }
+
+  let :gae_env do
+    {
+      "GAE_INSTANCE" => instance_name,
+      "GCLOUD_PROJECT" => project_id,
+      "GAE_SERVICE" => gae_service,
+      "GAE_VERSION" => gae_version,
+      "GAE_MEMORY_MB" => gae_memory_mb
+    }
+  end
+  let :gke_env do
+    {
+      "GKE_NAMESPACE_ID" => gke_namespace
+    }
+  end
+  let :cloud_shell_env do
+    {
+      "DEVSHELL_PROJECT_ID" => project_id,
+      "DEVSHELL_GCLOUD_CONFIG" => "cloudshell-1234"
+    }
+  end
+  let(:gce_env) { {} }
+  let(:ext_env) { {} }
+
+  def gce_stubs
+    ::Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get("") { |env| [200, {"Metadata-Flavor" => "Google"}, ""] }
+      stub.get("/computeMetadata/v1/project/project-id") { |env|
+        [200, {}, project_id]
+      }
+      stub.get("/computeMetadata/v1/project/numeric-project-id") { |env|
+        [200, {}, numeric_project_id.to_s]
+      }
+      stub.get("/computeMetadata/v1/instance/name") { |env|
+        [200, {}, instance_name]
+      }
+      stub.get("/computeMetadata/v1/instance/zone") { |env|
+        [200, {}, "/project/#{project_id}/zone/#{instance_zone}"]
+      }
+      stub.get("/computeMetadata/v1/instance/description") { |env|
+        [200, {}, instance_description]
+      }
+      stub.get("/computeMetadata/v1/instance/machine-type") { |env|
+        [200, {}, "/project/#{project_id}/zone/#{instance_machine_type}"]
+      }
+      stub.get("/computeMetadata/v1/instance/tags") { |env|
+        [200, {}, JSON.dump(instance_tags)]
+      }
+    end
+  end
+
+  let :gce_conn do
+    Faraday::Connection.new do |builder|
+      builder.adapter :test, gce_stubs do |stub|
+        stub.get(//) { |env| [404, {}, "not found"] }
+      end
+    end
+  end
+
+  let :gke_conn do
+    Faraday::Connection.new do |builder|
+      builder.adapter :test, gce_stubs do |stub|
+        stub.get("/computeMetadata/v1/instance/attributes/cluster-name") { |env|
+          [200, {}, gke_cluster]
+        }
+        stub.get(//) { |env| [404, {}, "not found"] }
+      end
+    end
+  end
+
+  let :ext_conn do
+    Faraday::Connection.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get(//) { |env| [404, {}, "not found"] }
+      end
+    end
+  end
+
+  it "returns correct values when running on app engine" do
+    env = ::Google::Cloud::Env.new env: gae_env, connection: gce_conn
+
+    env.app_engine?.must_equal true
+    env.container_engine?.must_equal false
+    env.cloud_shell?.must_equal false
+    env.compute_engine?.must_equal true
+    env.raw_compute_engine?.must_equal false
+
+    env.project_id.must_equal project_id
+    env.numeric_project_id.must_equal numeric_project_id
+    env.instance_name.must_equal instance_name
+    env.instance_description.must_equal instance_description
+    env.instance_machine_type.must_equal instance_machine_type
+    env.instance_tags.must_equal instance_tags
+
+    env.app_engine_service_id.must_equal gae_service
+    env.app_engine_service_version.must_equal gae_version
+    env.app_engine_memory_mb.must_equal gae_memory_mb
+
+    env.container_engine_cluster_name.must_be_nil
+    env.container_engine_namespace_id.must_be_nil
+  end
+
+  it "returns correct values when running on container engine" do
+    env = ::Google::Cloud::Env.new env: gke_env, connection: gke_conn
+
+    env.app_engine?.must_equal false
+    env.container_engine?.must_equal true
+    env.cloud_shell?.must_equal false
+    env.compute_engine?.must_equal true
+    env.raw_compute_engine?.must_equal false
+
+    env.project_id.must_equal project_id
+    env.numeric_project_id.must_equal numeric_project_id
+    env.instance_name.must_equal instance_name
+    env.instance_description.must_equal instance_description
+    env.instance_machine_type.must_equal instance_machine_type
+    env.instance_tags.must_equal instance_tags
+
+    env.app_engine_service_id.must_be_nil
+    env.app_engine_service_version.must_be_nil
+    env.app_engine_memory_mb.must_be_nil
+
+    env.container_engine_cluster_name.must_equal gke_cluster
+    env.container_engine_namespace_id.must_equal gke_namespace
+  end
+
+  it "returns correct values when running on cloud shell" do
+    env = ::Google::Cloud::Env.new env: cloud_shell_env, connection: gce_conn
+
+    env.app_engine?.must_equal false
+    env.container_engine?.must_equal false
+    env.cloud_shell?.must_equal true
+    env.compute_engine?.must_equal true
+    env.raw_compute_engine?.must_equal false
+
+    env.project_id.must_equal project_id
+    env.numeric_project_id.must_be_nil
+    env.instance_name.must_equal instance_name
+    env.instance_description.must_equal instance_description
+    env.instance_machine_type.must_equal instance_machine_type
+    env.instance_tags.must_equal instance_tags
+
+    env.app_engine_service_id.must_be_nil
+    env.app_engine_service_version.must_be_nil
+    env.app_engine_memory_mb.must_be_nil
+
+    env.container_engine_cluster_name.must_be_nil
+    env.container_engine_namespace_id.must_be_nil
+  end
+
+  it "returns correct values when running on compute engine" do
+    env = ::Google::Cloud::Env.new env: gce_env, connection: gce_conn
+
+    env.app_engine?.must_equal false
+    env.container_engine?.must_equal false
+    env.cloud_shell?.must_equal false
+    env.compute_engine?.must_equal true
+    env.raw_compute_engine?.must_equal true
+
+    env.project_id.must_equal project_id
+    env.numeric_project_id.must_equal numeric_project_id
+    env.instance_name.must_equal instance_name
+    env.instance_description.must_equal instance_description
+    env.instance_machine_type.must_equal instance_machine_type
+    env.instance_tags.must_equal instance_tags
+
+    env.app_engine_service_id.must_be_nil
+    env.app_engine_service_version.must_be_nil
+    env.app_engine_memory_mb.must_be_nil
+
+    env.container_engine_cluster_name.must_be_nil
+    env.container_engine_namespace_id.must_be_nil
+  end
+
+  it "returns correct values when not running on gcp" do
+    env = ::Google::Cloud::Env.new env: ext_env, connection: ext_conn
+
+    env.app_engine?.must_equal false
+    env.container_engine?.must_equal false
+    env.cloud_shell?.must_equal false
+    env.compute_engine?.must_equal false
+    env.raw_compute_engine?.must_equal false
+
+    env.project_id.must_be_nil
+    env.numeric_project_id.must_be_nil
+    env.instance_name.must_be_nil
+    env.instance_description.must_be_nil
+    env.instance_machine_type.must_be_nil
+    env.instance_tags.must_be_nil
+
+    env.app_engine_service_id.must_be_nil
+    env.app_engine_service_version.must_be_nil
+    env.app_engine_memory_mb.must_be_nil
+
+    env.container_engine_cluster_name.must_be_nil
+    env.container_engine_namespace_id.must_be_nil
+  end
+
+end

--- a/google-cloud-env/test/helper.rb
+++ b/google-cloud-env/test/helper.rb
@@ -1,0 +1,19 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gem "minitest"
+require "minitest/autorun"
+require "minitest/focus"
+require "minitest/rg"
+require "json"


### PR DESCRIPTION
Create and populate an initial version of google-cloud-env. This gem will provide information about the GCP hosting environment (such as whether App Engine is running, what project is hosting the app, or what machine type is hosting the app). It effectively wraps around the documented environment variables for the various hosting environments, and the functionality of the Compute Engine metadata service.

Once this gem goes live, we can pull this functionality out of google-cloud-core.