### PR TITLE
Update handling of BigQuery types

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -73,6 +73,8 @@ module Google
                 StringIO.new Base64.decode64 value
               elsif type == "TIMESTAMP"
                 ::Time.at Float(value)
+              elsif type == "TIME"
+                Bigquery::Time.new value
               else
                 value
               end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -75,6 +75,8 @@ module Google
                 ::Time.at Float(value)
               elsif type == "TIME"
                 Bigquery::Time.new value
+              elsif type == "DATETIME"
+                ::Time.parse("#{value} UTC").to_datetime
               else
                 value
               end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -1,0 +1,192 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/apis/bigquery_v2"
+require "stringio"
+require "base64"
+
+module Google
+  module Cloud
+    module Bigquery
+      # rubocop:disable all
+
+      ##
+      # @private
+      #
+      # Internal conversion of raw data values to/from Bigquery values
+      #
+      # | BigQuery    | Ruby           | Notes  |
+      # |-------------|----------------|---|
+      # | `BOOL`      | `true`/`false` | |
+      # | `INT64`     | `Integer`      | |
+      # | `FLOAT64`   | `Float`        | |
+      # | `STRING`    | `STRING`       | |
+      # | `DATETIME`  | `DateTime`  | `DATETIME` does not support time zone. |
+      # | `DATE`      | `Date`         | |
+      # | `TIMESTAMP` | `Time`         | |
+      # | `TIME`      | `Google::Cloud::BigQuery::Time` | |
+      # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
+      # | `ARRAY` | `Array` | Nested arrays, `nil` values are not supported. |
+      # | `STRUCT`    | `Hash`        | Hash keys may be strings or symbols. |
+
+      module Convert
+        ##
+        # @private
+        def self.format_rows rows, fields
+          headers = Array(fields).map { |f| f.name }
+          field_types = Array(fields).map { |f| f.type }
+
+          Array(rows).map do |row|
+            values = row.f.map { |f| f.v }
+            formatted_values = format_values field_types, values
+            Hash[headers.zip formatted_values]
+          end
+        end
+
+        ##
+        # @private
+        def self.format_values field_types, values
+          field_types.zip(values).map do |type, value|
+            begin
+              if value.nil?
+                nil
+              elsif type == "INTEGER"
+                Integer value
+              elsif type == "FLOAT"
+                Float value
+              elsif type == "BOOLEAN"
+                (value == "true" ? true : (value == "false" ? false : nil))
+              else
+                value
+              end
+            rescue => e
+              value
+            end
+          end
+        end
+
+        ##
+        # @private
+        def self.to_query_param value
+          if TrueClass === value
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "BOOL"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: true)
+            )
+          elsif FalseClass === value
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "BOOL"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: false)
+            )
+          elsif Integer === value
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "INT64"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: value)
+            )
+          elsif Float === value
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "FLOAT64"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: value)
+            )
+          elsif String === value
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "STRING"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: value)
+            )
+          elsif DateTime === value
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "DATETIME"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: value.strftime("%Y-%m-%d %H:%M:%S.%6N"))
+            )
+          elsif Date === value
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "DATE"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: value.to_s)
+            )
+          elsif ::Time === value
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "TIMESTAMP"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: value.strftime("%Y-%m-%d %H:%M:%S.%6N%:z"))
+            )
+          elsif Bigquery::Time === value
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+              type: "TIME"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: value.value)
+            )
+          elsif value.respond_to?(:read) && value.respond_to?(:rewind)
+            value.rewind
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "BYTES"),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                value: value.read.force_encoding("ASCII-8BIT"))
+            )
+          elsif Array === value
+            array_params = value.map { |param| Convert.to_query_param param }
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "ARRAY",
+                array_type: array_params.first.parameter_type
+              ),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                array_values: array_params.map(&:parameter_value)
+              )
+            )
+          elsif Hash === value
+            struct_pairs = value.map do |name, param|
+              struct_param = Convert.to_query_param param
+              [Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+                name: String(name),
+                type: struct_param.parameter_type
+              ), struct_param.parameter_value]
+            end
+
+            return Google::Apis::BigqueryV2::QueryParameter.new(
+              parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+                type: "STRUCT",
+                struct_types: struct_pairs.map(&:first)
+              ),
+              parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+                struct_values: struct_pairs.map(&:last)
+              )
+            )
+          else
+            fail "A query parameter of type #{value.class} is not supported."
+          end
+        end
+
+        # rubocop:enable all
+      end
+    end
+  end
+end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -17,6 +17,7 @@ require "google/apis/bigquery_v2"
 require "stringio"
 require "base64"
 require "time"
+require "date"
 
 module Google
   module Cloud
@@ -77,6 +78,8 @@ module Google
                 Bigquery::Time.new value
               elsif type == "DATETIME"
                 ::Time.parse("#{value} UTC").to_datetime
+              elsif type == "DATE"
+                Date.parse value
               else
                 value
               end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -68,6 +68,8 @@ module Google
                 Float value
               elsif type == "BOOLEAN"
                 (value == "true" ? true : (value == "false" ? false : nil))
+              elsif type == "BYTES"
+                StringIO.new Base64.decode64 value
               else
                 value
               end
@@ -149,7 +151,8 @@ module Google
               parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
                 type: "BYTES"),
               parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-                value: value.read.force_encoding("ASCII-8BIT"))
+                value: Base64.strict_encode64(
+                  value.read.force_encoding("ASCII-8BIT")))
             )
           elsif Array === value
             array_params = value.map { |param| Convert.to_query_param param }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -16,6 +16,7 @@
 require "google/apis/bigquery_v2"
 require "stringio"
 require "base64"
+require "time"
 
 module Google
   module Cloud
@@ -70,6 +71,8 @@ module Google
                 (value == "true" ? true : (value == "false" ? false : nil))
               elsif type == "BYTES"
                 StringIO.new Base64.decode64 value
+              elsif type == "TIMESTAMP"
+                ::Time.at Float(value)
               else
                 value
               end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -188,48 +188,13 @@ module Google
         ##
         # @private New Data from a response object.
         def self.from_gapi gapi, table
-          formatted_rows = format_rows gapi.rows, table.fields
+          formatted_rows = Convert.format_rows gapi.rows, table.fields
 
           data = new formatted_rows
           data.table = table
           data.gapi = gapi
           data
         end
-
-        # rubocop:disable all
-        # Disabled rubocop because this implementation will not last.
-
-        def self.format_rows rows, fields
-          headers = Array(fields).map { |f| f.name }
-          field_types = Array(fields).map { |f| f.type }
-
-          Array(rows).map do |row|
-            values = row.f.map { |f| f.v }
-            formatted_values = format_values field_types, values
-            Hash[headers.zip formatted_values]
-          end
-        end
-
-        def self.format_values field_types, values
-          field_types.zip(values).map do |type, value|
-            begin
-              if value.nil?
-                nil
-              elsif type == "INTEGER"
-                Integer value
-              elsif type == "FLOAT"
-                Float value
-              elsif type == "BOOLEAN"
-                (value == "true" ? true : (value == "false" ? false : nil))
-              else
-                value
-              end
-            rescue
-              value
-            end
-          end
-        end
-        # rubocop:enable all
 
         protected
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_data.rb
@@ -202,8 +202,7 @@ module Google
           if gapi.schema.nil?
             formatted_rows = []
           else
-            formatted_rows = format_rows gapi.rows,
-                                         gapi.schema.fields
+            formatted_rows = Convert.format_rows gapi.rows, gapi.schema.fields
           end
 
           data = new formatted_rows

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -213,6 +213,21 @@ module Google
         end
 
         ##
+        # Adds a datetime field to the schema.
+        #
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
+        def datetime name, description: nil, mode: :nullable
+          add_field name, :datetime, nil, description: description, mode: mode
+        end
+
+        ##
         # Adds a record field to the schema. A block must be passed describing
         # the nested fields of the record. For more information about nested
         # and repeated records, see [Preparing Data for BigQuery
@@ -274,7 +289,8 @@ module Google
           MODES = %w( NULLABLE REQUIRED REPEATED )
 
           # @private
-          TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP TIME RECORD )
+          TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP TIME DATETIME
+                      RECORD )
 
           def initialize name, type, description: nil,
                          mode: :nullable, fields: nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -228,6 +228,21 @@ module Google
         end
 
         ##
+        # Adds a date field to the schema.
+        #
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
+        def date name, description: nil, mode: :nullable
+          add_field name, :date, nil, description: description, mode: mode
+        end
+
+        ##
         # Adds a record field to the schema. A block must be passed describing
         # the nested fields of the record. For more information about nested
         # and repeated records, see [Preparing Data for BigQuery
@@ -290,7 +305,7 @@ module Google
 
           # @private
           TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP TIME DATETIME
