### PR TITLE
Logging::Middleware provides default logger

### DIFF
--- a/google-cloud-logging/docs/instrumentation.md
+++ b/google-cloud-logging/docs/instrumentation.md
@@ -1,16 +1,25 @@
 # Stackdriver Logging Instrumentation
 
-Then google-cloud-logging gem provides a Rack Middleware class that can easily integrate with Rack based application frameworks, such as Rails and Sinatra. When enabled, it sets an instance of Google::Cloud::Logging::Logger as the default Rack or Rails logger. Then all consequent log entries will be submitted to the Stackdriver Logging service. 
+Then google-cloud-logging gem provides a Rack Middleware class that can easily 
+integrate with Rack based application frameworks, such as Rails and Sinatra. 
+When enabled, it sets an instance of Google::Cloud::Logging::Logger as the 
+default Rack or Rails logger. Then all consequent log entries will be submitted 
+to the Stackdriver Logging service. 
 
-On top of that, the google-cloud-logging also implements a Railtie class that automatically enables the Rack Middleware in Rails applications when used.
+On top of that, the google-cloud-logging also implements a Railtie class that 
+automatically enables the Rack Middleware in Rails applications when used.
 
-## Rails Integration
+## Using instrumentation with Ruby on Rails
 
-To use the Stackdriver Logging Railtie for Ruby on Rails applications, simply add this line to config/application.rb:
+To install application instrumentation in your Ruby on Rails app, add this
+gem, `google-cloud-logging`, to your Gemfile and update your bundle. Then
+add the following line to your `config/application.rb` file:
 ```ruby
 require "google/cloud/logging/rails"
 ```
-Then the library can be configured through this set of Rails parameters in config/environments/*.rb:
+This will load a Railtie that automatically integrates with the Rails
+framework by injecting a Rack middleware. The logging instrumentation can be 
+configured with the following Rails configuration:
 ```ruby
 # Sharing authentication parameters
 config.google_cloud.project_id = "gcp-project-id"
@@ -30,11 +39,21 @@ config.google_cloud.logging.monitored_resource.type = "aws_ec2_instance"
 config.google_cloud.logging.monitored_resource.labels.instance_id = "ec2-instance-id"
 config.google_cloud.logging.monitored_resource.labels.aws_account = "AWS account number"
 ```
-Alternatively, check out [stackdriver](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver) gem, which enables this Railtie by default.
+## Using instrumentation with Sinatra
 
-## Rack Integration
+To install application instrumentation in your Sinatra app, add this gem,
+`google-cloud-logging`, to your Gemfile and update your bundle. Then add
+the following lines to your main application Ruby file:
 
-Other Rack base framework can also directly leverage the built-in Middleware.
+```ruby
+require "google/cloud/logging"
+use Google::Cloud::Logging::Middleware
+```
+
+This will install the logging middleware in your application.
+
+You may customize the logging instrumention by providing your own
+Google::Cloud::Logging::Logger:
 ```ruby
 require "google/cloud/logging"
  
@@ -44,3 +63,29 @@ logger = logging.logger "my-log-name",
                         resource
 use Google::Cloud::Logging::Middleware, logger: logger
 ```
+### Using instrumentation with other Rack-based frameworks
+
+To install application instrumentation in an app using another Rack-based
+web framework, add this gem, `google-cloud-logging`, to your Gemfile and
+update your bundle. Then add install the logging middleware in your
+middleware stack. In most cases, this means adding these lines to your
+`config.ru` Rack configuration file:
+
+```ruby
+require "google/cloud/logging"
+use Google::Cloud::Logging::Middleware
+```
+
+Some web frameworks have an alternate mechanism for modifying the
+middleware stack. Consult your web framework's documentation for more
+information.
+
+### The Stackdriver diagnostics suite
+
+The google-cloud-logging library is part of the Stackdriver diagnostics suite, 
+which also includes error reporting, tracing analysis, and real-time debugger. 
+If you include the `stackdriver` gem in your Gemfile, this logging library will
+be included automatically. In addition, if you include the `stackdriver`
+gem in an application using Ruby On Rails, the Railties will be installed
+automatically. See the documentation for the "stackdriver" gem
+for more details.

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -112,7 +112,7 @@ module Google
 
           # Return false if config.google_cloud.use_logging is explicitly false
           use_logging = logging_config[:use_logging]
-          return false if !use_logging.nil? && !use_logging
+          return false if use_logging == false
 
           project_id = logging_config[:project_id] ||
                        Google::Cloud::Logging::Project.default_project
@@ -144,7 +144,7 @@ module Google
         # @private Helper method to parse rails config into a flattened hash
         def self.parse_rails_config config
           gcp_config = config.google_cloud
-          logging_config = gcp_config[:logging]
+          logging_config = gcp_config.logging
           use_logging =
             gcp_config.key?(:use_logging) ? gcp_config.use_logging : nil
           {

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -18,6 +18,10 @@ module Google
   module Cloud
     module Logging
       ##
+      # Default log name to be used for Stackdriver Logging
+      DEFAULT_LOG_NAME = Middleware::DEFAULT_LOG_NAME
+
+      ##
       # Railtie
       #
       # Adds the {Google::Cloud::Logging::Middleware} to Rack in a Rails

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -46,8 +46,14 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
   }
 
   describe "#initialize" do
+    let(:default_credentials) { OpenStruct.new empty: true }
+
     it "creates a default logger object if one isn't provided" do
-      middleware = Google::Cloud::Logging::Middleware.new rack_app
+      Google::Cloud::Logging::Project.stub :default_project, project do
+        Google::Cloud::Logging::Credentials.stub :default, default_credentials do
+          middleware = Google::Cloud::Logging::Middleware.new rack_app
+        end
+      end
 
       middleware.logger.must_be_kind_of Google::Cloud::Logging::Logger
     end

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -45,6 +45,18 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
     Google::Cloud::Logging::Middleware.new rack_app, logger: logger
   }
 
+  describe "#initialize" do
+    it "creates a default logger object if one isn't provided" do
+      middleware = Google::Cloud::Logging::Middleware.new rack_app
+
+      middleware.logger.must_be_kind_of Google::Cloud::Logging::Logger
+    end
+
+    it "uses the logger provided if given" do
+      middleware.logger.must_equal logger
+    end
+  end
+
   describe "#call" do
     it "sets env[\"rack.logger\"] to the given logger" do
       stubbed_call = ->(env) {

--- a/google-cloud-logging/test/google/cloud/logging/rails_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/rails_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Logging::Railtie do
       @rails_config = ::ActiveSupport::OrderedOptions.new
       @rails_config.google_cloud = ::ActiveSupport::OrderedOptions.new
       @rails_config.google_cloud.logging = ::ActiveSupport::OrderedOptions.new
+      @rails_config.google_cloud.logging.monitored_resource = ::ActiveSupport::OrderedOptions.new
     end
 
     it "returns false if config.google_cloud.use_logging is explicitly false" do


### PR DESCRIPTION
Allow `Logging::Middleware` to instantiate a default logger if one isn't provided, instead of always requiring users to create a logger.

This simplifies the Sinatra instrumentation code if using all default configuration:
```ruby
require "google/cloud/logging"
use Google::Cloud::Logging::Middleware
```

The Rails integration isn't affected, but I just refactored the Railtie code a little bit to make it cleaner.
