### PR TITLE
Remove Natural Language encoding argument

### DIFF
--- a/google-cloud-language/acceptance/language/storage/html_url_test.rb
+++ b/google-cloud-language/acceptance/language/storage/html_url_test.rb
@@ -318,7 +318,7 @@ describe "Language (HTML/Storage URL)", :language do
       doc.must_be :html?
       doc.wont_be :text?
 
-      entities = doc.entities encoding: :UTF8
+      entities = doc.entities
 
       entities.language.must_equal "en"
 

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -53,14 +53,11 @@ module Google
     #
     # ## Creating documents
     #
-    # Cloud Natural Language API supports UTF-8, UTF-16, and UTF-32 encodings.
-    # (Ruby uses UTF-8 natively, which is the default sent to the API, so unless
-    # you're working with text processed in different platform, you should not
-    # need to set the encoding type.) Be aware that only English, Spanish, and
-    # Japanese language content are supported.
-    #
     # Use {Language::Project#document} to create documents for the Cloud Natural
-    # Language service. You can provide text or HTML content as a string:
+    # Language service. (The Cloud Natural Language API currently supports
+    # English, Spanish, and Japanese.)
+    #
+    # You can provide text or HTML content as a string:
     #
     # ```ruby
     # require "google/cloud/language"

--- a/google-cloud-language/lib/google/cloud/language/annotation.rb
+++ b/google-cloud-language/lib/google/cloud/language/annotation.rb
@@ -240,9 +240,17 @@ module Google
         # Represents a piece of text including relative location.
         #
         # @attr_reader [String] text The content of the output text.
-        # @attr_reader [Integer] offset The API calculates the beginning offset
-        #   of the content in the original document according to the `encoding`
-        #   specified in the API request.
+        # @attr_reader [Integer] offset The beginning offset
+        #   of the content in the original document.
+        #
+        #   The API calculates the beginning offset according to the client
+        #   system's default encoding. In Ruby this defaults to UTF-8. To change
+        #   the offset calculation you will need to change Ruby's default
+        #   encoding. This is commonly done by setting
+        #   `Encoding.default_internal` to `Encoding::UTF_16` or
+        #   `Encoding::UTF_32`. If the system is configured to use an encoding
+        #   other than UTF-16 or UTF-32 the offset will be calculated using
+        #   UTF-8.
         #
         # @example
         #   require "google/cloud/language"
@@ -384,9 +392,17 @@ module Google
           alias_method :content, :text
 
           ##
-          # The API calculates the beginning offset of the content in the
-          # original document according to the `encoding` specified in the
-          # API request. See {TextSpan#offset}.
+          # The beginning offset of the content in the original document. See
+          # {TextSpan#offset}.
+          #
+          # The API calculates the beginning offset according to the client
+          # system's default encoding. In Ruby this defaults to UTF-8. To change
+          # the offset calculation you will need to change Ruby's default
+          # encoding. This is commonly done by setting
+          # `Encoding.default_internal` to `Encoding::UTF_16` or
+          # `Encoding::UTF_32`. If the system is configured to use an encoding
+          # other than UTF-16 or UTF-32 the offset will be calculated using
+          # UTF-8.
           #
           # @return [Integer]
           #
@@ -535,11 +551,31 @@ module Google
             @lemma            = lemma
           end
 
+          ##
+          # The content of the output text. See {TextSpan#text}.
+          #
+          # @return [String]
+          #
           def text
             @text_span.text
           end
           alias_method :content, :text
 
+          ##
+          # The beginning offset of the content in the original document. See
+          # {TextSpan#offset}.
+          #
+          # The API calculates the beginning offset according to the client
+          # system's default encoding. In Ruby this defaults to UTF-8. To change
+          # the offset calculation you will need to change Ruby's default
+          # encoding. This is commonly done by setting
+          # `Encoding.default_internal` to `Encoding::UTF_16` or
+          # `Encoding::UTF_32`. If the system is configured to use an encoding
+          # other than UTF-16 or UTF-32 the offset will be calculated using
+          # UTF-8.
+          #
+          # @return [Integer]
+          #
           def offset
             @text_span.offset
           end
@@ -940,9 +976,17 @@ module Google
             alias_method :content, :text
 
             ##
