### PR TITLE
Speech use LINEAR16

### DIFF
--- a/google-cloud-speech/README.md
+++ b/google-cloud-speech/README.md
@@ -26,7 +26,7 @@ require "google/cloud/speech"
 speech = Google::Cloud::Speech.new
 
 audio = speech.audio "path/to/audio.raw",
-                     encoding: :raw,
+                     encoding: :linear16,
                      language: "en-US",
                      sample_rate: 16000
 

--- a/google-cloud-speech/acceptance/speech/async_test.rb
+++ b/google-cloud-speech/acceptance/speech/async_test.rb
@@ -22,7 +22,7 @@ describe "Asynchonous Recognition", :speech do
   let(:gcs_url)  { gcs_file.to_gs_url }
 
   it "recognizes audio from local file path" do
-    op = speech.process filepath, encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process filepath, encoding: :linear16, language: "en-US", sample_rate: 16000
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
     op.wont_be :done?
@@ -37,7 +37,7 @@ describe "Asynchonous Recognition", :speech do
   end
 
   it "recognizes audio from local file object" do
-    op = speech.process File.open(filepath, "rb"), encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process File.open(filepath, "rb"), encoding: :linear16, language: "en-US", sample_rate: 16000
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
     op.wont_be :done?
@@ -52,7 +52,7 @@ describe "Asynchonous Recognition", :speech do
   end
 
   it "recognizes audio from GCS URL" do
-    op = speech.process gcs_url, encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process gcs_url, encoding: :linear16, language: "en-US", sample_rate: 16000
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
     op.wont_be :done?
@@ -67,7 +67,7 @@ describe "Asynchonous Recognition", :speech do
   end
 
   it "recognizes audio from Storage File URL" do
-    op = speech.process gcs_file, encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process gcs_file, encoding: :linear16, language: "en-US", sample_rate: 16000
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
     op.wont_be :done?
@@ -83,7 +83,7 @@ describe "Asynchonous Recognition", :speech do
 
   it "recognizes audio from Audio object" do
     audio = speech.audio gcs_url
-    op = speech.process audio, encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process audio, encoding: :linear16, language: "en-US", sample_rate: 16000
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
     op.wont_be :done?
@@ -98,7 +98,7 @@ describe "Asynchonous Recognition", :speech do
   end
 
   it "recognizes audio from Audio object, preserving attributes" do
-    audio = speech.audio gcs_url, encoding: :raw, language: "en-US", sample_rate: 16000
+    audio = speech.audio gcs_url, encoding: :linear16, language: "en-US", sample_rate: 16000
     op = speech.process audio
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
@@ -114,7 +114,7 @@ describe "Asynchonous Recognition", :speech do
   end
 
   it "recognizes audio from Audio object, preserving attributes, language (Symbol)" do
-    audio = speech.audio gcs_url, encoding: :raw, language: "en-US", sample_rate: 16000
+    audio = speech.audio gcs_url, encoding: :linear16, language: "en-US", sample_rate: 16000
     op = speech.process audio
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
@@ -131,7 +131,7 @@ describe "Asynchonous Recognition", :speech do
 
   it "recognizes audio from Audio object, overriding attributes" do
     audio = speech.audio gcs_url, encoding: :flac, sample_rate: 48000, language: "es-ES"
-    op = speech.process audio, encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process audio, encoding: :linear16, language: "en-US", sample_rate: 16000
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
     op.wont_be :done?
@@ -146,7 +146,7 @@ describe "Asynchonous Recognition", :speech do
   end
 
   it "can retrieve operations by id" do
-    op = speech.process filepath, encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process filepath, encoding: :linear16, language: "en-US", sample_rate: 16000
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
     op.wont_be :done?

--- a/google-cloud-speech/acceptance/speech/stream_test.rb
+++ b/google-cloud-speech/acceptance/speech/stream_test.rb
@@ -20,7 +20,7 @@ describe "Streaming Recognition", :speech do
   it "default params" do
     counters = Hash.new { |h, k| h[k] = 0 }
 
-    stream = speech.stream encoding: :raw, sample_rate: 16000, language: "en-US"
+    stream = speech.stream encoding: :linear16, sample_rate: 16000, language: "en-US"
 
     stream.on_interim      { counters[:interim] += 1 }
     stream.on_result       { counters[:result] += 1 }
@@ -52,7 +52,7 @@ describe "Streaming Recognition", :speech do
   it "sends multiple times" do
     counters = Hash.new { |h, k| h[k] = 0 }
 
-    stream = speech.stream encoding: :raw, sample_rate: 16000, language: "en-US"
+    stream = speech.stream encoding: :linear16, sample_rate: 16000, language: "en-US"
 
     stream.on_interim      { counters[:interim] += 1 }
     stream.on_result       { counters[:result] += 1 }
