### PR TITLE
Add Storage Project#signed_url

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -614,7 +614,7 @@ module Google
         # @see https://cloud.google.com/storage/docs/access-control#Signed-URLs
         #   Access Control Signed URLs guide
         #
-        # @param [String] path Path to of the file in Google Cloud Storage.
+        # @param [String] path Path to the file in Google Cloud Storage.
         # @param [String] method The HTTP verb to be used with the signed URL.
         #   Signed URLs can be used
         #   with `GET`, `HEAD`, `PUT`, and `DELETE` requests. Default is `GET`.
@@ -651,6 +651,7 @@ module Google
         #   bucket = storage.bucket "my-todo-app"
         #   shared_url = bucket.signed_url "avatars/heidi/400x400.png",
         #                                  method: "PUT",
+        #                                  content_type: "image/png",
         #                                  expires: 300 # 5 minutes from now
         #
         # @example Using the issuer and signing_key options:
@@ -707,7 +708,7 @@ module Google
         #
         # @see https://cloud.google.com/storage/docs/xml-api/post-object
         #
-        # @param [String] path Path to of the file in Google Cloud Storage.
+        # @param [String] path Path to the file in Google Cloud Storage.
         # @param [Hash] policy The security policy that describes what
         #   can and cannot be uploaded in the form. When provided,
         #   the PostObject fields will include a Signature based on the JSON

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -17,6 +17,7 @@ require "uri"
 require "google/cloud/storage/file/acl"
 require "google/cloud/storage/file/list"
 require "google/cloud/storage/file/verifier"
+require "google/cloud/storage/file/signer"
 
 module Google
   module Cloud
@@ -661,7 +662,8 @@ module Google
         #
         #   bucket = storage.bucket "my-todo-app"
         #   file = bucket.file "avatars/heidi/400x400.png"
-        #   shared_url = file.signed_url method: "GET",
+        #   shared_url = file.signed_url method: "PUT",
+        #                                content_type: "image/png",
         #                                expires: 300 # 5 minutes from now
         #
         # @example Using the `issuer` and `signing_key` options:
@@ -685,7 +687,7 @@ module Google
         #   shared_url = file.signed_url method: "GET",
         #                                headers: {
         #                                  "x-goog-acl" => "public-read",
-        #                                  "x-goog-meta-foo" => bar,baz"
+        #                                  "x-goog-meta-foo" => "bar,baz"
         #                                }
         #
         def signed_url method: nil, expires: nil, content_type: nil,
@@ -821,122 +823,6 @@ module Google
             "multi_regional" => "MULTI_REGIONAL",
             "regional" => "REGIONAL",
             "standard" => "STANDARD" }[str.to_s.downcase] || str.to_s
