### PR TITLE
Google cloud debugger

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,17 @@
 environment:
   matrix:
     - RUBY_VERSION: 23-x64
+      DEVKIT: C:\Ruby23-x64\DevKit
     - RUBY_VERSION: 22-x64
+      DEVKIT: C:\Ruby23-x64\DevKit
     - RUBY_VERSION: 21-x64
+      DEVKIT: C:\Ruby23-x64\DevKit
     - RUBY_VERSION: 200-x64
+      DEVKIT: C:\Ruby23-x64\DevKit
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
-  - C:\Ruby21\DevKit\devkitvars.bat
+  - "%DEVKIT%\\devkitvars.bat"
   - bundle install
 
 build: off

--- a/google-cloud-debugger/test/google/cloud/debugger/async_actor_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/async_actor_test.rb
@@ -216,6 +216,7 @@ describe Google::Cloud::Debugger::AsyncActor do
       klass = Google::Cloud::Debugger::AsyncActor
       actor.async_start
       klass.instance_variable_get("@cleanup_list").must_include actor
+      actor.async_stop
     end
   end
 

--- a/google-cloud-debugger/test/google/cloud/debugger/transmitter_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/transmitter_test.rb
@@ -27,18 +27,27 @@ describe Google::Cloud::Debugger::Transmitter, :mock_debugger do
     end
 
     it "doesn't exceeds max_queue_size" do
-      max_queue_size = transmitter.max_queue_size
-      transmitter.start
+      max_queue_size = 3
+      transmitter.max_queue_size = max_queue_size
+      transmitter.instance_variable_set :@lock_cond, OpenStruct.new(broadcast: nil)
 
-      transmitter.instance_variable_get(:@lock_cond).stub :broadcast, nil do
-        max_queue_size.times do |i|
-          transmitter.submit i
-        end
-
-        transmitter.submit nil
-
-        transmitter.instance_variable_get(:@queue).size.must_equal max_queue_size
+      max_queue_size.times do |i|
+        transmitter.submit i
       end
+
+      wait_until_true do
+        transmitter.instance_variable_get(:@queue).size == max_queue_size
+      end
+
+      transmitter.submit nil
+
+      wait_until_true do
+        transmitter.instance_variable_get(:@queue).size == max_queue_size
+      end
+
+      transmitter.instance_variable_get(:@queue).size.must_equal max_queue_size
+
+      transmitter.instance_variable_set :@lock_cond, nil
     end
 
     it "wakes up the child queue to dequeue the breakpoints" do

--- a/google-cloud-debugger/test/helper.rb
+++ b/google-cloud-debugger/test/helper.rb
@@ -27,9 +27,21 @@ class MockDebugger < Minitest::Spec
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
   let(:module_name) { "test-service" }
   let(:module_version) { "vTest" }
+  let(:service) {
+    service = Google::Cloud::Debugger::Service.new(project, credentials)
+    mocked_debugger = Object.new
+    mocked_transmitter = Object.new
+    mocked_debugger.define_singleton_method :register_debuggee do |*_| end
+    mocked_debugger.define_singleton_method :list_active_breakpoints do |*_| end
+    mocked_transmitter.define_singleton_method :update_active_breakpoint do |*_| end
+
+    service.mocked_debugger = mocked_debugger
+    service.mocked_transmitter = mocked_transmitter
+    service
+  }
   let(:debugger) {
     Google::Cloud::Debugger::Project.new(
-      Google::Cloud::Debugger::Service.new(project, credentials),
+      service,
       module_name: module_name,
       module_version: module_version
     )


### PR DESCRIPTION
Update the DevKit path for Windows build again. This time, I actually tested the Windows builds from a private Appveyor CI project.

The unit tests were also hanging on Windows with Ruby 2.2. Seems like the some of the unit tests weren't stubbed correctly and were actually making gRPC calls. The GAPIC clients are now mocked and won't make any real gRPC calls.