### PR TITLE
Update BigQuery values formatting 

### DIFF
--- a/acceptance/data/kitten-test-data.json
+++ b/acceptance/data/kitten-test-data.json
@@ -1,3 +1,3 @@
-{"name":"mike","breed":"thecatkind","id":1,"dob":1414634759011}
-{"name":"chris","breed":"goldenretriever?","id":2,"dob":1414634759012}
-{"name":"jj","breed":"idkanycatbreeds","id":3,"dob":1414634759013}
+{"name":"mike","breed":"thecatkind","id":1,"dob":1488478362.209034}
+{"name":"chris","breed":"goldenretriever?","id":2,"dob":1488478362.209034}
+{"name":"jj","breed":"idkanycatbreeds","id":3,"dob":1488478362.209034}

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -1,0 +1,167 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bigquery_helper"
+
+describe Google::Cloud::Bigquery, :advanced, :bigquery do
+  let(:dataset_id) { "#{prefix}_dataset" }
+  let(:dataset) { bigquery.dataset(dataset_id) || bigquery.create_dataset(dataset_id) }
+  let(:table_id) { "examples_table" }
+  let(:table) { @table }
+
+  before do
+    @table = get_or_create_example_table dataset, table_id
+  end
+
+  it "loads and returns the properly formatted data" do
+    table.data.sort_by { |r| r["id"] }.zip(example_table_rows) do |returned_row, example_row|
+      assert_rows_equal returned_row, example_row
+    end
+  end
+
+  it "queries values in standard mode" do
+    rows = bigquery.query "SELECT * FROM #{dataset_id}.#{table_id} WHERE id = ?", params: [2]
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    row = rows.first
+
+    assert_rows_equal rows.first, example_table_rows[1]
+  end
+
+  it "queries repeated scalars in legacy mode" do
+    rows = bigquery.query "SELECT name, scores FROM [#{table.id}] WHERE id = 2", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 3
+    rows[0].must_equal({"name"=>"Gandalf", "scores"=>100.0})
+    rows[1].must_equal({"name"=>"Gandalf", "scores"=>99.0})
+    rows[2].must_equal({"name"=>"Gandalf", "scores"=>0.001})
+  end
+
+  it "queries repeated records in legacy mode" do
+    rows = bigquery.query "SELECT name, spells.name, spells.properties.name, spells.properties.power FROM [#{table.id}] WHERE id = 2", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 3
+    rows[0].must_equal({"name"=>"Gandalf", "spells_name"=>"Skydragon", "spells_properties_name"=>"Flying", "spells_properties_power"=>1.0})
+    rows[1].must_equal({"name"=>"Gandalf", "spells_name"=>"Skydragon", "spells_properties_name"=>"Creature", "spells_properties_power"=>1.0})
+    rows[2].must_equal({"name"=>"Gandalf", "spells_name"=>"Skydragon", "spells_properties_name"=>"Explodey", "spells_properties_power"=>11.0})
+  end
+
+  def assert_rows_equal returned_row, example_row
+    returned_row["id"].must_equal example_row[:id]
+    returned_row["name"].must_equal example_row[:name]
+    returned_row["age"].must_equal example_row[:age]
+    returned_row["weight"].must_equal example_row[:weight]
+    returned_row["is_magic"].must_equal example_row[:is_magic]
+    returned_row["scores"].must_equal example_row[:scores]
+    returned_row["spells"].zip example_row[:spells] do |row_spell, example_spell|
+      row_spell["name"].must_equal example_spell[:name]
+      row_spell["discovered_by"].must_equal example_spell[:discovered_by]
+      row_spell["properties"].zip example_spell[:properties] do |row_properties, example_properties|
+        row_properties["name"].must_equal example_properties[:name]
+        row_properties["power"].must_equal example_properties[:power]
+      end
+    end
+    returned_row["tea_time"].must_equal example_row[:tea_time]
+    returned_row["next_vacation"].must_equal example_row[:next_vacation]
+    returned_row["favorite_time"].must_equal example_row[:favorite_time]
+  end
+
+  def get_or_create_example_table dataset, table_id
+    t = dataset.table table_id
+    if t.nil?
+      t = dataset.create_table table_id do |schema|
+        schema.integer "id", mode: :nullable
+        schema.string "name", mode: :nullable
+        schema.integer "age", mode: :nullable
+        schema.float "weight", mode: :nullable
+        schema.boolean "is_magic", mode: :nullable
+        schema.float "scores", mode: :repeated
+        schema.record "spells", mode: :repeated do |spells|
+          spells.string "name", mode: :nullable
+          spells.string "discovered_by", mode: :nullable
+          spells.record "properties", mode: :repeated do |properties|
+            properties.string "name", mode: :nullable
+            properties.float "power", mode: :nullable
+          end
+          spells.bytes "icon", mode: :nullable
+          spells.timestamp "last_used", mode: :nullable
+        end
+        schema.time "tea_time", mode: :nullable
+        schema.date "next_vacation", mode: :nullable
+        schema.datetime "favorite_time", mode: :nullable
+      end
+      t.insert example_table_rows
+    end
+    t
+  end
+
+  def example_table_rows
+    [
+      { id: 1,
+        name: "Bilbo",
+        age: 111,
+        weight: 67.2,
+        is_magic: false,
+        scores: [],
+        spells: [],
+        tea_time: Google::Cloud::Bigquery::Time.new("10:00:00"),
+        next_vacation: Date.parse("2017-09-22"),
+        favorite_time: Time.parse("2031-04-01T05:09:27").utc.to_datetime
+      }, {
+        id: 2,
+        name: "Gandalf",
+        age: 1000,
+        weight: 198.6,
+        is_magic: true,
+        scores: [100.0, 99.0, 0.001],
+        spells: [
+          { name: "Skydragon",
+            discovered_by: "Firebreather",
+            properties: [
+              { name: "Flying", power: 1.0 },
+              { name: "Creature", power: 1.0 },
+              { name: "Explodey", power: 11.0 }
+            ],
+            icon: File.open("acceptance/data/kitten-test-data.json", "rb"),
+            last_used: Time.parse("2015-10-31 23:59:56 UTC")
+          }
+        ],
+        tea_time: Google::Cloud::Bigquery::Time.new("15:00:00"),
+        next_vacation: Date.parse("2666-06-06"),
+        favorite_time: Time.parse("2001-12-19T23:59:59").utc.to_datetime
+      }, {
+        id: 3,
+        name: "Sabrina",
+        age: 17,
+        weight: 128.3,
+        is_magic: true,
+        scores: [],
+        spells: [
+          { name: "Talking cats",
+            icon: StringIO.new("iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAAAgAAAAKAAAACAAAAAgAAABxj2CfowAAAGSSURBVHgB7Jc9TsNAEIX3JDkCPUV6KlpKFHEGlD4nyA04ACUXQKTgCEipUnKGNEbP0otentayicZ24SlWs7tjO/N9u/5J2b2+NUtuZcnwYE8BuQPyGZAPwXwLLPk5kG+BJa9+fgfkh1B+CeancL4F8i2Q/wWm/S/w+XFoTseftn0dvhu0OXfhpM+AGvzcEiYVAFisPqE9zrETJhHAlXfg2lglMK9z0f3RBfB+ZyRUV3x+erzsEIjjOBqc1xtNAIrvguybV3A9lkVHxlEE6GrrPb/ZvAySwlUnfCmlPQ+R8JCExvGtcRQBLFwj4FGkznX1VYDKPG/f2/MjwCksXACgdNUxJjwK9xwl4JihOwTFR0kIF+CABEPRnvsvPFctMoYKqAFSAFaMwB4pp3Y+bodIYL9WmIAaIOHxo7W8wiHvAjTvhUeNwwSgeAeAABbqOewC5hBdwFD4+9+7puzXV9fS6/b1wwT4tsaYAhwOOQdUQch5vgZCeAhAv3ZM31yYAAUgvApQQQ6n5w6FB/RVe1jdJOAPAAD//1eMQwoAAAGQSURBVO1UMU4DQQy8X9AgWopIUINEkS4VlJQo4gvwAV7AD3gEH4iSgidESpWSXyyZExP5lr0c7K5PsXBhec/2+jzjuWtent9CLdtu1mG5+gjz+WNr7IsY7eH+tvO+xfuqk4vz7CH91edFaF5v9nb6dBKm13edvrL+0Lk5lMzJkQDeJSkkgHF6mR8CHwMHCQR/NAQQGD0BAlwK4FCefQiefq+A2Vn29tG7igLAfmwcnJu/nJy3BMQkMN9HEPr8AL3bfBv7Bp+7/SoExMDjZwKEJwmyhnnmQIQEBIlz2x0iKoAvJkAC6TsTIH6MqRrEWUMSZF2zAwqT4Eu/e6pzFAIkmNSZ4OFT+VYBIIF//UqbJwnF/4DU0GwOn8r/JQYCpPGufEfJuZiA37ycQw/5uFeqPq4pfR6FADmkBCXjfWdZj3NfXW58dAJyB9W65wRoMWulryvAyqa05nQFaDFrpa8rwMqmtOZ0BWgxa6WvK8DKprTmdAVoMWulryvAyqa05nQFaDFrpa8rwMqmtOb89wr4AtQ4aPoL6yVpAAAAAElFTkSuQmCC"),
+            discovered_by: "Salem",
+            properties: [{ name: "Makes you look crazy", power: 1 }],
+            last_used: Time.parse("2017-02-14 12:07:23 UTC")
+          }
+        ],
+        tea_time: Google::Cloud::Bigquery::Time.new("12:00:00"),
+        next_vacation: Date.parse("2017-03-14"),
+        favorite_time: Time.parse("2000-10-31T23:27:46").utc.to_datetime
+      }
+    ]
+  end
+end