-            # The API calculates the beginning offset of the content in the
-            # original document according to the `encoding` specified in the
-            # API request. See {TextSpan#offset}.
+            # The beginning offset of the content in the original document. See
+            # {TextSpan#offset}.
+            #
+            # The API calculates the beginning offset according to the client
+            # system's default encoding. In Ruby this defaults to UTF-8. To
+            # change the offset calculation you will need to change Ruby's
+            # default encoding. This is commonly done by setting
+            # `Encoding.default_internal` to `Encoding::UTF_16` or
+            # `Encoding::UTF_32`. If the system is configured to use an encoding
+            # other than UTF-16 or UTF-32 the offset will be calculated using
+            # UTF-8.
             #
             # @return [Integer]
             #

--- a/google-cloud-language/lib/google/cloud/language/document.rb
+++ b/google-cloud-language/lib/google/cloud/language/document.rb
@@ -23,11 +23,6 @@ module Google
       #
       # Represents a document for the Language service.
       #
-      # Cloud Natural Language API supports UTF-8, UTF-16, and UTF-32 encodings.
-      # (Ruby uses UTF-8 natively, which is the default sent to the API, so
-      # unless you're working with text processed in different platform, you
-      # should not need to set the encoding type.)
-      #
       # Be aware that only English, Spanish, and Japanese language content are
       # supported.
       #
@@ -187,9 +182,6 @@ module Google
         # @param [Boolean] syntax Whether to perform syntactic analysis.
         #   Optional. The default is `false`. If every feature option is
         #   `false`, **all** features will be performed.
-        # @param [String, Symbol] encoding The encoding type used by the API to
-        #   calculate offsets. Acceptable values are: `utf8`, `utf16`, `utf32`.
-        #   The default value is `utf8`. Optional.
         #
         # @return [Annotation] The results of the content analysis.
         #
@@ -221,13 +213,11 @@ module Google
         #   annotation.sentences.count #=> 2
         #   annotation.tokens.count #=> 13
         #
-        def annotate sentiment: false, entities: false, syntax: false,
-                     encoding: nil
+        def annotate sentiment: false, entities: false, syntax: false
           ensure_service!
           grpc = service.annotate to_grpc, sentiment: sentiment,
                                            entities: entities,
-                                           syntax: syntax,
-                                           encoding: encoding
+                                           syntax: syntax
           Annotation.from_grpc grpc
         end
         alias_method :mark, :annotate
@@ -237,10 +227,6 @@ module Google
         # Syntactic analysis extracts linguistic information, breaking up the
         # given text into a series of sentences and tokens (generally, word
         # boundaries), providing further analysis on those tokens.
-        #
-        # @param [String, Symbol] encoding The encoding type used by the API to
-        #   calculate offsets. Acceptable values are: `utf8`, `utf16`, `utf32`.
-        #   The default value is `utf8`. Optional.
         #
         # @return [Annotation::Syntax] The results for the content analysis.
         #
@@ -268,9 +254,9 @@ module Google
         #   token.label #=> :TITLE
         #   token.lemma #=> "Star"
         #
-        def syntax encoding: nil
+        def syntax
           ensure_service!
-          grpc = service.syntax to_grpc, encoding: encoding
+          grpc = service.syntax to_grpc
           Annotation::Syntax.from_grpc grpc
         end
 
@@ -278,10 +264,6 @@ module Google
         # Entity analysis inspects the given text for known entities (proper
         # nouns such as public figures, landmarks, etc.) and returns information
         # about those entities.
-        #
-        # @param [String, Symbol] encoding The encoding type used by the API to
-        #   calculate offsets. Acceptable values are: `utf8`, `utf16`, `utf32`.
-        #   The default value is `utf8`. Optional.
         #
         # @return [Annotation::Entities] The results for the entities analysis.
         #
@@ -299,9 +281,9 @@ module Google
         #   entities.first.type #=> :WORK_OF_ART
         #   entities.first.mid #=> "/m/06mmr"
         #
-        def entities encoding: nil
+        def entities
           ensure_service!
-          grpc = service.entities to_grpc, encoding: encoding
+          grpc = service.entities to_grpc
           Annotation::Entities.from_grpc grpc
         end
 
@@ -310,10 +292,6 @@ module Google
         # prevailing emotional opinion within the text, especially to determine
         # a writer's attitude as positive, negative, or neutral. Currently, only
         # English is supported for sentiment analysis.
