### PR TITLE
Switch BigQuery to Standard SQL by default

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -15,7 +15,7 @@
 require "bigquery_helper"
 
 describe Google::Cloud::Bigquery, :bigquery do
-  let(:publicdata_query) { "SELECT url FROM [publicdata:samples.github_nested] LIMIT 100" }
+  let(:publicdata_query) { "SELECT url FROM publicdata.samples.github_nested LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
@@ -15,7 +15,7 @@
 require "bigquery_helper"
 
 describe Google::Cloud::Bigquery::Dataset, :access, :bigquery do
-  let(:publicdata_query) { "SELECT url FROM [publicdata:samples.github_nested] LIMIT 100" }
+  let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -15,7 +15,7 @@
 require "bigquery_helper"
 
 describe Google::Cloud::Bigquery::Dataset, :bigquery do
-  let(:publicdata_query) { "SELECT url FROM [publicdata:samples.github_nested] LIMIT 100" }
+  let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -53,7 +53,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
     fresh.project_id.must_equal bigquery.project
     fresh.id.must_equal "#{bigquery.project}:#{dataset.dataset_id}.#{table.table_id}"
-    fresh.query_id.must_equal "[#{bigquery.project}:#{dataset.dataset_id}.#{table.table_id}]"
+    fresh.query_id.must_equal "`#{bigquery.project}.#{dataset.dataset_id}.#{table.table_id}`"
     fresh.etag.wont_be :nil?
     fresh.api_url.wont_be :nil?
     fresh.bytes_count.wont_be :nil?

--- a/google-cloud-bigquery/acceptance/bigquery/view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/view_test.rb
@@ -15,8 +15,8 @@
 require "bigquery_helper"
 
 describe Google::Cloud::Bigquery, :bigquery do
-  let(:publicdata_query) { "SELECT url FROM [publicdata:samples.github_nested] LIMIT 100" }
-  let(:publicdata_query_2) { "SELECT url FROM [publicdata:samples.github_nested] LIMIT 50" }
+  let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
+  let(:publicdata_query_2) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 50" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id
@@ -40,7 +40,7 @@ describe Google::Cloud::Bigquery, :bigquery do
 
     fresh.project_id.must_equal bigquery.project
     fresh.id.must_equal "#{bigquery.project}:#{dataset.dataset_id}.#{view.table_id}"
-    fresh.query_id.must_equal "[#{bigquery.project}:#{dataset.dataset_id}.#{view.table_id}]"
+    fresh.query_id.must_equal "`#{bigquery.project}.#{dataset.dataset_id}.#{view.table_id}`"
     fresh.etag.wont_be :nil?
     fresh.api_url.wont_be :nil?
     fresh.query_id.must_equal view.query_id

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -95,33 +95,12 @@ module Google
     # explained in [Querying
     # Data](https://cloud.google.com/bigquery/querying-data).
     #
-    # ### Legacy SQL (formerly BigQuery SQL)
-    #
-    # Before version 2.0, BigQuery executed queries using a non-standard SQL
-    # dialect known as BigQuery SQL. This variant is still the default, and will
-    # be used unless you pass the flag `standard_sql: true` with your query.
-    # (If you get an SQL syntax error with a query that may be written in
-    # standard SQL, be sure that you are passing this option.)
-    #
-    # ```ruby
-    # require "google/cloud/bigquery"
-    #
-    # bigquery = Google::Cloud::Bigquery.new
-    #
-    # sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " \
-    #       "FROM [publicdata:samples.shakespeare]"
-    # data = bigquery.query sql
-    # ```
-    #
-    # Notice that in legacy SQL, a fully-qualified table name uses the following
-    # format: `[my-dashed-project:dataset1.tableName]`.
-    #
     # ### Standard SQL
     #
     # Standard SQL is the preferred SQL dialect for querying data stored in
     # BigQuery. It is compliant with the SQL 2011 standard, and has extensions
-    # that support querying nested and repeated data. It has several advantages
-    # over legacy SQL, including:
+    # that support querying nested and repeated data. This is the default
+    # syntax. It has several advantages over Legacy SQL, including:
     #
     # * Composability using `WITH` clauses and SQL functions
     # * Subqueries in the `SELECT` list and `WHERE` clause
@@ -136,8 +115,7 @@ module Google
     # For examples that demonstrate some of these features, see [Standard SQL
     # highlights](https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql#standard_sql_highlights).
     #
-    # Legacy SQL is still the default. To use standard SQL instead, pass the
-    # option `standard_sql: true` with your query.
+    # Standard SQL is the default.
     #
     # ```ruby
     # require "google/cloud/bigquery"
@@ -147,12 +125,35 @@ module Google
     # sql = "SELECT word, SUM(word_count) AS word_count " \
     #       "FROM `bigquery-public-data.samples.shakespeare`" \
     #       "WHERE word IN ('me', 'I', 'you') GROUP BY word"
-    # data = bigquery.query sql, standard_sql: true
+    # data = bigquery.query sql
     # ```
     #
-    # Notice that in standard SQL, the format for a fully-qualified table name
-    # uses back-ticks instead of brackets, and a dot instead of a semi-colon:
-    # <code>`my-dashed-project.dataset1.tableName`</code>.
+    # Notice that in standard SQL, a fully-qualified table name uses the
+    # following format: <code>`my-dashed-project.dataset1.tableName`</code>.
+    #
+    # ### Legacy SQL (formerly BigQuery SQL)
+    #
+    # Before version 2.0, BigQuery executed queries using a non-standard SQL
+    # dialect known as BigQuery SQL. This variant is optional, and can be
+    # enabled by passing the flag `legacy_sql: true` with your query. (If you
+    # get an SQL syntax error with a query that may be written in standard SQL,
+    # be sure that you are passing this option.)
+    #
+    # To use legacy SQL, pass the option `legacy_sql: true` with your query.
+    #
+    # ```ruby
+    # require "google/cloud/bigquery"
+    #
+    # bigquery = Google::Cloud::Bigquery.new
+    #
+    # sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " \
+    #       "FROM [publicdata:samples.shakespeare]"
+    # data = bigquery.query sql, legacy_sql: true
+    # ```
+    #
+    # Notice that in legacy SQL, a fully-qualified table name uses brackets
+    # instead of back-ticks, and a semi-colon instead of a dot to separate the
+    # project and the dataset: `[my-dashed-project:dataset1.tableName]`.
     #
     # #### Query parameters
     #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -239,6 +239,12 @@ module Google
           end
         end
 
+        def self.resolve_legacy_sql legacy_sql, standard_sql
+          return !standard_sql unless standard_sql.nil?
+          return legacy_sql unless legacy_sql.nil?
+          false
+        end
+
         # rubocop:enable all
       end
     end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -447,7 +447,8 @@ module Google
             description: description,
             view: Google::Apis::BigqueryV2::ViewDefinition.new(
               query: query,
-              use_legacy_sql: resolve_legacy_sql(legacy_sql, standard_sql)
+              use_legacy_sql: Convert.resolve_legacy_sql(legacy_sql,
+                                                         standard_sql)
             )
           }.delete_if { |_, v| v.nil? }
           new_view = Google::Apis::BigqueryV2::Table.new new_view_opts