-                      RECORD )
+                      DATE RECORD )
 
           def initialize name, type, description: nil,
                          mode: :nullable, fields: nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -168,6 +168,21 @@ module Google
         end
 
         ##
+        # Adds a bytes field to the schema.
+        #
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
+        def bytes name, description: nil, mode: :nullable
+          add_field name, :bytes, nil, description: description, mode: mode
+        end
+
+        ##
         # Adds a timestamp field to the schema.
         #
         # @param [String] name The field name. The name must contain only
@@ -244,7 +259,7 @@ module Google
           MODES = %w( NULLABLE REQUIRED REPEATED )
 
           # @private
-          TYPES = %w( STRING INTEGER FLOAT BOOLEAN TIMESTAMP RECORD )
+          TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP RECORD )
 
           def initialize name, type, description: nil,
                          mode: :nullable, fields: nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -198,6 +198,21 @@ module Google
         end
 
         ##
+        # Adds a time field to the schema.
+        #
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
+        def time name, description: nil, mode: :nullable
+          add_field name, :time, nil, description: description, mode: mode
+        end
+
+        ##
         # Adds a record field to the schema. A block must be passed describing
         # the nested fields of the record. For more information about nested
         # and repeated records, see [Preparing Data for BigQuery
@@ -259,7 +274,7 @@ module Google
           MODES = %w( NULLABLE REQUIRED REPEATED )
 
           # @private
-          TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP RECORD )
+          TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP TIME RECORD )
 
           def initialize name, type, description: nil,
                          mode: :nullable, fields: nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1123,12 +1123,40 @@ module Google
           #   bigquery = Google::Cloud::Bigquery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
-          #     schema.datetime "duration", mode: :required
+          #     schema.datetime "target_end", mode: :required
           #   end
           #
           # @!group Schema
           def datetime name, description: nil, mode: :nullable
             schema.datetime name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a date field to the schema.
+          #
+          # See {Schema#date}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.create_table "my_table" do |schema|
+          #     schema.date "birthday", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def date name, description: nil, mode: :nullable
+            schema.date name, description: description, mode: mode
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1076,6 +1076,34 @@ module Google
           end
 
           ##
+          # Adds a time field to the schema.
+          #
+          # See {Schema#time}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.create_table "my_table" do |schema|
+          #     schema.time "duration", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def time name, description: nil, mode: :nullable
+            schema.time name, description: description, mode: mode
+          end
+
+          ##
           # Adds a record field to the schema. A block must be passed describing
           # the nested fields of the record. For more information about nested
           # and repeated records, see [Preparing Data for BigQuery

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1104,6 +1104,34 @@ module Google
           end
 
           ##
+          # Adds a datetime field to the schema.
+          #
+          # See {Schema#datetime}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.create_table "my_table" do |schema|
+          #     schema.datetime "duration", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def datetime name, description: nil, mode: :nullable
+            schema.datetime name, description: description, mode: mode
+          end
+
+          ##
           # Adds a record field to the schema. A block must be passed describing
           # the nested fields of the record. For more information about nested
           # and repeated records, see [Preparing Data for BigQuery

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1020,6 +1020,34 @@ module Google
           end
 
           ##
+          # Adds a bytes field to the schema.
+          #
+          # See {Schema#bytes}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.create_table "my_table" do |schema|
+          #     schema.bytes "avatar", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def bytes name, description: nil, mode: :nullable
+            schema.bytes name, description: description, mode: mode
+          end
+
+          ##
           # Adds a timestamp field to the schema.
           #
           # See {Schema#timestamp}.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -44,6 +44,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[0]["avatar"].read.must_equal "image data"
     data[0]["started_at"].must_equal Time.parse("2016-12-25 13:00:00 UTC")
     data[0]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
+    data[0]["target_end"].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
 
     data[1].must_be_kind_of Hash
     data[1]["name"].must_equal "Aaron"
@@ -53,6 +54,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[1]["avatar"].must_equal nil
     data[1]["started_at"].must_equal nil
     data[1]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
+    data[1]["target_end"].must_equal nil
 
     data[2].must_be_kind_of Hash
     data[2]["name"].must_equal "Sally"
@@ -62,6 +64,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[2]["avatar"].must_equal nil
     data[2]["started_at"].must_equal nil
     data[2]["duration"].must_equal nil
