### PR TITLE
BigQuery Schema Changes

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -81,15 +81,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     end
   end
 
-  it "copies schema to a new table" do
-    tbl_copy = dataset.create_table "#{table.table_id}copy" do |tbl|
-      tbl.schema.fields = table.schema.fields
-    end
-
-    tbl_copy.refresh!
-    tbl_copy.headers.must_equal table.headers
-  end
-
   it "gets and sets metadata" do
     new_name = "New name"
     new_desc = "New description!"

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -166,7 +166,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     data.etag.wont_be :nil?
     data.total.must_be :nil?
     data.count.wont_be :nil?
-    data.raw.wont_be :nil?
     data.all(request_limit: 2).each do |row|
       row.must_be_kind_of Hash
       [:id, :breed, :name, :dob].each { |k| row.keys.must_include k }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -66,6 +66,24 @@ module Google
         end
 
         ##
+        # The schema of the data.
+        def schema
+          table.schema
+        end
+
+        ##
+        # The fields of the data.
+        def fields
+          schema.fields
+        end
+
+        ##
+        # The name of the columns in the data.
+        def headers
+          schema.headers
+        end
+
+        ##
         # Whether there is a next page of data.
         #
         # @return [Boolean]

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -196,14 +196,6 @@ module Google
         end
 
         ##