@@ -849,12 +850,6 @@ module Google
         # Raise an error unless an active service is available.
         def ensure_service!
           fail "Must have active connection" unless service
-        end
-
-        def resolve_legacy_sql legacy_sql, standard_sql
-          return legacy_sql unless legacy_sql.nil?
-          return !standard_sql unless standard_sql.nil?
-          false
         end
 
         def patch_gapi! *attributes

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -407,6 +407,14 @@ module Google
         #   is referenced.
         # @param [String] name A descriptive name for the table.
         # @param [String] description A user-friendly description of the table.
+        # @param [Boolean] standard_sql Specifies whether to use BigQuery's
+        #   [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   dialect. Optional. The default value is true.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect. Optional. The default value is false.
         #
         # @return [Google::Cloud::Bigquery::View]
         #
@@ -416,7 +424,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   view = dataset.create_view "my_view",
-        #             "SELECT name, age FROM [proj:dataset.users]"
+        #             "SELECT name, age FROM proj.dataset.users"
         #
         # @example A name and description can be provided:
         #   require "google/cloud/bigquery"
@@ -424,12 +432,13 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   view = dataset.create_view "my_view",
-        #             "SELECT name, age FROM [proj:dataset.users]",
+        #             "SELECT name, age FROM proj.dataset.users",
         #             name: "My View", description: "This is my view"
         #
         # @!group Table
         #