-        end
-
-        ##
-        # @private Create a signed_url for a file.
-        class Signer
-          def initialize bucket, path, service
-            @bucket = bucket
-            @path = path
-            @service = service
-          end
-
-          def self.from_file file
-            new file.bucket, file.name, file.service
-          end
-
-          def self.from_bucket bucket, path
-            new bucket.name, path, bucket.service
-          end
-
-          ##
-          # The external path to the file.
-          def ext_path
-            URI.escape "/#{@bucket}/#{@path}"
-          end
-
-          ##
-          # The external url to the file.
-          def ext_url
-            "#{GOOGLEAPIS_URL}#{ext_path}"
-          end
-
-          def apply_option_defaults options
-            adjusted_expires = (Time.now.utc + (options[:expires] || 300)).to_i
-            options[:expires] = adjusted_expires
-            options[:method]  ||= "GET"
-            options
-          end
-
-          def signature_str options
-            [options[:method], options[:content_md5],
-             options[:content_type], options[:expires],
-             format_extension_headers(options[:headers]) + ext_path].join "\n"
-          end
-
-          def determine_signing_key options = {}
-            options[:signing_key] || options[:private_key] ||
-              @service.credentials.signing_key
-          end
-
-          def determine_issuer options = {}
-            options[:issuer] || options[:client_email] ||
-              @service.credentials.issuer
-          end
-
-          def post_object options
-            options = apply_option_defaults options
-
-            fields = {
-              key: ext_path.sub("/", "")
-            }
-
-            p = options[:policy] || {}
-            fail "Policy must be given in a Hash" unless p.is_a? Hash
-
-            i = determine_issuer options
-            s = determine_signing_key options
-
-            fail SignedUrlUnavailable unless i && s
-
-            policy_str = p.to_json
-            policy = Base64.strict_encode64(policy_str).delete("\n")
-
-            signature = generate_signature s, policy
-
-            fields[:GoogleAccessId] = i
-            fields[:signature] = signature
-            fields[:policy] = policy
-
-            Google::Cloud::Storage::PostObject.new GOOGLEAPIS_URL, fields
-          end
-
-          def signed_url options
-            options = apply_option_defaults options
-
-            i = determine_issuer options
-            s = determine_signing_key options
-
-            fail SignedUrlUnavailable unless i && s
-
-            sig = generate_signature s, signature_str(options)
-            generate_signed_url i, sig, options[:expires]
-          end
-
-          def generate_signature signing_key, secret
-            unless signing_key.respond_to? :sign
-              signing_key = OpenSSL::PKey::RSA.new signing_key
-            end
-            signature = signing_key.sign OpenSSL::Digest::SHA256.new, secret
-            Base64.strict_encode64(signature).delete("\n")
-          end
-
-          def generate_signed_url issuer, signed_string, expires
-            "#{ext_url}?GoogleAccessId=#{CGI.escape issuer}" \
-              "&Expires=#{expires}" \
-              "&Signature=#{CGI.escape signed_string}"
-          end
-
-          def format_extension_headers headers
-            return "" if headers.nil?
-            fail "Headers must be given in a Hash" unless headers.is_a? Hash
-            flatten = headers.map do |key, value|
-              "#{key.to_s.downcase}:#{value.gsub(/\s+/, ' ')}\n"
-            end
-            flatten.reject! { |h| h.start_with? "x-goog-encryption-key" }
-            flatten.sort.join
-          end
         end
 
         ##

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
@@ -1,0 +1,142 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "base64"
+require "openssl"
+require "google/cloud/storage/errors"
+
+module Google
+  module Cloud
+    module Storage
+      class File
+        ##
+        # @private Create a signed_url for a file.
+        class Signer
+          def initialize bucket, path, service
+            @bucket = bucket
+            @path = path
+            @service = service
+          end
+
+          def self.from_file file
+            new file.bucket, file.name, file.service
+          end
+
+          def self.from_bucket bucket, path
+            new bucket.name, path, bucket.service
+          end
+
+          ##
+          # The external path to the file.
+          def ext_path
+            URI.escape "/#{@bucket}/#{@path}"
+          end
+
+          ##
+          # The external url to the file.
+          def ext_url
+            "#{GOOGLEAPIS_URL}#{ext_path}"
+          end
+
+          def apply_option_defaults options
+            adjusted_expires = (Time.now.utc + (options[:expires] || 300)).to_i
+            options[:expires] = adjusted_expires
+            options[:method]  ||= "GET"
+            options
+          end
+
+          def signature_str options
+            [options[:method], options[:content_md5],
+             options[:content_type], options[:expires],
+             format_extension_headers(options[:headers]) + ext_path].join "\n"
+          end
+
+          def determine_signing_key options = {}
+            options[:signing_key] || options[:private_key] ||
+              @service.credentials.signing_key
+          end
+
+          def determine_issuer options = {}
+            options[:issuer] || options[:client_email] ||
+              @service.credentials.issuer
+          end
+
+          def post_object options
+            options = apply_option_defaults options
+
+            fields = {
+              key: ext_path.sub("/", "")
+            }
+
+            p = options[:policy] || {}
+            fail "Policy must be given in a Hash" unless p.is_a? Hash
+
+            i = determine_issuer options
+            s = determine_signing_key options
+
+            fail SignedUrlUnavailable unless i && s
+
+            policy_str = p.to_json
+            policy = Base64.strict_encode64(policy_str).delete("\n")
+
+            signature = generate_signature s, policy
+
+            fields[:GoogleAccessId] = i
+            fields[:signature] = signature
+            fields[:policy] = policy
+
+            Google::Cloud::Storage::PostObject.new GOOGLEAPIS_URL, fields
+          end
+
+          def signed_url options
+            options = apply_option_defaults options
+
+            i = determine_issuer options
+            s = determine_signing_key options
+
+            fail SignedUrlUnavailable unless i && s
+
+            sig = generate_signature s, signature_str(options)
+            generate_signed_url i, sig, options[:expires]
+          end
+
+          def generate_signature signing_key, secret
+            unless signing_key.respond_to? :sign
+              signing_key = OpenSSL::PKey::RSA.new signing_key
+            end
+            signature = signing_key.sign OpenSSL::Digest::SHA256.new, secret
+            Base64.strict_encode64(signature).delete("\n")
+          end
+
+          def generate_signed_url issuer, signed_string, expires
+            "#{ext_url}?GoogleAccessId=#{CGI.escape issuer}" \
+              "&Expires=#{expires}" \
+              "&Signature=#{CGI.escape signed_string}"
+          end
+
+          def format_extension_headers headers
+            return "" if headers.nil?
+            fail "Headers must be given in a Hash" unless headers.is_a? Hash
+            flatten = headers.map do |key, value|
+              "#{key.to_s.downcase}:#{value.gsub(/\s+/, ' ')}\n"
+            end
+            flatten.reject! { |h| h.start_with? "x-goog-encryption-key" }
+            flatten.sort.join
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -26,13 +26,27 @@ class File
   end
 end
 
