### PR TITLE
Fix broken links in google-cloud (umbrella) gh-pages docs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -270,9 +270,27 @@ namespace :jsondoc do
 
     rm_rf gh_pages + "json/google-cloud/#{version}/google", verbose: true
 
-    excluded = ["gcloud", "google-cloud", "stackdriver", "stackdriver-core", "google-cloud-spanner", "google-cloud-env"]
+    google_cloud_gems = [
+      "google-cloud-bigquery",
+      "google-cloud-core",
+      "google-cloud-datastore",
+      "google-cloud-dns",
+      "google-cloud-error_reporting",
+      "google-cloud-language",
+      "google-cloud-logging",
+      "google-cloud-monitoring",
+      "google-cloud-pubsub",
+      "google-cloud-resource_manager",
+      "google-cloud-speech",
+      "google-cloud-storage",
+      "google-cloud-trace",
+      "google-cloud-translate",
+      "google-cloud-vision"
+    ]
+    # Currently excluded: "gcloud", "google-cloud", "stackdriver", "stackdriver-core",
+    #                     "google-cloud-spanner", "google-cloud-env"
     gems.each do |gem|
-      next if excluded.include? gem
+      next unless google_cloud_gems.include? gem
 
       ver = if version == "master"
               "master" # When building master, all content should be from master

--- a/Rakefile
+++ b/Rakefile
@@ -268,9 +268,7 @@ namespace :jsondoc do
 
     header "Copying all gems' jsondoc from gh-pages to google-cloud package in gh-pages"
 
-    unless Dir.exist? gh_pages + "json/google-cloud/#{version}/google/cloud/"
-      mkdir_p gh_pages + "json/google-cloud/#{version}/google/cloud/"
-    end
+    rm_rf gh_pages + "json/google-cloud/#{version}/google", verbose: true
 
     excluded = ["gcloud", "google-cloud", "stackdriver", "stackdriver-core", "google-cloud-spanner", "google-cloud-env"]
     gems.each do |gem|
@@ -291,53 +289,8 @@ namespace :jsondoc do
 
       header_2 "Copying #{gem_shortname} jsondoc from gh-pages to google-cloud package in gh-pages"
 
-      unless gem == "google-cloud-core" # There is no `core` subdir, copy files from google/cloud/
-        # Copy the contents of google/cloud subdir for the gem namespace.
-        rm_rf gh_pages + "json/google-cloud/#{version}/google/cloud/#{gem_shortname}", verbose: true
-        cp_r "#{src}/google/cloud/#{gem_shortname}",
-             gh_pages + "json/google-cloud/#{version}/google/cloud/#{gem_shortname}",
-             verbose: true
-
-        if Dir.exists? "#{src}/google/#{gem_shortname}"
-          header_2 "Copying  #{gem_shortname} jsondoc for GAPIC"
-          # Copy the contents of google subdir for the gem namespace for GAPIC.
-          rm_rf gh_pages + "json/google-cloud/#{version}/google/#{gem_shortname}", verbose: true
-          cp_r "#{src}/google/#{gem_shortname}",
-               gh_pages + "json/google-cloud/#{version}/google/#{gem_shortname}",
-               verbose: true
-        end
-
-        if Dir.exists? "#{src}/google/protobuf"
-          header_2 "Copying  #{gem_shortname} jsondoc for Protobuf"
-          # Copy the contents of google subdir for Protobufs, without deleting,
-          # since all gems copy to same destination.
-          # NOTE: later gems' protobuf definitions of same name will overwrite earlier!
-          mkdir_p gh_pages + "json/google-cloud/#{version}/google/protobuf", verbose: true
-          cp Dir["#{src}/google/protobuf/*.json"], gh_pages + "json/google-cloud/#{version}/google/protobuf/", verbose: true
-        end
-
-        # Copy GAPIC directories with names that do not match gem namespace
-        if Dir.exists?("#{src}/google/devtools")
-          mkdir_p gh_pages + "json/google-cloud/#{version}/google/devtools", verbose: true
-          # google-cloud-error_reporting
-          if gem == "google-cloud-error_reporting"
-            # Copy the gem's subdir in devtools
-            header_2 "Copying  #{gem_shortname} jsondoc for devtools"
-            cp_r Dir["#{src}/google/devtools/clouderrorreporting"],
-                 gh_pages + "json/google-cloud/#{version}/google/devtools/", verbose: true
-          end
-          # google-cloud-trace
-          if gem == "google-cloud-trace"
-            # Copy the gem's subdir in devtools
-            header_2 "Copying  #{gem_shortname} jsondoc for devtools"
-            cp_r Dir["#{src}/google/devtools/cloudtrace"],
-                 gh_pages + "json/google-cloud/#{version}/google/devtools/", verbose: true
-          end
-        end
-      end
-
       # Copy the contents of google/cloud/ for the gem. This also gets the core error files.