-        def create_view table_id, query, name: nil, description: nil
+        def create_view table_id, query, name: nil, description: nil,
+                        standard_sql: nil, legacy_sql: nil
           new_view_opts = {
             table_reference: Google::Apis::BigqueryV2::TableReference.new(
               project_id: project_id, dataset_id: dataset_id, table_id: table_id
@@ -437,7 +446,8 @@ module Google
             friendly_name: name,
             description: description,
             view: Google::Apis::BigqueryV2::ViewDefinition.new(
-              query: query
+              query: query,
+              use_legacy_sql: resolve_legacy_sql(legacy_sql, standard_sql)
             )
           }.delete_if { |_, v| v.nil? }
           new_view = Google::Apis::BigqueryV2::Table.new new_view_opts
@@ -585,15 +595,6 @@ module Google
         # @param [Boolean] flatten Flattens all nested and repeated fields in
         #   the query results. The default value is `true`. `large_results`
         #   parameter must be `true` if this is set to `false`.
-        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
-        #   [legacy
-        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
-        #   dialect for this query. If set to false, the query will use
-        #   BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
-        #   When set to false, the values of `large_results` and `flatten` are
-        #   ignored; the query will be run as if `large_results` is true and
-        #   `flatten` is false. Optional. The default value is true.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
         #   [standard
         #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
@@ -603,7 +604,16 @@ module Google
         #   dialect. When set to true, the values of `large_results` and
         #   `flatten` are ignored; the query will be run as if `large_results`
         #   is true and `flatten` is false. Optional. The default value is
-        #   false.
+        #   true.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect for this query. If set to false, the query will use
+        #   BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   When set to false, the values of `large_results` and `flatten` are
+        #   ignored; the query will be run as if `large_results` is true and
+        #   `flatten` is false. Optional. The default value is false.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -621,13 +631,13 @@ module Google
         #     end
         #   end
         #
-        # @example Query using standard SQL:
+        # @example Query using legacy SQL:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   job = bigquery.query_job "SELECT name FROM my_table",
-        #                            standard_sql: true
+        #                            legacy_sql: true
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -741,15 +751,6 @@ module Google
         #   whenever tables in the query are modified. The default value is
         #   true. For more information, see [query
         #   caching](https://developers.google.com/bigquery/querying-data).
-        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
-        #   [legacy
-        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
-        #   dialect for this query. If set to false, the query will use
-        #   BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
-        #   When set to false, the values of `large_results` and `flatten` are
-        #   ignored; the query will be run as if `large_results` is true and
-        #   `flatten` is false. Optional. The default value is true.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
         #   [standard
         #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
@@ -759,7 +760,16 @@ module Google
         #   dialect. When set to true, the values of `large_results` and
         #   `flatten` are ignored; the query will be run as if `large_results`
         #   is true and `flatten` is false. Optional. The default value is
-        #   false.
+        #   true.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect for this query. If set to false, the query will use
+        #   BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   When set to false, the values of `large_results` and `flatten` are
+        #   ignored; the query will be run as if `large_results` is true and
+        #   `flatten` is false. Optional. The default value is false.
         #
         # @return [Google::Cloud::Bigquery::QueryData]
         #
@@ -774,13 +784,13 @@ module Google
         #     puts row["name"]
         #   end
         #
-        # @example Query using standard SQL:
+        # @example Query using legacy SQL:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name FROM my_table",
-        #                         standard_sql: true
+        #                         legacy_sql: true
         #
         #   data.each do |row|
         #     puts row["name"]
@@ -813,7 +823,7 @@ module Google
         # @!group Data
         #
         def query query, params: nil, max: nil, timeout: 10000, dryrun: nil,
-                  cache: true, legacy_sql: nil, standard_sql: nil
+                  cache: true, standard_sql: nil, legacy_sql: nil
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
                       legacy_sql: legacy_sql, standard_sql: standard_sql,
                       params: params }
@@ -839,6 +849,12 @@ module Google
         # Raise an error unless an active service is available.
         def ensure_service!
           fail "Must have active connection" unless service
