### PR TITLE
Update google-gax dependency

### DIFF
--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 0.8.0"
+  gem.add_dependency "google-gax", "~> 0.8.2"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"


### PR DESCRIPTION
The latest GAPIC files require some changes that were added in google-gax 0.8.2.

[refs #1390]