@@ -94,7 +94,7 @@ describe "Streaming Recognition", :speech do
     it "default params" do
       counters = Hash.new { |h, k| h[k] = 0 }
 
-      stream = speech.stream encoding: :raw, sample_rate: 16000, language: "en-US", interim: true
+      stream = speech.stream encoding: :linear16, sample_rate: 16000, language: "en-US", interim: true
 
       stream.on_interim      { counters[:interim] += 1 }
       stream.on_result       { counters[:result] += 1 }
@@ -126,7 +126,7 @@ describe "Streaming Recognition", :speech do
     it "sends multiple times" do
       counters = Hash.new { |h, k| h[k] = 0 }
 
-      stream = speech.stream encoding: :raw, sample_rate: 16000, language: "en-US", interim: true
+      stream = speech.stream encoding: :linear16, sample_rate: 16000, language: "en-US", interim: true
 
       stream.on_interim      { counters[:interim] += 1 }
       stream.on_result       { counters[:result] += 1 }
@@ -166,7 +166,7 @@ describe "Streaming Recognition", :speech do
     it "default params" do
       counters = Hash.new { |h, k| h[k] = 0 }
 
-      stream = speech.stream encoding: :raw, sample_rate: 16000, language: "en-US", utterance: true
+      stream = speech.stream encoding: :linear16, sample_rate: 16000, language: "en-US", utterance: true
 
       stream.on_interim      { counters[:interim] += 1 }
       stream.on_result       { counters[:result] += 1 }
@@ -206,7 +206,7 @@ describe "Streaming Recognition", :speech do
     it "sends multiple times" do
       counters = Hash.new { |h, k| h[k] = 0 }
 
-      stream = speech.stream encoding: :raw, sample_rate: 16000, language: "en-US", utterance: true
+      stream = speech.stream encoding: :linear16, sample_rate: 16000, language: "en-US", utterance: true
 
       stream.on_interim      { counters[:interim] += 1 }
       stream.on_result       { counters[:result] += 1 }

--- a/google-cloud-speech/acceptance/speech/sync_test.rb
+++ b/google-cloud-speech/acceptance/speech/sync_test.rb
@@ -22,7 +22,7 @@ describe "Synchonous Recognition", :speech do
   let(:gcs_url)  { gcs_file.to_gs_url }
 
   it "recognizes audio from local file path" do
-    results = speech.recognize filepath, encoding: :raw, sample_rate: 16000, language: "en-US"
+    results = speech.recognize filepath, encoding: :linear16, sample_rate: 16000, language: "en-US"
 
     results.count.must_equal 1
     results.first.transcript.must_equal "how old is the Brooklyn Bridge"
@@ -31,7 +31,7 @@ describe "Synchonous Recognition", :speech do
   end
 
   it "recognizes audio from local file object" do
-    results = speech.recognize File.open(filepath, "rb"), encoding: :raw, sample_rate: 16000, language: "en-US"
+    results = speech.recognize File.open(filepath, "rb"), encoding: :linear16, sample_rate: 16000, language: "en-US"
 
     results.count.must_equal 1
     results.first.transcript.must_equal "how old is the Brooklyn Bridge"
@@ -40,7 +40,7 @@ describe "Synchonous Recognition", :speech do
   end
 
   it "recognizes audio from GCS URL" do
-    results = speech.recognize gcs_url, encoding: :raw, sample_rate: 16000, language: "en-US"
+    results = speech.recognize gcs_url, encoding: :linear16, sample_rate: 16000, language: "en-US"
 
     results.count.must_equal 1
     results.first.transcript.must_equal "how old is the Brooklyn Bridge"
@@ -49,7 +49,7 @@ describe "Synchonous Recognition", :speech do
   end
 
   it "recognizes audio from Storage File object" do
-    results = speech.recognize gcs_file, encoding: :raw, sample_rate: 16000, language: "en-US"
+    results = speech.recognize gcs_file, encoding: :linear16, sample_rate: 16000, language: "en-US"
 
     results.count.must_equal 1
     results.first.transcript.must_equal "how old is the Brooklyn Bridge"
@@ -58,7 +58,7 @@ describe "Synchonous Recognition", :speech do
   end
 
   it "recognizes audio from Audio object" do
-    audio = speech.audio gcs_url, encoding: :raw, sample_rate: 16000, language: "en-US"
+    audio = speech.audio gcs_url, encoding: :linear16, sample_rate: 16000, language: "en-US"
     results = speech.recognize audio
 
     results.count.must_equal 1
@@ -69,7 +69,7 @@ describe "Synchonous Recognition", :speech do
 
   it "recognizes audio from Audio object, preserving attributes" do
     audio = speech.audio gcs_url