+        end
+
+        def resolve_legacy_sql legacy_sql, standard_sql
+          return legacy_sql unless legacy_sql.nil?
+          return !standard_sql unless standard_sql.nil?
+          false
         end
 
         def patch_gapi! *attributes

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -163,15 +163,6 @@ module Google
         #   parameter must be `true` if this is set to `false`.
         # @param [Dataset, String] dataset Specifies the default dataset to use
         #   for unqualified table names in the query.
-        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
-        #   [legacy
-        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
-        #   dialect for this query. If set to false, the query will use
-        #   BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
-        #   When set to false, the values of `large_results` and `flatten` are
-        #   ignored; the query will be run as if `large_results` is true and
-        #   `flatten` is false. Optional. The default value is true.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
         #   [standard
         #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
@@ -181,7 +172,16 @@ module Google
         #   dialect. When set to true, the values of `large_results` and
         #   `flatten` are ignored; the query will be run as if `large_results`
         #   is true and `flatten` is false. Optional. The default value is
-        #   false.
+        #   true.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect for this query. If set to false, the query will use
+        #   BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   When set to false, the values of `large_results` and `flatten` are
+        #   ignored; the query will be run as if `large_results` is true and
+        #   `flatten` is false. Optional. The default value is false.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -200,14 +200,14 @@ module Google
         #     end
         #   end
         #
-        # @example Query using standard SQL:
+        # @example Query using legacy SQL:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "`my_proj.my_data.my_table`",
-        #                            standard_sql: true
+        #                            legacy_sql: true
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -252,8 +252,8 @@ module Google
         #
         def query_job query, params: nil, priority: "INTERACTIVE", cache: true,
                       table: nil, create: nil, write: nil, large_results: nil,
-                      flatten: nil, dataset: nil, legacy_sql: nil,
-                      standard_sql: nil
+                      flatten: nil, dataset: nil, standard_sql: nil,
+                      legacy_sql: nil
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
@@ -327,15 +327,6 @@ module Google
         # @param [String] project Specifies the default projectId to assume for
         #   any unqualified table names in the query. Only used if `dataset`
         #   option is set.
-        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
-        #   [legacy
-        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
-        #   dialect for this query. If set to false, the query will use
-        #   BigQuery's [standard
-        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
-        #   When set to false, the values of `large_results` and `flatten` are
-        #   ignored; the query will be run as if `large_results` is true and
-        #   `flatten` is false. Optional. The default value is true.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
         #   [standard
         #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
@@ -345,7 +336,16 @@ module Google
         #   dialect. When set to true, the values of `large_results` and
         #   `flatten` are ignored; the query will be run as if `large_results`
         #   is true and `flatten` is false. Optional. The default value is
-        #   false.
+        #   true.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect for this query. If set to false, the query will use
+        #   BigQuery's [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   When set to false, the values of `large_results` and `flatten` are
+        #   ignored; the query will be run as if `large_results` is true and
+        #   `flatten` is false. Optional. The default value is false.
         #
         # @return [Google::Cloud::Bigquery::QueryData]
         #
@@ -354,19 +354,19 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   data = bigquery.query "SELECT name FROM [my_proj:my_data.my_table]"
+        #   data = bigquery.query "SELECT name FROM `my_proj.my_data.my_table`"
         #
         #   data.each do |row|
         #     puts row["name"]
         #   end
         #
-        # @example Query using standard SQL:
+        # @example Query using legacy SQL:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   data = bigquery.query "SELECT name FROM `my_proj.my_data.my_table`",
-        #                         standard_sql: true
+        #   data = bigquery.query "SELECT name FROM [my_proj:my_data.my_table]",
+        #                         legacy_sql: true
         #
         #   data.each do |row|
         #     puts row["name"]
@@ -377,7 +377,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   data = bigquery.query "SELECT name FROM [my_proj:my_data.my_table]"
+        #   data = bigquery.query "SELECT name FROM `my_proj.my_data.my_table`"
         #
         #   data.all do |row|
         #     puts row["name"]
@@ -389,7 +389,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name " \
-        #                         "FROM [my_proj:my_data.my_table]" \
+        #                         "FROM `my_proj.my_data.my_table`" \
         #                         "WHERE id = ?",
         #                         params: [1]
         #