--- a/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
@@ -1,0 +1,87 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bigquery_helper"
+
+describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
+
+  it "queries a string value" do
+    rows = bigquery.query "SELECT 'hello' AS value", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_equal "hello"
+  end
+
+  it "queries an integer value" do
+    rows = bigquery.query "SELECT 999 AS value", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_equal 999
+  end
+
+  it "queries a float value" do
+    rows = bigquery.query "SELECT 12.0 AS value", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_equal 12.0
+  end
+
+  it "queries a boolean value" do
+    rows = bigquery.query "SELECT false AS value", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_equal false
+  end
+
+  it "queries a date value" do
+    rows = bigquery.query "SELECT CAST(CURRENT_DATE() AS DATE) AS value", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_be_kind_of Date
+  end
+
+  it "queries a datetime value" do
+    skip "Legacy SQL doesn't have a DATETIME type."
+  end
+
+  it "queries a timestamp value" do
+    rows = bigquery.query "SELECT CAST(CURRENT_TIMESTAMP() AS TIMESTAMP) AS value", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_be_kind_of ::Time
+  end
+
+  it "queries a time value" do
+    rows = bigquery.query "SELECT CAST(CURRENT_TIME() AS TIME) AS value", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_be_kind_of Google::Cloud::Bigquery::Time
+  end
+
+  it "queries a bytes value" do
+    rows = bigquery.query "SELECT CAST('hello' AS BYTES) AS value", legacy_sql: true
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_be_kind_of StringIO
+    rows.first["value"].read.must_equal "hello"
+  end
+end

