### PR TITLE
Require Google::Cloud::ErrorReporting::Middleware on Rails module

### DIFF
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -15,6 +15,7 @@
 
 require "google/cloud/core/environment"
 require "google/cloud/error_reporting/v1beta1"
+require "google/cloud/error_reporting/middleware"
 require "google/cloud/credentials"
 
 module Google


### PR DESCRIPTION
This PR requires ErrorReporting::Middleware on ErrorReporting::Rails module. Without this require, ErrorReporting::Rails returns the following error:

```ruby
error_reporting/rails.rb:82:in `block in <class:Railtie>':
uninitialized constant Google::Cloud::ErrorReporting::Railtie::Middleware (NameError)
```