### PR TITLE
Update Datastore docs

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -61,7 +61,7 @@ module Google
     # Records, called "entities" in Datastore, are retrieved by using a key.
     # The key is more than a numeric identifier, it is a complex data structure
     # that can be used to model relationships. The simplest key has a string
-    # <tt>kind</tt> value, and either a numeric <tt>id</tt> value, or a string
+    # <tt>kind</tt> value and either a numeric <tt>id</tt> value or a string
     # <tt>name</tt> value. A single record can be retrieved by calling
     # {Google::Cloud::Datastore::Dataset#find} and passing the parts of the key:
     #
@@ -242,8 +242,8 @@ module Google
     #
     # Entities hold properties. A property has a name that is a string or
     # symbol, and a value that is an object. Most value objects are supported,
-    # including String, Integer, Date, Time, and even other entity or key
-    # objects. Changes to the entity's properties are persisted by calling
+    # including `String`, `Integer`, `Date`, `Time`, and even other entity or
+    # key objects. Changes to the entity's properties are persisted by calling
     # {Google::Cloud::Datastore::Dataset#save}.
     #
     # ```ruby
@@ -302,7 +302,7 @@ module Google
     #
     # ## Transactions
     #
-    # Complex logic can be wrapped in a Transaction. All queries and updates
+    # Complex logic can be wrapped in a transaction. All queries and updates
     # within the {Google::Cloud::Datastore::Dataset#transaction} block are run
     # within the transaction scope, and will be automatically committed when the
     # block completes.

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -35,10 +35,9 @@ module Google
       # Dataset is the data saved in a project's Datastore.
       # Dataset is analogous to a database in relational database world.
       #
-      # Google::Cloud::Datastore::Dataset is the main object for interacting
-      # with Google Datastore. {Google::Cloud::Datastore::Entity} objects are
-      # created, read, updated, and deleted by
-      # Google::Cloud::Datastore::Dataset.
+      # Dataset is the main object for interacting with Google Datastore.
+      # {Google::Cloud::Datastore::Entity} objects are created, read, updated,
+      # and deleted by Dataset.
       #
       # See {Google::Cloud#datastore}
       #

--- a/google-cloud-datastore/lib/google/cloud/datastore/key.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/key.rb
@@ -24,6 +24,9 @@ module Google
       # either a key name string, assigned explicitly by the application, or an
       # integer numeric ID, assigned automatically by Datastore.
       #
+      # @see https://cloud.google.com/datastore/docs/concepts/entities Entities,
+      #   Properties, and Keys
+      #
       # @example
       #   require "google/cloud/datastore"
       #


### PR DESCRIPTION
I manually tested the examples in the Datastore guide (`datastore.rb` docs) and all passed. This PR makes some minor docs updates. It makes no changes to the examples.

[closes #1338]