### PR TITLE
Update support for BigQuery job cancellation

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -217,6 +217,21 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     copy_job.write_empty?.must_equal true
   end
 
+  it "creates and cancels jobs" do
+    load_job = table.load local_file
+
+    load_job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    load_job.wont_be :done?
+
+    load_job.cancel
+    load_job.wait_until_done!
+
+    load_job.must_be :done?
+
+    load_job.wont_be :failed?
+    load_job.gapi.must_be :nil?
+  end
+
   it "extracts data to a url in your bucket" do
     skip "The BigQuery to Storage acceptance tests are failing with internalError"
     begin

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -206,10 +206,12 @@ module Google
         end
 
         ##
-        # Cancel the job and return a gapi cancel job response.
+        # Cancels the job.
         def cancel
           ensure_service!
-          service.cancel_job job_id
+          resp = service.cancel_job job_id
+          @gapi = resp.job
+          true
         end
 
         ##

--- a/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
@@ -202,7 +202,7 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
 
   it "can cancel itself" do
     mock = Minitest::Mock.new
-    mock.expect :cancel_job, job_id,
+    mock.expect :cancel_job, Google::Apis::BigqueryV2::CancelJobResponse.new(job: job_gapi),
       [project, job_id]
     bigquery.service.mocked_service = mock
 


### PR DESCRIPTION
This PR adds some small changes to the code added in #1371.