-        #
-        # @param [String, Symbol] encoding The encoding type used by the API to
-        #   calculate offsets. Acceptable values are: `utf8`, `utf16`, `utf32`.
-        #   The default value is `utf8`. Optional.
         #
         # @return [Annotation::Sentiment] The results for the sentiment
         #   analysis.
@@ -336,9 +314,9 @@ module Google
         #   sentence.sentiment.score #=> 0.699999988079071
         #   sentence.sentiment.magnitude #=> 0.699999988079071
         #
-        def sentiment encoding: nil
+        def sentiment
           ensure_service!
-          grpc = service.sentiment to_grpc, encoding: encoding
+          grpc = service.sentiment to_grpc
           Annotation::Sentiment.from_grpc grpc
         end
 

--- a/google-cloud-language/lib/google/cloud/language/project.rb
+++ b/google-cloud-language/lib/google/cloud/language/project.rb
@@ -207,9 +207,6 @@ module Google
         # @param [String, Symbol] language The language of the document (if not
         #   specified, the language is automatically detected). Both ISO and
         #   BCP-47 language codes are accepted. Optional.
-        # @param [String, Symbol] encoding The encoding type used by the API to
-        #   calculate offsets. Acceptable values are: `utf8`, `utf16`, `utf32`.
-        #   The default value is `utf8`. Optional.
         #
         # @return [Annotation] The results for the content analysis.
         #
@@ -228,13 +225,12 @@ module Google
         #   annotation.tokens.count #=> 13
         #
         def annotate content, sentiment: false, entities: false, syntax: false,
-                     format: nil, language: nil, encoding: nil
+                     format: nil, language: nil
           ensure_service!
           doc = document content, language: language, format: format
           grpc = service.annotate doc.to_grpc, sentiment: sentiment,
                                                entities: entities,
-                                               syntax: syntax,
-                                               encoding: encoding
+                                               syntax: syntax
           Annotation.from_grpc grpc
         end
         alias_method :mark, :annotate
@@ -254,9 +250,6 @@ module Google
         # @param [String, Symbol] language The language of the document (if not
         #   specified, the language is automatically detected). Both ISO and
         #   BCP-47 language codes are accepted. Optional.
-        # @param [String, Symbol] encoding The encoding type used by the API to
-        #   calculate offsets. Acceptable values are: `utf8`, `utf16`, `utf32`.
-        #   The default value is `utf8`. Optional.
         #
         # @return [Annotation::Syntax] The results for the content syntax
         #   analysis.
@@ -285,10 +278,10 @@ module Google
         #   token.label #=> :TITLE
         #   token.lemma #=> "Star"
         #
-        def syntax content, format: nil, language: nil, encoding: nil
+        def syntax content, format: nil, language: nil
           ensure_service!
           doc = document content, language: language, format: format
-          grpc = service.syntax doc.to_grpc, encoding: encoding
+          grpc = service.syntax doc.to_grpc
           Annotation::Syntax.from_grpc grpc
         end
 
@@ -305,9 +298,6 @@ module Google
         # @param [String, Symbol] language The language of the document (if not
         #   specified, the language is automatically detected). Both ISO and
         #   BCP-47 language codes are accepted. Optional.
-        # @param [String, Symbol] encoding The encoding type used by the API to
-        #   calculate offsets. Acceptable values are: `utf8`, `utf16`, `utf32`.
-        #   The default value is `utf8`. Optional.
         #
         # @return [Annotation::Entities] The results for the entities analysis.
         #
@@ -322,10 +312,10 @@ module Google
         #   entities = language.entities document
         #   entities.count #=> 3
         #
-        def entities content, format: :text, language: nil, encoding: nil
+        def entities content, format: :text, language: nil
           ensure_service!
           doc = document content, language: language, format: format
-          grpc = service.entities doc.to_grpc, encoding: encoding
+          grpc = service.entities doc.to_grpc
           Annotation::Entities.from_grpc grpc
         end
 
@@ -343,9 +333,6 @@ module Google
         # @param [String, Symbol] language The language of the document (if not
         #   specified, the language is automatically detected). Both ISO and
         #   BCP-47 language codes are accepted. Optional.
