### PR TITLE
Add IAM methods to File

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -915,7 +915,7 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   policy = bucket.policy # API call
         #   policy_2 = bucket.policy # No API call
@@ -925,7 +925,7 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   policy = bucket.policy force: true # API call
         #   policy_2 = bucket.policy force: true # API call
@@ -935,10 +935,10 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   policy = bucket.policy do |p|
-        #     p.add "roles/owner", "user:owner@example.com"
+        #     p.add "roles/storage.admin", "user:owner@example.com"
         #   end # 2 API calls
         #
         def policy force: false
@@ -976,11 +976,11 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   policy = bucket.policy # API call
         #
-        #   policy.add "roles/owner", "user:owner@example.com"
+        #   policy.add "roles/storage.admin", "user:owner@example.com"
         #
         #   bucket.policy = policy # API call
         #
@@ -1009,7 +1009,7 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   permissions = bucket.test_permissions "storage.buckets.get",
         #                                         "storage.buckets.delete"

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -61,7 +61,7 @@ module Google
       #
       #   storage = Google::Cloud::Storage.new
       #
-      #   bucket = storage.bucket "my-todo-app"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   policy = bucket.policy # API call
       #
@@ -99,7 +99,7 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   policy = bucket.policy # API call
         #
@@ -129,7 +129,7 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   policy = bucket.policy # API call
         #
@@ -157,7 +157,7 @@ module Google
         #
         #   storage = Google::Cloud::Storage.new
         #
-        #   bucket = storage.bucket "my-todo-app"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   policy = bucket.policy
         #

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -323,6 +323,38 @@ module Google
         end
 
         ##
+        # Returns Google::Apis::StorageV1::Policy
+        def get_file_policy bucket_name, file_name
+          # get_object_iam_policy(bucket, object, generation: nil, fields: nil,
+          #                                       quota_user: nil, user_ip: nil,
+          #                                       options: nil)
+          execute { service.get_object_iam_policy bucket_name, file_name }
+        end
+
+        ##
+        # Returns Google::Apis::StorageV1::Policy
+        def set_file_policy bucket_name, file_name, new_policy
+          # set_object_iam_policy(bucket, object, policy_object = nil,
+          #                       generation: nil, fields: nil, quota_user: nil,
+          #                       user_ip: nil, options: nil)
+          execute do
+            service.set_object_iam_policy bucket_name, file_name, new_policy
+          end
+        end
+
+        ##
+        # Returns Google::Apis::StorageV1::TestIamPermissionsResponse
+        def test_file_permissions bucket_name, file_name, permissions
+          execute do
+            # test_object_iam_permissions(bucket, object, permissions,
+            # generation: nil, fields: nil, quota_user: nil, user_ip: nil,
+            # options: nil)
+            service.test_object_iam_permissions bucket_name, file_name,
+                                                permissions
+          end
+        end
+
+        ##
         # Retrieves the mime-type for a file path.
         # An empty string is returned if no mime-type can be found.
         def mime_type_for path

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -242,40 +242,40 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket#policy" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-bucket"]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#policy@Use `force` to retrieve the latest policy from the service:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-bucket"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-bucket"]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#policy@Update the policy by passing a block:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-bucket"]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-bucket", Google::Apis::StorageV1::Policy]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#policy=" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-bucket"]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-bucket", Google::Apis::StorageV1::Policy]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#test_permissions" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :test_bucket_iam_permissions, permissions_gapi, ["my-todo-app", ["storage.buckets.get", "storage.buckets.delete"]]
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-bucket"]
+      mock.expect :test_bucket_iam_permissions, bucket_permissions_gapi, ["my-bucket", ["storage.buckets.get", "storage.buckets.delete"]]
     end
   end
 
@@ -477,23 +477,6 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Bucket::Policy
-
-  doctest.before "Google::Cloud::Storage::Policy" do
-    mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
-    end
-  end
-
-  doctest.before "Google::Cloud::Storage::Policy#role" do
-    mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-    end
-  end
-
   # File
 
   doctest.before "Google::Cloud::Storage::File" do