+    data[2]["target_end"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -102,6 +105,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[0][4].must_equal Base64.strict_encode64(data[0]["avatar"].read)
     data.raw[0][5].must_equal "1482670800.0"
     data.raw[0][6].must_equal "04:00:00"
+    data.raw[0][7].must_equal "2017-01-01 00:00:00"
 
     data.raw[1][0].must_equal data[1]["name"].to_s
     data.raw[1][1].must_equal data[1]["age"].to_s
@@ -110,6 +114,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[1][4].must_equal nil
     data.raw[1][5].must_equal nil
     data.raw[1][6].must_equal "04:32:10.555555"
+    data.raw[1][7].must_equal nil
 
     data.raw[2][0].must_equal data[2]["name"].to_s
     data.raw[2][1].must_equal nil
@@ -118,6 +123,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[2][4].must_equal nil
     data.raw[2][5].must_equal nil
     data.raw[2][6].must_equal nil
+    data.raw[1][7].must_equal nil
   end
 
   it "knows the data metadata" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -42,18 +42,23 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[0]["active"].must_equal true
     data[0]["avatar"].must_be_kind_of StringIO
     data[0]["avatar"].read.must_equal "image data"
+    data[0]["started_at"].must_equal Time.parse("2016-12-25 13:00:00 UTC")
+
     data[1].must_be_kind_of Hash
     data[1]["name"].must_equal "Aaron"
     data[1]["age"].must_equal 42
     data[1]["score"].must_equal 8.15
     data[1]["active"].must_equal false
     data[1]["avatar"].must_equal nil
+    data[1]["started_at"].must_equal nil
+
     data[2].must_be_kind_of Hash
     data[2]["name"].must_equal "Sally"
     data[2]["age"].must_equal nil
     data[2]["score"].must_equal nil
     data[2]["active"].must_equal nil
     data[2]["avatar"].must_equal nil
+    data[2]["started_at"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -92,18 +97,21 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[0][2].must_equal data[0]["score"].to_s
     data.raw[0][3].must_equal data[0]["active"].to_s
     data.raw[0][4].must_equal Base64.strict_encode64(data[0]["avatar"].read)
+    data.raw[0][5].must_equal "1482670800.0"
 
     data.raw[1][0].must_equal data[1]["name"].to_s
     data.raw[1][1].must_equal data[1]["age"].to_s
     data.raw[1][2].must_equal data[1]["score"].to_s
     data.raw[1][3].must_equal data[1]["active"].to_s
     data.raw[1][4].must_equal nil
+    data.raw[1][5].must_equal nil
 
     data.raw[2][0].must_equal data[2]["name"].to_s
     data.raw[2][1].must_equal nil
     data.raw[2][2].must_equal nil
     data.raw[2][3].must_equal nil
     data.raw[2][4].must_equal nil
+    data.raw[2][5].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -278,35 +286,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     {
       "kind" => "bigquery#tableDataList",
       "etag" => "etag1234567890",
-      "rows" => [
-        {
-          "f" => [
-            { "v" => "Heidi" },
-            { "v" => "36" },
-            { "v" => "7.65" },
-            { "v" => "true" },
-            { "v" => "aW1hZ2UgZGF0YQ==" }
-          ]
-        },
-        {
-          "f" => [
-            { "v" => "Aaron" },
-            { "v" => "42" },
-            { "v" => "8.15" },
-            { "v" => "false" },
-            { "v" => nil }
-          ]
-        },
-        {
-          "f" => [
-            { "v" => "Sally" },
-            { "v" => nil },
-            { "v" => nil },
-            { "v" => nil },
-            { "v" => nil }
-          ]
-        }
-      ],
+      "rows" => random_data_rows,
       "pageToken" => token,
       "totalRows" => "3" # String per google/google-api-ruby-client#439
     }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -40,16 +40,20 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[0]["age"].must_equal 36
     data[0]["score"].must_equal 7.65
     data[0]["active"].must_equal true
+    data[0]["avatar"].must_be_kind_of StringIO
+    data[0]["avatar"].read.must_equal "image data"
     data[1].must_be_kind_of Hash
     data[1]["name"].must_equal "Aaron"
     data[1]["age"].must_equal 42
     data[1]["score"].must_equal 8.15
     data[1]["active"].must_equal false
+    data[1]["avatar"].must_equal nil
     data[2].must_be_kind_of Hash
     data[2]["name"].must_equal "Sally"
     data[2]["age"].must_equal nil
     data[2]["score"].must_equal nil
     data[2]["active"].must_equal nil
+    data[2]["avatar"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -87,16 +91,19 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[0][1].must_equal data[0]["age"].to_s
     data.raw[0][2].must_equal data[0]["score"].to_s
     data.raw[0][3].must_equal data[0]["active"].to_s
+    data.raw[0][4].must_equal Base64.strict_encode64(data[0]["avatar"].read)
 
     data.raw[1][0].must_equal data[1]["name"].to_s
     data.raw[1][1].must_equal data[1]["age"].to_s
     data.raw[1][2].must_equal data[1]["score"].to_s
     data.raw[1][3].must_equal data[1]["active"].to_s
+    data.raw[1][4].must_equal nil
 
     data.raw[2][0].must_equal data[2]["name"].to_s
     data.raw[2][1].must_equal nil
     data.raw[2][2].must_equal nil
     data.raw[2][3].must_equal nil
+    data.raw[2][4].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -274,50 +281,29 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
       "rows" => [
         {
           "f" => [
-            {
-              "v" => "Heidi"
-            },
-            {
-              "v" => "36"
-            },
-            {
-              "v" => "7.65"
-            },
-            {
-              "v" => "true"
-            }
+            { "v" => "Heidi" },
+            { "v" => "36" },
+            { "v" => "7.65" },
+            { "v" => "true" },
+            { "v" => "aW1hZ2UgZGF0YQ==" }
           ]
         },
         {
           "f" => [
-            {
-              "v" => "Aaron"
-            },
-            {
-              "v" => "42"
-            },
-            {
-              "v" => "8.15"
-            },
-            {
-              "v" => "false"
-            }
+            { "v" => "Aaron" },
+            { "v" => "42" },
+            { "v" => "8.15" },
+            { "v" => "false" },
+            { "v" => nil }
           ]
         },
         {
           "f" => [
-            {
-              "v" => "Sally"
-            },
-            {
-              "v" => nil
-            },
-            {
-              "v" => nil
-            },
-            {
-              "v" => nil
-            }
+            { "v" => "Sally" },
+            { "v" => nil },
+            { "v" => nil },
+            { "v" => nil },
+            { "v" => nil }
           ]
         }
       ],

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -43,6 +43,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[0]["avatar"].must_be_kind_of StringIO
     data[0]["avatar"].read.must_equal "image data"
     data[0]["started_at"].must_equal Time.parse("2016-12-25 13:00:00 UTC")
+    data[0]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
 
     data[1].must_be_kind_of Hash
     data[1]["name"].must_equal "Aaron"
@@ -51,6 +52,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[1]["active"].must_equal false
     data[1]["avatar"].must_equal nil
     data[1]["started_at"].must_equal nil
+    data[1]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
 
     data[2].must_be_kind_of Hash
     data[2]["name"].must_equal "Sally"
@@ -59,6 +61,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[2]["active"].must_equal nil
     data[2]["avatar"].must_equal nil
     data[2]["started_at"].must_equal nil
+    data[2]["duration"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -98,6 +101,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[0][3].must_equal data[0]["active"].to_s
     data.raw[0][4].must_equal Base64.strict_encode64(data[0]["avatar"].read)
     data.raw[0][5].must_equal "1482670800.0"
+    data.raw[0][6].must_equal "04:00:00"
 
     data.raw[1][0].must_equal data[1]["name"].to_s
     data.raw[1][1].must_equal data[1]["age"].to_s
@@ -105,6 +109,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[1][3].must_equal data[1]["active"].to_s
     data.raw[1][4].must_equal nil
     data.raw[1][5].must_equal nil
+    data.raw[1][6].must_equal "04:32:10.555555"
 
     data.raw[2][0].must_equal data[2]["name"].to_s
     data.raw[2][1].must_equal nil
@@ -112,6 +117,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[2][3].must_equal nil
     data.raw[2][4].must_equal nil
     data.raw[2][5].must_equal nil
+    data.raw[2][6].must_equal nil
   end
 
   it "knows the data metadata" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -45,6 +45,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[0]["started_at"].must_equal Time.parse("2016-12-25 13:00:00 UTC")
     data[0]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
     data[0]["target_end"].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
+    data[0]["birthday"].must_equal Date.parse("1968-10-20")
 
     data[1].must_be_kind_of Hash
     data[1]["name"].must_equal "Aaron"
@@ -55,6 +56,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[1]["started_at"].must_equal nil
     data[1]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
     data[1]["target_end"].must_equal nil
+    data[1]["birthday"].must_equal nil
 
     data[2].must_be_kind_of Hash
     data[2]["name"].must_equal "Sally"
@@ -65,6 +67,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[2]["started_at"].must_equal nil
     data[2]["duration"].must_equal nil
     data[2]["target_end"].must_equal nil
+    data[2]["birthday"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -106,6 +109,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[0][5].must_equal "1482670800.0"
     data.raw[0][6].must_equal "04:00:00"
     data.raw[0][7].must_equal "2017-01-01 00:00:00"
+    data.raw[0][8].must_equal "1968-10-20"
 
     data.raw[1][0].must_equal data[1]["name"].to_s
     data.raw[1][1].must_equal data[1]["age"].to_s
@@ -115,6 +119,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[1][5].must_equal nil
     data.raw[1][6].must_equal "04:32:10.555555"
     data.raw[1][7].must_equal nil
+    data.raw[1][8].must_equal nil
 
     data.raw[2][0].must_equal data[2]["name"].to_s
     data.raw[2][1].must_equal nil
@@ -123,7 +128,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[2][4].must_equal nil
     data.raw[2][5].must_equal nil
     data.raw[2][6].must_equal nil
-    data.raw[1][7].must_equal nil
+    data.raw[2][7].must_equal nil
+    data.raw[2][8].must_equal nil
   end
 
   it "knows the data metadata" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -264,7 +264,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
             type: "BYTES"
           ),
           parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-            value: File.read("acceptance/data/logo.jpg", mode: "rb")
+            value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
           )
         )
       ]
@@ -290,7 +290,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
             type: "BYTES"
           ),
           parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-            value: File.read("acceptance/data/logo.jpg", mode: "rb")
+            value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
           )
         )
       ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -254,7 +254,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]
@@ -279,7 +279,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -278,7 +278,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]
@@ -305,7 +305,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -268,7 +268,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
             type: "BYTES"
           ),
           parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-            value: File.read("acceptance/data/logo.jpg", mode: "rb")
+            value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
           )
         )
       ]
@@ -294,7 +294,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
             type: "BYTES"
           ),
           parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-            value: File.read("acceptance/data/logo.jpg", mode: "rb")
+            value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
           )
         )
       ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active, avatar FROM [some_project:some_dataset.users]" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active, avatar FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT * FROM [some_project:some_dataset.users]" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -30,7 +30,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         { mode: "REQUIRED", name: "name", type: "STRING"},
         { mode: "NULLABLE", name: "age", type: "INTEGER"},
         { mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0"},
-        { mode: "NULLABLE", name: "active", type: "BOOLEAN"}
+        { mode: "NULLABLE", name: "active", type: "BOOLEAN"},
+        { mode: "NULLABLE", name: "avatar", type: "BYTES"}
       ]
     }
   }
@@ -191,7 +192,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       Google::Cloud::Bigquery::Schema::Field.new("name", "STRING", mode: :required),
       Google::Cloud::Bigquery::Schema::Field.new("age", :INTEGER),
       Google::Cloud::Bigquery::Schema::Field.new("score", "float", description: "A score from 0.0 to 10.0"),
-      Google::Cloud::Bigquery::Schema::Field.new("active", :boolean)
+      Google::Cloud::Bigquery::Schema::Field.new("active", :boolean),
+      Google::Cloud::Bigquery::Schema::Field.new("avatar", :bytes)
     ]
     table = dataset.create_table table_id,
                                  name: table_name,
@@ -231,6 +233,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       t.schema.integer "age"
       t.schema.float "score", description: "A score from 0.0 to 10.0"
       t.schema.boolean "active"
+      t.schema.bytes "avatar"
     end
 
     mock.verify
@@ -255,6 +258,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REPEATED", name: "cities_lived",  type: "RECORD", fields: [
           Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "place",           type: "STRING",  fields: []),
@@ -271,6 +275,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema.integer "age"
       schema.float "score", description: "A score from 0.0 to 10.0"
       schema.boolean "active"
+      schema.bytes "avatar"
       schema.timestamp "creation_date"
       schema.record "cities_lived", mode: :repeated do |nested_schema|
         nested_schema.string "place"
@@ -312,6 +317,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         s.integer "age"
         s.float "score", description: "A score from 0.0 to 10.0"
         s.boolean "active"