-        # @param [String, Symbol] encoding The encoding type used by the API to
-        #   calculate offsets. Acceptable values are: `utf8`, `utf16`, `utf32`.
-        #   The default value is `utf8`. Optional.
         #
         # @return [Annotation::Sentiment] The results for the sentiment
         #   analysis.
@@ -368,10 +355,10 @@ module Google
         #   sentence.sentiment.score #=> 0.699999988079071
         #   sentence.sentiment.magnitude #=> 0.699999988079071
         #
-        def sentiment content, format: :text, language: nil, encoding: nil
+        def sentiment content, format: :text, language: nil
           ensure_service!
           doc = document content, language: language, format: format
-          grpc = service.sentiment doc.to_grpc, encoding: encoding
+          grpc = service.sentiment doc.to_grpc
           Annotation::Sentiment.from_grpc grpc
         end
 

--- a/google-cloud-language/test/google/cloud/language/default_encoding_test.rb
+++ b/google-cloud-language/test/google/cloud/language/default_encoding_test.rb
@@ -1,0 +1,149 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Language, :default_encoding, :mock_language do
+  it "detects the default encoding" do
+    grpc_doc = Google::Cloud::Language::V1::Document.new(
+      content: text_content, type: :PLAIN_TEXT)
+    features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
+      extract_syntax: true, extract_entities: true, extract_document_sentiment: true)
+    grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
+
+    mock = Minitest::Mock.new
+    mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
+
+    language.service.mocked_service = mock
+    annotation = language.annotate text_content
+    mock.verify
+
+    annotation.must_be_kind_of Google::Cloud::Language::Annotation
+  end
+
+  it "uses UTF8 when the internal encoding is nil" do
+    Encoding.stub :default_internal, nil do
+      grpc_doc = Google::Cloud::Language::V1::Document.new(
+        content: text_content, type: :PLAIN_TEXT)
+      features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
+        extract_syntax: true, extract_entities: true, extract_document_sentiment: true)
+      grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
+
+      mock = Minitest::Mock.new
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
+
+      language.service.mocked_service = mock
+      annotation = language.annotate text_content
+      mock.verify
+
+      annotation.must_be_kind_of Google::Cloud::Language::Annotation
+    end
+  end
+
+  it "uses UTF8 when the internal encoding is ISO-8859-1" do
+    Encoding.stub :default_internal, Encoding::ISO_8859_1 do
+      grpc_doc = Google::Cloud::Language::V1::Document.new(
+        content: text_content, type: :PLAIN_TEXT)
+      features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
+        extract_syntax: true, extract_entities: true, extract_document_sentiment: true)
+      grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
+
+      mock = Minitest::Mock.new
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
+
+      language.service.mocked_service = mock
+      annotation = language.annotate text_content
+      mock.verify
+
+      annotation.must_be_kind_of Google::Cloud::Language::Annotation
+    end
+  end
+
+  it "uses UTF8 when the internal encoding is US-ASCII" do
+    Encoding.stub :default_internal, Encoding::US_ASCII do
+      grpc_doc = Google::Cloud::Language::V1::Document.new(
+        content: text_content, type: :PLAIN_TEXT)
+      features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
+        extract_syntax: true, extract_entities: true, extract_document_sentiment: true)
+      grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
+
+      mock = Minitest::Mock.new
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
+
+      language.service.mocked_service = mock
+      annotation = language.annotate text_content
+      mock.verify
+
+      annotation.must_be_kind_of Google::Cloud::Language::Annotation
+    end
+  end
+
+  it "uses UTF8 when the internal encoding is UTF-8" do
+    Encoding.stub :default_internal, Encoding::UTF_8 do
+      grpc_doc = Google::Cloud::Language::V1::Document.new(
+        content: text_content, type: :PLAIN_TEXT)
+      features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
+        extract_syntax: true, extract_entities: true, extract_document_sentiment: true)
+      grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
+
+      mock = Minitest::Mock.new
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
+
+      language.service.mocked_service = mock
+      annotation = language.annotate text_content
+      mock.verify
+
+      annotation.must_be_kind_of Google::Cloud::Language::Annotation
+    end
+  end
+
+  it "uses UTF16 when the internal encoding is UTF-16" do
+    Encoding.stub :default_internal, Encoding::UTF_16 do
+      grpc_doc = Google::Cloud::Language::V1::Document.new(
+        content: text_content, type: :PLAIN_TEXT)
+      features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
+        extract_syntax: true, extract_entities: true, extract_document_sentiment: true)
+      grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
+
+      mock = Minitest::Mock.new
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF16, options: default_options]
+
+      language.service.mocked_service = mock
+      annotation = language.annotate text_content
+      mock.verify
+
+      annotation.must_be_kind_of Google::Cloud::Language::Annotation
+    end
+  end
+
+  it "uses UTF32 when the internal encoding is UTF-32" do
+    Encoding.stub :default_internal, Encoding::UTF_32 do
+      grpc_doc = Google::Cloud::Language::V1::Document.new(
+        content: text_content, type: :PLAIN_TEXT)
+      features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
+        extract_syntax: true, extract_entities: true, extract_document_sentiment: true)
+      grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
+
+      mock = Minitest::Mock.new
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF32, options: default_options]
+
+      language.service.mocked_service = mock
+      annotation = language.annotate text_content
+      mock.verify
+
+      annotation.must_be_kind_of Google::Cloud::Language::Annotation
+    end
+  end
+
+end

