### PR TITLE
Remove Storage ACL Workaround

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
@@ -76,11 +76,7 @@ module Google
           #
           def reload!
             gapi = @service.list_file_acls @bucket, @file
-            acls = Array(gapi.items).map do |acl|
-              next acl if acl.is_a? Google::Apis::StorageV1::ObjectAccessControl
-              fail "Unknown ACL format: #{acl.class}" unless acl.is_a? Hash
-              Google::Apis::StorageV1::ObjectAccessControl.from_json acl.to_json
-            end
+            acls = Array(gapi.items)
             @owners  = entities_from_acls acls, "OWNER"
             @readers = entities_from_acls acls, "READER"
           end


### PR DESCRIPTION
The workaround for google/google-api-ruby-client#436 can be removed now that the faulty behavior has been fixed.