### PR TITLE
Logging Entry new attributes

### DIFF
--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -28,11 +28,11 @@ Style/EmptyLines:
 Style/EmptyElse:
   Enabled: false
 Metrics/CyclomaticComplexity:
-  Max: 10
+  Max: 12
 Metrics/PerceivedComplexity:
-  Max: 10
+  Max: 12
 Metrics/AbcSize:
-  Max: 25
+  Max: 28
 Metrics/MethodLength:
   Max: 20
 Metrics/ParameterLists:

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -17,6 +17,7 @@ require "google/cloud/logging/convert"
 require "google/cloud/logging/resource"
 require "google/cloud/logging/entry/http_request"
 require "google/cloud/logging/entry/operation"
+require "google/cloud/logging/entry/source_location"
 require "google/cloud/logging/entry/list"
 
 module Google
@@ -67,6 +68,7 @@ module Google
           @http_request = HttpRequest.new
           @operation = Operation.new
           @severity = :DEFAULT
+          @source_location = SourceLocation.new
         end
 
         ##
@@ -359,6 +361,12 @@ module Google
         attr_accessor :trace
 
         ##
+        # Source code location information associated with the log entry, if
+        # any.
+        # @return [Google::Cloud::Logging::Entry::SourceLocation]
+        attr_reader :source_location
+
+        ##
         # @private Determines if the Entry has any data.
         def empty?
           log_name.nil? &&
@@ -369,7 +377,8 @@ module Google
             resource.empty? &&
             http_request.empty? &&
             operation.empty? &&
-            trace.nil?
+            trace.nil? &&
+            source_location.empty?
         end
 
         ##
@@ -385,7 +394,8 @@ module Google
             resource: resource.to_grpc,
             http_request: http_request.to_grpc,
             operation: operation.to_grpc,
-            trace: trace.to_s
+            trace: trace.to_s,
+            source_location: source_location.to_grpc
           )
           # Add payload
           append_payload grpc
@@ -410,6 +420,10 @@ module Google
             e.instance_variable_set "@operation",
                                     Operation.from_grpc(grpc.operation)
             e.trace = grpc.trace
+            e.instance_variable_set "@source_location",
+                                    SourceLocation.from_grpc(
+                                      grpc.source_location
+                                    )
           end
         end
 

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -350,6 +350,15 @@ module Google
         attr_reader :operation
 
         ##
+        # Resource name of the trace associated with the log entry, if any. If
+        # it contains a relative resource name, the name is assumed to be
+        # relative to `//tracing.googleapis.com`. Example:
+        # `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
+        # Optional.
+        # @return [String]
+        attr_accessor :trace
+
+        ##
         # @private Determines if the Entry has any data.
         def empty?
           log_name.nil? &&
@@ -359,7 +368,8 @@ module Google
             payload.nil? &&
             resource.empty? &&
             http_request.empty? &&
-            operation.empty?
+            operation.empty? &&
+            trace.nil?
         end
 
         ##
@@ -374,7 +384,8 @@ module Google
             labels: labels_grpc,
             resource: resource.to_grpc,
             http_request: http_request.to_grpc,
-            operation: operation.to_grpc
+            operation: operation.to_grpc,
+            trace: trace.to_s
           )
           # Add payload
           append_payload grpc
@@ -398,6 +409,7 @@ module Google
                                     HttpRequest.from_grpc(grpc.http_request)
             e.instance_variable_set "@operation",
                                     Operation.from_grpc(grpc.operation)
+            e.trace = grpc.trace
           end
         end
 

--- a/google-cloud-logging/lib/google/cloud/logging/entry/operation.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/operation.rb
@@ -74,7 +74,7 @@ module Google
           end
 
           ##
-          # @private New HttpRequest from a
+          # @private New Google::Cloud::Logging::Entry::Operation from a
           # Google::Logging::V2::LogEntryOperation object.
           def self.from_grpc grpc
             return new if grpc.nil?

--- a/google-cloud-logging/lib/google/cloud/logging/entry/source_location.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/source_location.rb
@@ -69,7 +69,7 @@ module Google
           end
 
           ##
-          # @private New HttpRequest from a
+          # @private New Google::Cloud::Logging::Entry::SourceLocation from a
           # Google::Logging::V2::LogEntrySourceLocation object.
           def self.from_grpc grpc
             return new if grpc.nil?