-        # Represents Table Data as a list of positional values (array of
-        # arrays). No type conversion is made, e.g. numbers are formatted as
-        # strings.
-        def raw
-          Array(gapi.rows).map { |row| row.f.map(&:v) }
-        end
-
-        ##
         # @private New Data from a response object.
         def self.from_gapi gapi, table
           formatted_rows = Convert.format_rows(gapi.rows,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -566,31 +566,28 @@ module Google
         #   * `append` - BigQuery appends the data to the table.
         #   * `empty` - A 'duplicate' error is returned in the job result if the
         #     table exists and contains data.
-        # @param [Boolean] large_results If `true`, allows the query to produce
-        #   arbitrarily large result tables at a slight cost in performance.
-        #   Requires `table` parameter to be set.
-        # @param [Boolean] flatten Flattens all nested and repeated fields in
-        #   the query results. The default value is `true`. `large_results`
-        #   parameter must be `true` if this is set to `false`.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
         #   [standard
         #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
         #   dialect for this query. If set to true, the query will use standard
         #   SQL rather than the [legacy
         #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
-        #   dialect. When set to true, the values of `large_results` and
-        #   `flatten` are ignored; the query will be run as if `large_results`
-        #   is true and `flatten` is false. Optional. The default value is
-        #   true.
+        #   dialect. Optional. The default value is true.
         # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
         #   [legacy
         #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
         #   dialect for this query. If set to false, the query will use
         #   BigQuery's [standard
         #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
-        #   When set to false, the values of `large_results` and `flatten` are
-        #   ignored; the query will be run as if `large_results` is true and
-        #   `flatten` is false. Optional. The default value is false.
+        #   dialect. Optional. The default value is false.
+        # @param [Boolean] large_results This option is specific to Legacy SQL.
+        #   If `true`, allows the query to produce arbitrarily large result
+        #   tables at a slight cost in performance. Requires `table` parameter
+        #   to be set.
+        # @param [Boolean] flatten This option is specific to Legacy SQL.
+        #   Flattens all nested and repeated fields in the query results. The
+        #   default value is `true`. `large_results` parameter must be `true` if
+        #   this is set to `false`.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -656,8 +653,8 @@ module Google
         # @!group Data
         #
         def query_job query, params: nil, priority: "INTERACTIVE", cache: true,
-                      table: nil, create: nil, write: nil, large_results: nil,
-                      flatten: nil, legacy_sql: nil, standard_sql: nil
+                      table: nil, create: nil, write: nil, standard_sql: nil,
+                      legacy_sql: nil, large_results: nil, flatten: nil
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -828,12 +828,6 @@ module Google
           fail "Must have active connection" unless service
         end
 
-        def resolve_legacy_sql legacy_sql, standard_sql
-          return legacy_sql unless legacy_sql.nil?
-          return !standard_sql unless standard_sql.nil?
-          false
-        end
-
         def patch_gapi! *attributes
           return if attributes.empty?
           ensure_service!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -852,6 +852,12 @@ module Google
           fail "Must have active connection" unless service
         end
 
+        def resolve_legacy_sql legacy_sql, standard_sql
+          return legacy_sql unless legacy_sql.nil?
+          return !standard_sql unless standard_sql.nil?
+          false
+        end
+
         def patch_gapi! *attributes
           return if attributes.empty?
           ensure_service!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -302,9 +302,6 @@ module Google
         #   length is 1,024 characters.
         # @param [String] name A descriptive name for the table.
         # @param [String] description A user-friendly description of the table.
-        # @param [Array<Schema::Field>] fields An array of Schema::Field objects
-        #   specifying the schema's data types for the table. The schema may
-        #   also be configured when passing a block.
         # @yield [table] a block for setting the table
         # @yieldparam [Table] table the table object to be updated
         #
@@ -325,26 +322,6 @@ module Google
         #   table = dataset.create_table "my_table",
         #                                name: "My Table",
         #                                description: "A description of table."
-        #
-        # @example The table's schema fields can be passed as an argument.
-        #   require "google/cloud/bigquery"
-        #
-        #   bigquery = Google::Cloud::Bigquery.new
-        #   dataset = bigquery.dataset "my_dataset"
-        #
-        #   schema_fields = [
-        #     Google::Cloud::Bigquery::Schema::Field.new(
-        #       "first_name", :string, mode: :required),
-        #     Google::Cloud::Bigquery::Schema::Field.new(
-        #       "cities_lived", :record, mode: :repeated,
-        #       fields: [
-        #         Google::Cloud::Bigquery::Schema::Field.new(
-        #           "place", :string, mode: :required),
-        #         Google::Cloud::Bigquery::Schema::Field.new(
-        #           "number_of_years", :integer, mode: :required),
-        #         ])
-        #   ]
-        #   table = dataset.create_table "my_table", fields: schema_fields
         #
         # @example Or the table's schema can be configured with the block.
         #   require "google/cloud/bigquery"
@@ -379,7 +356,7 @@ module Google
         #
         # @!group Table
         #
-        def create_table table_id, name: nil, description: nil, fields: nil
+        def create_table table_id, name: nil, description: nil
           ensure_service!
           new_tb = Google::Apis::BigqueryV2::Table.new(
             table_reference: Google::Apis::BigqueryV2::TableReference.new(
@@ -388,7 +365,6 @@ module Google
           updater = Table::Updater.new(new_tb).tap do |tb|
             tb.name = name unless name.nil?
             tb.description = description unless description.nil?
-            tb.schema.fields = fields unless fields.nil?
           end
 
           yield updater if block_given?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -158,30 +158,28 @@ module Google
         # @param [Boolean] large_results If `true`, allows the query to produce
         #   arbitrarily large result tables at a slight cost in performance.
         #   Requires `table` parameter to be set.
-        # @param [Boolean] flatten Flattens all nested and repeated fields in
-        #   the query results. The default value is `true`. `large_results`
-        #   parameter must be `true` if this is set to `false`.
-        # @param [Dataset, String] dataset Specifies the default dataset to use
-        #   for unqualified table names in the query.
         # @param [Boolean] standard_sql Specifies whether to use BigQuery's
         #   [standard
         #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
         #   dialect for this query. If set to true, the query will use standard
         #   SQL rather than the [legacy
         #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
-        #   dialect. When set to true, the values of `large_results` and
-        #   `flatten` are ignored; the query will be run as if `large_results`
-        #   is true and `flatten` is false. Optional. The default value is
-        #   true.
+        #   dialect. Optional. The default value is true.
         # @param [Boolean] legacy_sql Specifies whether to use BigQuery's
         #   [legacy
         #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
         #   dialect for this query. If set to false, the query will use
         #   BigQuery's [standard
         #   SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/)
-        #   When set to false, the values of `large_results` and `flatten` are
-        #   ignored; the query will be run as if `large_results` is true and
-        #   `flatten` is false. Optional. The default value is false.
+        #   dialect. Optional. The default value is false.
+        # @param [Boolean] large_results This option is specific to Legacy SQL.
+        #   If `true`, allows the query to produce arbitrarily large result
+        #   tables at a slight cost in performance. Requires `table` parameter
+        #   to be set.
+        # @param [Boolean] flatten This option is specific to Legacy SQL.
+        #   Flattens all nested and repeated fields in the query results. The
+        #   default value is `true`. `large_results` parameter must be `true` if
+        #   this is set to `false`.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -251,9 +249,9 @@ module Google
         #   end
         #
         def query_job query, params: nil, priority: "INTERACTIVE", cache: true,
-                      table: nil, create: nil, write: nil, large_results: nil,
-                      flatten: nil, dataset: nil, standard_sql: nil,
-                      legacy_sql: nil
+                      table: nil, create: nil, write: nil, dataset: nil,
+                      standard_sql: nil, legacy_sql: nil, large_results: nil,
+                      flatten: nil
           ensure_service!
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_data.rb
@@ -55,22 +55,24 @@ module Google
         ##
         # The schema of the data.
         def schema
-          Schema.from_gapi(@gapi.schema).freeze
+          @schema ||= begin
+            s = Schema.from_gapi(@gapi.schema)
+            # call fields so they will be available
+            s.fields
+            s.freeze
+          end
         end
 
         ##
         # The fields of the data.
         def fields
-          f = schema.fields
-          f = f.to_hash if f.respond_to? :to_hash
-          f = [] if f.nil?
-          f
+          schema.fields
         end
 
         ##
         # The name of the columns in the data.
         def headers
-          fields.map(&:name).map(&:to_sym)
+          schema.headers
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+require "google/cloud/bigquery/schema/field"
+
 module Google
   module Cloud
     module Bigquery
@@ -53,6 +55,10 @@ module Google
         def fields= new_fields
           @gapi.fields = Array(new_fields).map(&:to_gapi)
           @fields = @gapi.fields.map { |f| Field.from_gapi f }
+        end
+
+        def headers
+          fields.map(&:name).map(&:to_sym)
         end
 
         def empty?
@@ -294,123 +300,6 @@ module Google
           fields.reject! { |f| f.name == name }
           fields << Field.new(name, type, description: description,
                                           mode: mode, fields: nested_fields)
-        end
-
-        class Field
-          # @private
-          MODES = %w( NULLABLE REQUIRED REPEATED )
-
-          # @private
-          TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP TIME DATETIME
-                      DATE RECORD )
-
-          def initialize name, type, description: nil,
-                         mode: :nullable, fields: nil
-            @gapi = Google::Apis::BigqueryV2::TableFieldSchema.new
-            @gapi.update! name: name
-            @gapi.update! type: verify_type(type)
-            @gapi.update! description: description if description
-            @gapi.update! mode: verify_mode(mode) if mode
-            if fields
-              @fields = fields
-              check_for_changed_fields!
-            end
-            @original_json = @gapi.to_json
-          end
-
-          def name
-            @gapi.name
-          end
-
-          def name= new_name
-            @gapi.update! name: new_name
-          end
-
-          def type
-            @gapi.type
-          end
-
-          def type= new_type
-            @gapi.update! type: verify_type(new_type)
-          end
-
-          def description
-            @gapi.description
-          end
-
-          def description= new_description
-            @gapi.update! description: new_description
-          end
-
-          def mode
-            @gapi.mode
-          end
-
-          def mode= new_mode
-            @gapi.update! mode: verify_mode(new_mode)
-          end
-
-          def fields
-            @fields ||= Array(@gapi.fields).map { |f| Field.from_gapi f }
-          end
-
-          def fields= new_fields
-            @fields = new_fields
-          end
-
-          ##
-          # @private Make sure any fields are saved.
-          def check_for_changed_fields!
-            return if frozen?
-            fields.each(&:check_for_changed_fields!)
-            gapi_fields = Array(fields).map(&:to_gapi)
-            @gapi.update! fields: gapi_fields
-          end
-
-          # @private
-          def changed?
-            @original_json == to_gapi.to_json
-          end
-
-          # @private
-          def self.from_gapi gapi
-            new("to-be-replaced", "STRING").tap do |f|
-              f.instance_variable_set :@gapi, gapi
-              f.instance_variable_set :@original_json, gapi.to_json
-            end
-          end
-
-          # @private
-          def to_gapi
-            # make sure any changes are saved.
-            check_for_changed_fields!
-            @gapi
-          end
-
-          # @private
-          def == other
-            return false unless other.is_a? Field
-            to_gapi.to_h == other.to_gapi.to_h
-          end
-
-          protected
-
-          def verify_type type
-            upcase_type = type.to_s.upcase
-            unless TYPES.include? upcase_type
-              fail ArgumentError,
-                   "Type '#{upcase_type}' not found in #{TYPES.inspect}"
-            end
-            upcase_type
-          end
-
-          def verify_mode mode
-            upcase_mode = mode.to_s.upcase
-            unless MODES.include? upcase_mode
-              fail ArgumentError "Unable to determine mode for '#{mode}'"
-            end
-            upcase_mode
-          end
         end
       end
     end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -56,6 +56,13 @@ module Google
           fields.map(&:name).map(&:to_sym)
         end
 
+        def field name
+          f = fields.find { |fld| fld.name == name.to_s }
+          return nil if f.nil?
+          yield f if block_given?
+          f
+        end
+
         def empty?
           fields.empty?
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -44,6 +44,8 @@ module Google
       #   end
       #
       class Schema
+        ##
+        # The fields of the table schema.
         def fields
           if frozen?
             Array(@gapi.fields).map { |f| Field.from_gapi(f).freeze }.freeze
@@ -52,10 +54,14 @@ module Google
           end
         end
 
+        ##
+        # The names of the fields as symbols.
         def headers
           fields.map(&:name).map(&:to_sym)
         end
 
+        ##
+        # Retreive a fields by name.
         def field name
           f = fields.find { |fld| fld.name == name.to_s }
           return nil if f.nil?
@@ -63,35 +69,10 @@ module Google
           f
         end
 
+        ##
+        # Whether the schema has no fields defined.
         def empty?
           fields.empty?
-        end
-
-        # @private
-        def changed?
-          return false if frozen?
-          @original_json != @gapi.to_json
-        end
-
-        # @private
-        def self.from_gapi gapi
-          gapi ||= Google::Apis::BigqueryV2::TableSchema.new fields: []
-          gapi.fields ||= []
-          new.tap do |s|
-            s.instance_variable_set :@gapi, gapi
-            s.instance_variable_set :@original_json, gapi.to_json
-          end
-        end
-
-        # @private
-        def to_gapi
-          @gapi
-        end
-
-        # @private
-        def == other
-          return false unless other.is_a? Schema
-          to_gapi.to_json == other.to_gapi.to_json
         end
 
         ##
@@ -270,6 +251,33 @@ module Google
                                                   mode: mode
           yield nested_field
           nested_field
+        end
+
+        # @private
+        def changed?
+          return false if frozen?
+          @original_json != @gapi.to_json
+        end
+
+        # @private
+        def self.from_gapi gapi
+          gapi ||= Google::Apis::BigqueryV2::TableSchema.new fields: []
+          gapi.fields ||= []
+          new.tap do |s|
+            s.instance_variable_set :@gapi, gapi
+            s.instance_variable_set :@original_json, gapi.to_json
+          end
+        end
+
+        # @private
+        def to_gapi
+          @gapi
+        end
+
+        # @private
+        def == other
+          return false unless other.is_a? Schema
+          to_gapi.to_json == other.to_gapi.to_json
         end
 
         protected

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -25,20 +25,6 @@ module Google
           TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP TIME DATETIME
                       DATE RECORD )
 
-          def initialize name, type, description: nil,
-                         mode: :nullable, fields: nil
-            @gapi = Google::Apis::BigqueryV2::TableFieldSchema.new
-            @gapi.update! name: name
-            @gapi.update! type: verify_type(type)
-            @gapi.update! description: description if description
-            @gapi.update! mode: verify_mode(mode) if mode
-            if fields
-              @fields = fields
-              check_for_changed_fields!
-            end
-            @original_json = @gapi.to_json
-          end
-
           def name
             @gapi.name
           end
@@ -72,30 +58,234 @@ module Google
           end
 
           def fields
-            @fields ||= Array(@gapi.fields).map { |f| Field.from_gapi f }
-          end
-
-          def fields= new_fields
-            @fields = new_fields
+            if frozen?
+              Array(@gapi.fields).map { |f| Field.from_gapi(f).freeze }.freeze
+            else
+              Array(@gapi.fields).map { |f| Field.from_gapi f }
+            end
           end
 
           ##
-          # @private Make sure any fields are saved.
-          def check_for_changed_fields!
-            return if frozen?
-            fields.each(&:check_for_changed_fields!)
-            gapi_fields = Array(fields).map(&:to_gapi)
-            @gapi.update! fields: gapi_fields
+          # Adds a string field to the schema.
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          def string name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :string, description: description, mode: mode
           end
 
-          # @private
-          def changed?
-            @original_json == to_gapi.to_json
+          ##
+          # Adds an integer field to the schema.
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          def integer name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :integer, description: description, mode: mode
+          end
+
+          ##
+          # Adds a floating-point number field to the schema.
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          def float name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :float, description: description, mode: mode
+          end
+
+          ##
+          # Adds a boolean field to the schema.
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          def boolean name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :boolean, description: description, mode: mode
+          end
+
+          ##
+          # Adds a bytes field to the schema.
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          def bytes name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :bytes, description: description, mode: mode
+          end
+
+          ##
+          # Adds a timestamp field to the schema.
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          def timestamp name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :timestamp, description: description, mode: mode
+          end
+
+          ##
+          # Adds a time field to the schema.
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          def time name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :time, description: description, mode: mode
+          end
+
+          ##
+          # Adds a datetime field to the schema.
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          def datetime name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :datetime, description: description, mode: mode
+          end
+
+          ##
+          # Adds a date field to the schema.
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          def date name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :date, description: description, mode: mode
+          end
+
+          ##
+          # Adds a record field to the schema. A block must be passed describing
+          # the nested fields of the record. For more information about nested
+          # and repeated records, see [Preparing Data for BigQuery
+          # ](https://cloud.google.com/bigquery/preparing-data-for-bigquery).
+          #
+          # This can only be called on fields that are of type RECORD.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          # @yield [nested_schema] a block for setting the nested schema
+          # @yieldparam [Schema] nested_schema the object accepting the
+          #   nested schema
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.create_table "my_table"
+          #
+          #   table.schema do |schema|
+          #     schema.string "first_name", mode: :required
+          #     schema.record "cities_lived", mode: :repeated do |cities_lived|
+          #       cities_lived.string "place", mode: :required
+          #       cities_lived.integer "number_of_years", mode: :required
+          #     end
+          #   end
+          #
+          def record name, description: nil, mode: nil
+            record_check!
+
+            # TODO: do we need to fail if no block was given?
+            fail ArgumentError, "a block is required" unless block_given?
+
+            nested_field = add_field name, :record, description: description,
+                                                    mode: mode
+            yield nested_field
+            nested_field
           end
 
           # @private
           def self.from_gapi gapi
-            new("to-be-replaced", "STRING").tap do |f|
+            new.tap do |f|
               f.instance_variable_set :@gapi, gapi
               f.instance_variable_set :@original_json, gapi.to_json
             end
@@ -103,8 +293,6 @@ module Google
 
           # @private
           def to_gapi
-            # make sure any changes are saved.
-            check_for_changed_fields!
             @gapi
           end
 
@@ -116,21 +304,53 @@ module Google
 
           protected
 
+          def frozen_check!
+            return unless frozen?
+            fail ArgumentError, "Cannot modify a frozen field"
+          end
+
+          def record_check!
+            return unless type != "RECORD"
+            fail ArgumentError,
+                 "Cannot add fields to a non-RECORD field (#{type})"
+          end
+
+          def add_field name, type, description: nil, mode: :nullable
+            frozen_check!
+
+            new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
+              name: String(name),
+              type: verify_type(type),
+              description: description,
+              mode: verify_mode(mode),
+              fields: [])
+
+            # Remove any existing field of this name
+            @gapi.fields ||= []
+            @gapi.fields.reject! { |f| f.name == new_gapi.name }
+            # Add to the nested fields
+            @gapi.fields << new_gapi
+
+            # return the public API object
+            Field.from_gapi new_gapi
+          end
+
           def verify_type type
