### PR TITLE
Add IAM methods to Bucket

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -1,0 +1,212 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/errors"
+require "google/apis/storage_v1"
+
+module Google
+  module Cloud
+    module Storage
+      ##
+      # # Policy
+      #
+      # Represents a Cloud IAM Policy for the Cloud Storage service.
+      #
+      # A common pattern for updating a resource's metadata, such as its Policy,
+      # is to read the current data from the service, update the data locally,
+      # and then send the modified data for writing. This pattern may result in
+      # a conflict if two or more processes attempt the sequence simultaneously.
+      # IAM solves this problem with the
+      # {Google::Cloud::Storage::Policy#etag} property, which is used to
+      # verify whether the policy has changed since the last request. When you
+      # make a request to with an `etag` value, Cloud IAM compares the `etag`
+      # value in the request with the existing `etag` value associated with the
+      # policy. It writes the policy only if the `etag` values match.
+      #
+      # When you update a policy, first read the policy (and its current `etag`)
+      # from the service, then modify the policy locally, and then write the
+      # modified policy to the service. See
+      # {Google::Cloud::Storage::Bucket#policy} and
+      # {Google::Cloud::Storage::Bucket#policy=}.
+      #
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   policies
+      # @see https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy
+      #   Buckets: setIamPolicy
+      #
+      # @attr [String] etag Used to verify whether the policy has changed since
+      #   the last request. The policy will be written only if the `etag` values
+      #   match.
+      # @attr [Hash{String => Array<String>}] roles The bindings that associate
+      #   roles with an array of members. See [Understanding
+      #   Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+      #   listing of primitive and curated roles. See [Buckets:
+      #   setIamPolicy](https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy)
+      #   for a listing of values and patterns for members.
+      #
+      # @example
+      #   require "google/cloud/storage"
+      #
+      #   storage = Google::Cloud::Storage.new
+      #
+      #   bucket = storage.bucket "my-todo-app"
+      #
+      #   policy = bucket.policy # API call
+      #
+      #   policy.remove "roles/storage.admin", "user:owner@example.com"
+      #   policy.add "roles/storage.admin", "user:newowner@example.com"
+      #   policy.roles["roles/storage.objectViewer"] = ["allUsers"]
+      #
+      #   bucket.policy = policy # API call
+      #
+      class Policy
+        attr_reader :etag, :roles
+
+        ##
+        # @private Creates a Policy object.
+        def initialize etag, roles
+          @etag = etag
+          @roles = roles
+        end
+
+        ##
+        # Convenience method for adding a member to a binding on this policy.
+        # See [Understanding
+        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+        # listing of primitive and curated roles. See [Buckets:
+        # setIamPolicy](https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy)
+        # for a listing of values and patterns for members.
+        #
+        # @param [String] role_name A Cloud IAM role, such as
+        #   `"roles/storage.admin"`.
+        # @param [String] member A Cloud IAM identity, such as
+        #   `"user:owner@example.com"`.
+        #
+        # @example
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   policy = bucket.policy # API call
+        #
+        #   policy.add "roles/storage.admin", "user:newowner@example.com"
+        #
+        #   bucket.policy = policy # API call
+        #
+        def add role_name, member
+          role(role_name) << member
+        end
+
+        ##
+        # Convenience method for removing a member from a binding on this
+        # policy. See [Understanding
+        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+        # listing of primitive and curated roles. See [Buckets:
+        # setIamPolicy](https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy)
+        # for a listing of values and patterns for members.
+        #
+        # @param [String] role_name A Cloud IAM role, such as
+        #   `"roles/storage.admin"`.
+        # @param [String] member A Cloud IAM identity, such as
+        #   `"user:owner@example.com"`.
+        #
+        # @example
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   policy = bucket.policy # API call
+        #
+        #   policy.remove "roles/storage.admin", "user:owner@example.com"
+        #
+        #   bucket.policy = policy # API call
+        #
+        def remove role_name, member
+          role(role_name).delete member
+        end
+
+        ##
+        # Convenience method returning the array of members bound to a role in
+        # this policy, or an empty array if no value is present for the role in
+        # {#roles}. See [Understanding
+        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+        # listing of primitive and curated roles. See [Buckets:
+        # setIamPolicy](https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy)
+        # for a listing of values and patterns for members.
+        #
+        # @return [Array<String>] The members strings, or an empty array.
+        #
+        # @example
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "my-todo-app"
+        #
+        #   policy = bucket.policy
+        #
+        #   policy.role("roles/storage.admin") << "user:owner@example.com"
+        #
+        def role role_name
+          roles[role_name] ||= []
+        end
+
+        ##
+        # Returns a deep copy of the policy.
+        #
+        # @return [Policy]
+        #
+        def deep_dup
+          dup.tap do |p|
+            roles_dup = p.roles.each_with_object({}) do |(k, v), memo|
+              memo[k] = v.dup rescue value
+            end
+            p.instance_variable_set "@roles", roles_dup
+          end
+        end
+
+        ##
+        # @private Convert the Policy to a
+        # Google::Apis::StorageV1::Policy.
+        def to_gapi
+          Google::Apis::StorageV1::Policy.new(
+            etag: etag,
+            bindings: roles.keys.map do |role_name|
+              next if roles[role_name].empty?
+              Google::Apis::StorageV1::Policy::Binding.new(
+                role: role_name,
+                members: roles[role_name]
+              )
+            end
+          )
+        end
+
+        ##
+        # @private New Policy from a
+        # Google::Apis::StorageV1::Policy object.
+        def self.from_gapi gapi
+          roles = gapi.bindings.each_with_object({}) do |binding, memo|
+            memo[binding.role] = binding.members.to_a
+          end
+          new gapi.etag, roles
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -157,6 +157,30 @@ module Google
         end
 
         ##
