### PR TITLE
Allow file downloads using IO object

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -465,7 +465,9 @@ module Google
         # and you can read or update the metadata of an encrypted file without
         # providing the encryption key.
         #
-        # @param [String] file Path of the file on the filesystem to upload.
+        # @param [String, IO] file Path of the file on the filesystem to
+        #   upload. Can be an IO object, or IO-ish object like StringIO. If the
+        #   IO object does not have path, the path argument must be provided.
         # @param [String] path Path to store the file in Google Cloud Storage.
         # @param [String] acl A predefined set of access controls to apply to
         #   this file.

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -52,14 +52,24 @@ module Google
           end
 
           def self.md5_for local_file
-            ::File.open(Pathname(local_file).to_path, "rb") do |f|
-              ::Digest::MD5.file(f).base64digest
+            if local_file.respond_to? :path
+              ::File.open(Pathname(local_file).to_path, "rb") do |f|
+                ::Digest::MD5.file(f).base64digest
+              end
+            else # StringIO
+              local_file.rewind
+              ::Digest::MD5.base64digest local_file.read
             end
           end
 
           def self.crc32c_for local_file
-            ::File.open(Pathname(local_file).to_path, "rb") do |f|
-              ::Digest::CRC32c.file(f).base64digest
+            if local_file.respond_to? :path
+              ::File.open(Pathname(local_file).to_path, "rb") do |f|
+                ::Digest::CRC32c.file(f).base64digest
+              end
+            else # StringIO
+              local_file.rewind
+              ::Digest::CRC32c.base64digest local_file.read
             end
           end
         end


### PR DESCRIPTION
Add the ability for Storage File objects to be downloaded to an in-memory IO object instead of a File object that exists on the file system.

```ruby
require "google/cloud/storage"

storage = Google::Cloud::Storage.new
bucket = storage.bucket "my-bucket"

uploaded = bucket.create_file StringIO.new("Hello world!"),
                              "hello-world.txt"

downloaded = uploaded.download
downloaded.rewind
downloaded.read #=> "Hello world!"
```

[closes #1356]