@@ -403,7 +403,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   data = bigquery.query "SELECT name " \
-        #                         "FROM [my_proj:my_data.my_table]" \
+        #                         "FROM `my_proj.my_data.my_table`" \
         #                         "WHERE id = @id",
         #                         params: { id: 1 }
         #
@@ -412,8 +412,8 @@ module Google
         #   end
         #
         def query query, params: nil, max: nil, timeout: 10000, dryrun: nil,
-                  cache: true, dataset: nil, project: nil, legacy_sql: nil,
-                  standard_sql: nil
+                  cache: true, dataset: nil, project: nil, standard_sql: nil,
+                  legacy_sql: nil
           ensure_service!
           options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
                       dataset: dataset, project: project,
@@ -710,7 +710,7 @@ module Google
         #
         #   fourpm = bigquery.time 16, 0, 0
         #   data = bigquery.query "SELECT name " \
-        #                         "FROM [my_proj:my_data.my_table]" \
+        #                         "FROM `my_proj.my_data.my_table`" \
         #                         "WHERE time_of_date = @time",
         #                         params: { time: fourpm }
         #
@@ -725,7 +725,7 @@ module Google
         #
         #   precise_time = bigquery.time 16, 35, 15.376541
         #   data = bigquery.query "SELECT name " \
-        #                         "FROM [my_proj:my_data.my_table]" \
+        #                         "FROM `my_proj.my_data.my_table`" \
         #                         "WHERE time_of_date >= @time",
         #                         params: { time: precise_time }
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -473,6 +473,7 @@ module Google
         def resolve_legacy_sql legacy_sql, standard_sql
           return legacy_sql unless legacy_sql.nil?
           return !standard_sql unless standard_sql.nil?
+          false
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -402,8 +402,9 @@ module Google
                 allow_large_results: options[:large_results],
                 flatten_results: options[:flatten],
                 default_dataset: default_dataset,
-                use_legacy_sql: resolve_legacy_sql(options[:legacy_sql],
-                                                   options[:standard_sql])
+                use_legacy_sql: Convert.resolve_legacy_sql(
+                  options[:legacy_sql], options[:standard_sql])
+
               )
             )
           )
@@ -441,8 +442,8 @@ module Google
             timeout_ms: options[:timeout],
             dry_run: options[:dryrun],
             use_query_cache: options[:cache],
-            use_legacy_sql: resolve_legacy_sql(options[:legacy_sql],
-                                               options[:standard_sql])
+            use_legacy_sql: Convert.resolve_legacy_sql(
+              options[:legacy_sql], options[:standard_sql])
           )
 
           if options[:params]
@@ -469,12 +470,6 @@ module Google
         end
 
         # rubocop:enable all
-
-        def resolve_legacy_sql legacy_sql, standard_sql
-          return legacy_sql unless legacy_sql.nil?
-          return !standard_sql unless standard_sql.nil?
-          false
-        end
 
         ##
         # Job description for copy job

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -158,7 +158,7 @@ module Google
         # @!group Attributes
         #
         def query_id standard_sql: nil, legacy_sql: nil
-          if resolve_legacy_sql legacy_sql, standard_sql
+          if Convert.resolve_legacy_sql legacy_sql, standard_sql
             "[#{id}]"
           else
             "`#{project_id}.#{dataset_id}.#{table_id}`"
@@ -854,12 +854,6 @@ module Google
           else
             Service.table_ref_from_s table, table_ref
           end
-        end
-
-        def resolve_legacy_sql legacy_sql, standard_sql
-          return legacy_sql unless legacy_sql.nil?
-          return !standard_sql unless standard_sql.nil?
-          false
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -120,7 +120,7 @@ module Google
 
         ##
         # The combined Project ID, Dataset ID, and Table ID for this table, in
-        # the format specified by the [Query
+        # the format specified by the [Legacy SQL Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # `project_name:datasetId.tableId`. To use this value in queries see
         # {#query_id}.
@@ -137,6 +137,15 @@ module Google
         # Reference](https://cloud.google.com/bigquery/query-reference#from).
         # Useful in queries.
         #
+        # @param [Boolean] standard_sql Specifies whether to use BigQuery's
+        #   [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   dialect. Optional. The default value is true.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect. Optional. The default value is false.
+        #
         # @example
         #   require "google/cloud/bigquery"
         #