--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,66 +14,108 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery, :positional_params, :bigquery do
+describe Google::Cloud::Bigquery, :named_params, :bigquery do
   it "queries the data with a string parameter" do
-    rows = bigquery.query "SELECT repository.name, public FROM `publicdata.samples.github_nested` WHERE repository.owner = @owner LIMIT 1", params: { owner: "blowmage" }
+    rows = bigquery.query "SELECT @value AS value", params: { value: "hello" }
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
+    rows.first["value"].must_equal "hello"
   end
 
   it "queries the data with an integer parameter" do
-    rows = bigquery.query "SELECT repository.name, repository.forks FROM `publicdata.samples.github_nested` WHERE repository.owner = @owner AND repository.forks > @forks LIMIT 5", params: { owner: "blowmage", forks: 10 }
+    rows = bigquery.query "SELECT @value AS value", params: { value: 999 }
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
-    rows.count.must_equal 5
+    rows.count.must_equal 1
+    rows.first["value"].must_equal 999
   end
 
   it "queries the data with a float parameter" do
-    rows = bigquery.query "SELECT station_number, year, month, day, snow_depth FROM `publicdata.samples.gsod` WHERE snow_depth >= @depth LIMIT 5", params: { depth: 12.0 }
+    rows = bigquery.query "SELECT @value AS value", params: { value: 12.0 }
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
-    rows.count.must_equal 5
+    rows.count.must_equal 1
+    rows.first["value"].must_equal 12.0
   end
 
   it "queries the data with a boolean parameter" do