@@ -604,6 +587,50 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::File#policy" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :get_object_iam_policy, policy_gapi, ["my-bucket", "path/to/my-file.ext"]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::File#policy@Use `force` to retrieve the latest policy from the service:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :get_object_iam_policy, policy_gapi, ["my-bucket", "path/to/my-file.ext"]
+      mock.expect :get_object_iam_policy, policy_gapi, ["my-bucket", "path/to/my-file.ext"]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::File#policy@Update the policy by passing a block:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :get_object_iam_policy, policy_gapi, ["my-bucket", "path/to/my-file.ext"]
+      mock.expect :set_object_iam_policy, new_policy_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Policy]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::File#policy=" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :get_object_iam_policy, policy_gapi, ["my-bucket", "path/to/my-file.ext"]
+      mock.expect :set_object_iam_policy, new_policy_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Policy]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::File#test_permissions" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :get_object_iam_policy, policy_gapi, ["my-bucket", "path/to/my-file.ext"]
+      mock.expect :test_object_iam_permissions, file_permissions_gapi, ["my-bucket", "path/to/my-file.ext", ["storage.objects.get", "storage.objects.delete"]]
+    end
+  end
+
   # File::Acl
 
   doctest.before "Google::Cloud::Storage::File::Acl" do
@@ -709,6 +736,23 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
       mock.expect :list_objects, list_files_gapi, ["my-bucket", {:delimiter=>nil, :max_results=>nil, :page_token=>nil, :prefix=>nil, :versions=>nil}]
+    end
+  end
+
+  # Policy
+
+  doctest.before "Google::Cloud::Storage::Policy" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-bucket"]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-bucket", Google::Apis::StorageV1::Policy]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Policy#role" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi("my-bucket"), ["my-bucket"]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-bucket"]
     end
   end
 
@@ -1046,8 +1090,14 @@ def new_policy_gapi
   )
 end
 
-def permissions_gapi
+def bucket_permissions_gapi
   Google::Apis::StorageV1::TestIamPermissionsResponse.new(
     permissions: ["storage.buckets.get"]
+  )
+end
+
+def file_permissions_gapi
+  Google::Apis::StorageV1::TestIamPermissionsResponse.new(
+    permissions: ["storage.objects.get"]
   )
 end