+        s.bytes "avatar"
       end
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -262,6 +262,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "birthday",      type: "DATE", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REPEATED", name: "cities_lived",  type: "RECORD", fields: [
           Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "place",           type: "STRING",  fields: []),
           Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "number_of_years", type: "INTEGER", fields: [])])
@@ -281,6 +282,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema.timestamp "creation_date"
       schema.time "duration"
       schema.datetime "target_end"
+      schema.date "birthday"
       schema.record "cities_lived", mode: :repeated do |nested_schema|
         nested_schema.string "place"
         nested_schema.integer "number_of_years"\

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -261,6 +261,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REPEATED", name: "cities_lived",  type: "RECORD", fields: [
           Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "place",           type: "STRING",  fields: []),
           Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "number_of_years", type: "INTEGER", fields: [])])
@@ -279,6 +280,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema.bytes "avatar"
       schema.timestamp "creation_date"
       schema.time "duration"
+      schema.datetime "target_end"
       schema.record "cities_lived", mode: :repeated do |nested_schema|
         nested_schema.string "place"
         nested_schema.integer "number_of_years"\

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -260,6 +260,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REPEATED", name: "cities_lived",  type: "RECORD", fields: [
           Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "place",           type: "STRING",  fields: []),
           Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "number_of_years", type: "INTEGER", fields: [])])
@@ -277,6 +278,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema.boolean "active"
       schema.bytes "avatar"
       schema.timestamp "creation_date"
+      schema.time "duration"
       schema.record "cities_lived", mode: :repeated do |nested_schema|
         nested_schema.string "place"
         nested_schema.integer "number_of_years"\

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     job.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     job.schema.must_be :frozen?
     job.schema.fields.wont_be :empty?
-    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
+    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
   end
 
   it "knows its load config" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     job.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     job.schema.must_be :frozen?
     job.schema.fields.wont_be :empty?
-    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
+    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
   end
 
   it "knows its load config" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     job.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     job.schema.must_be :frozen?
     job.schema.fields.wont_be :empty?
-    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active"]
+    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar"]
   end
 
   it "knows its load config" do
@@ -97,18 +97,31 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
       "writeDisposition" => "WRITE_EMPTY",
       "schema" => {
         "fields" => [
-          { "name" => "name",
+          {
+            "name" => "name",
             "type" => "STRING",
-            "mode" => "NULLABLE" },
-          { "name" => "age",
+            "mode" => "REQUIRED"
+          },
+          {
+            "name" => "age",
             "type" => "INTEGER",
-            "mode" => "NULLABLE" },
-          { "name" => "score",
+            "mode" => "NULLABLE"
+          },
+          {
+            "name" => "score",
             "type" => "FLOAT",
-            "mode" => "NULLABLE" },
-          { "name" => "active",
+            "mode" => "NULLABLE"
+          },
+          {
+            "name" => "active",
             "type" => "BOOLEAN",
-            "mode" => "NULLABLE" }]},
+            "mode" => "NULLABLE"
+          },
+          {
+            "name" => "avatar",
+            "type" => "BYTES",
+            "mode" => "NULLABLE"
+          }]},
       "fieldDelimiter" => ",",
       "skipLeadingRows" => 0,
       "encoding" => "UTF-8",

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     job.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     job.schema.must_be :frozen?
     job.schema.fields.wont_be :empty?
-    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar", "started_at"]
+    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
   end
 
   it "knows its load config" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     job.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     job.schema.must_be :frozen?
     job.schema.fields.wont_be :empty?
-    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar"]
+    job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar", "started_at"]
   end
 
   it "knows its load config" do
@@ -95,33 +95,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
       },
       "createDisposition" => "CREATE_IF_NEEDED",
       "writeDisposition" => "WRITE_EMPTY",
-      "schema" => {
-        "fields" => [
-          {
-            "name" => "name",
-            "type" => "STRING",
-            "mode" => "REQUIRED"
-          },
-          {
-            "name" => "age",
-            "type" => "INTEGER",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "score",
-            "type" => "FLOAT",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "active",
-            "type" => "BOOLEAN",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "avatar",
-            "type" => "BYTES",
-            "mode" => "NULLABLE"
-          }]},
+      "schema" => random_schema_hash,
       "fieldDelimiter" => ",",
       "skipLeadingRows" => 0,
       "encoding" => "UTF-8",

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -267,7 +267,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]
@@ -293,7 +293,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -257,7 +257,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]
@@ -282,7 +282,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -282,7 +282,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]
@@ -309,7 +309,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -272,7 +272,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]
@@ -298,7 +298,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           type: "BYTES"
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          value: File.read("acceptance/data/logo.jpg", mode: "rb")
+          value: Base64.strict_encode64(File.read("acceptance/data/logo.jpg", mode: "rb"))
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
@@ -25,16 +25,20 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[0]["age"].must_equal 36
     query_data[0]["score"].must_equal 7.65
     query_data[0]["active"].must_equal true
+    query_data[0]["avatar"].must_be_kind_of StringIO
+    query_data[0]["avatar"].read.must_equal "image data"
     query_data[1].must_be_kind_of Hash
     query_data[1]["name"].must_equal "Aaron"
     query_data[1]["age"].must_equal 42
     query_data[1]["score"].must_equal 8.15
     query_data[1]["active"].must_equal false
+    query_data[1]["avatar"].must_equal nil
     query_data[2].must_be_kind_of Hash
     query_data[2]["name"].must_equal "Sally"
     query_data[2]["age"].must_equal nil
     query_data[2]["score"].must_equal nil
     query_data[2]["active"].must_equal nil
