### PR TITLE
Integration test support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -134,6 +134,21 @@ namespace :acceptance do
     end
   end
 
+  # Runs each gem's acceptance tests without verifying that a test environment
+  # is used. May delete production data! Use only with caution!
+  task :unsafe, :bundleupdate do |t, args|
+    bundleupdate = args[:bundleupdate]
+    Rake::Task["bundleupdate"].invoke if bundleupdate
+    gems.each do |gem|
+      Dir.chdir gem do
+        Bundler.with_clean_env do
+          header "UNSAFE ACCEPTANCE TESTS FOR #{gem}"
+          sh "bundle exec rake acceptance:run -v"
+        end
+      end
+    end
+  end
+
   desc "Runs acceptance tests with coverage for all gems."
   task :coverage do
     FileUtils.remove_dir "coverage", force: true

--- a/gcloud/Rakefile
+++ b/gcloud/Rakefile
@@ -30,6 +30,9 @@ task :acceptance do
 end
 
 namespace :acceptance do
+  task :run do
+    puts "This gem does not have acceptance tests."
+  end
   desc "Run acceptance cleanup."
   task :cleanup do
   end

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -47,8 +47,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["STORAGE_KEYFILE"] = nil
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/bigquery/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -94,6 +93,11 @@ namespace :acceptance do
         puts e.message
       end
     end
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/bigquery/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-core/Rakefile
+++ b/google-cloud-core/Rakefile
@@ -30,6 +30,9 @@ task :acceptance do
 end
 
 namespace :acceptance do