+class OpenSSL::PKey::RSA
+  def self.new *args
+    "rsa key"
+  end
+end
+
 module Google
   module Cloud
     module Storage
+      class Project
+        def signed_url bucket, path, method: nil, expires: nil,
+                       content_type: nil, content_md5: nil, headers: nil,
+                       issuer: nil, client_email: nil, signing_key: nil,
+                       private_key: nil
+          # no-op stub, but ensures that calls match this copied signature
+        end
+      end
       class Bucket
         def signed_url path, method: nil, expires: nil, content_type: nil,
-                       content_md5: nil, issuer: nil, client_email: nil,
-                       signing_key: nil, private_key: nil
+                       content_md5: nil, headers: nil, issuer: nil,
+                       client_email: nil, signing_key: nil, private_key: nil
           # no-op stub, but ensures that calls match this copied signature
         end
 
@@ -46,20 +60,13 @@ module Google
               policy: "ABC...XYZ=" }
         end
       end
-    end
-  end
-end
-
-module Google
-  module Cloud
-    module Storage
       class File
         def download path, verify: :md5, encryption_key: nil
           # no-op stub, but ensures that calls match this copied signature
         end
         def signed_url method: nil, expires: nil, content_type: nil,
-                       content_md5: nil, issuer: nil, client_email: nil,
-                       signing_key: nil, private_key: nil
+                       content_md5: nil, headers: nil, issuer: nil,
+                       client_email: nil, signing_key: nil, private_key: nil
           # no-op stub, but ensures that calls match this copied signature
         end
       end
@@ -198,13 +205,11 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Due to failing line in example: key = OpenSSL::PKey::RSA.new "-----BEGIN PRIVATE KEY-----\n..."
-  doctest.skip "Google::Cloud::Storage::Bucket#signed_url"
-  # doctest.before "Google::Cloud::Storage::Bucket#signed_url" do
-  #   mock_storage do |mock|
-  #     mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-  #   end
-  # end
+  doctest.before "Google::Cloud::Storage::Bucket#signed_url" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+    end
+  end
 
   doctest.before "Google::Cloud::Storage::Bucket#acl" do
     mock_storage do |mock|