-    rows = bigquery.query "SELECT repository.name, public FROM `publicdata.samples.github_nested` WHERE repository.owner = @owner AND public = @public LIMIT 1", params: { owner: "blowmage", public: true }
+    rows = bigquery.query "SELECT @value AS value", params: { value: false }
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
+    rows.first["value"].must_equal false
   end
 
   it "queries the data with a date parameter" do
-    skip "Don't know of any sample data that uses DATE values"
-  end
-
-  it "queries the data with a datetime parameter" do
-    skip "Don't know of any sample data that uses DATETIME values"
-  end
-
-  it "queries the data with a timestamp parameter" do
-    rows = bigquery.query "SELECT subject FROM `bigquery-public-data.github_repos.commits` WHERE author.name = @author AND author.date < @date LIMIT 1", params: { author: "blowmage", date: Time.now }
+    today = Date.today
+    rows = bigquery.query "SELECT @value AS value", params: { value: today }
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
+    rows.first["value"].must_equal Date.today
+  end
+
+  it "queries the data with a datetime parameter" do
+    now = Time.now.utc.to_datetime
+    rows = bigquery.query "SELECT @value AS value", params: { value: now }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_be_kind_of DateTime
+    rows.first["value"].must_be_close_to now
+    # rows.first["value"].must_equal now.to_s
+  end
+
+  it "queries the data with a timestamp parameter" do
+    now = Time.now
+    rows = bigquery.query "SELECT @value AS value", params: { value: now }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_be_kind_of ::Time
+    rows.first["value"].must_be_close_to now
   end
 
   it "queries the data with a time parameter" do
-    skip "Don't know of any sample data that uses TIME values"
+    rows = bigquery.query "SELECT @value AS value", params: { value: bigquery.time(12, 30, 0) }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_be_kind_of Google::Cloud::Bigquery::Time
+    rows.first["value"].value.must_equal "12:30:00"
   end
 
   it "queries the data with a bytes parameter" do
-    skip "Don't know of any sample data that uses BYTES values"
-  end
-
-  it "queries the data with an array parameter" do
-    rows = bigquery.query "SELECT * FROM UNNEST (@list)", params: { list: [25,26,27,28,29] }
+    rows = bigquery.query "SELECT @value AS value", params: { value: StringIO.new("hello world!") }
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
-    rows.count.must_equal 5
+    rows.count.must_equal 1
+    rows.first["value"].must_be_kind_of StringIO
+    rows.first["value"].read.must_equal "hello world!"
+  end
+
+  it "queries the data with an array of integers parameter" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: [1, 2, 3, 4] }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_equal [1, 2, 3, 4]
+  end
+
+  it "queries the data with an array of strings parameter" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: ["foo", "bar", "baz"] }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first["value"].must_equal ["foo", "bar", "baz"]
   end
 
   it "queries the data with a struct parameter" do
-    skip "Don't know how to query with struct parameters"
+    rows = bigquery.query "SELECT @hitchhiker.message, @hitchhiker.repeat", params: { hitchhiker: { message: "hello", repeat: 1 } }
+
+    rows.class.must_equal Google::Cloud::Bigquery::QueryData
+    rows.count.must_equal 1
+    rows.first.must_equal({ "message" => "hello", "repeat" => 1 })
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
@@ -14,108 +14,94 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery, :positional_params, :bigquery do
-  it "queries the data with a string parameter" do
-    rows = bigquery.query "SELECT ? AS value", params: ["hello"]
+describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
+
+  it "queries a string value" do
+    rows = bigquery.query "SELECT 'hello' AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_equal "hello"
   end
 
