### PR TITLE
Add Natural Language GAPIC V1Beta2 to docs TOC

### DIFF
--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -112,6 +112,16 @@ task :jsondoc => :yard do
             include: ["google/cloud/language/v1"]
           }
         ]
+      },
+      {
+        type: "toc",
+        title: "Google::Cloud::Language::V1beta2::DataTypes",
+        modules: [
+          {
+            title: "Google::Cloud::Language::V1beta2",
+            include: ["google/cloud/language/v1beta2"]
+          }
+        ]
       }
     ]
   }

--- a/google-cloud-language/docs/toc.json
+++ b/google-cloud-language/docs/toc.json
@@ -49,7 +49,7 @@
         {
           "title": "V1",
           "type": "google/cloud/language/v1",
-          "patterns": ["\/language\/v1"],
+          "patterns": ["\/language\/v1$", "\/language\/v1\/"],
           "nav": [
             {
               "title": "LanguageServiceClient",
@@ -58,6 +58,21 @@
             {
               "title": "Data Types",
               "type": "google/cloud/language/v1/datatypes"
+            }
+          ]
+        },
+        {
+          "title": "V1Beta2",
+          "type": "google/cloud/language/v1beta2",
+          "patterns": ["\/language\/v1beta2"],
+          "nav": [
+            {
+              "title": "LanguageServiceClient",
+              "type": "google/cloud/language/v1beta2/languageserviceclient"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/cloud/language/v1beta2/datatypes"
             }
           ]
         }

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -287,7 +287,7 @@
         {
           "title": "V1",
           "type": "google/cloud/language/v1",
-          "patterns": ["\/language\/v1"],
+          "patterns": ["\/language\/v1$", "\/language\/v1\/"],
           "nav": [
             {
               "title": "LanguageServiceClient",
@@ -296,6 +296,21 @@
             {
               "title": "Data Types",
               "type": "google/cloud/language/v1/datatypes"
+            }
+          ]
+        },
+        {
+          "title": "V1Beta2",
+          "type": "google/cloud/language/v1beta2",
+          "patterns": ["\/language\/v1beta2"],
+          "nav": [
+            {
+              "title": "LanguageServiceClient",
+              "type": "google/cloud/language/v1beta2/languageserviceclient"
+            },
+            {
+              "title": "Data Types",
+              "type": "google/cloud/language/v1beta2/datatypes"
             }
           ]
         }


### PR DESCRIPTION
This PR adds the new Natural Language `V1Beta2` to the left nav in the gh-pages site.

I have already deployed this change to the master branch docs for both [`google-cloud`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/google/cloud/language) and [`google-cloud-language`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-language/master/google/cloud/language). These updates can be rolled back if needed.