### PR TITLE
Add support for BigQuery job cancellation

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -206,6 +206,13 @@ module Google
         end
 
         ##
+        # Cancel the job and return a gapi cancel job response.
+        def cancel
+          ensure_service!
+          service.cancel_job job_id
+        end
+
+        ##
         # Created a new job with the current configuration.
         def rerun!
           ensure_service!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -204,6 +204,12 @@ module Google
         end
 
         ##
+        # Cancel the job specified by jobId.
+        def cancel_job job_id
+          execute { service.cancel_job @project, job_id }
+        end
+
+        ##
         # Returns the job specified by jobID.
         def get_job job_id
           execute { service.get_job @project, job_id }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
@@ -199,4 +199,14 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
     job.must_be :done?
     mock.verify
   end
+
+  it "can cancel itself" do
+    mock = Minitest::Mock.new
+    mock.expect :cancel_job, job_id,
+      [project, job_id]
+    bigquery.service.mocked_service = mock
+
+    job.cancel
+    mock.verify
+  end
 end


### PR DESCRIPTION
The `google-api-ruby-client` library supports BigQuery job cancellation:  https://github.com/google/google-api-ruby-client/blob/master/generated/google/apis/bigquery_v2/service.rb#L340

This PR adds support issuing a cancel request on a job.