@@ -520,15 +525,12 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-
-  # Due to failing line in example: key = OpenSSL::PKey::RSA.new "-----BEGIN PRIVATE KEY-----\n..."
-  doctest.skip "Google::Cloud::Storage::File#signed_url"
-  # doctest.before "Google::Cloud::Storage::File#signed_url" do
-  #   mock_storage do |mock|
-  #     mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-  #     mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", {:generation=>nil, :options=>{}}]
-  #   end
-  # end
+  doctest.before "Google::Cloud::Storage::File#signed_url" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", {:generation=>nil, :options=>{}}]
+    end
+  end
 
   # File::Acl
 

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_test.rb
@@ -1,0 +1,150 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe Google::Cloud::Storage::Project, :signed_url, :mock_storage do
+  let(:bucket_name) { "bucket" }
+  let(:file_path) { "file.ext" }
+
+  it "uses the credentials' issuer and signing_key to generate signed_url" do
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = signing_key_mock
+
+      signed_url = storage.signed_url bucket_name, file_path
+
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+
+      signing_key_mock.verify
+    end
+  end
+
+  it "allows issuer and signing_key to be passed in as options" do
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = PoisonSigningKey.new
+
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
+
+      signed_url = storage.signed_url bucket_name, file_path,
+                                      issuer: "option_issuer",
+                                      signing_key: signing_key_mock
+
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+
+      signing_key_mock.verify
+    end
+  end
+
+  it "allows client_email and private to be passed in as options" do
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = PoisonSigningKey.new
+
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
+
+      OpenSSL::PKey::RSA.stub :new, signing_key_mock do
+
+        signed_url = storage.signed_url bucket_name, file_path,
+                                        client_email: "option_client_email",
+                                        private_key: "option_private_key"
+
+        signed_url_params = CGI::parse(URI(signed_url).query)
+        signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
+        signed_url_params["Signature"].must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+
+      end
+
+      signing_key_mock.verify
+    end
+  end
+
+  it "allows headers to be passed in as options" do
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\nx-goog-acl:public-read\nx-goog-meta-foo:bar,baz\n/bucket/file.ext"]
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = signing_key_mock
+
+      signed_url = storage.signed_url bucket_name, file_path,
+                                      headers: { "X-Goog-Meta-FOO" => "bar,baz",
+                                                 "X-Goog-ACL" => "public-read" }
+
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+
+      signing_key_mock.verify
+    end
+  end
+
+  it "raises when missing issuer" do
+    credentials.issuer = nil
+    credentials.signing_key = PoisonSigningKey.new
+
+    expect {
+      storage.signed_url bucket_name, file_path
+    }.must_raise Google::Cloud::Storage::SignedUrlUnavailable
+  end
+
+  it "raises when missing signing_key" do
+    credentials.issuer = "native_issuer"
+    credentials.signing_key = nil
+
+    expect {
+      storage.signed_url bucket_name, file_path
+    }.must_raise Google::Cloud::Storage::SignedUrlUnavailable
+  end
+
+  describe "Files with spaces in them" do
+    let(:file_path) { "hello world.txt" }
+
+    it "properly escapes the path when generating signed_url" do
+      Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+        signing_key_mock = Minitest::Mock.new
+        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world.txt"]
+        credentials.issuer = "native_client_email"
+        credentials.signing_key = signing_key_mock
+
+        signed_url = storage.signed_url bucket_name, file_path
+
+        signed_uri = URI signed_url
+        signed_uri.path.must_equal "/bucket/hello%20world.txt"
+
+        signed_url_params = CGI::parse signed_uri.query
+        signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+        signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+
+        signing_key_mock.verify
+      end
+    end
+  end
+
+  class PoisonSigningKey
+    def sign kind, sig
+      raise "The wrong signing_key was used"
+    end
+  end
+end


### PR DESCRIPTION
This PR is an attempt to reduce overhead for creating signed URLs by not requiring either a Bucket or a File object to be created.

```ruby
require "google/cloud/storage"

storage = Google::Cloud::Storage.new

bucket_name = "my-todo-app"
file_path = "avatars/heidi/400x400.png"
shared_url = storage.signed_url bucket_name, file_path,
                                method: "PUT",
                                content_type: "image/png",
                                expires: 300 # 5 minutes from now
```
[refs #1359]