-            upcase_type = type.to_s.upcase
-            unless TYPES.include? upcase_type
+            type = type.to_s.upcase
+            unless TYPES.include? type
               fail ArgumentError,
-                   "Type '#{upcase_type}' not found in #{TYPES.inspect}"
+                   "Type '#{type}' not found in #{TYPES.inspect}"
             end
-            upcase_type
+            type
           end
 
           def verify_mode mode
-            upcase_mode = mode.to_s.upcase
-            unless MODES.include? upcase_mode
+            mode = :nullable if mode.nil?
+            mode = mode.to_s.upcase
+            unless MODES.include? mode
               fail ArgumentError "Unable to determine mode for '#{mode}'"
             end
-            upcase_mode
+            mode
           end
         end
       end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -17,6 +17,23 @@ module Google
   module Cloud
     module Bigquery
       class Schema
+        ##
+        # # Schema Field
+        #
+        # The fields of a table schema.
+        #
+        # @see https://cloud.google.com/bigquery/preparing-data-for-bigquery
+        #   Preparing Data for BigQuery
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   name_field = table.schema.field "name"
+        #   name_field.required? #=> true
         class Field
           # @private
           MODES = %w( NULLABLE REQUIRED REPEATED )
@@ -25,38 +42,143 @@ module Google
           TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP TIME DATETIME
                       DATE RECORD )
 