@@ -148,8 +157,12 @@ module Google
         #
         # @!group Attributes
         #
-        def query_id
-          project_id["-"] ? "[#{id}]" : id
+        def query_id standard_sql: nil, legacy_sql: nil
+          if resolve_legacy_sql legacy_sql, standard_sql
+            "[#{id}]"
+          else
+            "`#{project_id}.#{dataset_id}.#{table_id}`"
+          end
         end
 
         ##
@@ -841,6 +854,12 @@ module Google
           else
             Service.table_ref_from_s table, table_ref
           end
+        end
+
+        def resolve_legacy_sql legacy_sql, standard_sql
+          return legacy_sql unless legacy_sql.nil?
+          return !standard_sql unless standard_sql.nil?
+          false
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
@@ -30,7 +30,7 @@ module Google
       #
       #   fourpm = Google::Cloud::Bigquery::Time.new "16:00:00"
       #   data = bigquery.query "SELECT name " \
-      #                         "FROM [my_proj:my_data.my_table]" \
+      #                         "FROM `my_proj.my_data.my_table`" \
       #                         "WHERE time_of_date = @time",
       #                         params: { time: fourpm }
       #
@@ -45,7 +45,7 @@ module Google
       #
       #   precise_time = Google::Cloud::Bigquery::Time.new "16:35:15.376541"
       #   data = bigquery.query "SELECT name " \
-      #                         "FROM [my_proj:my_data.my_table]" \
+      #                         "FROM `my_proj.my_data.my_table`" \
       #                         "WHERE time_of_date >= @time",
       #                         params: { time: precise_time }
       #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -40,7 +40,7 @@ module Google
       #   bigquery = Google::Cloud::Bigquery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   view = dataset.create_view "my_view",
-      #            "SELECT name, age FROM [proj:dataset.users]"
+      #            "SELECT name, age FROM proj.dataset.users"
       #
       class View
         ##
@@ -98,7 +98,7 @@ module Google
 
         ##
         # The combined Project ID, Dataset ID, and Table ID for this table, in
-        # the format specified by the [Query
+        # the format specified by the [Legacy SQL Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # `project_name:datasetId.tableId`. To use this value in queries see
         # {#query_id}.
@@ -115,6 +115,15 @@ module Google
         # Reference](https://cloud.google.com/bigquery/query-reference#from).
         # Useful in queries.
         #
+        # @param [Boolean] standard_sql Specifies whether to use BigQuery's
+        #   [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   dialect. Optional. The default value is true.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect. Optional. The default value is false.
+        #
         # @example
         #   require "google/cloud/bigquery"
         #
@@ -126,8 +135,12 @@ module Google
         #
         # @!group Attributes
         #
-        def query_id
-          project_id["-"] ? "[#{id}]" : id
+        def query_id standard_sql: nil, legacy_sql: nil
+          if resolve_legacy_sql legacy_sql, standard_sql
+            "[#{id}]"
+          else
+            "`#{project_id}.#{dataset_id}.#{table_id}`"
+          end
         end
 
         ##
@@ -306,6 +319,14 @@ module Google
         #   Reference
         #
         # @param [String] new_query The query that defines the view.
+        # @param [Boolean] standard_sql Specifies whether to use BigQuery's
+        #   [standard
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
+        #   dialect. Optional. The default value is true.
+        # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
+        #   [legacy
+        #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
+        #   dialect. Optional. The default value is false.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -315,13 +336,15 @@ module Google
         #   view = dataset.table "my_view"
         #
         #   view.query = "SELECT first_name FROM " \
-        #                "[my_project:my_dataset.my_table]"
+        #                "`my_project.my_dataset.my_table`"
         #
         # @!group Lifecycle
         #
-        def query= new_query
+        def query= new_query, standard_sql: nil, legacy_sql: nil
           @gapi.view ||= Google::Apis::BigqueryV2::ViewDefinition.new
           @gapi.view.update! query: new_query
+          @gapi.view.update! use_legacy_sql: \
+            resolve_legacy_sql(legacy_sql, standard_sql)
           patch_view_gapi! :query
         end
 
@@ -424,6 +447,12 @@ module Google
         # Raise an error unless an active service is available.
         def ensure_service!
           fail "Must have active connection" unless service