-  it "queries the data with an integer parameter" do
-    rows = bigquery.query "SELECT ? AS value", params: [999]
+  it "queries an integer value" do
+    rows = bigquery.query "SELECT 999 AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_equal 999
   end
 
-  it "queries the data with a float parameter" do
-    rows = bigquery.query "SELECT ? AS value", params: [12.0]
+  it "queries a float value" do
+    rows = bigquery.query "SELECT 12.0 AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_equal 12.0
   end
 
-  it "queries the data with a boolean parameter" do
-    rows = bigquery.query "SELECT ? AS value", params: [false]
+  it "queries a boolean value" do
+    rows = bigquery.query "SELECT false AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_equal false
   end
 
-  it "queries the data with a date parameter" do
-    today = Date.today
-    rows = bigquery.query "SELECT ? AS value", params: [today]
+  it "queries a date value" do
+    rows = bigquery.query "SELECT CURRENT_DATE() AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
-    rows.first["value"].must_equal Date.today
+    rows.first["value"].must_be_kind_of Date
   end
 
-  it "queries the data with a datetime parameter" do
-    now = Time.now.utc.to_datetime
-    rows = bigquery.query "SELECT ? AS value", params: [now]
+  it "queries a datetime value" do
+    rows = bigquery.query "SELECT CURRENT_DATETIME() AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_be_kind_of DateTime
-    rows.first["value"].must_be_close_to now
-    # rows.first["value"].must_equal now.to_s
   end
 
-  it "queries the data with a timestamp parameter" do
-    now = Time.now
-    rows = bigquery.query "SELECT ? AS value", params: [now]
+  it "queries a timestamp value" do
+    rows = bigquery.query "SELECT CURRENT_TIMESTAMP() AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_be_kind_of ::Time
-    rows.first["value"].must_be_close_to now
   end
 
-  it "queries the data with a time parameter" do
-    rows = bigquery.query "SELECT ? AS value", params: [bigquery.time(12, 30, 0)]
+  it "queries a time value" do
+    rows = bigquery.query "SELECT CURRENT_TIME() AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_be_kind_of Google::Cloud::Bigquery::Time
-    rows.first["value"].value.must_equal "12:30:00"
   end
 
-  it "queries the data with a bytes parameter" do
-    rows = bigquery.query "SELECT ? AS value", params: [StringIO.new("hello world!")]
+  it "queries a bytes value" do
+    rows = bigquery.query "SELECT CAST('hello' AS BYTES) AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_be_kind_of StringIO
-    rows.first["value"].read.must_equal "hello world!"
+    rows.first["value"].read.must_equal "hello"
   end
 
-  it "queries the data with an array of integers parameter" do
-    rows = bigquery.query "SELECT ? AS value", params: [[1, 2, 3, 4]]
+  it "queries an array of integers value" do
+    rows = bigquery.query "SELECT [1, 2, 3, 4] AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_equal [1, 2, 3, 4]
   end
 
-  it "queries the data with an array of strings parameter" do
-    rows = bigquery.query "SELECT ? AS value", params: [["foo", "bar", "baz"]]
+  it "queries an array of strings value" do
+    rows = bigquery.query "SELECT ['foo', 'bar', 'baz'] AS value", standard_sql: true
 
     rows.class.must_equal Google::Cloud::Bigquery::QueryData
     rows.count.must_equal 1
     rows.first["value"].must_equal ["foo", "bar", "baz"]
-  end
-
-  it "queries the data with a struct parameter" do
-    rows = bigquery.query "SELECT ?.message, ?.repeat", params: [{ message: "hello" }, { repeat: 1 }]
-
-    rows.class.must_equal Google::Cloud::Bigquery::QueryData
-    rows.count.must_equal 1
-    rows.first.must_equal({ "message" => "hello", "repeat" => 1 })
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -47,45 +47,53 @@ module Google
         ##
         # @private
         def self.format_rows rows, fields
-          headers = Array(fields).map { |f| f.name }
-          field_types = Array(fields).map { |f| f.type }
-
           Array(rows).map do |row|