+        # Returns Google::Apis::StorageV1::Policy
+        def get_bucket_policy bucket_name
+          # get_bucket_iam_policy(bucket, fields: nil, quota_user: nil,
+          #                               user_ip: nil, options: nil)
+          execute { service.get_bucket_iam_policy bucket_name }
+        end
+
+        ##
+        # Returns Google::Apis::StorageV1::Policy
+        def set_bucket_policy bucket_name, new_policy
+          execute do
+            service.set_bucket_iam_policy bucket_name, new_policy
+          end
+        end
+
+        ##
+        # Returns Google::Apis::StorageV1::TestIamPermissionsResponse
+        def test_bucket_permissions bucket_name, permissions
+          execute do
+            service.test_bucket_iam_permissions bucket_name, permissions
+          end
+        end
+
+        ##
         # Retrieves a list of files matching the criteria.
         def list_files bucket_name, options = {}
           execute do

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -240,6 +240,45 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::Bucket#policy" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Bucket#policy@Use `force` to retrieve the latest policy from the service:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Bucket#policy@Update the policy by passing a block:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Bucket#policy=" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Bucket#test_permissions" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+      mock.expect :test_bucket_iam_permissions, permissions_gapi, ["my-todo-app", ["storage.buckets.get", "storage.buckets.delete"]]
+    end
+  end
+
   # Bucket::Acl
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#reload!" do
@@ -435,6 +474,23 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Storage::Bucket::List" do
     mock_storage do |mock|
       mock.expect :list_buckets, list_buckets_gapi, ["my-todo-project", {:prefix=>nil, :page_token=>nil, :max_results=>nil}]
+    end
+  end
+
+  # Bucket::Policy
+
+  doctest.before "Google::Cloud::Storage::Policy" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Policy#role" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
     end
   end
 
@@ -959,4 +1015,39 @@ def random_file_acl_hash bucket_name, file_name
     }
    ]
   }
+end
+
+def policy_gapi
+  Google::Apis::StorageV1::Policy.new(
+    etag: "CAE=",
+    bindings: [
+      Google::Apis::StorageV1::Policy::Binding.new(
+        role: "roles/storage.objectViewer",
+        members: [
+          "user:viewer@example.com"
+        ]
+      )
+    ]
+  )
+end
+
+def new_policy_gapi
+  Google::Apis::StorageV1::Policy.new(
+    etag: "CAE=",
+    bindings: [
+      Google::Apis::StorageV1::Policy::Binding.new(
+        role: "roles/storage.objectViewer",
+        members: [
+          "user:viewer@example.com",
+          "serviceAccount:1234567890@developer.gserviceaccount.com"
+        ]
+      )
+    ]
+  )
+end
+
+def permissions_gapi
+  Google::Apis::StorageV1::TestIamPermissionsResponse.new(
+    permissions: ["storage.buckets.get"]
+  )
 end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -1,0 +1,182 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
