### PR TITLE
Regenerate Datastore Gapic to use new HTTP headers.

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -58,8 +58,8 @@ module Google
             channel: channel,
             timeout: timeout,
             client_config: client_config,
-            app_name: "gcloud-ruby",
-            app_version: Google::Cloud::Datastore::VERSION)
+            lib_name: "gccl",
+            lib_version: Google::Cloud::Datastore::VERSION)
         end
         attr_accessor :mocked_service
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
@@ -50,8 +50,6 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
-          CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
-
           DEFAULT_TIMEOUT = 30
 
           # The scopes needed to make gRPC calls to all of the methods defined in
@@ -76,10 +74,6 @@ module Google
           #   or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
-          # @param app_name [String]
-          #   The codename of the calling service.
-          # @param app_version [String]
-          #   The version of the calling service.
           def initialize \
               service_path: SERVICE_ADDRESS,
               port: DEFAULT_SERVICE_PORT,
@@ -88,17 +82,27 @@ module Google
               scopes: ALL_SCOPES,
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
-              app_name: "gax",
-              app_version: Google::Gax::VERSION
+              app_name: nil,
+              app_version: nil,
+              lib_name: nil,
+              lib_version: ""
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/datastore/v1/datastore_services_pb"
 
-            google_api_client = "#{app_name}/#{app_version} " \
-              "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " \
-              "ruby/#{RUBY_VERSION}".freeze
+
+            if app_name || app_version
+              warn "`app_name` and `app_version` are no longer being used in the request headers."
+            end
+
+            google_api_client = "gl-ruby/#{RUBY_VERSION}"
+            google_api_client << " #{lib_name}/#{lib_version}" if lib_name
+            google_api_client << " gapic/ gax/#{Google::Gax::VERSION}"
+            google_api_client << " grpc/#{GRPC::VERSION}"
+            google_api_client.freeze
+
             headers = { :"x-goog-api-client" => google_api_client }
             client_config_file = Pathname.new(__dir__).join(
               "datastore_client_config.json"

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client_config.json
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client_config.json
@@ -2,11 +2,11 @@
   "interfaces": {
     "google.datastore.v1.Datastore": {
       "retry_codes": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
@@ -1,10 +1,10 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/entity.rb
@@ -1,10 +1,10 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/query.rb
@@ -1,10 +1,10 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -267,6 +267,7 @@ module Google
       #     In a single transaction, subsequent query result batches for the same query
       #     can have a greater snapshot version number. Each batch's snapshot version
       #     is valid for all preceding batches.
+      #     The value will be zero for eventually consistent queries.
       class QueryResultBatch
         # The possible values for the +more_results+ field.
         module MoreResultsType

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/wrappers.rb
@@ -1,10 +1,10 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Updates: https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1268

cc @swcloud @bjwatson 