+        end
+
+        def resolve_legacy_sql legacy_sql, standard_sql
+          return legacy_sql unless legacy_sql.nil?
+          return !standard_sql unless standard_sql.nil?
+          false
         end
 
         def patch_gapi! *attributes

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -136,7 +136,7 @@ module Google
         # @!group Attributes
         #
         def query_id standard_sql: nil, legacy_sql: nil
-          if resolve_legacy_sql legacy_sql, standard_sql
+          if Convert.resolve_legacy_sql legacy_sql, standard_sql
             "[#{id}]"
           else
             "`#{project_id}.#{dataset_id}.#{table_id}`"
@@ -344,7 +344,7 @@ module Google
           @gapi.view ||= Google::Apis::BigqueryV2::ViewDefinition.new
           @gapi.view.update! query: new_query
           @gapi.view.update! use_legacy_sql: \
-            resolve_legacy_sql(legacy_sql, standard_sql)
+            Convert.resolve_legacy_sql(legacy_sql, standard_sql)
           patch_view_gapi! :query
         end
 
@@ -447,12 +447,6 @@ module Google
         # Raise an error unless an active service is available.
         def ensure_service!
           fail "Must have active connection" unless service
-        end
-
-        def resolve_legacy_sql legacy_sql, standard_sql
-          return legacy_sql unless legacy_sql.nil?
-          return !standard_sql unless standard_sql.nil?
-          false
         end
 
         def patch_gapi! *attributes

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -648,7 +648,7 @@ def view_full_hash project = "my-project-id", dataset = "my-dataset-id", id = ni
 
   hash = table_full_hash project, dataset, id, name, description
   hash["type"] = "VIEW"
-  hash["view"] = { "query" => "SELECT name, age, score, active FROM [external:publicdata.users]" }
+  hash["view"] = { "query" => "SELECT name, age, score, active FROM `external.publicdata.users`" }
   hash
 end
 