+    query_data[2]["avatar"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -55,22 +59,25 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[0][1].must_equal query_data[0]["age"].to_s
     query_data.raw[0][2].must_equal query_data[0]["score"].to_s
     query_data.raw[0][3].must_equal query_data[0]["active"].to_s
+    query_data.raw[0][4].must_equal Base64.strict_encode64(query_data[0]["avatar"].read)
 
     query_data.raw[1][0].must_equal query_data[1]["name"].to_s
     query_data.raw[1][1].must_equal query_data[1]["age"].to_s
     query_data.raw[1][2].must_equal query_data[1]["score"].to_s
     query_data.raw[1][3].must_equal query_data[1]["active"].to_s
+    query_data.raw[1][4].must_equal nil
 
     query_data.raw[2][0].must_equal query_data[2]["name"].to_s
     query_data.raw[2][1].must_equal nil
     query_data.raw[2][2].must_equal nil
     query_data.raw[2][3].must_equal nil
+    query_data.raw[2][4].must_equal nil
   end
 
   it "knows schema, fields, and headers" do
     query_data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     query_data.fields.must_equal query_data.schema.fields
-    query_data.headers.must_equal ["name", "age", "score", "active"]
+    query_data.headers.must_equal ["name", "age", "score", "active", "avatar"]
   end
 
   it "can get the job associated with the data" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
@@ -29,6 +29,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[0]["avatar"].read.must_equal "image data"
     query_data[0]["started_at"].must_equal Time.parse("2016-12-25 13:00:00 UTC")
     query_data[0]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
+    query_data[0]["target_end"].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
 
     query_data[1].must_be_kind_of Hash
     query_data[1]["name"].must_equal "Aaron"
@@ -38,6 +39,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[1]["avatar"].must_equal nil
     query_data[1]["started_at"].must_equal nil
     query_data[1]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
+    query_data[1]["target_end"].must_equal nil
 
     query_data[2].must_be_kind_of Hash
     query_data[2]["name"].must_equal "Sally"
@@ -47,6 +49,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[2]["avatar"].must_equal nil
     query_data[2]["started_at"].must_equal nil
     query_data[2]["duration"].must_equal nil
+    query_data[2]["target_end"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -70,6 +73,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[0][4].must_equal Base64.strict_encode64(query_data[0]["avatar"].read)
     query_data.raw[0][5].must_equal "1482670800.0"
     query_data.raw[0][6].must_equal "04:00:00"
+    query_data.raw[0][7].must_equal "2017-01-01 00:00:00"
 
     query_data.raw[1][0].must_equal query_data[1]["name"].to_s
     query_data.raw[1][1].must_equal query_data[1]["age"].to_s
@@ -78,6 +82,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[1][4].must_equal nil
     query_data.raw[1][5].must_equal nil
     query_data.raw[1][6].must_equal "04:32:10.555555"
+    query_data.raw[1][7].must_equal nil
 
     query_data.raw[2][0].must_equal query_data[2]["name"].to_s
     query_data.raw[2][1].must_equal nil
@@ -86,12 +91,13 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[2][4].must_equal nil
     query_data.raw[2][5].must_equal nil
     query_data.raw[2][6].must_equal nil
+    query_data.raw[2][7].must_equal nil
   end
 
   it "knows schema, fields, and headers" do
     query_data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     query_data.fields.must_equal query_data.schema.fields
-    query_data.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
+    query_data.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
   end
 
   it "can get the job associated with the data" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
@@ -30,6 +30,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[0]["started_at"].must_equal Time.parse("2016-12-25 13:00:00 UTC")
     query_data[0]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
     query_data[0]["target_end"].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
+    query_data[0]["birthday"].must_equal Date.parse("1968-10-20")
 
     query_data[1].must_be_kind_of Hash
     query_data[1]["name"].must_equal "Aaron"
@@ -40,6 +41,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[1]["started_at"].must_equal nil
     query_data[1]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
     query_data[1]["target_end"].must_equal nil
+    query_data[1]["birthday"].must_equal nil
 
     query_data[2].must_be_kind_of Hash
     query_data[2]["name"].must_equal "Sally"
@@ -50,6 +52,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[2]["started_at"].must_equal nil
     query_data[2]["duration"].must_equal nil
     query_data[2]["target_end"].must_equal nil
+    query_data[2]["birthday"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -74,6 +77,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[0][5].must_equal "1482670800.0"
     query_data.raw[0][6].must_equal "04:00:00"
     query_data.raw[0][7].must_equal "2017-01-01 00:00:00"
+    query_data.raw[0][8].must_equal "1968-10-20"
 
     query_data.raw[1][0].must_equal query_data[1]["name"].to_s
     query_data.raw[1][1].must_equal query_data[1]["age"].to_s
@@ -83,6 +87,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[1][5].must_equal nil
     query_data.raw[1][6].must_equal "04:32:10.555555"
     query_data.raw[1][7].must_equal nil
+    query_data.raw[1][8].must_equal nil
 
     query_data.raw[2][0].must_equal query_data[2]["name"].to_s
     query_data.raw[2][1].must_equal nil
@@ -92,12 +97,13 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[2][5].must_equal nil
     query_data.raw[2][6].must_equal nil
     query_data.raw[2][7].must_equal nil
+    query_data.raw[2][8].must_equal nil
   end
 
   it "knows schema, fields, and headers" do
     query_data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     query_data.fields.must_equal query_data.schema.fields
-    query_data.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
+    query_data.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
   end
 
   it "can get the job associated with the data" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
@@ -27,18 +27,23 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[0]["active"].must_equal true
     query_data[0]["avatar"].must_be_kind_of StringIO
     query_data[0]["avatar"].read.must_equal "image data"
+    query_data[0]["started_at"].must_equal Time.parse("2016-12-25 13:00:00 UTC")
+
     query_data[1].must_be_kind_of Hash
     query_data[1]["name"].must_equal "Aaron"
     query_data[1]["age"].must_equal 42
     query_data[1]["score"].must_equal 8.15
     query_data[1]["active"].must_equal false
     query_data[1]["avatar"].must_equal nil
+    query_data[1]["started_at"].must_equal nil
+
     query_data[2].must_be_kind_of Hash
     query_data[2]["name"].must_equal "Sally"
     query_data[2]["age"].must_equal nil
     query_data[2]["score"].must_equal nil
     query_data[2]["active"].must_equal nil
     query_data[2]["avatar"].must_equal nil
+    query_data[2]["started_at"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -60,24 +65,27 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[0][2].must_equal query_data[0]["score"].to_s
     query_data.raw[0][3].must_equal query_data[0]["active"].to_s
     query_data.raw[0][4].must_equal Base64.strict_encode64(query_data[0]["avatar"].read)
+    query_data.raw[0][5].must_equal "1482670800.0"
 
     query_data.raw[1][0].must_equal query_data[1]["name"].to_s
     query_data.raw[1][1].must_equal query_data[1]["age"].to_s
     query_data.raw[1][2].must_equal query_data[1]["score"].to_s
     query_data.raw[1][3].must_equal query_data[1]["active"].to_s
     query_data.raw[1][4].must_equal nil
+    query_data.raw[1][5].must_equal nil
 
     query_data.raw[2][0].must_equal query_data[2]["name"].to_s
     query_data.raw[2][1].must_equal nil
     query_data.raw[2][2].must_equal nil
     query_data.raw[2][3].must_equal nil
     query_data.raw[2][4].must_equal nil
+    query_data.raw[2][5].must_equal nil
   end
 
   it "knows schema, fields, and headers" do
     query_data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     query_data.fields.must_equal query_data.schema.fields
-    query_data.headers.must_equal ["name", "age", "score", "active", "avatar"]
+    query_data.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
   end
 
   it "can get the job associated with the data" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
@@ -28,6 +28,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[0]["avatar"].must_be_kind_of StringIO
     query_data[0]["avatar"].read.must_equal "image data"
     query_data[0]["started_at"].must_equal Time.parse("2016-12-25 13:00:00 UTC")
+    query_data[0]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
 
     query_data[1].must_be_kind_of Hash
     query_data[1]["name"].must_equal "Aaron"
@@ -36,6 +37,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[1]["active"].must_equal false
     query_data[1]["avatar"].must_equal nil
     query_data[1]["started_at"].must_equal nil
+    query_data[1]["duration"].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
 
     query_data[2].must_be_kind_of Hash
     query_data[2]["name"].must_equal "Sally"
@@ -44,6 +46,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data[2]["active"].must_equal nil
     query_data[2]["avatar"].must_equal nil
     query_data[2]["started_at"].must_equal nil
+    query_data[2]["duration"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -66,6 +69,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[0][3].must_equal query_data[0]["active"].to_s
     query_data.raw[0][4].must_equal Base64.strict_encode64(query_data[0]["avatar"].read)
     query_data.raw[0][5].must_equal "1482670800.0"
+    query_data.raw[0][6].must_equal "04:00:00"
 
     query_data.raw[1][0].must_equal query_data[1]["name"].to_s
     query_data.raw[1][1].must_equal query_data[1]["age"].to_s
@@ -73,6 +77,7 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[1][3].must_equal query_data[1]["active"].to_s
     query_data.raw[1][4].must_equal nil
     query_data.raw[1][5].must_equal nil
+    query_data.raw[1][6].must_equal "04:32:10.555555"
 
     query_data.raw[2][0].must_equal query_data[2]["name"].to_s
     query_data.raw[2][1].must_equal nil
@@ -80,12 +85,13 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.raw[2][3].must_equal nil
     query_data.raw[2][4].must_equal nil
     query_data.raw[2][5].must_equal nil
+    query_data.raw[2][6].must_equal nil
   end
 
   it "knows schema, fields, and headers" do
     query_data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     query_data.fields.must_equal query_data.schema.fields
-    query_data.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
+    query_data.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
   end
 
   it "can get the job associated with the data" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
     table.schema.must_be :frozen?
     table.schema.fields.wont_be :empty?
     table.fields.wont_be :empty?
-    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
     table.schema.must_be :frozen?
     table.schema.fields.wont_be :empty?
     table.fields.wont_be :empty?
-    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
     table.schema.must_be :frozen?
     table.schema.fields.wont_be :empty?
     table.fields.wont_be :empty?
-    table.headers.must_equal ["name", "age", "score", "active"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
     table.schema.must_be :frozen?
     table.schema.fields.wont_be :empty?
     table.fields.wont_be :empty?
-    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
     table.schema.must_be :frozen?
     table.schema.fields.wont_be :empty?
     table.fields.wont_be :empty?
-    table.headers.must_equal ["name", "age", "score", "active", "avatar"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -39,7 +39,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", fields: [] }
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", fields: [] }
   let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", fields: [] }
-  let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "start_date", type: "TIMESTAMP", mode: "NULLABLE", fields: [] }
+  let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", fields: [] }
   let(:field_record_repeated_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "cities_lived", type: "RECORD", mode: "REPEATED", fields: [ field_integer_gapi, field_timestamp_gapi ] }
 
   let(:field_string_required) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_string_required_gapi }
@@ -52,7 +52,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   it "gets the schema, fields, and headers" do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
-    table.schema.fields.count.must_equal 5
+    table.schema.fields.count.must_equal 6
 
     table.schema.fields[0].name.must_equal "name"
     table.schema.fields[0].type.must_equal "STRING"
@@ -79,9 +79,14 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.fields[4].description.must_equal nil
     table.schema.fields[4].mode.must_equal "NULLABLE"
 
-    table.fields.count.must_equal 5
+    table.schema.fields[5].name.must_equal "started_at"
+    table.schema.fields[5].type.must_equal "TIMESTAMP"
+    table.schema.fields[5].description.must_equal nil
+    table.schema.fields[5].mode.must_equal "NULLABLE"
+
+    table.fields.count.must_equal 6
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active", "avatar"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
   end
 
   it "sets a flat schema via a block with replace option true" do
@@ -107,7 +112,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.float "accuracy"
       schema.boolean "approved"
       schema.bytes "avatar"
-      schema.timestamp "start_date"
+      schema.timestamp "started_at"
     end
 
     mock.verify
@@ -147,7 +152,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
-      schema.timestamp "start_date"
+      schema.timestamp "started_at"
     end
 
     mock.verify
@@ -170,7 +175,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.string "first_name", mode: :required
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"
-        nested.timestamp "start_date"
+        nested.timestamp "started_at"
       end
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -41,6 +41,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", fields: [] }
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", fields: [] }
   let(:field_time_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "duration", type: "TIME", mode: "NULLABLE", fields: [] }
+  let(:field_datetime_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "target_end", type: "DATETIME", mode: "NULLABLE", fields: [] }
   let(:field_record_repeated_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "cities_lived", type: "RECORD", mode: "REPEATED", fields: [ field_integer_gapi, field_timestamp_gapi ] }
 
   let(:field_string_required) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_string_required_gapi }
@@ -53,7 +54,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   it "gets the schema, fields, and headers" do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
-    table.schema.fields.count.must_equal 7
+    table.schema.fields.count.must_equal 8
 
     table.schema.fields[0].name.must_equal "name"
     table.schema.fields[0].type.must_equal "STRING"
@@ -90,9 +91,14 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.fields[6].description.must_equal nil
     table.schema.fields[6].mode.must_equal "NULLABLE"
 
-    table.fields.count.must_equal 7
+    table.schema.fields[7].name.must_equal "target_end"
+    table.schema.fields[7].type.must_equal "DATETIME"
+    table.schema.fields[7].description.must_equal nil
+    table.schema.fields[7].mode.must_equal "NULLABLE"
+
+    table.fields.count.must_equal 8
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
   end
 
   it "sets a flat schema via a block with replace option true" do
@@ -103,7 +109,8 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
                field_boolean_gapi,
                field_bytes_gapi,
                field_timestamp_gapi,
-               field_time_gapi])
+               field_time_gapi,
+               field_datetime_gapi])
 
     mock = Minitest::Mock.new
     returned_table_gapi = table_gapi.dup