-    results = speech.recognize audio, encoding: :raw, sample_rate: 16000, language: "en-US"
+    results = speech.recognize audio, encoding: :linear16, sample_rate: 16000, language: "en-US"
 
     results.count.must_equal 1
     results.first.transcript.must_equal "how old is the Brooklyn Bridge"
@@ -79,7 +79,7 @@ describe "Synchonous Recognition", :speech do
 
   it "recognizes audio from Audio object, preserving attributes, language (Symbol)" do
     audio = speech.audio gcs_url
-    results = speech.recognize audio, encoding: :raw, sample_rate: 16000, language: "en-US".to_sym
+    results = speech.recognize audio, encoding: :linear16, sample_rate: 16000, language: "en-US".to_sym
 
     results.count.must_equal 1
     results.first.transcript.must_equal "how old is the Brooklyn Bridge"
@@ -89,7 +89,7 @@ describe "Synchonous Recognition", :speech do
 
   it "recognizes audio from Audio object, overriding attributes" do
     audio = speech.audio gcs_url, encoding: :flac, sample_rate: 48000, language: "es-ES"
-    results = speech.recognize audio, encoding: :raw, sample_rate: 16000, language: "en-US"
+    results = speech.recognize audio, encoding: :linear16, sample_rate: 16000, language: "en-US"
 
     results.count.must_equal 1
     results.first.transcript.must_equal "how old is the Brooklyn Bridge"

--- a/google-cloud-speech/lib/google-cloud-speech.rb
+++ b/google-cloud-speech/lib/google-cloud-speech.rb
@@ -51,7 +51,7 @@ module Google
     #   speech = gcloud.speech
     #
     #   audio = speech.audio "path/to/audio.raw",
-    #                        encoding: :raw,
+    #                        encoding: :linear16,
     #                        language: "en-US",
     #                        sample_rate: 16000
     #
@@ -99,7 +99,7 @@ module Google
     #   speech = Google::Cloud.speech
     #
     #   audio = speech.audio "path/to/audio.raw",
-    #                        encoding: :raw,
+    #                        encoding: :linear16,
     #                        language: "en-US",
     #                        sample_rate: 16000
     #

--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -56,7 +56,7 @@ module Google
     # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio "path/to/audio.raw",
-    #                      encoding: :raw,
+    #                      encoding: :linear16,
     #                      language: "en-US",
     #                      sample_rate: 16000
     # ```
@@ -69,7 +69,7 @@ module Google
     # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio "gs://bucket-name/path/to/audio.raw",
-    #                      encoding: :raw,
+    #                      encoding: :linear16,
     #                      language: "en-US",
     #                      sample_rate: 16000
     # ```
@@ -89,7 +89,7 @@ module Google
     # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio file,
-    #                      encoding: :raw,
+    #                      encoding: :linear16,
     #                      language: "en-US",
     #                      sample_rate: 16000
     # ```
@@ -112,7 +112,7 @@ module Google
     # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio "path/to/audio.raw",
-    #                      encoding: :raw,
+    #                      encoding: :linear16,
     #                      language: "en-US",
     #                      sample_rate: 16000
     #
@@ -133,7 +133,7 @@ module Google
     # speech = Google::Cloud::Speech.new
     #
     # audio = speech.audio "path/to/audio.raw",
-    #                      encoding: :raw,
+    #                      encoding: :linear16,
     #                      language: "en-US",
     #                      sample_rate: 16000
     #
@@ -160,7 +160,7 @@ module Google
     #
     # audio = speech.audio "path/to/audio.raw"
     #
-    # stream = audio.stream encoding: :raw,
+    # stream = audio.stream encoding: :linear16,
     #                       language: "en-US",
     #                       sample_rate: 16000
     #
@@ -215,7 +215,7 @@ module Google
       #   speech = Google::Cloud::Speech.new
       #
       #   audio = speech.audio "path/to/audio.raw",
-      #                        encoding: :raw,
+      #                        encoding: :linear16,
       #                        language: "en-US",
       #                        sample_rate: 16000
       #

--- a/google-cloud-speech/lib/google/cloud/speech/audio.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/audio.rb
@@ -39,7 +39,7 @@ module Google
       #   speech = Google::Cloud::Speech.new
       #
       #   audio = speech.audio "path/to/audio.raw",
-      #                        encoding: :raw,
+      #                        encoding: :linear16,
       #                        language: "en-US",
       #                        sample_rate: 16000
       #
@@ -59,7 +59,7 @@ module Google
         #
         #   Acceptable values are:
         #