--- a/google-cloud-logging/lib/google/cloud/logging/entry/source_location.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/source_location.rb
@@ -1,0 +1,86 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Logging
+      class Entry
+        ##
+        # # SourceLocation
+        #
+        # Additional information about the source code location that produced
+        # the log entry.
+        #
+        # See also {Google::Cloud::Logging::Entry#source_location}.
+        #
+        class SourceLocation
+          ##
+          # @private Create an empty SourceLocation object.
+          def initialize
+          end
+
+          ##
+          # Source file name. Depending on the runtime environment, this might
+          # be a simple name or a fully-qualified name. Optional.
+          attr_accessor :file
+
+          ##
+          # Line within the source file. 1-based; `0` indicates no line number
+          # available. Optional.
+          attr_accessor :line
+
+          ##
+          # Human-readable name of the function or method being invoked, with
+          # optional context such as the class or package name. This information
+          # may be used in contexts such as the logs viewer, where a file and
+          # line number are less meaningful. Optional.
+          attr_accessor :function
+
+          ##
+          # @private Determines if the SourceLocation has any data.
+          def empty?
+            file.nil? &&
+              line.nil? &&
+              function.nil?
+          end
+
+          ##
+          # @private Exports the SourceLocation to a
+          # Google::Logging::V2::LogEntrySourceLocation object.
+          def to_grpc
+            return nil if empty?
+            Google::Logging::V2::LogEntrySourceLocation.new(
+              file:       file.to_s,
+              line:       line,
+              function:   function.to_s
+            )
+          end
+
+          ##
+          # @private New HttpRequest from a
+          # Google::Logging::V2::LogEntrySourceLocation object.
+          def self.from_grpc grpc
+            return new if grpc.nil?
+            new.tap do |o|
+              o.file       = grpc.file
+              o.line       = grpc.line
+              o.function   = grpc.function
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
@@ -33,6 +33,7 @@ describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
     grpc.proto_payload.must_be :nil?
     grpc.http_request.must_be :nil?
     grpc.operation.must_be :nil?
+    grpc.trace.must_be :empty?
   end
 
   it "returns the correct data when data is added" do
@@ -66,6 +67,8 @@ describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
     entry.operation.first = true
     entry.operation.last = false
 
+    entry.trace = "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
+
     grpc = entry.to_grpc
 
     grpc.log_name.must_equal "projects/test/logs/testlog"
@@ -98,5 +101,7 @@ describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
     grpc.operation.producer.must_equal "NewApp.NewClass#new_method"
     grpc.operation.first.must_equal true
     grpc.operation.last.must_equal false
+
+    grpc.trace.must_equal "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
@@ -34,6 +34,7 @@ describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
     grpc.http_request.must_be :nil?
     grpc.operation.must_be :nil?
     grpc.trace.must_be :empty?
+    grpc.source_location.must_be :nil?
   end
 
   it "returns the correct data when data is added" do
@@ -69,6 +70,10 @@ describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
 
     entry.trace = "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
 
+    entry.source_location.file = "my_app/my_class.rb"
+    entry.source_location.line = 123
+    entry.source_location.function = "#my_method"
+
     grpc = entry.to_grpc
 
     grpc.log_name.must_equal "projects/test/logs/testlog"
@@ -103,5 +108,9 @@ describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
     grpc.operation.last.must_equal false
 
     grpc.trace.must_equal "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
+
+    grpc.source_location.file.must_equal "my_app/my_class.rb"
+    grpc.source_location.line.must_equal 123
+    grpc.source_location.function.must_equal "#my_method"
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry_test.rb
@@ -33,6 +33,7 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
     entry.http_request.must_be_kind_of    Google::Cloud::Logging::Entry::HttpRequest
     entry.operation.must_be_kind_of       Google::Cloud::Logging::Entry::Operation
     entry.trace.must_equal                "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
+    entry.source_location.must_be_kind_of       Google::Cloud::Logging::Entry::SourceLocation
   end
 
   it "timestamp gives the correct time when a timestamp is present" do
@@ -140,5 +141,21 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
     entry.operation.producer.must_be :nil?
     entry.operation.first.must_be :nil?
     entry.operation.last.must_be :nil?
+  end
+
+  it "has the correct source location attributes" do
+    entry.source_location.file.must_equal "my_app/my_class.rb"
+    entry.source_location.line.must_equal 321
+    entry.source_location.function.must_equal "#my_method"
+  end
+
+  it "has a source location even if the Google API object doesn't have it" do
+    entry_hash.delete "source_location"
+
+    entry.source_location.wont_be :nil?
+    entry.source_location.must_be_kind_of Google::Cloud::Logging::Entry::SourceLocation
+    entry.source_location.file.must_be :nil?
+    entry.source_location.line.must_be :nil?
+    entry.source_location.function.must_be :nil?
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry_test.rb
@@ -32,6 +32,7 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
     entry.payload.must_equal              "payload"
     entry.http_request.must_be_kind_of    Google::Cloud::Logging::Entry::HttpRequest
     entry.operation.must_be_kind_of       Google::Cloud::Logging::Entry::Operation
+    entry.trace.must_equal                "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
   end
 
   it "timestamp gives the correct time when a timestamp is present" do

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -79,7 +79,8 @@ class MockLogging < Minitest::Spec
       "text_payload" => "payload",
       "http_request" => random_http_request_hash,
       "operation"    => random_operation_hash,
-      "trace"        => "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
+      "trace"        => "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824",
+      "source_location"    => random_source_location_hash
     }
   end
 
@@ -104,6 +105,14 @@ class MockLogging < Minitest::Spec
       "producer" => "MyApp.MyClass#my_method",
       "first" => false,
       "last" => false
+    }
+  end
+
+  def random_source_location_hash
+    {
+      "file" => "my_app/my_class.rb",
+      "line" => 321,
+      "function" => "#my_method"
     }
   end
 

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -78,7 +78,8 @@ class MockLogging < Minitest::Spec
       },
       "text_payload" => "payload",
       "http_request" => random_http_request_hash,
-      "operation"    => random_operation_hash
+      "operation"    => random_operation_hash,
+      "trace"        => "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
     }
   end
 


### PR DESCRIPTION
This PR adds support for two new attributes in the protobuf definitions for LogEntry that were added in #1272.

[closes #1279, closes #1280]