-            values = row.f.map { |f| f.v }
-            formatted_values = format_values field_types, values
-            Hash[headers.zip formatted_values]
+            # convert TableRow to hash to handle nested TableCell values
+            format_row row.to_h, fields
           end
         end
 
         ##
         # @private
-        def self.format_values field_types, values
-          field_types.zip(values).map do |type, value|
-            begin
-              if value.nil?
-                nil
-              elsif type == "INTEGER"
-                Integer value
-              elsif type == "FLOAT"
-                Float value
-              elsif type == "BOOLEAN"
-                (value == "true" ? true : (value == "false" ? false : nil))
-              elsif type == "BYTES"
-                StringIO.new Base64.decode64 value
-              elsif type == "TIMESTAMP"
-                ::Time.at Float(value)
-              elsif type == "TIME"
-                Bigquery::Time.new value
-              elsif type == "DATETIME"
-                ::Time.parse("#{value} UTC").to_datetime
-              elsif type == "DATE"
-                Date.parse value
-              else
-                value
-              end
-            rescue => e
-              value
+        def self.format_row row, fields
+          Hash[fields.zip(row[:f]).map { |f, v | [f.name, format_value(v, f)] }]
+        end
+
+        def self.format_value value, field
+          if value.nil?
+            nil
+          elsif value.empty?
+            nil
+          elsif value[:v].nil?
+            nil
+          elsif Array === value[:v]
+            value[:v].map { |v| format_value v, field }
+          elsif Hash === value[:v]
+            if value[:v].empty?
+              nil
+            else
+              format_row value[:v], field.fields
             end
+          elsif field.type == "STRING"
+            String value[:v]
+          elsif field.type == "INTEGER"
+            Integer value[:v]
+          elsif field.type == "FLOAT"
+            Float value[:v]
+          elsif field.type == "BOOLEAN"
+            (value[:v] == "true" ? true : (value[:v] == "false" ? false : nil))
+          elsif field.type == "BYTES"
+            StringIO.new Base64.decode64 value[:v]
+          elsif field.type == "TIMESTAMP"
+            ::Time.at Float(value[:v])
+          elsif field.type == "TIME"
+            Bigquery::Time.new value[:v]
+          elsif field.type == "DATETIME"
+            ::Time.parse("#{value[:v]} UTC").to_datetime
+          elsif field.type == "DATE"
+            Date.parse value[:v]
+          else
+            value[:v]
           end
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -183,6 +183,9 @@ module Google
                 type: struct_param.parameter_type
               ), struct_param.parameter_value]
             end
+            struct_values = Hash[struct_pairs.map do |type, value|
+              [type.name, value]
+            end]
 
             return Google::Apis::BigqueryV2::QueryParameter.new(
               parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
@@ -190,7 +193,7 @@ module Google
                 struct_types: struct_pairs.map(&:first)
               ),
               parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-                struct_values: struct_pairs.map(&:last)
+                struct_values: struct_values
               )
             )
           else

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -209,6 +209,36 @@ module Google
           end
         end
 
+        ##
+        # @private
+        def self.to_json_rows rows
+          rows.map do |row|
+            Hash[row.map { |k, v| [k.to_s, to_json_value(v)] }]
+          end
+        end
+        ##
+        # @private
+        def self.to_json_value value
+          if DateTime === value
+            value.strftime "%Y-%m-%d %H:%M:%S.%6N"
+          elsif Date === value
+            value.to_s
+          elsif ::Time === value
+            value.strftime "%Y-%m-%d %H:%M:%S.%6N%:z"
+          elsif Bigquery::Time === value
+            value.value
+          elsif value.respond_to?(:read) && value.respond_to?(:rewind)
+            value.rewind
+            Base64.strict_encode64(value.read.force_encoding("ASCII-8BIT"))
+          elsif Array === value
+            value.map { |v| to_json_value v }
+          elsif Hash === value
+            Hash[value.map { |k, v| [k.to_s, to_json_value(v)] }]
+          else
+            value
+          end
+        end
+
         # rubocop:enable all
       end
     end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -188,7 +188,8 @@ module Google
         ##
         # @private New Data from a response object.
         def self.from_gapi gapi, table