-        #   * `raw` - Uncompressed 16-bit signed little-endian samples.
+        #   * `linear16` - Uncompressed 16-bit signed little-endian samples.
         #     (LINEAR16)
         #   * `flac` - The [Free Lossless Audio
         #     Codec](http://flac.sourceforge.net/documentation.html) encoding.
@@ -92,8 +92,8 @@ module Google
         #                        language: "en-US",
         #                        sample_rate: 16000
         #
-        #   audio.encoding = :raw
-        #   audio.encoding #=> :raw
+        #   audio.encoding = :linear16
+        #   audio.encoding #=> :linear16
         #
         attr_accessor :encoding
 
@@ -113,7 +113,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
-        #                        encoding: :raw,
+        #                        encoding: :linear16,
         #                        sample_rate: 16000
         #
         #   audio.language = "en-US"
@@ -135,7 +135,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
-        #                        encoding: :raw,
+        #                        encoding: :linear16,
         #                        language: "en-US"
         #
         #   audio.sample_rate = 16000
@@ -200,7 +200,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
-        #                        encoding: :raw,
+        #                        encoding: :linear16,
         #                        language: "en-US",
         #                        sample_rate: 16000
         #
@@ -249,7 +249,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
-        #                        encoding: :raw,
+        #                        encoding: :linear16,
         #                        language: "en-US",
         #                        sample_rate: 16000
         #

--- a/google-cloud-speech/lib/google/cloud/speech/operation.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/operation.rb
@@ -39,7 +39,7 @@ module Google
       #   speech = Google::Cloud::Speech.new
       #
       #   op = speech.process "path/to/audio.raw",
-      #                       encoding: :raw,
+      #                       encoding: :linear16,
       #                       language: "en-US",
       #                       sample_rate: 16000
       #
@@ -70,7 +70,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #
@@ -92,7 +92,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #
@@ -114,7 +114,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #
@@ -141,7 +141,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #
@@ -165,7 +165,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #
@@ -190,7 +190,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #
@@ -212,7 +212,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #
@@ -236,7 +236,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -623,7 +623,7 @@ module Google
         end
 
         def convert_encoding encoding