@@ -121,6 +128,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.bytes "avatar"
       schema.timestamp "started_at"
       schema.time "duration"
+      schema.datetime "target_end"
     end
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -40,6 +40,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", fields: [] }
   let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", fields: [] }
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", fields: [] }
+  let(:field_time_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "duration", type: "TIME", mode: "NULLABLE", fields: [] }
   let(:field_record_repeated_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "cities_lived", type: "RECORD", mode: "REPEATED", fields: [ field_integer_gapi, field_timestamp_gapi ] }
 
   let(:field_string_required) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_string_required_gapi }
@@ -52,7 +53,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   it "gets the schema, fields, and headers" do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
-    table.schema.fields.count.must_equal 6
+    table.schema.fields.count.must_equal 7
 
     table.schema.fields[0].name.must_equal "name"
     table.schema.fields[0].type.must_equal "STRING"
@@ -84,9 +85,14 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.fields[5].description.must_equal nil
     table.schema.fields[5].mode.must_equal "NULLABLE"
 
-    table.fields.count.must_equal 6
+    table.schema.fields[6].name.must_equal "duration"
+    table.schema.fields[6].type.must_equal "TIME"
+    table.schema.fields[6].description.must_equal nil
+    table.schema.fields[6].mode.must_equal "NULLABLE"
+
+    table.fields.count.must_equal 7
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
   end
 
   it "sets a flat schema via a block with replace option true" do
@@ -96,7 +102,8 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
                field_float_gapi,
                field_boolean_gapi,
                field_bytes_gapi,
-               field_timestamp_gapi])
+               field_timestamp_gapi,
+               field_time_gapi])
 
     mock = Minitest::Mock.new
     returned_table_gapi = table_gapi.dup
@@ -113,6 +120,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.boolean "approved"
       schema.bytes "avatar"
       schema.timestamp "started_at"
+      schema.time "duration"
     end
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -38,6 +38,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_integer_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", mode: "NULLABLE", fields: [] }
   let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", fields: [] }
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", fields: [] }
+  let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", fields: [] }
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "start_date", type: "TIMESTAMP", mode: "NULLABLE", fields: [] }
   let(:field_record_repeated_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "cities_lived", type: "RECORD", mode: "REPEATED", fields: [ field_integer_gapi, field_timestamp_gapi ] }
 
@@ -51,7 +52,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   it "gets the schema, fields, and headers" do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
-    table.schema.fields.count.must_equal 4
+    table.schema.fields.count.must_equal 5
 
     table.schema.fields[0].name.must_equal "name"
     table.schema.fields[0].type.must_equal "STRING"
@@ -61,21 +62,26 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.fields[1].name.must_equal "age"
     table.schema.fields[1].type.must_equal "INTEGER"
     table.schema.fields[1].description.must_equal nil
-    table.schema.fields[1].mode.must_equal nil
+    table.schema.fields[1].mode.must_equal "NULLABLE"
 
     table.schema.fields[2].name.must_equal "score"
     table.schema.fields[2].type.must_equal "FLOAT"
-    table.schema.fields[2].description.must_equal "A score from 0.0 to 10.0"
-    table.schema.fields[2].mode.must_equal nil
+    table.schema.fields[2].description.must_equal nil
+    table.schema.fields[2].mode.must_equal "NULLABLE"
 
     table.schema.fields[3].name.must_equal "active"
     table.schema.fields[3].type.must_equal "BOOLEAN"
     table.schema.fields[3].description.must_equal nil
-    table.schema.fields[3].mode.must_equal nil
+    table.schema.fields[3].mode.must_equal "NULLABLE"
 
-    table.fields.count.must_equal 4
+    table.schema.fields[4].name.must_equal "avatar"
+    table.schema.fields[4].type.must_equal "BYTES"
+    table.schema.fields[4].description.must_equal nil
+    table.schema.fields[4].mode.must_equal "NULLABLE"
+
+    table.fields.count.must_equal 5
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar"]
   end
 
   it "sets a flat schema via a block with replace option true" do
@@ -84,6 +90,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
                field_integer_gapi,
                field_float_gapi,
                field_boolean_gapi,
+               field_bytes_gapi,
                field_timestamp_gapi])
 
     mock = Minitest::Mock.new
@@ -99,6 +106,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.integer "rank", description: "An integer value from 1 to 100"
       schema.float "accuracy"
       schema.boolean "approved"
+      schema.bytes "avatar"
       schema.timestamp "start_date"
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -42,6 +42,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", fields: [] }
   let(:field_time_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "duration", type: "TIME", mode: "NULLABLE", fields: [] }
   let(:field_datetime_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "target_end", type: "DATETIME", mode: "NULLABLE", fields: [] }
+  let(:field_date_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "birthday", type: "DATE", mode: "NULLABLE", fields: [] }
   let(:field_record_repeated_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "cities_lived", type: "RECORD", mode: "REPEATED", fields: [ field_integer_gapi, field_timestamp_gapi ] }
 
   let(:field_string_required) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_string_required_gapi }
@@ -54,7 +55,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   it "gets the schema, fields, and headers" do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
-    table.schema.fields.count.must_equal 8
+    table.schema.fields.count.must_equal 9
 
     table.schema.fields[0].name.must_equal "name"
     table.schema.fields[0].type.must_equal "STRING"
@@ -96,9 +97,14 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.fields[7].description.must_equal nil
     table.schema.fields[7].mode.must_equal "NULLABLE"
 
-    table.fields.count.must_equal 8
+    table.schema.fields[8].name.must_equal "birthday"
+    table.schema.fields[8].type.must_equal "DATE"
+    table.schema.fields[8].description.must_equal nil
+    table.schema.fields[8].mode.must_equal "NULLABLE"
+
+    table.fields.count.must_equal 9
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
   end
 
   it "sets a flat schema via a block with replace option true" do
@@ -110,7 +116,8 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
                field_bytes_gapi,
                field_timestamp_gapi,
                field_time_gapi,
-               field_datetime_gapi])
+               field_datetime_gapi,
+               field_date_gapi])
 
     mock = Minitest::Mock.new
     returned_table_gapi = table_gapi.dup
@@ -129,6 +136,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.timestamp "started_at"
       schema.time "duration"
       schema.datetime "target_end"