+  task :run do
+    puts "This gem does not have acceptance tests."
+  end
   desc "Run acceptance cleanup."
   task :cleanup do
   end

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -44,8 +44,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["DATASTORE_KEYFILE"] = nil
   ENV["DATASTORE_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -63,6 +62,11 @@ namespace :acceptance do
 
   desc "Run acceptance cleanup."
   task :cleanup do
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
   end
 
   # TODO: Add a setup task to create indexes for the datastore

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -44,8 +44,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["DNS_KEYFILE"] = nil
   ENV["DNS_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -90,6 +89,11 @@ namespace :acceptance do
         puts e.message
       end
     end
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-env/Rakefile
+++ b/google-cloud-env/Rakefile
@@ -30,6 +30,9 @@ task :acceptance do
 end
 
 namespace :acceptance do
+  task :run do
+    puts "This gem does not have acceptance tests."
+  end
   desc "Run acceptance cleanup."
   task :cleanup do
   end

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -37,6 +37,9 @@ task :acceptance do
 end
 
 namespace :acceptance do
+  task :run do
+    puts "This gem does not have acceptance tests."
+  end
   desc "Run acceptance cleanup."
   task :cleanup do
   end

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -80,10 +80,13 @@ describe Google::Cloud::ErrorReporting::Middleware do
 
     it "raises ArgumentError if empty project_id provided" do
       assert_raises ArgumentError do
-        Google::Cloud::ErrorReporting::V1beta1::ReportErrorsServiceClient.stub \
-        :new, "A default error_reporting" do
-          ENV.stub :[], nil do
-            Google::Cloud::ErrorReporting::Middleware.new nil
+        # Prevent return of actual project in any environment including GCE, etc.
+        Google::Cloud::Core::Environment.stub :project_id, nil do
+          Google::Cloud::ErrorReporting::V1beta1::ReportErrorsServiceClient.stub \
+          :new, "A default error_reporting" do
+            ENV.stub :[], nil do
+              Google::Cloud::ErrorReporting::Middleware.new nil
+            end
           end
         end
       end

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -47,8 +47,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["STORAGE_KEYFILE"] = nil
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -62,6 +61,11 @@ namespace :acceptance do
     end
 
     Rake::Task["acceptance"].invoke
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -44,8 +44,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["LOGGING_KEYFILE"] = nil
   ENV["LOGGING_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/logging/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -89,6 +88,11 @@ namespace :acceptance do
     rescue Google::Cloud::Error => e
       puts e.message
     end
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/logging/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-monitoring/Rakefile
+++ b/google-cloud-monitoring/Rakefile
@@ -37,6 +37,10 @@ task :acceptance do
 end
 
 namespace :acceptance do
+  task :run do
+    puts "This gem does not have acceptance tests."
+  end
+
   desc "Run acceptance tests with coverage."
   task :coverage do
   end

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -44,8 +44,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["PUBSUB_KEYFILE"] = nil
   ENV["PUBSUB_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/pubsub/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -85,6 +84,11 @@ namespace :acceptance do
     puts "Cleaning up Pub/Sub topics and subscriptions"
     Google::Cloud.pubsub.topics.all &:delete
     Google::Cloud.pubsub.subscriptions.all &:delete
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/pubsub/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-resource_manager/Rakefile
+++ b/google-cloud-resource_manager/Rakefile
@@ -30,6 +30,10 @@ task :acceptance do
 end
 
 namespace :acceptance do
+  task :run do
+    puts "This gem does not have acceptance tests."
+  end
+
   desc "Run acceptance cleanup."
   task :cleanup do
   end

--- a/google-cloud-spanner/Rakefile
+++ b/google-cloud-spanner/Rakefile
@@ -44,8 +44,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["SPANNER_KEYFILE"] = nil
   ENV["SPANNER_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -93,6 +92,11 @@ namespace :acceptance do
         puts "Error while cleaning up #{instance.instance_id} instance.\n\n#{e}"
       end
     end
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -47,8 +47,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["STORAGE_KEYFILE"] = nil
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -62,6 +61,11 @@ namespace :acceptance do
     end
 
     Rake::Task["acceptance"].invoke
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -44,8 +44,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["STORAGE_KEYFILE"] = nil
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -93,6 +92,11 @@ namespace :acceptance do
         puts "Error while cleaning up bucket #{b.name}\n\n#{e}"
       end
     end
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -59,8 +59,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["TRACE_KEYFILE"] = nil
   ENV["TRACE_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/trace/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -74,6 +73,11 @@ namespace :acceptance do
     end
 
     Rake::Task["acceptance"].invoke
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/trace/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -58,8 +58,7 @@ task :acceptance, :project, :keyfile, :key do |t, args|
   ENV["TRANSLATE_KEYFILE_JSON"] = keyfile
   ENV["TRANSLATE_KEY"] = nil
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -79,8 +78,7 @@ namespace :acceptance do
     ENV["GCLOUD_KEYFILE_JSON"] = nil
     ENV["TRANSLATE_KEY"] = key
 
-    $LOAD_PATH.unshift "lib", "acceptance"
-    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+    Rake::Task["acceptance:run"].invoke
   end
 
   desc "Run acceptance tests with coverage."
@@ -93,6 +91,11 @@ namespace :acceptance do
     end
 
     Rake::Task["acceptance"].invoke
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-translate/test/google/cloud/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate_test.rb
@@ -111,46 +111,49 @@ describe Google::Cloud do
       stubbed_env = ->(name) {
         "found-api-key" if name == "GOOGLE_CLOUD_KEY"
       }
-      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, key: nil) {
         key.must_equal "found-api-key"
         project.must_be :empty?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
+        credentials.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
         OpenStruct.new key: key
       }
 
-      # Clear all environment variables
-      # ENV.stub :[], nil do
-      ENV.stub :[], stubbed_env do
-        Google::Cloud::Translate::Service.stub :new, stubbed_service do
-          translate = Google::Cloud.translate
-          translate.must_be_kind_of Google::Cloud::Translate::Api
-          translate.service.must_be_kind_of OpenStruct
-          translate.service.key.must_equal "found-api-key"
+      # Prevent return of actual project in any environment including GCE, etc.
+      Google::Cloud::Translate::Api.stub :default_project, nil do
+        # Clear all environment variables
+        # ENV.stub :[], nil do
+        ENV.stub :[], stubbed_env do
+          Google::Cloud::Translate::Service.stub :new, stubbed_service do
+            translate = Google::Cloud.translate
+            translate.must_be_kind_of Google::Cloud::Translate::Api
+            translate.service.must_be_kind_of OpenStruct
+            translate.service.key.must_equal "found-api-key"
+          end
         end
       end
     end
 
     it "uses provided api key" do
-      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, key: nil) {
         key.must_equal "my-api-key"
         project.must_be :empty?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
+        credentials.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
         OpenStruct.new key: key
       }
-
-      # Clear all environment variables
-      ENV.stub :[], nil do
-        Google::Cloud::Translate::Service.stub :new, stubbed_service do
-          translate = Google::Cloud.translate "my-api-key"
-          translate.must_be_kind_of Google::Cloud::Translate::Api
-          translate.service.must_be_kind_of OpenStruct
-          translate.service.key.must_equal "my-api-key"
+      # Prevent return of actual project in any environment including GCE, etc.
+      Google::Cloud::Translate::Api.stub :default_project, nil do
+        # Clear all environment variables
+        ENV.stub :[], nil do
+          Google::Cloud::Translate::Service.stub :new, stubbed_service do
+            translate = Google::Cloud.translate "my-api-key"
+            translate.must_be_kind_of Google::Cloud::Translate::Api
+            translate.service.must_be_kind_of OpenStruct
+            translate.service.key.must_equal "my-api-key"
+          end
         end
       end
     end
@@ -176,10 +179,9 @@ describe Google::Cloud do
         scope.must_be :nil?
         "translate-credentials"
       }
-      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, key: nil) {
         project.must_equal "project-id"
-        keyfile.must_equal "translate-credentials"
-        scope.must_be :nil?
+        credentials.must_equal "translate-credentials"
         key.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
@@ -212,46 +214,50 @@ describe Google::Cloud do
       stubbed_env = ->(name) {
         "found-api-key" if name == "GOOGLE_CLOUD_KEY"
       }
-      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, key: nil) {
         key.must_equal "found-api-key"
         project.must_be :empty?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
+        credentials.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
         OpenStruct.new key: key
       }
 
-      # Clear all environment variables
-      # ENV.stub :[], nil do
-      ENV.stub :[], stubbed_env do
-        Google::Cloud::Translate::Service.stub :new, stubbed_service do
-          translate = Google::Cloud::Translate.new
-          translate.must_be_kind_of Google::Cloud::Translate::Api
-          translate.service.must_be_kind_of OpenStruct
-          translate.service.key.must_equal "found-api-key"
+      # Prevent return of actual project in any environment including GCE, etc.
+      Google::Cloud::Translate::Api.stub :default_project, nil do
+        # Clear all environment variables
+        # ENV.stub :[], nil do
+        ENV.stub :[], stubbed_env do
+          Google::Cloud::Translate::Service.stub :new, stubbed_service do
+            translate = Google::Cloud::Translate.new
+            translate.must_be_kind_of Google::Cloud::Translate::Api
+            translate.service.must_be_kind_of OpenStruct
+            translate.service.key.must_equal "found-api-key"
+          end
         end
       end
     end
 
     it "uses provided api key" do
-      stubbed_service = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, key: nil) {
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, key: nil) {
         key.must_equal "my-api-key"
         project.must_be :empty?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
+        credentials.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
         OpenStruct.new key: key
       }
 
-      # Clear all environment variables
-      ENV.stub :[], nil do
-        Google::Cloud::Translate::Service.stub :new, stubbed_service do
-          translate = Google::Cloud::Translate.new key: "my-api-key"
-          translate.must_be_kind_of Google::Cloud::Translate::Api
-          translate.service.must_be_kind_of OpenStruct
-          translate.service.key.must_equal "my-api-key"
+      # Prevent return of actual project in any environment including GCE, etc.
+      Google::Cloud::Translate::Api.stub :default_project, nil do
+        # Clear all environment variables
+        ENV.stub :[], nil do
+          Google::Cloud::Translate::Service.stub :new, stubbed_service do
+            translate = Google::Cloud::Translate.new key: "my-api-key"
+            translate.must_be_kind_of Google::Cloud::Translate::Api
+            translate.service.must_be_kind_of OpenStruct
+            translate.service.key.must_equal "my-api-key"
+          end
         end
       end
     end

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -47,8 +47,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["STORAGE_KEYFILE"] = nil
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
-  $LOAD_PATH.unshift "lib", "acceptance"
-  Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
@@ -62,6 +61,11 @@ namespace :acceptance do
     end
 
     Rake::Task["acceptance"].invoke
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud/Rakefile
+++ b/google-cloud/Rakefile
@@ -30,6 +30,9 @@ task :acceptance do
 end
 
 namespace :acceptance do
+  task :run do
+    puts "This gem does not have acceptance tests."
+  end
   desc "Run acceptance cleanup."
   task :cleanup do
   end

--- a/stackdriver-core/Rakefile
+++ b/stackdriver-core/Rakefile
@@ -30,6 +30,10 @@ task :acceptance do
 end
 
 namespace :acceptance do
+  task :run do
+    puts "This gem does not have acceptance tests."
+  end
+
   desc "Run acceptance cleanup."
   task :cleanup do
   end

--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -45,6 +45,10 @@ task :acceptance do
 end
 
 namespace :acceptance do
+  task :run do
+    puts "This gem does not have acceptance tests."
+  end
+
   desc "Run acceptance cleanup."
   task :cleanup do
   end


### PR DESCRIPTION
This PR does the following in support of #1333:

* Unit tests
  * Fix stub signature for Translate Service.
  * Prevent return of actual project in any environment including GCE.
* Acceptance tests
  * Add rake task `acceptance:unsafe` to support using default credentials for acceptance testing.