--- a/google-cloud-language/test/google/cloud/language/project/full_text_annotation_test.rb
+++ b/google-cloud-language/test/google/cloud/language/project/full_text_annotation_test.rb
@@ -50,7 +50,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       assert_text_annotation annotation
     end
 
-    it "runs full annotation with content and TEXT format and en language and UTF16 encoding options" do
+    it "runs full annotation with content and TEXT format and en language options" do
       grpc_doc = Google::Cloud::Language::V1::Document.new(
         content: text_content, type: :PLAIN_TEXT, language: "en")
       features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
@@ -58,10 +58,10 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF16, options: default_options]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
-      annotation = language.annotate text_content, format: :text, language: :en, encoding: :UTF16
+      annotation = language.annotate text_content, format: :text, language: :en
       mock.verify
 
       assert_text_annotation annotation
@@ -122,7 +122,7 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       assert_text_annotation annotation
     end
 
-    it "runs full annotation with document object using TEXT format and en language and UTF32 encoding options" do
+    it "runs full annotation with document object using TEXT format and en language options" do
       grpc_doc = Google::Cloud::Language::V1::Document.new(
         content: text_content, type: :PLAIN_TEXT, language: "en")
       features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
@@ -130,11 +130,11 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
 
       mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF32, options: default_options]
+      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF8, options: default_options]
 
       language.service.mocked_service = mock
       doc = language.document text_content, format: :text, language: :en
-      annotation = language.annotate doc, encoding: "utf-32"
+      annotation = language.annotate doc
       mock.verify
 
       assert_text_annotation annotation
@@ -530,25 +530,6 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
       assert_text_annotation annotation
     end
 
