### PR TITLE
Upload to Storage with IO

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -178,7 +178,8 @@ module Google
             content_encoding: content_encoding, crc32c: crc32c,
             content_language: content_language, metadata: metadata,
             storage_class: storage_class }.delete_if { |_k, v| v.nil? })
-          content_type ||= mime_type_for(Pathname(source).to_path)
+          content_type ||= mime_type_for(path || Pathname(source).to_path)
+
           execute do
             service.insert_object \
               bucket_name, file_obj,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -143,6 +143,28 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     end
   end
 
+  it "creates a file with a StringIO for file contents" do
+    new_file_name = random_file_path
+    new_file_contents = StringIO.new "Hello world"
+
+    mock = Minitest::Mock.new
+    mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
+      [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: new_file_contents, content_encoding: nil, content_type: "text/plain", options: {}]
+
+    bucket.service.mocked_service = mock
+
+    bucket.create_file new_file_contents, new_file_name
+
+    mock.verify
+  end
+
+  it "raises when creating a file with a StringIO and missing path" do
+    new_file_contents = StringIO.new "Hello world"
+
+    err = expect { bucket.create_file new_file_contents }.must_raise ArgumentError
+    err.message.must_equal "must provide path"
+  end
+
   it "creates a file with predefined acl" do
     new_file_name = random_file_path
 


### PR DESCRIPTION
Allow IO-ish objects to be uploaded to Storage to create new files. This looks to have been allowed since the Google Cloud API 0.10.0 release.