### PR TITLE
Pin google-gax to public repo

### DIFF
--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -7,3 +7,6 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
+
+# Use public repo until google-gax 0.8.1 is released
+gem "google-gax", git: "https://github.com/googleapis/gax-ruby.git"


### PR DESCRIPTION
This is to work around a dependency on an unreleased change that made its way into master. This change will fix the build. Remove this when google-gax 0.8.1 is released.