+          ##
+          # The name of the field.
+          #
           def name
             @gapi.name
           end
 
+          ##
+          # Updates the name of the field.
+          #
           def name= new_name
             @gapi.update! name: String(new_name)
           end
 
+          ##
+          # The type of the field.
+          #
           def type
             @gapi.type
           end
 
+          ##
+          # Updates the type of the field.
+          #
           def type= new_type
             @gapi.update! type: verify_type(new_type)
           end
 
+          ##
+          # Checks if the type of the field is `NULLABLE`.
+          def nullable?
+            mode == "NULLABLE"
+          end
+
+          ##
+          # Checks if the type of the field is `REQUIRED`.
+          def required?
+            mode == "REQUIRED"
+          end
+
+          ##
+          # Checks if the type of the field is `REPEATED`.
+          def repeated?
+            mode == "REPEATED"
+          end
+
+          ##
+          # The description of the field.
+          #
           def description
             @gapi.description
           end
 
+          ##
+          # Updates the description of the field.
+          #
           def description= new_description
             @gapi.update! description: new_description
           end
 
+          ##
+          # The mode of the field.
+          #
           def mode
             @gapi.mode
           end
 
+          ##
+          # Updates the mode of the field.
+          #
           def mode= new_mode
             @gapi.update! mode: verify_mode(new_mode)
           end
 
