### PR TITLE
Add Project#logs

### DIFF
--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -134,12 +134,15 @@ describe Google::Cloud::Logging, :logging do
 
     let(:resource) { logging.resource "gce_instance", zone: "global", instance_id: "3" }
 
-    it "writes and lists log entries" do
+    it "writes entries and lists entries and logs" do
       # logging.write_entries [entry1, entry2, entry3], resource: resource
       logging.write_entries [entry1, entry2], resource: resource
 
       logging.entries.wont_be :empty?
       logging.entries(max: 1).length.must_equal 1
+
+      logging.logs.wont_be :empty?
+      logging.logs(max: 1).length.must_equal 1
     end
   end
 

--- a/google-cloud-logging/lib/google/cloud/logging/log/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/log/list.rb
@@ -1,0 +1,155 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "delegate"
+
+module Google
+  module Cloud
+    module Logging
+      class Log
+        ##
+        # Log::List is a special case Array with additional values.
+        class List < DelegateClass(::Array)
+          ##
+          # If not empty, indicates that there are more records that match
+          # the request and this value should be passed to continue.
+          attr_accessor :token
+
+          ##
+          # @private Create a new Log::List with an array of log names.
+          def initialize arr = []
+            super arr
+          end
+
+          ##
+          # Whether there is a next page of logs.
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/logging"
+          #
+          #   logging = Google::Cloud::Logging.new
+          #
+          #   logs = logging.logs
+          #   if logs.next?
+          #     next_logs = logs.next
+          #   end
+          #
+          def next?
+            !token.nil?
+          end
+
+          ##
+          # Retrieve the next page of logs.
+          #
+          # @return [Sink::List]
+          #
+          # @example
+          #   require "google/cloud/logging"
+          #
+          #   logging = Google::Cloud::Logging.new
+          #
+          #   logs = logging.logs
+          #   if logs.next?
+          #     next_logs = logs.next
+          #   end
+          #
+          def next
+            return nil unless next?
+            ensure_service!
+            grpc = @service.list_logs token: token, resource: @resource,
+                                      max: @max
+            self.class.from_grpc grpc, @service
+          end
+
+          ##
+          # Retrieves all log names by repeatedly loading {#next} until
+          # {#next?} returns `false`. Calls the given block once for each log
+          # name, which is passed as the parameter.
+          #
+          # An Enumerator is returned if no block is given.
+          #
+          # This method may make several API calls until all log names are
+          # retrieved. Be sure to use as narrow a search criteria as possible.
+          # Please use with caution.
+          #
+          # @param [Integer] request_limit The upper limit of API requests to
+          #   make to load all log names. Default is no limit.
+          # @yield [log] The block for accessing each log name.
+          # @yieldparam [String] log The log name.
+          #
+          # @return [Enumerator]
+          #
+          # @example Iterating each log name by passing a block:
+          #   require "google/cloud/logging"
+          #
+          #   logging = Google::Cloud::Logging.new
+          #   logs = logging.logs
+          #
+          #   logs.all { |l| puts l }
+          #
+          # @example Limit the number of API calls made:
+          #   require "google/cloud/logging"
+          #
+          #   logging = Google::Cloud::Logging.new
+          #   logs = logging.logs
+          #
+          #   logs.all(request_limit: 10) { |l| puts l }
+          #
+          def all request_limit: nil
+            request_limit = request_limit.to_i if request_limit
+            unless block_given?
+              return enum_for(:all, request_limit: request_limit)
+            end
+            results = self
+            loop do
+              results.each { |r| yield r }
+              if request_limit
+                request_limit -= 1
+                break if request_limit < 0
+              end
+              break unless results.next?
+              results = results.next
+            end
+          end
+
+          ##
+          # @private New Log::List from a
+          # Google::Logging::V2::ListLogsResponse object.
+          def self.from_grpc grpc_list, service, resource: nil, max: nil
+            logs = new(Array(grpc_list.log_names))
+            token = grpc_list.next_page_token
+            token = nil if token == ""
+            logs.instance_variable_set "@token", token
+            logs.instance_variable_set "@service", service
+            logs.instance_variable_set "@resource", resource
+            logs.instance_variable_set "@max", max
+            logs
+          end
+
+          protected
+
+          ##
+          # @private Raise an error unless an active connection to the service
+          # is available.
+          def ensure_service!
+            fail "Must have active connection to service" unless @service
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -17,6 +17,7 @@ require "google/cloud/errors"
 require "google/cloud/core/environment"
 require "google/cloud/logging/service"
 require "google/cloud/logging/credentials"
