### PR TITLE
Fix Windows build for debugger

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ environment:
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - C:\Ruby21\DevKit\devkitvars.bat
   - bundle install
 
 build: off

--- a/google-cloud-debugger/test/google/cloud/debugger/debuggee/app_uniquifier_generator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/debuggee/app_uniquifier_generator_test.rb
@@ -57,8 +57,8 @@ describe Google::Cloud::Debugger::Debuggee::AppUniquifierGenerator do
 
       sha.to_s.must_equal expected_sha.to_s
 
-      test_file = Pathname.new "#{File.dirname(__FILE__)}/test_dir/test_ruby_file.rb"
-      expected_sha << "#{test_file.expand_path}:56"
+      test_file = Pathname.new File.join(File.dirname(__FILE__), "test_dir", "test_ruby_file.rb")
+      expected_sha << "#{test_file.expand_path}:#{test_file.stat.size}"
 
       Google::Cloud::Debugger::Debuggee::AppUniquifierGenerator.process_directory sha, "#{File.dirname(__FILE__)}/test_dir"
       sha.to_s.must_equal expected_sha.to_s


### PR DESCRIPTION
In order for Windows builds to compile the google-cloud-debugger C extensions, it needs to include all the compilation tools from DevKit. According to this [post](http://help.appveyor.com/discussions/problems/2504-what-is-the-right-way-to-include-the-ruby-devkit), the DevKit initialization script is located at `C:\Ruby21\DevKit\devkitvars.bat`. This script is applied to all Ruby 2.x versions.

Also fixes this one unit test that's failing on Windows. Now it should pass on both Windows and Linux.