+          ##
+          # Checks if the mode of the field is `STRING`.
+          def string?
+            mode == "STRING"
+          end
+
+          ##
+          # Checks if the mode of the field is `INTEGER`.
+          def integer?
+            mode == "INTEGER"
+          end
+
+          ##
+          # Checks if the mode of the field is `FLOAT`.
+          def float?
+            mode == "FLOAT"
+          end
+
+          ##
+          # Checks if the mode of the field is `BOOLEAN`.
+          def boolean?
+            mode == "BOOLEAN"
+          end
+
+          ##
+          # Checks if the mode of the field is `BYTES`.
+          def bytes?
+            mode == "BYTES"
+          end
+
+          ##
+          # Checks if the mode of the field is `TIMESTAMP`.
+          def timestamp?
+            mode == "TIMESTAMP"
+          end
+
+          ##
+          # Checks if the mode of the field is `TIME`.
+          def time?
+            mode == "TIME"
+          end
+
+          ##
+          # Checks if the mode of the field is `DATETIME`.
+          def datetime?
+            mode == "DATETIME"
+          end
+
+          ##
+          # Checks if the mode of the field is `DATE`.
+          def date?
+            mode == "DATE"
+          end
+
+          ##
+          # Checks if the mode of the field is `RECORD`.
+          def record?
+            mode == "RECORD"
+          end
+
+          ##
+          # The nested fields if the type property is set to `RECORD`. Will be
+          # empty otherwise.
           def fields
             if frozen?
               Array(@gapi.fields).map { |f| Field.from_gapi(f).freeze }.freeze
@@ -65,10 +187,16 @@ module Google
             end
           end
 
+          ##
+          # The names of the nested fields as symbols if the type property is
+          # set to `RECORD`. Will be empty otherwise.
           def headers
             fields.map(&:name).map(&:to_sym)
           end
 
+          ##
+          # Retreive a nested fields by name, if the type property is
+          # set to `RECORD`. Will return `nil` otherwise.
           def field name
             f = fields.find { |fld| fld.name == name.to_s }
             return nil if f.nil?
@@ -79,7 +207,7 @@ module Google
           ##
           # Adds a string field to the schema.
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -98,7 +226,7 @@ module Google
           ##
           # Adds an integer field to the schema.
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -117,7 +245,7 @@ module Google
           ##
           # Adds a floating-point number field to the schema.
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -136,7 +264,7 @@ module Google
           ##
           # Adds a boolean field to the schema.
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -155,7 +283,7 @@ module Google
           ##
           # Adds a bytes field to the schema.
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -174,7 +302,7 @@ module Google
           ##
           # Adds a timestamp field to the schema.
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -193,7 +321,7 @@ module Google
           ##
           # Adds a time field to the schema.
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -212,7 +340,7 @@ module Google
           ##
           # Adds a datetime field to the schema.
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -231,7 +359,7 @@ module Google
           ##
           # Adds a date field to the schema.
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -253,7 +381,7 @@ module Google
           # and repeated records, see [Preparing Data for BigQuery
           # ](https://cloud.google.com/bigquery/preparing-data-for-bigquery).
           #
-          # This can only be called on fields that are of type RECORD.
+          # This can only be called on fields that are of type `RECORD`.
           #
           # @param [String] name The field name. The name must contain only
           #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -1,0 +1,139 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Bigquery