+      schema.date "birthday"
     end
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active", "avatar"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
-    table.headers.must_equal ["name", "age", "score", "active"]
+    table.headers.must_equal ["name", "age", "score", "active", "avatar"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::Bigquery::View, :attributes, :mock_bigquery do
     view.schema.must_be :frozen?
     view.schema.fields.wont_be :empty?
     view.fields.wont_be :empty?
-    view.headers.must_equal ["name", "age", "score", "active", "avatar"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::Bigquery::View, :attributes, :mock_bigquery do
     view.schema.must_be :frozen?
     view.schema.fields.wont_be :empty?
     view.fields.wont_be :empty?
-    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::Bigquery::View, :attributes, :mock_bigquery do
     view.schema.must_be :frozen?
     view.schema.fields.wont_be :empty?
     view.fields.wont_be :empty?
-    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::Bigquery::View, :attributes, :mock_bigquery do
     view.schema.must_be :frozen?
     view.schema.fields.wont_be :empty?
     view.fields.wont_be :empty?
-    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::Bigquery::View, :attributes, :mock_bigquery do
     view.schema.must_be :frozen?
     view.schema.fields.wont_be :empty?
     view.fields.wont_be :empty?
-    view.headers.must_equal ["name", "age", "score", "active"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar"]
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
@@ -48,16 +48,20 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
     data[0]["age"].must_equal 36
     data[0]["score"].must_equal 7.65
     data[0]["active"].must_equal true
+    data[0]["avatar"].must_be_kind_of StringIO
+    data[0]["avatar"].read.must_equal "image data"
     data[1].must_be_kind_of Hash
     data[1]["name"].must_equal "Aaron"
     data[1]["age"].must_equal 42
     data[1]["score"].must_equal 8.15
     data[1]["active"].must_equal false
+    data[1]["avatar"].must_equal nil
     data[2].must_be_kind_of Hash
     data[2]["name"].must_equal "Sally"
     data[2]["age"].must_equal nil
     data[2]["score"].must_equal nil
     data[2]["active"].must_equal nil
+    data[2]["avatar"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -90,16 +94,19 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
     data.raw[0][1].must_equal data[0]["age"].to_s
     data.raw[0][2].must_equal data[0]["score"].to_s
     data.raw[0][3].must_equal data[0]["active"].to_s
+    data.raw[0][4].must_equal Base64.strict_encode64(data[0]["avatar"].read)
 
     data.raw[1][0].must_equal data[1]["name"].to_s
     data.raw[1][1].must_equal data[1]["age"].to_s
     data.raw[1][2].must_equal data[1]["score"].to_s
     data.raw[1][3].must_equal data[1]["active"].to_s
+    data.raw[1][4].must_equal nil
 
     data.raw[2][0].must_equal data[2]["name"].to_s
     data.raw[2][1].must_equal nil
     data.raw[2][2].must_equal nil
     data.raw[2][3].must_equal nil
+    data.raw[2][4].must_equal nil
   end
 
   it "paginates data using next? and next" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
@@ -50,18 +50,23 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
     data[0]["active"].must_equal true
     data[0]["avatar"].must_be_kind_of StringIO
     data[0]["avatar"].read.must_equal "image data"
+    data[0]["started_at"].must_equal Time.parse("2016-12-25 13:00:00 UTC")
+
     data[1].must_be_kind_of Hash
     data[1]["name"].must_equal "Aaron"
     data[1]["age"].must_equal 42
     data[1]["score"].must_equal 8.15
     data[1]["active"].must_equal false
     data[1]["avatar"].must_equal nil
+    data[1]["started_at"].must_equal nil
+
     data[2].must_be_kind_of Hash
     data[2]["name"].must_equal "Sally"
     data[2]["age"].must_equal nil
     data[2]["score"].must_equal nil
     data[2]["active"].must_equal nil
     data[2]["avatar"].must_equal nil
+    data[2]["started_at"].must_equal nil
   end
 
   it "knows the data metadata" do
@@ -95,18 +100,21 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
     data.raw[0][2].must_equal data[0]["score"].to_s
     data.raw[0][3].must_equal data[0]["active"].to_s
     data.raw[0][4].must_equal Base64.strict_encode64(data[0]["avatar"].read)
+    data.raw[0][5].must_equal "1482670800.0"
 
     data.raw[1][0].must_equal data[1]["name"].to_s
     data.raw[1][1].must_equal data[1]["age"].to_s
     data.raw[1][2].must_equal data[1]["score"].to_s
     data.raw[1][3].must_equal data[1]["active"].to_s
     data.raw[1][4].must_equal nil
+    data.raw[1][5].must_equal nil
 
     data.raw[2][0].must_equal data[2]["name"].to_s
     data.raw[2][1].must_equal nil
     data.raw[2][2].must_equal nil
     data.raw[2][3].must_equal nil
     data.raw[2][4].must_equal nil
+    data.raw[2][5].must_equal nil
   end
 
   it "paginates data using next? and next" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Bigquery::View, :mock_bigquery do
     view.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     view.schema.must_be :frozen?
     view.fields.map(&:name).must_equal view.schema.fields.map(&:name)
-    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Bigquery::View, :mock_bigquery do
     view.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     view.schema.must_be :frozen?
     view.fields.map(&:name).must_equal view.schema.fields.map(&:name)
-    view.headers.must_equal ["name", "age", "score", "active", "avatar"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Bigquery::View, :mock_bigquery do
     view.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     view.schema.must_be :frozen?
     view.fields.map(&:name).must_equal view.schema.fields.map(&:name)
-    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Bigquery::View, :mock_bigquery do
     view.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     view.schema.must_be :frozen?
     view.fields.map(&:name).must_equal view.schema.fields.map(&:name)
-    view.headers.must_equal ["name", "age", "score", "active"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Bigquery::View, :mock_bigquery do
     view.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     view.schema.must_be :frozen?
     view.fields.map(&:name).must_equal view.schema.fields.map(&:name)
-    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end"]
+    view.headers.must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
   end
 
   it "can delete itself" do

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -129,6 +129,11 @@ class MockBigquery < Minitest::Spec
           "name" => "started_at",
           "type" => "TIMESTAMP",
           "mode" => "NULLABLE"
+        },
+        {
+          "name" => "duration",
+          "type" => "TIME",
+          "mode" => "NULLABLE"
         }
       ]
     }
@@ -143,7 +148,8 @@ class MockBigquery < Minitest::Spec
           { "v" => "7.65" },
           { "v" => "true" },
           { "v" => "aW1hZ2UgZGF0YQ==" },
-          { "v" => "1482670800.0" }
+          { "v" => "1482670800.0" },
+          { "v" => "04:00:00" }
         ]
       },
       {
@@ -153,12 +159,14 @@ class MockBigquery < Minitest::Spec
           { "v" => "8.15" },
           { "v" => "false" },
           { "v" => nil },
-          { "v" => nil }
+          { "v" => nil },
+          { "v" => "04:32:10.555555" }
         ]
       },
       {
         "f" => [
           { "v" => "Sally" },
+          { "v" => nil },
           { "v" => nil },
           { "v" => nil },
           { "v" => nil },

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -134,6 +134,11 @@ class MockBigquery < Minitest::Spec
           "name" => "duration",
           "type" => "TIME",
           "mode" => "NULLABLE"
+        },
+        {
+          "name" => "target_end",
+          "type" => "DATETIME",
+          "mode" => "NULLABLE"
         }
       ]
     }
@@ -149,7 +154,8 @@ class MockBigquery < Minitest::Spec
           { "v" => "true" },
           { "v" => "aW1hZ2UgZGF0YQ==" },
           { "v" => "1482670800.0" },
-          { "v" => "04:00:00" }
+          { "v" => "04:00:00" },
+          { "v" => "2017-01-01 00:00:00" }
         ]
       },
       {
@@ -160,12 +166,14 @@ class MockBigquery < Minitest::Spec
           { "v" => "false" },
           { "v" => nil },
           { "v" => nil },
-          { "v" => "04:32:10.555555" }
+          { "v" => "04:32:10.555555" },
+          { "v" => nil }
         ]
       },
       {
         "f" => [
           { "v" => "Sally" },
+          { "v" => nil },
           { "v" => nil },
           { "v" => nil },
           { "v" => nil },

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -97,6 +97,78 @@ class MockBigquery < Minitest::Spec
     }
   end
 
+  def random_schema_hash
+    {
+      "fields" => [
+        {
+          "name" => "name",
+          "type" => "STRING",
+          "mode" => "REQUIRED"
+        },
+        {
+          "name" => "age",
+          "type" => "INTEGER",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "score",
+          "type" => "FLOAT",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "active",
+          "type" => "BOOLEAN",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "avatar",
+          "type" => "BYTES",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "started_at",
+          "type" => "TIMESTAMP",
+          "mode" => "NULLABLE"
+        }
+      ]
+    }
+  end
+
+  def random_data_rows
+    [
+      {
+        "f" => [
+          { "v" => "Heidi" },
+          { "v" => "36" },
+          { "v" => "7.65" },
+          { "v" => "true" },
+          { "v" => "aW1hZ2UgZGF0YQ==" },
+          { "v" => "1482670800.0" }
+        ]
+      },
+      {
+        "f" => [
+          { "v" => "Aaron" },
+          { "v" => "42" },
+          { "v" => "8.15" },
+          { "v" => "false" },
+          { "v" => nil },
+          { "v" => nil }
+        ]
+      },
+      {
+        "f" => [
+          { "v" => "Sally" },
+          { "v" => nil },
+          { "v" => nil },
+          { "v" => nil },
+          { "v" => nil },
+          { "v" => nil }
+        ]
+      }
+    ]
+  end
+
   def random_table_gapi dataset, id = nil, name = nil, description = nil, project_id = nil
     json = random_table_hash(dataset, id, name, description, project_id).to_json
     Google::Apis::BigqueryV2::Table.from_json json
@@ -118,35 +190,7 @@ class MockBigquery < Minitest::Spec
       },
       "friendlyName" => name,
       "description" => description,