--- a/google-cloud-storage/test/google/cloud/storage/file_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_iam_test.rb
@@ -1,0 +1,185 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Storage::File, :iam, :mock_storage do
+  let(:bucket_name) { "bucket" }
+  let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash(bucket_name).to_json }
+  let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
+
+  let(:file_name) { "file.ext" }
+  let(:file_hash) { random_file_hash bucket.name, file_name }
+  let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
+  let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
+  
+  let(:old_policy_gapi) {
+    Google::Apis::StorageV1::Policy.new(
+      etag: "CAE=",
+      bindings: [
+        Google::Apis::StorageV1::Policy::Binding.new(
+          role: "roles/storage.objectViewer",
+          members: [
+            "user:viewer@example.com"
+          ]
+        )
+      ]
+    )
+  }
+  let(:new_policy_gapi) {
+    Google::Apis::StorageV1::Policy.new(
+      etag: "CAE=",
+      bindings: [
+        Google::Apis::StorageV1::Policy::Binding.new(
+          role: "roles/storage.objectViewer",
+          members: [
+            "user:viewer@example.com",
+            "serviceAccount:1234567890@developer.gserviceaccount.com"
+          ]
+        )
+      ]
+    )
+  }
+  let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
+  let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
+
+  it "gets the policy" do
+    mock = Minitest::Mock.new
+    mock.expect :get_object_iam_policy, old_policy_gapi, [bucket_name, file_name]
+
+    storage.service.mocked_service = mock
+    policy = file.policy
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 1
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+  end
+
+  it "memoizes policy" do
+    file.instance_variable_set "@policy", old_policy
+
+    # No mocks, no errors, no HTTP calls are made
+    policy = file.policy
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 1
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+  end
+
+  it "can force load the policy" do
+    mock = Minitest::Mock.new
+    mock.expect :get_object_iam_policy, new_policy_gapi, [bucket_name, file_name]
+
+    storage.service.mocked_service = mock
+    policy = file.policy force: true
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "can force load the policy, even if already memoized" do
+    # memoize the policy object
+    file.instance_variable_set "@policy", old_policy
+
+    returned_policy = file.policy
+    returned_policy.must_be_kind_of Google::Cloud::Storage::Policy
+    returned_policy.roles.must_be_kind_of Hash
+    returned_policy.roles.size.must_equal 1
+    returned_policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    returned_policy.roles["roles/storage.objectViewer"].count.must_equal 1
+    returned_policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_object_iam_policy, new_policy_gapi, [bucket_name, file_name]
+
+    storage.service.mocked_service = mock
+    policy = file.policy force: true
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "sets the policy" do
+    mock = Minitest::Mock.new
+    mock.expect :set_object_iam_policy, new_policy_gapi, [bucket_name, file_name, new_policy_gapi]
+
+    storage.service.mocked_service = mock
+    file.policy = new_policy
+    mock.verify
+
+    # Setting the policy also memoizes the policy
+    file.policy.must_be_kind_of Google::Cloud::Storage::Policy
+    file.policy.roles.must_be_kind_of Hash
+    file.policy.roles.size.must_equal 1
+    file.policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    file.policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    file.policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    file.policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "sets the policy in a block" do
+    # memoize the policy object, to ensure that it is reloaded for update
+    file.instance_variable_set "@policy", old_policy
+
+    mock = Minitest::Mock.new
+    mock.expect :get_object_iam_policy, old_policy_gapi, [bucket_name, file_name]
+
+    mock.expect :set_object_iam_policy, new_policy_gapi, [bucket_name, file_name, new_policy_gapi]
+
+    storage.service.mocked_service = mock
+    policy = file.policy do |p|
+      p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    file.policy.roles.size.must_equal 1
+    file.policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    file.policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    file.policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    file.policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "tests the permissions available" do
+    mock = Minitest::Mock.new
+    update_policy_response = Google::Apis::StorageV1::TestIamPermissionsResponse.new permissions: ["storage.objects.get"]
+    mock.expect :test_object_iam_permissions, update_policy_response, [bucket_name, file_name, ["storage.objects.get", "storage.objects.delete"]]
+
+    storage.service.mocked_service = mock
+    permissions = file.test_permissions "storage.objects.get",
+                                           "storage.objects.delete"
+    mock.verify
+
+    permissions.must_equal ["storage.objects.get"]
+  end
+end


### PR DESCRIPTION
This bucket adds the three IAM methods to File, and also (superficially) updates the bucket name used in Bucket examples to match File examples.

[closes #1383]

This PR is currently blocked by a service error and should not be merged. (Note: The `roles/storage.objectCreator` role is listed in the [Objects: setIamPolicy docs](https://cloud.google.com/storage/docs/json_api/v1/objects/setIamPolicy).)

```sh
  1) Error:
Google::Cloud::Storage::File::storage::IAM Policies and Permissions#test_0001_allows policy to be updated on a file:
Google::Cloud::InvalidArgumentError: invalid: roles/storage.objectCreator is not a valid role for buckets/gcloud-ruby-acceptance-2017-04-07t22-39-30z-fcff6925/objects/CloudLogoPolicyUpdateFile.png#0.
    /Users/quartzmo/code/google/codez/gcloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:405:in `rescue in execute'
    /Users/quartzmo/code/google/codez/gcloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:403:in `execute'
    /Users/quartzmo/code/google/codez/gcloud-ruby/google-cloud-storage/lib/google/cloud/storage/service.rb:340:in `set_file_policy'
    /Users/quartzmo/code/google/codez/gcloud-ruby/google-cloud-storage/lib/google/cloud/storage/file.rb:908:in `policy='
    /Users/quartzmo/code/google/codez/gcloud-ruby/google-cloud-storage/lib/google/cloud/storage/file.rb:871:in `policy'
    /Users/quartzmo/code/google/codez/gcloud-ruby/google-cloud-storage/acceptance/storage/file_test.rb:547:in `block (3 levels) in <top (required)>'
```