+      class Schema
+        class Field
+          # @private
+          MODES = %w( NULLABLE REQUIRED REPEATED )
+
+          # @private
+          TYPES = %w( STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP TIME DATETIME
+                      DATE RECORD )
+
+          def initialize name, type, description: nil,
+                         mode: :nullable, fields: nil
+            @gapi = Google::Apis::BigqueryV2::TableFieldSchema.new
+            @gapi.update! name: name
+            @gapi.update! type: verify_type(type)
+            @gapi.update! description: description if description
+            @gapi.update! mode: verify_mode(mode) if mode
+            if fields
+              @fields = fields
+              check_for_changed_fields!
+            end
+            @original_json = @gapi.to_json
+          end
+
+          def name
+            @gapi.name
+          end
+
+          def name= new_name
+            @gapi.update! name: String(new_name)
+          end
+
+          def type
+            @gapi.type
+          end
+
+          def type= new_type
+            @gapi.update! type: verify_type(new_type)
+          end
+
+          def description
+            @gapi.description
+          end
+
+          def description= new_description
+            @gapi.update! description: new_description
+          end
+
+          def mode
+            @gapi.mode
+          end
+
+          def mode= new_mode
+            @gapi.update! mode: verify_mode(new_mode)
+          end
+
+          def fields
+            @fields ||= Array(@gapi.fields).map { |f| Field.from_gapi f }
+          end
+
+          def fields= new_fields
+            @fields = new_fields
+          end
+
+          ##
+          # @private Make sure any fields are saved.
+          def check_for_changed_fields!
+            return if frozen?
+            fields.each(&:check_for_changed_fields!)
+            gapi_fields = Array(fields).map(&:to_gapi)
+            @gapi.update! fields: gapi_fields
+          end
+
+          # @private
+          def changed?
+            @original_json == to_gapi.to_json
+          end
+
+          # @private
+          def self.from_gapi gapi
+            new("to-be-replaced", "STRING").tap do |f|
+              f.instance_variable_set :@gapi, gapi
+              f.instance_variable_set :@original_json, gapi.to_json
+            end
+          end
+
+          # @private
+          def to_gapi
+            # make sure any changes are saved.
+            check_for_changed_fields!
+            @gapi
+          end
+
+          # @private
+          def == other
+            return false unless other.is_a? Field
+            to_gapi.to_h == other.to_gapi.to_h
+          end
+
+          protected
+
+          def verify_type type
+            upcase_type = type.to_s.upcase
+            unless TYPES.include? upcase_type
+              fail ArgumentError,
+                   "Type '#{upcase_type}' not found in #{TYPES.inspect}"
+            end
+            upcase_type
+          end
+
+          def verify_mode mode
+            upcase_mode = mode.to_s.upcase
+            unless MODES.include? upcase_mode
+              fail ArgumentError "Unable to determine mode for '#{mode}'"
+            end
+            upcase_mode
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -65,6 +65,17 @@ module Google
             end
           end
 
+          def headers
+            fields.map(&:name).map(&:to_sym)
+          end
+
+          def field name
+            f = fields.find { |fld| fld.name == name.to_s }
+            return nil if f.nil?
+            yield f if block_given?
+            f
+          end
+
           ##
           # Adds a string field to the schema.
           #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -367,7 +367,7 @@ module Google
               schema_builder = Schema.from_gapi empty_schema
             end
             yield schema_builder
-            schema_builder.check_for_mutated_schema!
+            # schema_builder.check_for_mutated_schema!
             if schema_builder.changed?
               @gapi.schema = schema_builder.to_gapi
               patch_gapi! :schema
@@ -1221,7 +1221,7 @@ module Google
           # Make sure any access changes are saved
           def check_for_mutated_schema!
             return if @schema.nil?
-            @schema.check_for_mutated_schema!
+            # @schema.check_for_mutated_schema!
             return unless @schema.changed?
             @gapi.schema = @schema.to_gapi
             patch_gapi! :schema

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -367,7 +367,6 @@ module Google
               schema_builder = Schema.from_gapi empty_schema
             end
             yield schema_builder
-            # schema_builder.check_for_mutated_schema!
             if schema_builder.changed?
               @gapi.schema = schema_builder.to_gapi
               patch_gapi! :schema
@@ -856,12 +855,6 @@ module Google
           end
         end
 
-        def resolve_legacy_sql legacy_sql, standard_sql
-          return legacy_sql unless legacy_sql.nil?
-          return !standard_sql unless standard_sql.nil?
-          false
-        end
-
         ##
         # Yielded to a block to accumulate changes for a patch request.
         class Updater < Table
@@ -1221,7 +1214,6 @@ module Google
           # Make sure any access changes are saved
           def check_for_mutated_schema!
             return if @schema.nil?
-            # @schema.check_for_mutated_schema!
             return unless @schema.changed?
             @gapi.schema = @schema.to_gapi
             patch_gapi! :schema

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -391,7 +391,7 @@ module Google
         # @!group Attributes
         #
         def headers
-          fields.map(&:name).map(&:to_sym)
+          schema.headers
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -856,6 +856,12 @@ module Google
           end
         end
 
+        def resolve_legacy_sql legacy_sql, standard_sql
+          return legacy_sql unless legacy_sql.nil?
+          return !standard_sql unless standard_sql.nil?
+          false
+        end
+
         ##
         # Yielded to a block to accumulate changes for a patch request.
         class Updater < Table

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -300,7 +300,7 @@ module Google
         # @!group Attributes
         #
         def headers
-          fields.map(&:name).map(&:to_sym)
+          schema.headers
         end
 
         ##

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -341,6 +341,20 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Schema::Field" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
+    end
+  end
+  doctest.before "Google::Cloud::Bigquery::Schema::Field#record" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::Table" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -102,52 +102,6 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]
   end
 
