### PR TITLE
Update google-cloud-debugger dependencies

### DIFF
--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.extensions << "ext/google/cloud/debugger/debugger_c/extconf.rb"
 
   gem.add_dependency "binding_of_caller", "~> 0.7"
-  gem.add_dependency "google-cloud-core", "~> 0.21.1"
+  gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "google-gax", "~> 0.8.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
Update google-cloud-core to `1.0`.