### PR TITLE
GAE Rails integration tests compatible with gcloud SDK v147

### DIFF
--- a/integration/deploy.rb
+++ b/integration/deploy.rb
@@ -31,12 +31,6 @@ def deploy_gae_flex app_dir
     last_gae_version = get_gae_versions.last
     sh "gcloud app deploy -q" do |ok, res|
       if ok
-        # GAE Flex has a bug that the service is really avaible shortly after
-        # the deployment commands returns successfully. So we explicitly sleeps
-        # for 30 seconds before accessing the GAE Flex service.
-        # TODO: Remove this sleep when GAE Flex deployment becomes smooth
-        sleep 30
-
         yield
 
         # Delete the last version of Google App Engine if successfully deployed

--- a/integration/rails4_app/app.yaml.example
+++ b/integration/rails4_app/app.yaml.example
@@ -1,5 +1,5 @@
 runtime: ruby
 env: flex
-entrypoint: cd integration/rails4_app; bundle install; bundle exec rackup -p 8080 config.ru
+entrypoint: bash -c "cd integration/rails4_app; bundle install; bundle exec rackup -p 8080 config.ru"
 health_check:
   enable_health_check: False

--- a/integration/rails5_app/app.yaml.example
+++ b/integration/rails5_app/app.yaml.example
@@ -1,5 +1,5 @@
 runtime: ruby
 env: flex
-entrypoint: cd integration/rails5_app; bundle install; bundle exec rackup -p 8080 config.ru
+entrypoint: bash -c "cd integration/rails5_app; bundle install; bundle exec rackup -p 8080 config.ru"
 health_check:
   enable_health_check: False


### PR DESCRIPTION
gcloud SDK starts to prepand `exec` in docker image entrypoint in version 147.0.0. This change has broken the GAE Rails integration test workflows. We can wrap the Rails test applications' entrypoints in `bash -c` to work around this change.

To test this change, upgrade gcloud SDK to version 147.0.0 or later, then run `rake integration:gae` and verify this task complete successfully.

I also noticed GAE Flex has fixed the load balancer unavailable right after deployment bug. So we can safely remove that `sleep` statement.