### PR TITLE
Regenerate Errorreporting Gapic to use new HTTP headers.

### DIFF
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -64,9 +64,7 @@ module Google
             service_version = er_config.service_version
 
             error_reporting = V1beta1::ReportErrorsServiceClient.new(
-              channel: channel,
-              app_name: service_name,
-              app_version: service_version
+              channel: channel
             )
 
             # In later versions of Rails, ActionDispatch::DebugExceptions is

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
@@ -1,10 +1,10 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/error_stats_service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/error_stats_service.rb
@@ -1,10 +1,10 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/report_errors_service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/report_errors_service.rb
@@ -1,10 +1,10 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/duration.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/duration.rb
@@ -1,10 +1,10 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
@@ -1,10 +1,10 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
@@ -45,8 +45,6 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
-          CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
-
           DEFAULT_TIMEOUT = 30
 
           # The scopes needed to make gRPC calls to all of the methods defined in
@@ -101,10 +99,6 @@ module Google
           #   or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
-          # @param app_name [String]
-          #   The codename of the calling service.
-          # @param app_version [String]
-          #   The version of the calling service.
           def initialize \
               service_path: SERVICE_ADDRESS,
               port: DEFAULT_SERVICE_PORT,
@@ -113,8 +107,10 @@ module Google
               scopes: ALL_SCOPES,
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
-              app_name: "gax",
-              app_version: Google::Gax::VERSION
+              app_name: nil,
+              app_version: nil,
+              lib_name: nil,
+              lib_version: ""
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -122,9 +118,16 @@ module Google
             require "google/devtools/clouderrorreporting/v1beta1/error_group_service_services_pb"
 
 
-            google_api_client = "#{app_name}/#{app_version} " \
-              "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " \
-              "ruby/#{RUBY_VERSION}".freeze
+            if app_name || app_version
+              warn "`app_name` and `app_version` are no longer being used in the request headers."
+            end
+
+            google_api_client = "gl-ruby/#{RUBY_VERSION}"
+            google_api_client << " #{lib_name}/#{lib_version}" if lib_name
+            google_api_client << " gapic/ gax/#{Google::Gax::VERSION}"
+            google_api_client << " grpc/#{GRPC::VERSION}"
+            google_api_client.freeze
+
             headers = { :"x-goog-api-client" => google_api_client }
             client_config_file = Pathname.new(__dir__).join(
               "error_group_service_client_config.json"

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client_config.json
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client_config.json
@@ -2,11 +2,11 @@
   "interfaces": {
     "google.devtools.clouderrorreporting.v1beta1.ErrorGroupService": {
       "retry_codes": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
@@ -46,8 +46,6 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
-          CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
-
           DEFAULT_TIMEOUT = 30
 
           PAGE_DESCRIPTORS = {
@@ -106,10 +104,6 @@ module Google
           #   or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
-          # @param app_name [String]
-          #   The codename of the calling service.
-          # @param app_version [String]
-          #   The version of the calling service.
           def initialize \
               service_path: SERVICE_ADDRESS,
               port: DEFAULT_SERVICE_PORT,
@@ -118,8 +112,10 @@ module Google
               scopes: ALL_SCOPES,
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
-              app_name: "gax",
-              app_version: Google::Gax::VERSION
+              app_name: nil,
+              app_version: nil,
+              lib_name: nil,
+              lib_version: ""
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -127,9 +123,16 @@ module Google
             require "google/devtools/clouderrorreporting/v1beta1/error_stats_service_services_pb"
 
 
-            google_api_client = "#{app_name}/#{app_version} " \
-              "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " \
-              "ruby/#{RUBY_VERSION}".freeze
+            if app_name || app_version
+              warn "`app_name` and `app_version` are no longer being used in the request headers."
+            end
+
+            google_api_client = "gl-ruby/#{RUBY_VERSION}"
+            google_api_client << " #{lib_name}/#{lib_version}" if lib_name
+            google_api_client << " gapic/ gax/#{Google::Gax::VERSION}"
+            google_api_client << " grpc/#{GRPC::VERSION}"
+            google_api_client.freeze
+
             headers = { :"x-goog-api-client" => google_api_client }
             client_config_file = Pathname.new(__dir__).join(
               "error_stats_service_client_config.json"

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client_config.json
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client_config.json
@@ -2,11 +2,11 @@
   "interfaces": {
     "google.devtools.clouderrorreporting.v1beta1.ErrorStatsService": {
       "retry_codes": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
@@ -45,8 +45,6 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
-          CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
-
           DEFAULT_TIMEOUT = 30
 
           # The scopes needed to make gRPC calls to all of the methods defined in
@@ -92,10 +90,6 @@ module Google
           #   or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
-          # @param app_name [String]
-          #   The codename of the calling service.
-          # @param app_version [String]
-          #   The version of the calling service.
           def initialize \
               service_path: SERVICE_ADDRESS,
               port: DEFAULT_SERVICE_PORT,
@@ -104,8 +98,10 @@ module Google
               scopes: ALL_SCOPES,
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
-              app_name: "gax",
-              app_version: Google::Gax::VERSION
+              app_name: nil,
+              app_version: nil,
+              lib_name: nil,
+              lib_version: ""
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -113,9 +109,16 @@ module Google
             require "google/devtools/clouderrorreporting/v1beta1/report_errors_service_services_pb"
 
 
-            google_api_client = "#{app_name}/#{app_version} " \
-              "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " \
-              "ruby/#{RUBY_VERSION}".freeze
+            if app_name || app_version
+              warn "`app_name` and `app_version` are no longer being used in the request headers."
+            end
+
+            google_api_client = "gl-ruby/#{RUBY_VERSION}"
+            google_api_client << " #{lib_name}/#{lib_version}" if lib_name
+            google_api_client << " gapic/ gax/#{Google::Gax::VERSION}"
+            google_api_client << " grpc/#{GRPC::VERSION}"
+            google_api_client.freeze
+
             headers = { :"x-goog-api-client" => google_api_client }
             client_config_file = Pathname.new(__dir__).join(
               "report_errors_service_client_config.json"

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client_config.json
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client_config.json
@@ -2,11 +2,11 @@
   "interfaces": {
     "google.devtools.clouderrorreporting.v1beta1.ReportErrorsService": {
       "retry_codes": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/integration/sinatra1_app/app.rb
+++ b/integration/sinatra1_app/app.rb
@@ -36,9 +36,7 @@ er_chan = GRPC::Core::Channel.new Google::Cloud::ErrorReporting::V1beta1::Report
 er_service_name = "google-cloud-ruby_integration_test"
 er_serivce_version = ENV['USER']
 
-error_reporting = Google::Cloud::ErrorReporting::V1beta1::ReportErrorsServiceClient.new channel: er_chan,
-                                                                                     app_name: er_service_name,
-                                                                                     app_version: er_serivce_version
+error_reporting = Google::Cloud::ErrorReporting::V1beta1::ReportErrorsServiceClient.new channel: er_chan
 
 use Google::Cloud::ErrorReporting::Middleware, error_reporting: error_reporting,
                                                service_name: er_service_name,


### PR DESCRIPTION
Updates #1268 

cc @swcloud @bjwatson 