-      "schema" => {
-        "fields" => [
-          {
-            "name" => "name",
-            "type" => "STRING",
-            "mode" => "REQUIRED"
-          },
-          {
-            "name" => "age",
-            "type" => "INTEGER",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "score",
-            "type" => "FLOAT",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "active",
-            "type" => "BOOLEAN",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "avatar",
-            "type" => "BYTES",
-            "mode" => "NULLABLE"
-          }
-        ]
-      },
+      "schema" => random_schema_hash,
       "numBytes" => "1000", # String per google/google-api-ruby-client#439
       "numRows" => "100",   # String per google/google-api-ruby-client#439
       "creationTime" => time_millis,
@@ -223,35 +267,7 @@ class MockBigquery < Minitest::Spec
       },
       "friendlyName" => name,
       "description" => description,
-      "schema" => {
-        "fields" => [
-          {
-            "name" => "name",
-            "type" => "STRING",
-            "mode" => "REQUIRED"
-          },
-          {
-            "name" => "age",
-            "type" => "INTEGER",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "score",
-            "type" => "FLOAT",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "active",
-            "type" => "BOOLEAN",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "avatar",
-            "type" => "BYTES",
-            "mode" => "NULLABLE"
-          }
-        ]
-      },
+      "schema" => random_schema_hash,
       "creationTime" => time_millis,
       "expirationTime" => time_millis,
       "lastModifiedTime" => time_millis,
@@ -354,7 +370,7 @@ class MockBigquery < Minitest::Spec
       ),
       dry_run: nil,
       max_results: nil,
-      query: "SELECT name, age, score, active, avatar FROM [some_project:some_dataset.users]",
+      query: "SELECT * FROM [some_project:some_dataset.users]",
       timeout_ms: 10000,
       use_query_cache: true,
       use_legacy_sql: nil,
@@ -373,64 +389,8 @@ class MockBigquery < Minitest::Spec
         "projectId" => project,
         "jobId" => "job9876543210"
       },
-      "schema" => {
-        "fields" => [
-          {
-            "name" => "name",
-            "type" => "STRING",
-            "mode" => "REQUIRED"
-          },
-          {
-            "name" => "age",
-            "type" => "INTEGER",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "score",
-            "type" => "FLOAT",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "active",
-            "type" => "BOOLEAN",
-            "mode" => "NULLABLE"
-          },
-          {
-            "name" => "avatar",
-            "type" => "BYTES",
-            "mode" => "NULLABLE"
-          }
-        ]
-      },
-      "rows" => [
-        {
-          "f" => [
-            { "v" => "Heidi" },
-            { "v" => "36" },
-            { "v" => "7.65" },
-            { "v" => "true" },
-            { "v" => "aW1hZ2UgZGF0YQ==" }
-          ]
-        },
-        {
-          "f" => [
-            { "v" => "Aaron" },
-            { "v" => "42" },
-            { "v" => "8.15" },
-            { "v" => "false" },
-            { "v" => nil }
-          ]
-        },
-        {
-          "f" => [
-            { "v" => "Sally" },
-            { "v" => nil },
-            { "v" => nil },
-            { "v" => nil },
-            { "v" => nil }
-          ]
-        }
-      ],
+      "schema" => random_schema_hash,
+      "rows" => random_data_rows,
       "pageToken" => token,
       "totalRows" => 3,
       "totalBytesProcessed" => "456789", # String per google/google-api-ruby-client#439

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -127,16 +127,23 @@ class MockBigquery < Minitest::Spec
           },
           {
             "name" => "age",
-            "type" => "INTEGER"
+            "type" => "INTEGER",
+            "mode" => "NULLABLE"
           },
           {
             "name" => "score",
             "type" => "FLOAT",
-            "description" => "A score from 0.0 to 10.0"
+            "mode" => "NULLABLE"
           },
           {
             "name" => "active",
-            "type" => "BOOLEAN"
+            "type" => "BOOLEAN",
+            "mode" => "NULLABLE"
+          },
+          {
+            "name" => "avatar",
+            "type" => "BYTES",
+            "mode" => "NULLABLE"
           }
         ]
       },
@@ -221,7 +228,7 @@ class MockBigquery < Minitest::Spec
           {
             "name" => "name",
             "type" => "STRING",
-            "mode" => "NULLABLE"
+            "mode" => "REQUIRED"
           },
           {
             "name" => "age",
@@ -236,6 +243,11 @@ class MockBigquery < Minitest::Spec
           {
             "name" => "active",
             "type" => "BOOLEAN",
+            "mode" => "NULLABLE"
+          },
+          {
+            "name" => "avatar",
+            "type" => "BYTES",
             "mode" => "NULLABLE"
           }
         ]
@@ -342,7 +354,7 @@ class MockBigquery < Minitest::Spec
       ),
       dry_run: nil,
       max_results: nil,
-      query: "SELECT name, age, score, active FROM [some_project:some_dataset.users]",
+      query: "SELECT name, age, score, active, avatar FROM [some_project:some_dataset.users]",
       timeout_ms: 10000,
       use_query_cache: true,
       use_legacy_sql: nil,
@@ -366,7 +378,7 @@ class MockBigquery < Minitest::Spec
           {
             "name" => "name",
             "type" => "STRING",
-            "mode" => "NULLABLE"
+            "mode" => "REQUIRED"
           },
           {
             "name" => "age",
@@ -382,6 +394,11 @@ class MockBigquery < Minitest::Spec
             "name" => "active",
             "type" => "BOOLEAN",
             "mode" => "NULLABLE"
+          },
+          {
+            "name" => "avatar",
+            "type" => "BYTES",
+            "mode" => "NULLABLE"
           }
         ]
       },
@@ -391,7 +408,8 @@ class MockBigquery < Minitest::Spec
             { "v" => "Heidi" },
             { "v" => "36" },
             { "v" => "7.65" },
-            { "v" => "true" }
+            { "v" => "true" },
+            { "v" => "aW1hZ2UgZGF0YQ==" }
           ]
         },
         {
@@ -399,12 +417,14 @@ class MockBigquery < Minitest::Spec
             { "v" => "Aaron" },
             { "v" => "42" },
             { "v" => "8.15" },
-            { "v" => "false" }
+            { "v" => "false" },
+            { "v" => nil }
           ]
         },
         {
           "f" => [
             { "v" => "Sally" },
+            { "v" => nil },
             { "v" => nil },
             { "v" => nil },
             { "v" => nil }

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -139,6 +139,11 @@ class MockBigquery < Minitest::Spec
           "name" => "target_end",
           "type" => "DATETIME",
           "mode" => "NULLABLE"
+        },
+        {
+          "name" => "birthday",
+          "type" => "DATE",
+          "mode" => "NULLABLE"
         }
       ]
     }
@@ -155,7 +160,8 @@ class MockBigquery < Minitest::Spec
           { "v" => "aW1hZ2UgZGF0YQ==" },
           { "v" => "1482670800.0" },
           { "v" => "04:00:00" },
-          { "v" => "2017-01-01 00:00:00" }
+          { "v" => "2017-01-01 00:00:00" },
+          { "v" => "1968-10-20" }
         ]
       },
       {
@@ -167,12 +173,14 @@ class MockBigquery < Minitest::Spec
           { "v" => nil },
           { "v" => nil },
           { "v" => "04:32:10.555555" },
+          { "v" => nil },
           { "v" => nil }
         ]
       },
       {
         "f" => [
           { "v" => "Sally" },
+          { "v" => nil },
           { "v" => nil },
           { "v" => nil },
           { "v" => nil },


### PR DESCRIPTION
Fix several bugs with the handling of types in BigQuery. Make sure that the format of the value objects returned from BigQuery match the format used for the query parameters. Time, DateTime, Date, etc.

This is part of a larger set of changes discovered by adding additional acceptance tests (#1238).