### PR TITLE
Natural Language Acceptance Test Fix

### DIFF
--- a/google-cloud-language/acceptance/language/html_test.rb
+++ b/google-cloud-language/acceptance/language/html_test.rb
@@ -225,8 +225,6 @@ describe "Language (HTML)", :language do
 
       annotation.language.must_equal "en"
 
-      annotation.sentiment.must_be :nil?
-
       annotation.entities.count.must_equal 5
       annotation.entities.language.must_equal "en"
       annotation.entities.unknown.map(&:name).must_equal []

--- a/google-cloud-language/acceptance/language/storage/html_file_test.rb
+++ b/google-cloud-language/acceptance/language/storage/html_file_test.rb
@@ -209,8 +209,6 @@ describe "Language (HTML/Storage File)", :language do
 
       annotation.language.must_equal "en"
 
-      annotation.sentiment.must_be :nil?
-
       annotation.entities.must_be :empty?
 
       annotation.sentences.map(&:text).must_equal [hello, sayhi, ruby]
@@ -271,8 +269,6 @@ describe "Language (HTML/Storage File)", :language do
       annotation = doc.annotate entities: true
 
       annotation.language.must_equal "en"
-
-      annotation.sentiment.must_be :nil?
 
       annotation.entities.count.must_equal 5
       annotation.entities.language.must_equal "en"

--- a/google-cloud-language/acceptance/language/storage/html_url_test.rb
+++ b/google-cloud-language/acceptance/language/storage/html_url_test.rb
@@ -213,8 +213,6 @@ describe "Language (HTML/Storage URL)", :language do
 
       annotation.language.must_equal "en"
 
-      annotation.sentiment.must_be :nil?
-
       annotation.entities.must_be :empty?
 
       annotation.sentences.map(&:text).must_equal [hello, sayhi, ruby]
@@ -277,8 +275,6 @@ describe "Language (HTML/Storage URL)", :language do
       annotation = doc.annotate entities: true
 
       annotation.language.must_equal "en"
-
-      annotation.sentiment.must_be :nil?
 
       annotation.entities.count.must_equal 5
       annotation.entities.language.must_equal "en"

--- a/google-cloud-language/acceptance/language/storage/text_file_test.rb
+++ b/google-cloud-language/acceptance/language/storage/text_file_test.rb
@@ -211,8 +211,6 @@ describe "Language (TEXT/Storage File)", :language do
 
       annotation.language.must_equal "en"
 
-      annotation.sentiment.must_be :nil?
-
       annotation.entities.must_be :empty?
 
       annotation.sentences.map(&:text).must_equal [hello, sayhi, ruby]
@@ -275,8 +273,6 @@ describe "Language (TEXT/Storage File)", :language do
       annotation = doc.annotate entities: true
 
       annotation.language.must_equal "en"
-
-      annotation.sentiment.must_be :nil?
 
       annotation.entities.count.must_equal 5
       annotation.entities.language.must_equal "en"

--- a/google-cloud-language/acceptance/language/storage/text_url_test.rb
+++ b/google-cloud-language/acceptance/language/storage/text_url_test.rb
@@ -212,8 +212,6 @@ describe "Language (TEXT/Storage URL)", :language do
 
       annotation.language.must_equal "en"
 
-      annotation.sentiment.must_be :nil?
-
       annotation.entities.must_be :empty?
 
       annotation.sentences.map(&:text).must_equal [hello, sayhi, ruby]
@@ -276,8 +274,6 @@ describe "Language (TEXT/Storage URL)", :language do
       annotation = doc.annotate entities: true
 
       annotation.language.must_equal "en"
-
-      annotation.sentiment.must_be :nil?
 
       annotation.entities.count.must_equal 5
       annotation.entities.language.must_equal "en"

--- a/google-cloud-language/acceptance/language/text_test.rb
+++ b/google-cloud-language/acceptance/language/text_test.rb
@@ -269,8 +269,6 @@ describe "Language (TEXT)", :language do
 
       annotation.language.must_equal "en"
 
-      annotation.sentiment.must_be :nil?
-
       annotation.entities.count.must_equal 5
       annotation.entities.language.must_equal "en"
       annotation.entities.unknown.map(&:name).must_equal []


### PR DESCRIPTION
It looks like Natural Language is rolling out an update, and these checks are failing.
The behavior we are starting to see is that this Sentiment is returned.
Sometimes the Sentiment is empty, sometimes it is not.
Disable the sentiment nil checks so the build will pass.