-      cp Dir["#{src}/google/cloud/*.json"], gh_pages + "json/google-cloud/#{version}/google/cloud/", verbose: true
+      cp_r "#{src}/google", gh_pages + "json/google-cloud/#{version}/", verbose: true
       all_types << JSON.parse(File.read("#{src}/types.json"))
       all_google_cloud_methods << JSON.parse(File.read("#{src}/google/cloud.json"))["methods"]
     end

--- a/gcloud/Rakefile
+++ b/gcloud/Rakefile
@@ -67,6 +67,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "gcloud"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -129,6 +129,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-bigquery"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-core/Rakefile
+++ b/google-cloud-core/Rakefile
@@ -66,6 +66,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-core"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -122,6 +122,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry,
                                              "google-cloud-datastore",
                                              generate: toc_config
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -125,6 +125,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-dns"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-env/Rakefile
+++ b/google-cloud-env/Rakefile
@@ -65,6 +65,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-env"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -126,6 +126,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry,
                                              "google-cloud-error_reporting",
                                              generate: toc_config
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -114,6 +114,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry,
                                              "google-cloud-language",
                                              generate: toc_config
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -180,6 +180,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry,
                                              "google-cloud-logging",
                                              generate: toc_config
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-monitoring/Rakefile
+++ b/google-cloud-monitoring/Rakefile
@@ -93,6 +93,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry,
                                              "google-cloud-monitoring",
                                              generate: toc_config
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -141,6 +141,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry,
                                              "google-cloud-pubsub",
                                              generate: toc_config
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-resource_manager/Rakefile
+++ b/google-cloud-resource_manager/Rakefile
@@ -66,6 +66,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-resource_manager"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-spanner/Rakefile
+++ b/google-cloud-spanner/Rakefile
@@ -167,6 +167,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry,
                                              "google-cloud-spanner",
                                              generate: toc_config
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -97,6 +97,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-speech"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -128,6 +128,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-storage"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -130,6 +130,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry,
                                              "google-cloud-trace",
                                              generate: toc_config
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/instrumentation.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -128,6 +128,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud-translate"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -127,6 +127,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry,
                                              "google-cloud-vision",
                                              generate: toc_config
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/google-cloud/Rakefile
+++ b/google-cloud/Rakefile
@@ -67,6 +67,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "google-cloud"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end

--- a/stackdriver-core/Rakefile
+++ b/stackdriver-core/Rakefile
@@ -65,6 +65,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "stackdriver-core"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/toc.json"], "jsondoc", verbose: true
 end

--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -78,6 +78,7 @@ task :jsondoc => :yard do
 
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry, "stackdriver"
+  rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
   cp ["docs/toc.json"], "jsondoc", verbose: true
 end


### PR DESCRIPTION
This PR updates the `jsondoc:google_cloud` task to correctly copy all JSON doc files in the root `google` namespace from all included packages. It adds a clean step to the `jsondoc` task in all Rakefiles. It also updates the `jsondoc:google_cloud` task to include packages by opt-in rather than opt-out.

[fixes #1217]

/cc @dazuma 