### PR TITLE
Set version constraints on stackdriver service gem dependencies

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,6 +90,6 @@ After all [pull requests](https://github.com/GoogleCloudPlatform/google-cloud-ru
 
 1. Some time later, after they have completed, confirm that [Travis CI (Mac OS X)](https://travis-ci.org/GoogleCloudPlatform/google-cloud-ruby) and [Appveyor CI (Windows)](https://ci.appveyor.com/project/GoogleCloudPlatform/google-cloud-ruby) builds are also green.
 
-1. If your version change is greater than the [semver](http://semver.org/) patch version, then when you are done releasing all individual packages, you should follow these same instructions to release the `google-cloud` umbrella package.
+1. If your version change is greater than the [semver](http://semver.org/) patch version, then when you are done releasing all individual packages, you should follow these same instructions to release the `google-cloud` umbrella package. Furthermore, if your major releases included at least one dependency of the `stackdriver` umbrella package (currently those dependencies are `google-cloud-logging`, `google-cloud-trace`, `google-cloud-error_reporting`, and `google-cloud-monitoring`), then you should also follow these same instructions to release the `stackdriver` umbrella package. It is important that the dependencies of the `google-cloud` and `stackdriver` gems remain compatible so the two can co-exist in the same bundle.
 
 High fives all around!

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_runtime_dependency "google-cloud-error_reporting"
-  gem.add_runtime_dependency "google-cloud-logging"
-  gem.add_runtime_dependency "google-cloud-monitoring"
-  gem.add_runtime_dependency "google-cloud-trace"
+  gem.add_runtime_dependency "google-cloud-error_reporting", "~> 0.23.0"
+  gem.add_runtime_dependency "google-cloud-logging", "~> 0.24.0"
+  gem.add_runtime_dependency "google-cloud-monitoring", "~> 0.23.0"
+  gem.add_runtime_dependency "google-cloud-trace", "~> 0.23.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_runtime_dependency "google-cloud-error_reporting", "~> 0.23.0"
+  gem.add_runtime_dependency "google-cloud-error_reporting", "~> 0.23.1"
   gem.add_runtime_dependency "google-cloud-logging", "~> 0.24.0"
   gem.add_runtime_dependency "google-cloud-monitoring", "~> 0.23.0"
   gem.add_runtime_dependency "google-cloud-trace", "~> 0.23.0"


### PR DESCRIPTION
The stackdriver gem should provide constraints on the versions to guard against future backwards-incompatible changes in the constituent gems. Major version updates should be handled similarly to how we handle the google-cloud gem.

Note: this means we're coupling major versions of google-cloud and stackdriver to each other. Updates have to be made in lock step to maintain version compatibility in the upstream gems. I don't especially like this, but I don't have a good alternative at the moment. Suggestions welcome.