### PR TITLE
Update Storage File copy

### DIFF
--- a/google-cloud-storage/.rubocop.yml
+++ b/google-cloud-storage/.rubocop.yml
@@ -28,9 +28,9 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 10
 Metrics/AbcSize:
-  Max: 25
+  Max: 30
 Metrics/MethodLength:
-  Max: 20
+  Max: 25
 Metrics/ParameterLists:
   Enabled: false
 Style/RescueModifier:

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -208,13 +208,14 @@ module Google
         # destination bucket/object.
         def copy_file source_bucket_name, source_file_path,
                       destination_bucket_name, destination_file_path,
-                      options = {}
+                      file_gapi = nil, options = {}
           key_options = rewrite_key_options options[:key],
                                             options[:key]
           execute do
             service.rewrite_object \
               source_bucket_name, source_file_path,
               destination_bucket_name, destination_file_path,
+              file_gapi,
               destination_predefined_acl: options[:acl],
               source_generation: options[:generation],
               rewrite_token: options[:token],
@@ -226,30 +227,18 @@ module Google
         # destination bucket/object.
         def rewrite_file source_bucket_name, source_file_path,
                          destination_bucket_name, destination_file_path,
-                         options = {}
+                         file_gapi = nil, options = {}
           key_options = rewrite_key_options options[:source_key],
                                             options[:destination_key]
           execute do
             service.rewrite_object \
               source_bucket_name, source_file_path,
               destination_bucket_name, destination_file_path,
+              file_gapi,
               destination_predefined_acl: options[:acl],
               source_generation: options[:generation],
               rewrite_token: options[:token],
               options: key_options
-          end
-        end
-
-        ## Rewrite a file from source bucket/object to a
-        # destination bucket/object.
-        def update_file_storage_class bucket_name, file_path, storage_class,
-                                      token = nil
-          execute do
-            service.rewrite_object \
-              bucket_name, file_path,
-              bucket_name, file_path,
-              Google::Apis::StorageV1::Object.new(storage_class: storage_class),
-              rewrite_token: token
           end
         end
 

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -480,6 +480,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::File#copy@The file can be modified during copying:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", Google::Apis::StorageV1::Object, {:destination_predefined_acl=>nil, :source_generation=>nil, :rewrite_token => nil, :options=>{}}]
+    end
+  end
+
   doctest.before "Google::Cloud::Storage::File#rotate" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket"]

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -460,7 +460,7 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
       mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", {:destination_predefined_acl=>nil, :source_generation=>nil, :rewrite_token => nil, :options=>{}}]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", nil, {:destination_predefined_acl=>nil, :source_generation=>nil, :rewrite_token => nil, :options=>{}}]
     end
   end
 
@@ -468,7 +468,7 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
       mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "path/to/destination/file.ext", {:destination_predefined_acl=>nil, :source_generation=>nil, :rewrite_token => nil, :options=>{}}]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "path/to/destination/file.ext", nil, {:destination_predefined_acl=>nil, :source_generation=>nil, :rewrite_token => nil, :options=>{}}]
     end
   end
 
@@ -476,7 +476,7 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
       mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "copy/of/previous/generation/file.ext", {:destination_predefined_acl=>nil, :source_generation=>123456, :rewrite_token => nil, :options=>{}}]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "copy/of/previous/generation/file.ext", nil, {:destination_predefined_acl=>nil, :source_generation=>123456, :rewrite_token => nil, :options=>{}}]
     end
   end
 
@@ -484,7 +484,7 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
       mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
-      mock.expect :rewrite_object, OpenStruct.new(done: true, resource: file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, OpenStruct.new(done: true, resource: file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "path/to/my-file.ext", nil, Hash]
     end
   end
 

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -370,7 +370,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself in the same bucket" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -382,7 +382,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself in the same bucket with generation" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -394,7 +394,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself in the same bucket with predefined ACL" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -406,7 +406,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself in the same bucket with ACL alias" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -418,7 +418,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself with customer-supplied encryption key" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: copy_key_options]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: copy_key_options]
 
     file.service.mocked_service = mock
 
@@ -430,7 +430,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself to a different bucket" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -442,7 +442,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself to a different bucket with generation" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -454,7 +454,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself to a different bucket with predefined ACL" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -466,7 +466,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself to a different bucket with ACL alias" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -478,7 +478,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself to a different bucket with customer-supplied encryption key" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: copy_key_options]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: copy_key_options]
 
     file.service.mocked_service = mock
 
@@ -490,13 +490,13 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself calling rewrite multiple times" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", options: {}]
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", options: {}]
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", options: {}]
 
     file.service.mocked_service = mock
 
@@ -513,7 +513,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock = Minitest::Mock.new
     options = { header: source_key_headers.merge(key_headers) }
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-                [bucket.name, file.name, bucket.name, file.name,
+                [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
                  rewrite_token: nil, options: options ]
 
@@ -529,7 +529,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock = Minitest::Mock.new
     options = { header: key_headers }
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-                [bucket.name, file.name, bucket.name, file.name,
+                [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
                  rewrite_token: nil, options: options ]
 
@@ -545,7 +545,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock = Minitest::Mock.new
     options = { header: source_key_headers }
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-                [bucket.name, file.name, bucket.name, file.name,
+                [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
                  rewrite_token: nil, options: options ]
 
@@ -561,11 +561,11 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock = Minitest::Mock.new
     options = { header: source_key_headers.merge(key_headers) }
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-                [bucket.name, file.name, bucket.name, file.name,
+                [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
                  rewrite_token: nil, options: options ]
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-                [bucket.name, file.name, bucket.name, file.name,
+                [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
                  rewrite_token: "notyetcomplete", options: options ]
 

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -509,6 +509,36 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
+  it "can copy itself while updating its attributes" do
+    mock = Minitest::Mock.new
+    update_file_gapi = Google::Apis::StorageV1::Object.new(
+      cache_control: "private, max-age=0, no-cache",
+      content_disposition: "inline; filename=filename.ext",
+      content_encoding: "deflate",
+      content_language: "de",
+      content_type: "application/json",
+      metadata: { "player" => "Bob", "score" => "10" },
+      storage_class: "NEARLINE"
+    )
+    mock.expect :rewrite_object, done_rewrite(file_gapi),
+      [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+
+    file.service.mocked_service = mock
+
+    file.copy "new-file.ext" do |f|
+      f.cache_control = "private, max-age=0, no-cache"
+      f.content_disposition = "inline; filename=filename.ext"
+      f.content_encoding = "deflate"
+      f.content_language = "de"
+      f.content_type = "application/json"
+      f.metadata["player"] = "Bob"
+      f.metadata["score"] = "10"
+      f.storage_class = :nearline
+    end
+
+    mock.verify
+  end
+
   it "can rotate its customer-supplied encryption keys" do
     mock = Minitest::Mock.new
     options = { header: source_key_headers.merge(key_headers) }


### PR DESCRIPTION
Allow `File#copy` to update a file's attributes when, including `storage_class`.