-          formatted_rows = Convert.format_rows gapi.rows, table.fields
+          formatted_rows = Convert.format_rows(gapi.rows,
+                                               table.gapi.schema.fields)
 
           data = new formatted_rows
           data.table = table

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -276,12 +276,9 @@ module Google
         #   end
         #
         def record name, description: nil, mode: nil
-          fail ArgumentError, "nested RECORD type is not permitted" if @nested
           fail ArgumentError, "a block is required" unless block_given?
           empty_schema = Google::Apis::BigqueryV2::TableSchema.new fields: []
-          nested_schema = self.class.from_gapi(empty_schema).tap do |s|
-            s.instance_variable_set :@nested, true
-          end
+          nested_schema = self.class.from_gapi empty_schema
           yield nested_schema
           add_field name, :record, nested_schema.fields,
                     description: description, mode: mode

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -713,6 +713,7 @@ module Google
         #
         def insert rows, skip_invalid: nil, ignore_unknown: nil
           rows = [rows] if rows.is_a? Hash
+          rows = Convert.to_json_rows rows
           ensure_service!
           options = { skip_invalid: skip_invalid,
                       ignore_unknown: ignore_unknown }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -450,12 +450,12 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
           ]
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          struct_values: [
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
-          ]
+          struct_values: {
+            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          }
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -425,12 +425,12 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
           ]
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          struct_values: [
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
-          ]
+          struct_values: {
+            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          }
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -468,12 +468,12 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
           ]
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          struct_values: [
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
-          ]
+          struct_values: {
+            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          }
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -443,12 +443,12 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
           ]
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          struct_values: [
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
-          ]
+          struct_values: {
+            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          }
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -453,12 +453,12 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
           ]
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          struct_values: [
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
-          ]
+          struct_values: {
+            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          }
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -428,12 +428,12 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
           ]
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          struct_values: [
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
-          ]
+          struct_values: {
+            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          }
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -472,12 +472,12 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
           ]
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          struct_values: [
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
-          ]
+          struct_values: {
+            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          }
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -447,12 +447,12 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
           ]
         ),
         parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
-          struct_values: [
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
-            Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
-          ]
+          struct_values: {
+            "name" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "Testy McTesterson"),
+            "age" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 42),
+            "active" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: false),
+            "score" => Google::Apis::BigqueryV2::QueryParameterValue.new(value: 98.7)
+          }
         )
       )
     ]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
@@ -159,7 +159,7 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
     inserted_row = { "id"=>2, "name"=>"Gandalf", "age"=>1000, "weight"=>198.6,
                     "is_magic"=>true, "scores"=>[100.0, 99.0, 0.001],
                     "spells"=>[{"name"=>"Skydragon", "discovered_by"=>"Firebreather", "properties"=>[{"name"=>"Flying", "power"=>1.0}, {"name"=>"Creature", "power"=>1.0}, {"name"=>"Explodey", "power"=>11.0}],
-                    "icon"=>"eyJuYW1lIjoibWlrZSIsImJyZWVkIjoidGhlY2F0a2luZCIsImlkIjoxLCJkb2IiOjE0MTQ2MzQ3NTkwMTF9CnsibmFtZSI6ImNocmlzIiwiYnJlZWQiOiJnb2xkZW5yZXRyaWV2ZXI/IiwiaWQiOjIsImRvYiI6MTQxNDYzNDc1OTAxMn0KeyJuYW1lIjoiamoiLCJicmVlZCI6Imlka2FueWNhdGJyZWVkcyIsImlkIjozLCJkb2IiOjE0MTQ2MzQ3NTkwMTN9Cg==",
+                    "icon"=>"eyJuYW1lIjoibWlrZSIsImJyZWVkIjoidGhlY2F0a2luZCIsImlkIjoxLCJkb2IiOjE0ODg0NzgzNjIuMjA5MDM0fQp7Im5hbWUiOiJjaHJpcyIsImJyZWVkIjoiZ29sZGVucmV0cmlldmVyPyIsImlkIjoyLCJkb2IiOjE0ODg0NzgzNjIuMjA5MDM0fQp7Im5hbWUiOiJqaiIsImJyZWVkIjoiaWRrYW55Y2F0YnJlZWRzIiwiaWQiOjMsImRvYiI6MTQ4ODQ3ODM2Mi4yMDkwMzR9Cg==",
                     "last_used"=>"2015-10-31 23:59:56.000000+00:00"}],
                     "tea_time"=>"15:00:00", "next_vacation"=>"2666-06-06",
                     "favorite_time"=>"2001-12-20 06:59:59.000000"}

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
@@ -132,6 +132,57 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
     result.error_count.must_equal 0
   end
 