-          mapping = { raw: :LINEAR16, linear: :LINEAR16, linear16: :LINEAR16,
+          mapping = { linear: :LINEAR16, linear16: :LINEAR16,
                       flac: :FLAC, mulaw: :MULAW, amr: :AMR, amr_wb: :AMR_WB,
                       ogg_opus: :OGG_OPUS, speex: :SPEEX_WITH_HEADER_BYTE }
           mapping[encoding] || encoding

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -44,7 +44,7 @@ module Google
       #   speech = Google::Cloud::Speech.new
       #
       #   audio = speech.audio "path/to/audio.raw",
-      #                        encoding: :raw,
+      #                        encoding: :linear16,
       #                        language: "en-US",
       #                        sample_rate: 16000
       #   results = audio.recognize
@@ -110,7 +110,7 @@ module Google
         #
         #   Acceptable values are:
         #
-        #   * `raw` - Uncompressed 16-bit signed little-endian samples.
+        #   * `linear16` - Uncompressed 16-bit signed little-endian samples.
         #     (LINEAR16)
         #   * `flac` - The [Free Lossless Audio
         #     Codec](http://flac.sourceforge.net/documentation.html) encoding.
@@ -152,7 +152,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
-        #                        encoding: :raw,
+        #                        encoding: :linear16,
         #                        language: "en-US",
         #                        sample_rate: 16000
         #
@@ -162,7 +162,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "gs://bucket-name/path/to/audio.raw",
-        #                        encoding: :raw,
+        #                        encoding: :linear16,
         #                        language: "en-US",
         #                        sample_rate: 16000
         #
@@ -179,7 +179,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio file,
-        #                        encoding: :raw,
+        #                        encoding: :linear16,
         #                        language: "en-US",
         #                        sample_rate: 16000
         #
@@ -222,7 +222,7 @@ module Google
         #
         #   Acceptable values are:
         #
-        #   * `raw` - Uncompressed 16-bit signed little-endian samples.
+        #   * `linear16` - Uncompressed 16-bit signed little-endian samples.
         #     (LINEAR16)
         #   * `flac` - The [Free Lossless Audio
         #     Codec](http://flac.sourceforge.net/documentation.html) encoding.
@@ -275,7 +275,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   results = speech.recognize "path/to/audio.raw",
-        #                              encoding: :raw,
+        #                              encoding: :linear16,
         #                              language: "en-US",
         #                              sample_rate: 16000
         #
@@ -285,7 +285,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   results = speech.recognize "gs://bucket-name/path/to/audio.raw",
-        #                              encoding: :raw,
+        #                              encoding: :linear16,
         #                              language: "en-US",
         #                              sample_rate: 16000
         #
@@ -302,7 +302,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   results = speech.recognize file,
-        #                              encoding: :raw,
+        #                              encoding: :linear16,
         #                              language: "en-US",
         #                              sample_rate: 16000,
         #                              max_alternatives: 10
@@ -344,7 +344,7 @@ module Google
         #
         #   Acceptable values are:
         #
-        #   * `raw` - Uncompressed 16-bit signed little-endian samples.
+        #   * `linear16` - Uncompressed 16-bit signed little-endian samples.
         #     (LINEAR16)
         #   * `flac` - The [Free Lossless Audio
         #     Codec](http://flac.sourceforge.net/documentation.html) encoding.
@@ -398,7 +398,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #
@@ -411,7 +411,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process "gs://bucket-name/path/to/audio.raw",
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000
         #
@@ -431,7 +431,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   op = speech.process file,
-        #                       encoding: :raw,
+        #                       encoding: :linear16,
         #                       language: "en-US",
         #                       sample_rate: 16000,
         #                       max_alternatives: 10
@@ -469,7 +469,7 @@ module Google
         #
         #   Acceptable values are:
         #
-        #   * `raw` - Uncompressed 16-bit signed little-endian samples.
+        #   * `linear16` - Uncompressed 16-bit signed little-endian samples.
         #     (LINEAR16)
         #   * `flac` - The [Free Lossless Audio
         #     Codec](http://flac.sourceforge.net/documentation.html) encoding.
@@ -530,7 +530,7 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000
         #

--- a/google-cloud-speech/lib/google/cloud/speech/result.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/result.rb
@@ -46,7 +46,7 @@ module Google
       #   speech = Google::Cloud::Speech.new
       #
       #   audio = speech.audio "path/to/audio.raw",
-      #                        encoding: :raw,
+      #                        encoding: :linear16,
       #                        language: "en-US",
       #                        sample_rate: 16000
       #   results = audio.recognize
@@ -96,7 +96,7 @@ module Google
         #   speech = Google::Cloud::Speech.new
         #
         #   audio = speech.audio "path/to/audio.raw",
-        #                        encoding: :raw,
+        #                        encoding: :linear16,
         #                        language: "en-US",
         #                        sample_rate: 16000
         #   results = audio.recognize
@@ -154,7 +154,7 @@ module Google
       #
       #   speech = Google::Cloud::Speech.new
       #
-      #   stream = speech.stream encoding: :raw,
+      #   stream = speech.stream encoding: :linear16,
       #                          language: "en-US",
       #                          sample_rate: 16000
       #

--- a/google-cloud-speech/lib/google/cloud/speech/stream.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/stream.rb
@@ -31,7 +31,7 @@ module Google
       #
       #   speech = Google::Cloud::Speech.new
       #
-      #   stream = speech.stream encoding: :raw,
+      #   stream = speech.stream encoding: :linear16,
       #                          language: "en-US",
       #                          sample_rate: 16000
       #
@@ -96,7 +96,7 @@ module Google
         #
         #   audio = speech.audio "path/to/audio.raw"
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000
         #
@@ -155,7 +155,7 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000
         #
@@ -189,7 +189,7 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000
         #
@@ -224,7 +224,7 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000
         #
@@ -266,7 +266,7 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000
         #
@@ -312,7 +312,7 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000
         #
@@ -357,7 +357,7 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000
         #
@@ -404,7 +404,7 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000,
         #                          utterance: true
@@ -449,7 +449,7 @@ module Google
         #
         #   speech = Google::Cloud::Speech.new
         #
-        #   stream = speech.stream encoding: :raw,
+        #   stream = speech.stream encoding: :linear16,
         #                          language: "en-US",
         #                          sample_rate: 16000
         #

--- a/google-cloud-speech/test/google/cloud/speech/audio/process_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/process_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Speech::Audio, :process, :mock_speech do
     mock = Minitest::Mock.new
     mock.expect :long_running_recognize, op_grpc, [config_grpc, audio_grpc, options: default_options]
 
-    audio.encoding = :raw
+    audio.encoding = :linear16
     audio.sample_rate = 16000
     audio.language = "en-US"
 
@@ -46,7 +46,7 @@ describe Google::Cloud::Speech::Audio, :process, :mock_speech do
     mock = Minitest::Mock.new
     mock.expect :long_running_recognize, op_grpc, [config_grpc, audio_grpc, options: default_options]
 
-    audio.encoding = :raw
+    audio.encoding = :linear16
     audio.sample_rate = 16000
     audio.language = :en
 

--- a/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Speech::Audio, :recognize, :mock_speech do
     mock = Minitest::Mock.new
     mock.expect :recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
-    audio.encoding = :raw
+    audio.encoding = :linear16
     audio.sample_rate = 16000
     audio.language = "en-US"
 
@@ -48,7 +48,7 @@ describe Google::Cloud::Speech::Audio, :recognize, :mock_speech do
     mock = Minitest::Mock.new
     mock.expect :recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
-    audio.encoding = :raw
+    audio.encoding = :linear16
     audio.sample_rate = 16000
     audio.language = :en
 

--- a/google-cloud-speech/test/google/cloud/speech/project/audio_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/audio_test.rb
@@ -20,12 +20,12 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
   let(:filepath) { "acceptance/data/audio.raw" }
 
   it "can create from an existing file path" do
-    audio = speech.audio filepath, encoding: :raw, sample_rate: 16000
+    audio = speech.audio filepath, encoding: :linear16, sample_rate: 16000
 
     audio.must_be_kind_of Google::Cloud::Speech::Audio
     audio.must_be :content?
     audio.wont_be :url?
-    audio.encoding.must_equal :raw
+    audio.encoding.must_equal :linear16
     audio.sample_rate.must_equal 16000
     audio.language.must_be :nil?
 
@@ -36,12 +36,12 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
   end
 
   it "can create from a Pathname object" do
-    audio = speech.audio Pathname.new(filepath), encoding: :raw, language: "en-US"
+    audio = speech.audio Pathname.new(filepath), encoding: :linear16, language: "en-US"
 
     audio.must_be_kind_of Google::Cloud::Speech::Audio
     audio.must_be :content?
     audio.wont_be :url?
-    audio.encoding.must_equal :raw
+    audio.encoding.must_equal :linear16
     audio.sample_rate.must_be :nil?
     audio.language.must_equal "en-US"
 
@@ -52,12 +52,12 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
   end
 
   it "can create from a File object" do
-    audio = speech.audio File.open(filepath, "rb"), encoding: :raw, language: "en-US", sample_rate: 16000
+    audio = speech.audio File.open(filepath, "rb"), encoding: :linear16, language: "en-US", sample_rate: 16000
 
     audio.must_be_kind_of Google::Cloud::Speech::Audio
     audio.must_be :content?
     audio.wont_be :url?
-    audio.encoding.must_equal :raw
+    audio.encoding.must_equal :linear16
     audio.sample_rate.must_equal 16000
     audio.language.must_equal "en-US"
 
@@ -90,12 +90,12 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
       tmpfile.write File.read(filepath, mode: "rb")
       # tmpfile.rewind
 
-      audio = speech.audio tmpfile, encoding: :raw, language: "en-US", sample_rate: 16000
+      audio = speech.audio tmpfile, encoding: :linear16, language: "en-US", sample_rate: 16000
 
       audio.must_be_kind_of Google::Cloud::Speech::Audio
       audio.must_be :content?
       audio.wont_be :url?
-      audio.encoding.must_equal :raw
+      audio.encoding.must_equal :linear16
       audio.sample_rate.must_equal 16000
       audio.language.must_equal "en-US"
 
@@ -107,12 +107,12 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
   end
 
   it "can create from a Google Storage URL" do
-    audio = speech.audio "gs://test/file.ext", encoding: :raw, language: "en-US", sample_rate: 16000
+    audio = speech.audio "gs://test/file.ext", encoding: :linear16, language: "en-US", sample_rate: 16000
 
     audio.must_be_kind_of Google::Cloud::Speech::Audio
     audio.wont_be :content?
     audio.must_be :url?
-    audio.encoding.must_equal :raw
+    audio.encoding.must_equal :linear16
     audio.sample_rate.must_equal 16000
     audio.language.must_equal "en-US"
 
@@ -124,12 +124,12 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
 
   it "can create from a Storage::File object" do
     gs_img = OpenStruct.new to_gs_url: "gs://test/file.ext"
-    audio = speech.audio gs_img, encoding: :raw, language: "en-US", sample_rate: 16000
+    audio = speech.audio gs_img, encoding: :linear16, language: "en-US", sample_rate: 16000
 
     audio.must_be_kind_of Google::Cloud::Speech::Audio
     audio.wont_be :content?
     audio.must_be :url?
-    audio.encoding.must_equal :raw
+    audio.encoding.must_equal :linear16
     audio.sample_rate.must_equal 16000
     audio.language.must_equal "en-US"
 
@@ -140,13 +140,13 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
   end
 
   it "can take an Audio object as the source" do
-    orig_audio = speech.audio "gs://test/file.ext", encoding: :raw, language: "en-US", sample_rate: 16000
+    orig_audio = speech.audio "gs://test/file.ext", encoding: :linear16, language: "en-US", sample_rate: 16000
     audio = speech.audio orig_audio
 
     audio.must_be_kind_of Google::Cloud::Speech::Audio
     audio.wont_be :content?
     audio.must_be :url?
-    audio.encoding.must_equal :raw
+    audio.encoding.must_equal :linear16
     audio.sample_rate.must_equal 16000
     audio.language.must_equal "en-US"
 
@@ -157,13 +157,13 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
   end
 
   it "preserves attributes from Audio object as the source" do
-    orig_audio = speech.audio Pathname.new(filepath), encoding: :raw, language: "en-US", sample_rate: 16000
+    orig_audio = speech.audio Pathname.new(filepath), encoding: :linear16, language: "en-US", sample_rate: 16000
     audio = speech.audio orig_audio
 
     audio.must_be_kind_of Google::Cloud::Speech::Audio
     audio.must_be :content?
     audio.wont_be :url?
-    audio.encoding.must_equal :raw
+    audio.encoding.must_equal :linear16
     audio.sample_rate.must_equal 16000
     audio.language.must_equal "en-US"
 
@@ -174,7 +174,7 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
   end
 
   it "overrides attributes from Audio object as the source" do
-    orig_audio = speech.audio Pathname.new(filepath), encoding: :raw, language: "en-US", sample_rate: 16000
+    orig_audio = speech.audio Pathname.new(filepath), encoding: :linear16, language: "en-US", sample_rate: 16000
     audio = speech.audio orig_audio, encoding: :flac, sample_rate: 48000, language: "es-ES"
 
     audio.must_be_kind_of Google::Cloud::Speech::Audio
@@ -193,6 +193,6 @@ describe Google::Cloud::Speech::Project, :audio, :mock_speech do
   it "raises when giving an object that is not IO or a Google Storage URL" do
     obj = OpenStruct.new hello: "world"
 
-    expect { speech.audio obj, encoding: :raw, language: "en-US", sample_rate: 16000 }.must_raise ArgumentError
+    expect { speech.audio obj, encoding: :linear16, language: "en-US", sample_rate: 16000 }.must_raise ArgumentError
   end
 end

--- a/google-cloud-speech/test/google/cloud/speech/project/process_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/process_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Speech::Project, :process, :mock_speech do
     mock.expect :long_running_recognize, op_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
-    op = speech.process "acceptance/data/audio.raw", encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process "acceptance/data/audio.raw", encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
@@ -42,7 +42,7 @@ describe Google::Cloud::Speech::Project, :process, :mock_speech do
     mock.expect :long_running_recognize, op_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
-    op = speech.process File.open("acceptance/data/audio.raw", "rb"), encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process File.open("acceptance/data/audio.raw", "rb"), encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
@@ -59,7 +59,7 @@ describe Google::Cloud::Speech::Project, :process, :mock_speech do
     mock.expect :long_running_recognize, op_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
-    op = speech.process "gs://some_bucket/audio.raw", encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process "gs://some_bucket/audio.raw", encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
@@ -76,7 +76,7 @@ describe Google::Cloud::Speech::Project, :process, :mock_speech do
 
     speech.service.mocked_service = mock
     gcs_fake = OpenStruct.new to_gs_url: "gs://some_bucket/audio.raw"
-    op = speech.process gcs_fake, encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process gcs_fake, encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
@@ -93,7 +93,7 @@ describe Google::Cloud::Speech::Project, :process, :mock_speech do
 
     speech.service.mocked_service = mock
     audio = speech.audio "gs://some_bucket/audio.raw"
-    op = speech.process audio, encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process audio, encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     op.must_be_kind_of Google::Cloud::Speech::Operation
@@ -109,7 +109,7 @@ describe Google::Cloud::Speech::Project, :process, :mock_speech do
     mock.expect :long_running_recognize, op_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
-    audio = speech.audio "gs://some_bucket/audio.raw", encoding: :raw, language: "en-US", sample_rate: 16000
+    audio = speech.audio "gs://some_bucket/audio.raw", encoding: :linear16, language: "en-US", sample_rate: 16000
     op = speech.process audio
     mock.verify
 
@@ -127,7 +127,7 @@ describe Google::Cloud::Speech::Project, :process, :mock_speech do
 
     speech.service.mocked_service = mock
     audio = speech.audio "gs://some_bucket/audio.raw", encoding: :flac, sample_rate: 48000, language: "en-US"
-    op = speech.process audio, encoding: :raw, language: "en-US", sample_rate: 16000
+    op = speech.process audio, encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     op.must_be_kind_of Google::Cloud::Speech::Operation

--- a/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     mock.expect :recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
-    results = speech.recognize filepath, encoding: :raw, language: "en-US", sample_rate: 16000
+    results = speech.recognize filepath, encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     results.count.must_equal 1
@@ -45,7 +45,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     mock.expect :recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
-    results = speech.recognize File.open(filepath, "rb"), encoding: :raw, language: "en-US", sample_rate: 16000
+    results = speech.recognize File.open(filepath, "rb"), encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     results.count.must_equal 1
@@ -62,7 +62,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     mock.expect :recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
-    results = speech.recognize "gs://some_bucket/audio.raw", encoding: :raw, language: "en-US", sample_rate: 16000
+    results = speech.recognize "gs://some_bucket/audio.raw", encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     results.count.must_equal 1
@@ -80,7 +80,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
 
     speech.service.mocked_service = mock
     gcs_fake = OpenStruct.new to_gs_url: "gs://some_bucket/audio.raw"
-    results = speech.recognize gcs_fake, encoding: :raw, language: "en-US", sample_rate: 16000
+    results = speech.recognize gcs_fake, encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     results.count.must_equal 1
@@ -97,7 +97,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     mock.expect :recognize, results_grpc, [config_grpc, audio_grpc, options: default_options]
 
     speech.service.mocked_service = mock
-    audio = speech.audio filepath, encoding: :raw, language: "en-US", sample_rate: 16000
+    audio = speech.audio filepath, encoding: :linear16, language: "en-US", sample_rate: 16000
     results = speech.recognize audio
     mock.verify
 
@@ -116,7 +116,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
 
     speech.service.mocked_service = mock
     audio = speech.audio filepath
-    results = speech.recognize audio, encoding: :raw, language: "en-US", sample_rate: 16000
+    results = speech.recognize audio, encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     results.count.must_equal 1
@@ -134,7 +134,7 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
 
     speech.service.mocked_service = mock
     audio = speech.audio filepath, encoding: :flac, sample_rate: 48000, language: "en-US"
-    results = speech.recognize audio, encoding: :raw, language: "en-US", sample_rate: 16000
+    results = speech.recognize audio, encoding: :linear16, language: "en-US", sample_rate: 16000
     mock.verify
 
     results.count.must_equal 1

--- a/google-cloud-speech/test/google/cloud/speech/project/stream_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/stream_test.rb
@@ -30,7 +30,7 @@ end
 
 describe Google::Cloud::Speech::Project, :stream, :mock_speech do
   it "streams audio" do
-    stream = speech.stream encoding: :raw, language: "en-US", sample_rate: 16000
+    stream = speech.stream encoding: :linear16, language: "en-US", sample_rate: 16000
     stream.must_be_kind_of Google::Cloud::Speech::Stream
     stream.wont_be :started?
     stream.wont_be :stopped?
@@ -77,7 +77,7 @@ describe Google::Cloud::Speech::Project, :stream, :mock_speech do
   end
 
   it "streams audio over several sends" do
-    stream = speech.stream encoding: :raw, language: "en-US", sample_rate: 16000
+    stream = speech.stream encoding: :linear16, language: "en-US", sample_rate: 16000
     stream.must_be_kind_of Google::Cloud::Speech::Stream
     stream.wont_be :started?
     stream.wont_be :stopped?
@@ -131,7 +131,7 @@ describe Google::Cloud::Speech::Project, :stream, :mock_speech do
   end
 
   it "streams audio with alternatives and interum results" do
-    stream = speech.stream encoding: :raw, language: "en-US", sample_rate: 16000, max_alternatives: 10, interim: true
+    stream = speech.stream encoding: :linear16, language: "en-US", sample_rate: 16000, max_alternatives: 10, interim: true
     stream.must_be_kind_of Google::Cloud::Speech::Stream
     stream.wont_be :started?
     stream.wont_be :stopped?
@@ -192,7 +192,7 @@ describe Google::Cloud::Speech::Project, :stream, :mock_speech do
   end
 
   it "streams for a single utterance" do
-    stream = speech.stream encoding: :raw, language: "en-US", sample_rate: 16000, max_alternatives: 10, interim: true
+    stream = speech.stream encoding: :linear16, language: "en-US", sample_rate: 16000, max_alternatives: 10, interim: true
     stream.must_be_kind_of Google::Cloud::Speech::Stream
     stream.wont_be :started?
     stream.wont_be :stopped?

--- a/google-cloud-speech/test/google/cloud/speech/stream_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/stream_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Google::Cloud::Speech::Stream, :mock_speech do
   it "knows itself" do
-    stream = speech.stream encoding: :raw, language: "en-US", sample_rate: 16000
+    stream = speech.stream encoding: :linear16, language: "en-US", sample_rate: 16000
     stream.must_be_kind_of Google::Cloud::Speech::Stream
     stream.wont_be :started?
     stream.wont_be :stopped?


### PR DESCRIPTION
Replace the value :raw with :linear16, at the request of the Speech team. Update documentation and code examples to use :linear16.

[closes #1426]