### PR TITLE
Correct encoding of BYTES parameters

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
@@ -133,8 +133,7 @@ module Google
               obj.rewind
               content = obj.read.force_encoding("ASCII-8BIT")
               encoded_content = Base64.strict_encode64(content)
-              [Google::Protobuf::Value.new(string_value: encoded_content),
-               Google::Spanner::V1::Type.new(code: :BYTES)]
+              Google::Protobuf::Value.new(string_value: encoded_content)
             else
               raise ArgumentError,
                     "A value of type #{obj.class} is not supported."

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/raw_to_params_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/raw_to_params_test.rb
@@ -116,6 +116,16 @@ describe Google::Cloud::Spanner::Convert, :raw_to_params, :mock_spanner do
                                             Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRING))] })
   end
 
+  it "converts an Array of IO-ish values" do
+    array = [StringIO.new("foo"), StringIO.new("bar"), StringIO.new("baz")]
+
+    foo, bar, baz = %w[ foo bar baz ].map {|raw| Base64.strict_encode64(raw) }
+
+    combined_params = Google::Cloud::Spanner::Convert.raw_to_params list: array
+    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: foo), Google::Protobuf::Value.new(string_value: bar), Google::Protobuf::Value.new(string_value: baz)])),
+                                            Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :BYTES))] })
+  end
+
   it "converts a simple Hash value" do
     combined_params = Google::Cloud::Spanner::Convert.raw_to_params settings: { foo: :bar }
     combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"foo"=>Google::Protobuf::Value.new(string_value: "bar")})),


### PR DESCRIPTION
This change allows users to send BYTES fields in parameter lists,
which are necessary in `google.spanner.v1.Write.values` or
`google.spanner.v1.KeySet.keys` for example.

Such fields used to be rejected, saying

> TypeError: Invalid type Array to assign to submessage field.