+  it "properly formats values when inserting" do
+    inserting_row = {
+      id: 2,
+      name: "Gandalf",
+      age: 1000,
+      weight: 198.6,
+      is_magic: true,
+      scores: [100.0, 99.0, 0.001],
+      spells: [
+        { name: "Skydragon",
+          discovered_by: "Firebreather",
+          properties: [
+            { name: "Flying", power: 1.0 },
+            { name: "Creature", power: 1.0 },
+            { name: "Explodey", power: 11.0 }
+          ],
+          icon: File.open("acceptance/data/kitten-test-data.json", "rb"),
+          last_used: Time.parse("2015-10-31 23:59:56 UTC")
+        }
+      ],
+      tea_time: Google::Cloud::Bigquery::Time.new("15:00:00"),
+      next_vacation: Date.parse("2666-06-06"),
+      favorite_time: Time.parse("2001-12-19T23:59:59").utc.to_datetime
+    }
+    inserted_row = { "id"=>2, "name"=>"Gandalf", "age"=>1000, "weight"=>198.6,
+                    "is_magic"=>true, "scores"=>[100.0, 99.0, 0.001],
+                    "spells"=>[{"name"=>"Skydragon", "discovered_by"=>"Firebreather", "properties"=>[{"name"=>"Flying", "power"=>1.0}, {"name"=>"Creature", "power"=>1.0}, {"name"=>"Explodey", "power"=>11.0}],
+                    "icon"=>"eyJuYW1lIjoibWlrZSIsImJyZWVkIjoidGhlY2F0a2luZCIsImlkIjoxLCJkb2IiOjE0MTQ2MzQ3NTkwMTF9CnsibmFtZSI6ImNocmlzIiwiYnJlZWQiOiJnb2xkZW5yZXRyaWV2ZXI/IiwiaWQiOjIsImRvYiI6MTQxNDYzNDc1OTAxMn0KeyJuYW1lIjoiamoiLCJicmVlZCI6Imlka2FueWNhdGJyZWVkcyIsImlkIjozLCJkb2IiOjE0MTQ2MzQ3NTkwMTN9Cg==",
+                    "last_used"=>"2015-10-31 23:59:56.000000+00:00"}],
+                    "tea_time"=>"15:00:00", "next_vacation"=>"2666-06-06",
+                    "favorite_time"=>"2001-12-20 06:59:59.000000"}
+    inserted_row_gapi = Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
+      insert_id: Digest::MD5.base64digest(inserted_row.inspect),
+      json: inserted_row
+    )
+    mock = Minitest::Mock.new
+    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+      rows: [inserted_row_gapi], ignore_unknown_values: nil, skip_invalid_rows: nil)
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [table.project_id, table.dataset_id, table.table_id, insert_req]
+    table.service.mocked_service = mock
+
+    result = table.insert [inserting_row]
+
+    mock.verify
+
+    result.must_be :success?
+    result.insert_count.must_equal 1
+    result.error_count.must_equal 0
+  end
+
   def success_table_insert_gapi
     Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(
       insert_errors: []


### PR DESCRIPTION
This PR focuses on the formatting of values returned from data listing and queries. Several fixes have been made to repeated scalar values, nested record values, repeated record values, and nested repeated record values. All returned values should now matching the format used by query parameters.

This means that dates and timestamps will be returned as Date and Time objects, instead of strings. And when using Standard SQL records will be returned as a Hash, and repeated values as an Array. These objects can also be used while inserting.