-  it "knows the raw, unformatted data" do
-    skip
-    mock = Minitest::Mock.new
-    bigquery.service.mocked_service = mock
-    mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
-
-    data = table.data
-    mock.verify
-
-    data.class.must_equal Google::Cloud::Bigquery::Data
-
-    data.raw.wont_be :nil?
-    data.raw.count.must_equal data.count
-    data.raw[0][0].must_equal data[0]["name"].to_s
-    data.raw[0][1].must_equal data[0]["age"].to_s
-    data.raw[0][2].must_equal data[0]["score"].to_s
-    data.raw[0][3].must_equal data[0]["active"].to_s
-    data.raw[0][4].must_equal Base64.strict_encode64(data[0]["avatar"].read)
-    data.raw[0][5].must_equal "1482670800.0"
-    data.raw[0][6].must_equal "04:00:00"
-    data.raw[0][7].must_equal "2017-01-01 00:00:00"
-    data.raw[0][8].must_equal "1968-10-20"
-
-    data.raw[1][0].must_equal data[1]["name"].to_s
-    data.raw[1][1].must_equal data[1]["age"].to_s
-    data.raw[1][2].must_equal data[1]["score"].to_s
-    data.raw[1][3].must_equal data[1]["active"].to_s
-    data.raw[1][4].must_equal nil
-    data.raw[1][5].must_equal nil
-    data.raw[1][6].must_equal "04:32:10.555555"
-    data.raw[1][7].must_equal nil
-    data.raw[1][8].must_equal nil
-
-    data.raw[2][0].must_equal data[2]["name"].to_s
-    data.raw[2][1].must_equal nil
-    data.raw[2][2].must_equal nil
-    data.raw[2][3].must_equal nil
-    data.raw[2][4].must_equal nil
-    data.raw[2][5].must_equal nil
-    data.raw[2][6].must_equal nil
-    data.raw[2][7].must_equal nil
-    data.raw[2][8].must_equal nil
-  end
-
   it "handles missing rows and fields" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -87,6 +87,21 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.total.must_equal 3
   end
 
+  it "knows schema, fields, and headers" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :list_table_data,
+                table_data_gapi,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+
+    data = table.data
+    mock.verify
+
+    data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    data.fields.must_equal data.schema.fields
+    data.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+  end
+
   it "knows the raw, unformatted data" do
     skip
     mock = Minitest::Mock.new
@@ -131,23 +146,6 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data.raw[2][6].must_equal nil
     data.raw[2][7].must_equal nil
     data.raw[2][8].must_equal nil
-  end
-
-  it "knows the data metadata" do
-    mock = Minitest::Mock.new
-    bigquery.service.mocked_service = mock
-    mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
-
-    data = table.data
-    mock.verify
-
-    data.class.must_equal Google::Cloud::Bigquery::Data
-    data.kind.must_equal "bigquery#tableDataList"
-    data.etag.must_equal "etag1234567890"
-    data.token.must_equal "token1234567890"
-    data.total.must_equal 3
   end
 
   it "handles missing rows and fields" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -27,11 +27,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:table_schema) {
     {
       fields: [
-        { mode: "REQUIRED", name: "name", type: "STRING"},
-        { mode: "NULLABLE", name: "age", type: "INTEGER"},
-        { mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0"},
-        { mode: "NULLABLE", name: "active", type: "BOOLEAN"},
-        { mode: "NULLABLE", name: "avatar", type: "BYTES"}
+        { mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: [] },
+        { mode: "NULLABLE", name: "age", type: "INTEGER", description: nil, fields: [] },
+        { mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0", fields: [] },
+        { mode: "NULLABLE", name: "active", type: "BOOLEAN", description: nil, fields: [] },
+        { mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [] }
       ]
     }
   }
@@ -174,44 +174,6 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     table.wont_be :view?
   end
 
-  it "creates a table with a fields option" do
-    mock = Minitest::Mock.new
-    insert_table = Google::Apis::BigqueryV2::Table.new(
-      table_reference: Google::Apis::BigqueryV2::TableReference.new(
-        project_id: project, dataset_id: dataset_id, table_id: table_id),
-      friendly_name: table_name,
-      description: table_description,
-      schema: table_schema_gapi)
-    return_table = create_table_gapi table_id, table_name, table_description
-    return_table.schema = table_schema_gapi
-    mock.expect :insert_table, return_table,
-      [project, dataset_id, insert_table]
-    dataset.service.mocked_service = mock
-
-    schema_fields = [
-      Google::Cloud::Bigquery::Schema::Field.new("name", "STRING", mode: :required),
-      Google::Cloud::Bigquery::Schema::Field.new("age", :INTEGER),
-      Google::Cloud::Bigquery::Schema::Field.new("score", "float", description: "A score from 0.0 to 10.0"),
-      Google::Cloud::Bigquery::Schema::Field.new("active", :boolean),
-      Google::Cloud::Bigquery::Schema::Field.new("avatar", :bytes)
-    ]
-    table = dataset.create_table table_id,
-                                 name: table_name,
-                                 description: table_description,
-                                 fields: schema_fields
-
-    mock.verify
-
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
-    table.table_id.must_equal table_id
-    table.name.must_equal table_name
-    table.description.must_equal table_description
-    table.schema.wont_be :empty?
-    table.schema.must_be :frozen?
-    table.must_be :table?
-    table.wont_be :view?
-  end
-
   it "creates a table with a schema inline" do
     mock = Minitest::Mock.new
     insert_table = Google::Apis::BigqueryV2::Table.new(
@@ -254,18 +216,18 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       table_reference: Google::Apis::BigqueryV2::TableReference.new(
         project_id: project, dataset_id: dataset_id, table_id: table_id),
       schema: Google::Apis::BigqueryV2::TableSchema.new(fields: [
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "birthday",      type: "DATE", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REPEATED", name: "cities_lived",  type: "RECORD", fields: [
-          Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "place",           type: "STRING",  fields: []),
-          Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "number_of_years", type: "INTEGER", fields: [])])
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "birthday",      type: "DATE", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REPEATED", name: "cities_lived",  type: "RECORD", description: nil, fields: [
+          Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "place",           type: "STRING",  description: nil, fields: []),
+          Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "number_of_years", type: "INTEGER", description: nil, fields: [])])
         ]))
     return_table = create_table_gapi table_id, table_name, table_description
     return_table.schema = table_schema_gapi