+  let(:bucket_name) { "found-bucket" }
+  let(:bucket_hash) { random_bucket_hash bucket_name }
+  let(:bucket_json) { bucket_hash.to_json }
+  let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json bucket_json }
+  let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
+  
+  let(:old_policy_gapi) {
+    Google::Apis::StorageV1::Policy.new(
+      etag: "CAE=",
+      bindings: [
+        Google::Apis::StorageV1::Policy::Binding.new(
+          role: "roles/storage.objectViewer",
+          members: [
+            "user:viewer@example.com"
+          ]
+        )
+      ]
+    )
+  }
+  let(:new_policy_gapi) {
+    Google::Apis::StorageV1::Policy.new(
+      etag: "CAE=",
+      bindings: [
+        Google::Apis::StorageV1::Policy::Binding.new(
+          role: "roles/storage.objectViewer",
+          members: [
+            "user:viewer@example.com",
+            "serviceAccount:1234567890@developer.gserviceaccount.com"
+          ]
+        )
+      ]
+    )
+  }
+  let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
+  let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
+
+  it "gets the policy" do
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name]
+
+    storage.service.mocked_service = mock
+    policy = bucket.policy
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 1
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+  end
+
+  it "memoizes policy" do
+    bucket.instance_variable_set "@policy", old_policy
+
+    # No mocks, no errors, no HTTP calls are made
+    policy = bucket.policy
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 1
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+  end
+
+  it "can force load the policy" do
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket_iam_policy, new_policy_gapi, [bucket_name]
+
+    storage.service.mocked_service = mock
+    policy = bucket.policy force: true
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "can force load the policy, even if already memoized" do
+    # memoize the policy object
+    bucket.instance_variable_set "@policy", old_policy
+
+    returned_policy = bucket.policy
+    returned_policy.must_be_kind_of Google::Cloud::Storage::Policy
+    returned_policy.roles.must_be_kind_of Hash
+    returned_policy.roles.size.must_equal 1
+    returned_policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    returned_policy.roles["roles/storage.objectViewer"].count.must_equal 1
+    returned_policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket_iam_policy, new_policy_gapi, [bucket_name]
+
+    storage.service.mocked_service = mock
+    policy = bucket.policy force: true
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "sets the policy" do
+    mock = Minitest::Mock.new
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi]
+
+    storage.service.mocked_service = mock
+    bucket.policy = new_policy
+    mock.verify
+
+    # Setting the policy also memoizes the policy
+    bucket.policy.must_be_kind_of Google::Cloud::Storage::Policy
+    bucket.policy.roles.must_be_kind_of Hash
+    bucket.policy.roles.size.must_equal 1
+    bucket.policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    bucket.policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    bucket.policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    bucket.policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "sets the policy in a block" do
+    # memoize the policy object, to ensure that it is reloaded for update
+    bucket.instance_variable_set "@policy", old_policy
+
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name]
+
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi]
+
+    storage.service.mocked_service = mock
+    policy = bucket.policy do |p|
+      p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    bucket.policy.roles.size.must_equal 1
+    bucket.policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    bucket.policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    bucket.policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    bucket.policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "tests the permissions available" do
+    mock = Minitest::Mock.new
+    update_policy_response = Google::Apis::StorageV1::TestIamPermissionsResponse.new permissions: ["storage.buckets.get"]
+    mock.expect :test_bucket_iam_permissions, update_policy_response, [bucket_name, ["storage.buckets.get", "storage.buckets.delete"]]
+
+    storage.service.mocked_service = mock
+    permissions = bucket.test_permissions "storage.buckets.get",
+                                           "storage.buckets.delete"
+    mock.verify
+
+    permissions.must_equal ["storage.buckets.get"]
+  end
+end


### PR DESCRIPTION
This PR adds a Policy class as well as the IAM methods for Bucket to Storage.

It does not add the IAM methods for File (Object).

Acceptance tests are passing for me locally now after whitelisting projects.

[refs #1383]