+require "google/cloud/logging/log/list"
 require "google/cloud/logging/entry"
 require "google/cloud/logging/resource_descriptor"
 require "google/cloud/logging/sink"
@@ -381,6 +382,48 @@ module Google
         def logger log_name, resource, labels = {}
           Logger.new shared_async_writer, log_name, resource, labels
         end
+
+        ##
+        # Lists log names. Use this method to retrieve log names from Cloud
+        # Logging.
+        #
+        # @param [String] resource The cloud resource from which to retrieve log
+        #   names. Optional. If `nil`, the ID of the receiving project instance
+        #   will be used. Examples: `"projects/my-project-1A"`,
+        #   `"projects/1234567890"`.
+        # @param [String] token A previously-returned page token representing
+        #   part of the larger set of results to view.
+        # @param [Integer] max Maximum number of log names to return.
+        #
+        # @return [Array<String>] A list of log names. For example,
+        #   `projects/my-project/syslog` or
+        #   `organizations/123/cloudresourcemanager.googleapis.com%2Factivity`.
+        #   (See {Google::Cloud::Logging::Log::List})
+        #
+        # @example
+        #   require "google/cloud/logging"
+        #
+        #   logging = Google::Cloud::Logging.new
+        #   logs = logging.logs
+        #   logs.each { |l| puts l }
+        #
+        # @example Retrieve all log names: (See {Log::List#all})
+        #   require "google/cloud/logging"
+        #
+        #   logging = Google::Cloud::Logging.new
+        #   logs = logging.logs
+        #
+        #   logs.all { |l| puts l }
+        #
+        def logs resource: nil, token: nil, max: nil
+          ensure_service!
+          list_grpc = service.list_logs resource: resource, token: token,
+                                        max: max
+          Log::List.from_grpc list_grpc, service, resource: resource, max: max
+        end
+        alias_method :find_logs, :logs
+        alias_method :log_names, :logs
+        alias_method :find_log_names, :logs
 
         ##
         # Deletes a log and all its log entries. The log will reappear if it

--- a/google-cloud-logging/lib/google/cloud/logging/service.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/service.rb
@@ -129,6 +129,21 @@ module Google
           end
         end
 
+        def list_logs resource: nil, token: nil, max: nil
+          parent = resource || "projects/#{@project}"
+          call_opts = default_options
+          if token
+            call_opts = Google::Gax::CallOptions.new(kwargs: default_headers,
+                                                     page_token: token)
+          end
+
+          execute do
+            paged_enum = logging.list_logs parent, page_size: max,
+                                                   options: call_opts
+            paged_enum.page.response
+          end
+        end
+
         def delete_log name
           execute do
             logging.delete_log log_path(name), options: default_options

