### PR TITLE
Update Rails warnings when Stackdriver services are disabled.

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -103,16 +103,16 @@ module Google
             Google::Cloud::Debugger::Credentials.credentials_with_scope(
               debugger_config[:keyfile])
           rescue => e
-            Rails.logger.warn "Google::Cloud::Debugger is not activated due " \
-              "to authorization error: #{e.message}"
+            STDOUT.puts "Note: Google::Cloud::Debugger is disabled because " \
+              "it failed to authorize with the service. (#{e.message})"
             return false
           end
 
           project_id = debugger_config[:project_id] ||
                        Google::Cloud::Debugger::Project.default_project
           if project_id.to_s.empty?
-            Rails.logger.warn "Google::Cloud::Debugger is not activated due " \
-              "to empty project_id"
+            STDOUT.puts "Note: Google::Cloud::Debugger is disabled because " \
+              "the project ID could not be determined."
             return false
           end
 

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -145,14 +145,14 @@ module Google
           begin
             grpc_channel keyfile
           rescue StandardError => e
-            Rails.logger.warn "Google::Cloud::ErrorReporting is not " \
-            "activated due to authorization error: #{e.message}"
+            STDOUT.puts "Note: Google::Cloud::ErrorReporting is disabled " \
+              "because it failed to authorize with the service. (#{e.message})"
             return false
           end
 
           if project_id(config).to_s.empty?
-            Rails.logger.warn "Google::Cloud::ErrorReporting is not " \
-            "activated due to empty project_id"
+            STDOUT.puts "Note: Google::Cloud::ErrorReporting is disabled " \
+              "because the project ID could not be determined."
             return false
           end
 

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -123,15 +123,16 @@ module Google
           begin
             Google::Cloud::Logging::Credentials.credentials_with_scope keyfile
           rescue Exception => e
-            warn "Google::Cloud::Logging is not activated due to " \
-              "authorization error: #{e.message}\nFalling back to default " \
-              "logger"
+            STDOUT.puts "Note: Google::Cloud::Logging is disabled because " \
+              "it failed to authorize with the service. (#{e.message}) " \
+              "Falling back to the default Rails logger."
             return false
           end
 
           if project_id.to_s.empty?
-            warn "Google::Cloud::Logging is not activated due to empty " \
-              "project_id; falling back to default logger"
+            STDOUT.puts "Note: Google::Cloud::Logging is disabled because " \
+              "the project ID could not be determined. " \
+              "Falling back to the default Rails logger."
             return false
           end
 

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -166,13 +166,14 @@ module Google
           begin
             Google::Cloud::Trace::Credentials.credentials_with_scope keyfile
           rescue Exception => e
-            warn "Unable to initialize Google::Cloud::Trace due " \
-              "to authorization error: #{e.message}"
+            STDOUT.puts "Note: Google::Cloud::Trace is disabled because " \
+              "it failed to authorize with the service. (#{e.message})"
             return false
           end
 
           if project_id(config).to_s.empty?
-            warn "Google::Cloud::Trace is not activated due to empty project_id"
+            STDOUT.puts "Note: Google::Cloud::Trace is disabled because " \
+              "the project ID could not be determined."
             return false
           end
 


### PR DESCRIPTION
Changes to the notices printed when the Rails integration for Stackdriver instrumentation is disabled due to missing auth information.

* Printed to STDOUT rather than STDERR to avoid the text showing up in red when doing Docker builds. (The previous code calls `Kernel#warn` which writes to STDERR.)
* Standardized the language across the four existing instrumentation gems.