-    it "runs full annotation with document object using UTF32 encoding options" do
-      grpc_doc = Google::Cloud::Language::V1::Document.new(
-        gcs_content_uri: "gs://bucket/path.ext", type: :PLAIN_TEXT)
-      features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
-        extract_syntax: true, extract_entities: true, extract_document_sentiment: true)
-      grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
-
-      mock = Minitest::Mock.new
-      mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF32, options: default_options]
-
-      language.service.mocked_service = mock
-      gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
-      doc = language.document gcs_fake
-      annotation = language.annotate doc, encoding: :utf32
-      mock.verify
-
-      assert_text_annotation annotation
-    end
-
     describe "using #text helper" do
       it "runs full annotation using empty options" do
         grpc_doc = Google::Cloud::Language::V1::Document.new(
@@ -583,25 +564,6 @@ describe Google::Cloud::Language::Project, :full_text_annotation, :mock_language
         gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
         doc = language.document gcs_fake, language: :en
         annotation = language.annotate doc
-        mock.verify
-
-        assert_text_annotation annotation
-      end
-
-      it "runs full annotation using UTF16 encoding options" do
-        grpc_doc = Google::Cloud::Language::V1::Document.new(
-          gcs_content_uri: "gs://bucket/path.ext", type: :PLAIN_TEXT, language: "en")
-        features = Google::Cloud::Language::V1::AnnotateTextRequest::Features.new(
-          extract_syntax: true, extract_entities: true, extract_document_sentiment: true)
-        grpc_resp = Google::Cloud::Language::V1::AnnotateTextResponse.decode_json text_json
-
-        mock = Minitest::Mock.new
-        mock.expect :annotate_text, grpc_resp, [grpc_doc, features, :UTF16, options: default_options]
-
-        language.service.mocked_service = mock
-        gcs_fake = OpenStruct.new to_gs_url: "gs://bucket/path.ext"
-        doc = language.document gcs_fake, language: :en
-        annotation = language.annotate doc, encoding: "UTF-16"
         mock.verify
 
         assert_text_annotation annotation

--- a/google-cloud-language/test/google/cloud/language/project/sentiment_test.rb
+++ b/google-cloud-language/test/google/cloud/language/project/sentiment_test.rb
@@ -63,22 +63,7 @@ describe Google::Cloud::Language::Project, :sentiment, :mock_language do
     assert_text_sentiment sentiment
   end
 
-  it "runs sentiment with UTF8 encoding options" do
-    grpc_doc = Google::Cloud::Language::V1::Document.new(
-      content: text_content, type: :PLAIN_TEXT)
-    grpc_resp = Google::Cloud::Language::V1::AnalyzeSentimentResponse.decode_json sentiment_text_json
-
-    mock = Minitest::Mock.new
-    mock.expect :analyze_sentiment, grpc_resp, [grpc_doc, encoding_type: :UTF8, options: default_options]
-
-    language.service.mocked_service = mock
-    sentiment = language.sentiment text_content, encoding: "utf-8"
-    mock.verify
-
-    assert_text_sentiment sentiment
-  end
-
-  it "runs sentiment with TEXT format and en language and UTF8 encoding options" do
+  it "runs sentiment with TEXT format and en language options" do
     grpc_doc = Google::Cloud::Language::V1::Document.new(
       content: text_content, type: :PLAIN_TEXT, language: "en")
     grpc_resp = Google::Cloud::Language::V1::AnalyzeSentimentResponse.decode_json sentiment_text_json
@@ -87,7 +72,7 @@ describe Google::Cloud::Language::Project, :sentiment, :mock_language do
     mock.expect :analyze_sentiment, grpc_resp, [grpc_doc, encoding_type: :UTF8, options: default_options]
 
     language.service.mocked_service = mock
-    sentiment = language.sentiment text_content, format: :text, language: :en, encoding: :utf8
+    sentiment = language.sentiment text_content, format: :text, language: :en
     mock.verify
 
     assert_text_sentiment sentiment
@@ -108,16 +93,16 @@ describe Google::Cloud::Language::Project, :sentiment, :mock_language do
     assert_html_sentiment sentiment
   end
 
-  it "runs sentiment with HTML format and en language and UTF16 encoding options" do
+  it "runs sentiment with HTML format and en language options" do
     grpc_doc = Google::Cloud::Language::V1::Document.new(
       content: html_content, type: :HTML, language: "en")
     grpc_resp = Google::Cloud::Language::V1::AnalyzeSentimentResponse.decode_json sentiment_html_json
 
     mock = Minitest::Mock.new
-    mock.expect :analyze_sentiment, grpc_resp, [grpc_doc, encoding_type: :UTF16, options: default_options]
+    mock.expect :analyze_sentiment, grpc_resp, [grpc_doc, encoding_type: :UTF8, options: default_options]
 
     language.service.mocked_service = mock
-    sentiment = language.sentiment html_content, format: :html, language: :en, encoding: :utf16
+    sentiment = language.sentiment html_content, format: :html, language: :en
     mock.verify
 
     assert_html_sentiment sentiment

--- a/google-cloud-language/test/google/cloud/language/project/syntax_test.rb
+++ b/google-cloud-language/test/google/cloud/language/project/syntax_test.rb
@@ -64,7 +64,7 @@ describe Google::Cloud::Language::Project, :syntax, :mock_language do
     assert_text_syntax syntax
   end
 
-  it "runs syntax with en language options" do
+  it "runs syntax with TEXT format and en language options" do
     grpc_doc = Google::Cloud::Language::V1::Document.new(
       content: text_content, type: :PLAIN_TEXT, language: "en")
     grpc_resp = Google::Cloud::Language::V1::AnalyzeSyntaxResponse.decode_json syntax_text_json
@@ -73,37 +73,7 @@ describe Google::Cloud::Language::Project, :syntax, :mock_language do
     mock.expect :analyze_syntax, grpc_resp, [grpc_doc, :UTF8, options: default_options]
 
     language.service.mocked_service = mock
-    syntax = language.syntax text_content, language: :en
-    mock.verify
-
-    assert_text_syntax syntax
-  end
-
-  it "runs syntax with UTF16 encoding options" do
-    grpc_doc = Google::Cloud::Language::V1::Document.new(
-      content: text_content, type: :PLAIN_TEXT)
-    grpc_resp = Google::Cloud::Language::V1::AnalyzeSyntaxResponse.decode_json syntax_text_json
-
-    mock = Minitest::Mock.new
-    mock.expect :analyze_syntax, grpc_resp, [grpc_doc, :UTF16, options: default_options]
-
-    language.service.mocked_service = mock
-    syntax = language.syntax text_content, encoding: :UTF16
-    mock.verify
-
-    assert_text_syntax syntax
-  end
-
-  it "runs syntax with TEXT format and en language and UTF32 encoding options" do
-    grpc_doc = Google::Cloud::Language::V1::Document.new(
-      content: text_content, type: :PLAIN_TEXT, language: "en")
-    grpc_resp = Google::Cloud::Language::V1::AnalyzeSyntaxResponse.decode_json syntax_text_json
-
-    mock = Minitest::Mock.new
-    mock.expect :analyze_syntax, grpc_resp, [grpc_doc, :UTF32, options: default_options]
-
-    language.service.mocked_service = mock
-    syntax = language.syntax text_content, format: :text, language: :en, encoding: "UTF32"
+    syntax = language.syntax text_content, format: :text, language: :en
     mock.verify
 
     assert_text_syntax syntax
@@ -124,7 +94,7 @@ describe Google::Cloud::Language::Project, :syntax, :mock_language do
     assert_html_syntax syntax
   end
 
-  it "runs syntax with en language options" do
+  it "runs syntax with HTML format and en language options" do
     grpc_doc = Google::Cloud::Language::V1::Document.new(
       content: text_content, type: :HTML, language: "en")
     grpc_resp = Google::Cloud::Language::V1::AnalyzeSyntaxResponse.decode_json syntax_html_json
@@ -133,37 +103,7 @@ describe Google::Cloud::Language::Project, :syntax, :mock_language do
     mock.expect :analyze_syntax, grpc_resp, [grpc_doc, :UTF8, options: default_options]
 
     language.service.mocked_service = mock
-    syntax = language.syntax text_content, format: :html, language: "en"
-    mock.verify
-
-    assert_html_syntax syntax
-  end
-
-  it "runs syntax with UTF16 encoding options" do
-    grpc_doc = Google::Cloud::Language::V1::Document.new(
-      content: text_content, type: :HTML)
-    grpc_resp = Google::Cloud::Language::V1::AnalyzeSyntaxResponse.decode_json syntax_html_json
-
-    mock = Minitest::Mock.new
-    mock.expect :analyze_syntax, grpc_resp, [grpc_doc, :UTF16, options: default_options]
-
-    language.service.mocked_service = mock
-    syntax = language.syntax text_content, format: :html, encoding: "utf-16"
-    mock.verify
-
-    assert_html_syntax syntax
-  end
-
-  it "runs syntax with HTML format and en language and UTF32 encoding options" do
-    grpc_doc = Google::Cloud::Language::V1::Document.new(
-      content: text_content, type: :HTML, language: "en")
-    grpc_resp = Google::Cloud::Language::V1::AnalyzeSyntaxResponse.decode_json syntax_html_json
-
-    mock = Minitest::Mock.new
-    mock.expect :analyze_syntax, grpc_resp, [grpc_doc, :UTF32, options: default_options]
-
-    language.service.mocked_service = mock
-    syntax = language.syntax text_content, format: :html, language: :en, encoding: "utf-32".to_sym
+    syntax = language.syntax text_content, format: :html, language: :en
     mock.verify
 
     assert_html_syntax syntax


### PR DESCRIPTION
Switch to detecting the system encoding and using that instead.
Ruby's default encoding is UTF-8, and the default is API encoding is :UTF8.
Only use :UTF16 or :UTF32 if the system is explicitly set to those encodings.

[closes #1255]