--- a/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
@@ -1,0 +1,191 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
+  it "lists logs" do
+    num_logs = 3
+
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(num_logs))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_logs, list_res, ["projects/#{project}", page_size: nil, options: default_options]
+    logging.service.mocked_logging = mock
+
+    logs = logging.logs
+
+    mock.verify
+
+    logs.each { |m| m.must_be_kind_of String }
+    logs.size.must_equal num_logs
+  end
+
+  it "lists logs with find_logs alias" do
+    num_logs = 3
+
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(num_logs))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_logs, list_res, ["projects/#{project}", page_size: nil, options: default_options]
+    logging.service.mocked_logging = mock
+
+    logs = logging.find_logs
+
+    mock.verify
+
+    logs.each { |m| m.must_be_kind_of String }
+    logs.size.must_equal num_logs
+  end
+
+  it "paginates logs" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(2))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
+    mock.expect :list_logs, second_list_res, ["projects/#{project}", page_size: nil, options: token_options("next_page_token")]
+    logging.service.mocked_logging = mock
+
+    first_logs = logging.logs
+    second_logs = logging.logs token: first_logs.token
+
+    mock.verify
+
+    first_logs.each { |m| m.must_be_kind_of String }
+    first_logs.count.must_equal 3
+    first_logs.token.wont_be :nil?
+    first_logs.token.must_equal "next_page_token"
+
+    second_logs.each { |m| m.must_be_kind_of String }
+    second_logs.count.must_equal 2
+    second_logs.token.must_be :nil?
+  end
+
+  it "paginates logs using next? and next" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(2))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
+    mock.expect :list_logs, second_list_res, ["projects/#{project}", page_size: nil, options: token_options("next_page_token")]
+    logging.service.mocked_logging = mock
+
+    first_logs = logging.logs
+    second_logs = first_logs.next
+
+    mock.verify
+
+    first_logs.each { |m| m.must_be_kind_of String }
+    first_logs.count.must_equal 3
+    first_logs.next?.must_equal true #must_be :next?
+
+    second_logs.each { |m| m.must_be_kind_of String }
+    second_logs.count.must_equal 2
+    second_logs.next?.must_equal false #wont_be :next?
+  end
+
+  it "paginates logs using all" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(2))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
+    mock.expect :list_logs, second_list_res, ["projects/#{project}", page_size: nil, options: token_options("next_page_token")]
+    logging.service.mocked_logging = mock
+
+    all_logs = logging.logs.all.to_a
+
+    mock.verify
+
+    all_logs.each { |m| m.must_be_kind_of String }
+    all_logs.count.must_equal 5
+  end
+
+  it "paginates logs using all using Enumerator" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "second_page_token"))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
+    mock.expect :list_logs, second_list_res, ["projects/#{project}", page_size: nil, options: token_options("next_page_token")]
+    logging.service.mocked_logging = mock
+
+    all_logs = logging.logs.all.take(5)
+
+    mock.verify
+
+    all_logs.each { |m| m.must_be_kind_of String }
+    all_logs.count.must_equal 5
+  end
+
+  it "paginates logs using all with request_limit set" do
+    first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "second_page_token"))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_logs, first_list_res, ["projects/#{project}", page_size: nil, options: default_options]
+    mock.expect :list_logs, second_list_res, ["projects/#{project}", page_size: nil, options: token_options("next_page_token")]
+    logging.service.mocked_logging = mock
+
+    all_logs = logging.logs.all(request_limit: 1).to_a
+
+    mock.verify
+
+    all_logs.each { |m| m.must_be_kind_of String }
+    all_logs.count.must_equal 6
+  end
+
+  it "paginates logs with a resource" do
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_logs, list_res, ["projects/project1", page_size: nil, options: default_options]
+    logging.service.mocked_logging = mock
+
+    logs = logging.logs resource: "projects/project1"
+
+    mock.verify
+
+    logs.each { |m| m.must_be_kind_of String }
+    logs.count.must_equal 3
+    logs.token.wont_be :nil?
+    logs.token.must_equal "next_page_token"
+  end
+
+  it "paginates logs with max set" do
+    list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogsResponse.decode_json(list_logs_json(3, "next_page_token"))))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_logs, list_res, ["projects/#{project}", page_size: 3, options: default_options]
+
+    logging.service.mocked_logging = mock
+
+    logs = logging.logs max: 3
+
+    mock.verify
+
+    logs.each { |m| m.must_be_kind_of String }
+    logs.count.must_equal 3
+    logs.token.wont_be :nil?
+    logs.token.must_equal "next_page_token"
+  end
+
+  def list_logs_json count = 2, token = nil
+    {
+      log_names: count.times.map { "log-name" },
+      next_page_token: token
+    }.delete_if { |_, v| v.nil? }.to_json
+  end
+end


### PR DESCRIPTION
This PR adds `Project#logs` to retrieve paginated log names (strings) for the current project or another resource. It does not define a new `Log` class, but simply exposes the logs as string names.

[closes #1281]