@@ -285,7 +247,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema.date "birthday"
       schema.record "cities_lived", mode: :repeated do |nested_schema|
         nested_schema.string "place"
-        nested_schema.integer "number_of_years"\
+        nested_schema.integer "number_of_years"
       end
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_data_test.rb
@@ -65,42 +65,6 @@ describe Google::Cloud::Bigquery::QueryData, :mock_bigquery do
     query_data.cache_hit?.must_equal false
   end
 
-  it "knows the raw, unformatted data" do
-    skip
-    query_data.raw.wont_be :nil?
-    query_data.raw.count.must_equal query_data.count
-
-    query_data.raw[0][0].must_equal query_data[0]["name"].to_s
-    query_data.raw[0][1].must_equal query_data[0]["age"].to_s
-    query_data.raw[0][2].must_equal query_data[0]["score"].to_s
-    query_data.raw[0][3].must_equal query_data[0]["active"].to_s
-    query_data.raw[0][4].must_equal Base64.strict_encode64(query_data[0]["avatar"].read)
-    query_data.raw[0][5].must_equal "1482670800.0"
-    query_data.raw[0][6].must_equal "04:00:00"
-    query_data.raw[0][7].must_equal "2017-01-01 00:00:00"
-    query_data.raw[0][8].must_equal "1968-10-20"
-
-    query_data.raw[1][0].must_equal query_data[1]["name"].to_s
-    query_data.raw[1][1].must_equal query_data[1]["age"].to_s
-    query_data.raw[1][2].must_equal query_data[1]["score"].to_s
-    query_data.raw[1][3].must_equal query_data[1]["active"].to_s
-    query_data.raw[1][4].must_equal nil
-    query_data.raw[1][5].must_equal nil
-    query_data.raw[1][6].must_equal "04:32:10.555555"
-    query_data.raw[1][7].must_equal nil
-    query_data.raw[1][8].must_equal nil
-
-    query_data.raw[2][0].must_equal query_data[2]["name"].to_s
-    query_data.raw[2][1].must_equal nil
-    query_data.raw[2][2].must_equal nil
-    query_data.raw[2][3].must_equal nil
-    query_data.raw[2][4].must_equal nil
-    query_data.raw[2][5].must_equal nil
-    query_data.raw[2][6].must_equal nil
-    query_data.raw[2][7].must_equal nil
-    query_data.raw[2][8].must_equal nil
-  end
-
   it "knows schema, fields, and headers" do
     query_data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     query_data.fields.must_equal query_data.schema.fields

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -34,16 +34,16 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
 
   let(:new_table_hash) { random_table_hash dataset, table_id, table_name, description }
 
-  let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", fields: [] }
+  let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [] }
   let(:field_integer_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", mode: "NULLABLE", fields: [] }
-  let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", fields: [] }
-  let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", fields: [] }
-  let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", fields: [] }
-  let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", fields: [] }
-  let(:field_time_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "duration", type: "TIME", mode: "NULLABLE", fields: [] }
-  let(:field_datetime_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "target_end", type: "DATETIME", mode: "NULLABLE", fields: [] }
-  let(:field_date_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "birthday", type: "DATE", mode: "NULLABLE", fields: [] }
-  let(:field_record_repeated_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "cities_lived", type: "RECORD", mode: "REPEATED", fields: [ field_integer_gapi, field_timestamp_gapi ] }
+  let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_time_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "duration", type: "TIME", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_datetime_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "target_end", type: "DATETIME", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_date_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "birthday", type: "DATE", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_record_repeated_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "cities_lived", type: "RECORD", mode: "REPEATED", description: nil, fields: [ field_integer_gapi, field_timestamp_gapi ] }
 
   let(:field_string_required) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_string_required_gapi }
   let(:field_integer) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_integer_gapi }
@@ -147,6 +147,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     end_date_timestamp_gapi = field_timestamp_gapi.dup
     end_date_timestamp_gapi.name = "end_date"
     new_schema_gapi = table_gapi.schema.dup
+    new_schema_gapi.fields = table_gapi.schema.fields.dup
     new_schema_gapi.fields << end_date_timestamp_gapi
     returned_table_gapi = table_gapi.dup
     returned_table_gapi.schema = new_schema_gapi
@@ -214,9 +215,9 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     mock = Minitest::Mock.new
     nested_schema_hash = {
       fields: [
-        { name: "first_name", type: "STRING", mode: "REQUIRED", fields: [] },
-        { name: "countries_lived", type: "RECORD", mode: "REPEATED", fields: [
-            { name: "cities_lived", type: "RECORD", mode: "REPEATED", fields: [
+        { name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [] },
+        { name: "countries_lived", type: "RECORD", mode: "REPEATED", description: nil, fields: [
+            { name: "cities_lived", type: "RECORD", mode: "REPEATED", description: nil, fields: [
                 { mode: "NULLABLE", name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", fields: [] }
               ]
             }


### PR DESCRIPTION
This PR refactors the internals of Schema to make maintenance easier. Since we are in the midst of other breaking changes, some changes have been made here. The biggest ones are:

* Nested fields no longer yield a Schema object, but the Field object
* Field has been updated to act like Schema, and can add nested fields
* Removal of `Schema#fields=`, users should use the API to modify fields
* Removal of `fields` argument on `Dataset#create_table`, users should use the yielded `table` object to define the schema
* Remove `Data#raw` because we now have much higher confidence in the format of the data
* Additional convenience methods
* Updated documentation