@@ -767,7 +767,7 @@ end
 def query_job_hash
   hash = random_job_hash
   hash["configuration"]["query"] = {
-    "query" => "SELECT name, age, score, active FROM [users]",
+    "query" => "SELECT name, age, score, active FROM `users`",
     "destinationTable" => {
       "projectId" => "target_project_id",
       "datasetId" => "target_dataset_id",

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active FROM `some_project.some_dataset.users`" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
-  let(:query) { "SELECT * FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT * FROM `some_project.some_dataset.users`" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -346,7 +346,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         project_id: project, dataset_id: dataset_id, table_id: view_id
       ),
       view: Google::Apis::BigqueryV2::ViewDefinition.new(
-        query: query
+        query: query,
+        use_legacy_sql: false
       )
     )
     return_view = create_view_gapi view_id, query
@@ -373,7 +374,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       friendly_name: view_name,
       description: view_description,
       view: Google::Apis::BigqueryV2::ViewDefinition.new(
-        query: query
+        query: query,
+        use_legacy_sql: false
       )
     )
     return_view = create_view_gapi view_id, query, view_name, view_description

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active FROM `some_project.some_dataset.users`" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_bigquery do
-  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM [some_project:some_dataset.users]" }
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
@@ -184,7 +184,7 @@ describe Google::Cloud::Bigquery::QueryJob, :query_results, :mock_bigquery do
   def query_job_hash
     hash = random_job_hash("job9876543210")
     hash["configuration"]["query"] = {
-      "query" => "SELECT name, age, score, active FROM [users]",
+      "query" => "SELECT name, age, score, active FROM `users`",
       "destinationTable" => {
         "projectId" => "target_project_id",
         "datasetId" => "target_dataset_id",
@@ -201,7 +201,7 @@ describe Google::Cloud::Bigquery::QueryJob, :query_results, :mock_bigquery do
       "allowLargeResults" => true,
       "useQueryCache" => true,
       "flattenResults" => true,
-      "useLegacySql" => nil,
+      "useLegacySql" => false,
     }
     hash
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -45,8 +45,8 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     job.must_be :large_results?
     job.must_be :cache?
     job.must_be :flatten?
-    job.must_be :legacy_sql?
-    job.wont_be :standard_sql?
+    job.wont_be :legacy_sql?
+    job.must_be :standard_sql?
   end
 
   it "knows its statistics data" do
@@ -68,7 +68,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
   def query_job_hash
     hash = random_job_hash
     hash["configuration"]["query"] = {
-      "query" => "SELECT name, age, score, active FROM [users]",
+      "query" => "SELECT name, age, score, active FROM `users`",
       "destinationTable" => {
         "projectId" => "target_project_id",
         "datasetId" => "target_dataset_id",
@@ -85,7 +85,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
       "allowLargeResults" => true,
       "useQueryCache" => true,
       "flattenResults" => true,
-      "useLegacySql" => nil
+      "useLegacySql" => false
     }
     hash["statistics"]["query"] = {
       "cacheHit" => false,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -45,7 +45,14 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   end
 
   it "knows its fully-qualified query ID" do
-    table.query_id.must_equal "[#{project}:#{dataset}.#{table_id}]"
+    standard_id = "`#{project}.#{dataset}.#{table_id}`"
+    legacy_id = "[#{project}:#{dataset}.#{table_id}]"
+
+    table.query_id.must_equal standard_id
+    table.query_id(standard_sql: true).must_equal standard_id
+    table.query_id(standard_sql: false).must_equal legacy_id
+    table.query_id(legacy_sql: true).must_equal legacy_id
+    table.query_id(legacy_sql: false).must_equal standard_id
   end
 
   it "knows its creation and modification and expiration times" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
@@ -18,8 +18,8 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
   let(:query_request) {
     qrg = query_request_gapi
     qrg.default_dataset = nil
-    qrg.query = "SELECT * FROM [test-project:my_dataset.my_view]"
-    qrg.use_legacy_sql = nil
+    qrg.query = "SELECT * FROM `test-project.my_dataset.my_view`"
+    qrg.use_legacy_sql = false
     qrg
   }
   let(:dataset_id) { "my_dataset" }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::View, :update, :mock_bigquery do
   end
 
   it "updates its query" do
-    new_query = "SELECT name, age FROM [users]"
+    new_query = "SELECT name, age FROM `users`"
 
     mock = Minitest::Mock.new
     view_hash = random_view_hash dataset_id, table_id, table_name, description

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -297,7 +297,7 @@ class MockBigquery < Minitest::Spec
       "lastModifiedTime" => time_millis,
       "type" => "VIEW",
       "view" => {
-        "query" => "SELECT name, age, score, active FROM [external:publicdata.users]"
+        "query" => "SELECT name, age, score, active FROM `external:publicdata.users`"
       },
       "location" => "US"
     }
@@ -381,7 +381,7 @@ class MockBigquery < Minitest::Spec
           "allowLargeResults" => nil,
           "useQueryCache" => true,
           "flattenResults" => nil,
-          "useLegacySql" => nil
+          "useLegacySql" => false
         }
       }
     }.to_json
@@ -394,10 +394,10 @@ class MockBigquery < Minitest::Spec
       ),
       dry_run: nil,
       max_results: nil,
-      query: "SELECT * FROM [some_project:some_dataset.users]",
+      query: "SELECT * FROM `some_project.some_dataset.users`",
       timeout_ms: 10000,
       use_query_cache: true,
-      use_legacy_sql: nil,
+      use_legacy_sql: false,
     )
   end
 


### PR DESCRIPTION
Standard SQL has many more features than Legacy SQL. It makes sense for Standard SQL to be the default.

This change allows nested values to be returned by default, and legacy support is switched to an option flag.

```ruby
require "google/cloud/bigquery"

bigquery = Google::Cloud::Bigquery.new
db = bigquery.dataset "mine"

# standard sql is default and returns properly formatted values
# no standard_sql argument needed!
db.query "SELECT * FROM stuff"
rows == [{"name"=>"mike", "foo"=>[{"bar"=>"hey", "baz"=>{"bif"=>1}}, {"bar"=>"world", "baz"=>{"bif"=>2}}]}] #=> true

# legacy sql can be supported and will flattened nested and repeated records
db.query "SELECT * FROM stuff", legacy_sql: true
rows == [{"name"=>"mike", "foo_bar"=>"hey", "foo_baz_bif"=>1}, {"name"=>"mike", "foo_bar"=>"world", "foo_baz_bif"=>2}] #=> true
```

This is part of a larger set of changes for BigQuery.