### PR TITLE
Spanner retry for broken streams

### DIFF
--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "google-gax", "~> 0.8.1"
+  gem.add_dependency "grpc", "~> 1.1"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.8"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -14,6 +14,7 @@
 
 
 require "google/cloud/spanner/convert"
+require "google/cloud/errors"
 
 module Google
   module Cloud
@@ -85,6 +86,7 @@ module Google
 
           fields = @metadata.row_type.fields
           values = []
+          cached_responses = []
           chunked_value = nil
           resume_token = nil
 
@@ -98,22 +100,56 @@ module Google
               @metadata ||= grpc.metadata
               @stats ||= grpc.stats
 
-              if chunked_value
-                grpc.values.unshift merge(chunked_value, grpc.values.shift)
-                chunked_value = nil
-              end
-              to_iterate = values + grpc.values
-              chunked_value = to_iterate.pop if grpc.chunked_value
+              cached_responses << grpc
 
-              resume_token = grpc.resume_token
+              if grpc.resume_token && grpc.resume_token != ""
+                resume_token = grpc.resume_token
 
-              values = to_iterate.pop(to_iterate.count % fields.count)
-              to_iterate.each_slice(fields.count) do |slice|
-                yield Convert.row_to_raw(fields, slice)
+                cached_responses.each do |resp|
+                  if chunked_value
+                    resp.values.unshift merge(chunked_value, resp.values.shift)
+                    chunked_value = nil
+                  end
+                  to_iterate = values + Array(resp.values)
+                  chunked_value = to_iterate.pop if resp.chunked_value
+                  values = to_iterate.pop(to_iterate.count % fields.count)
+                  to_iterate.each_slice(fields.count) do |slice|
+                    yield Convert.row_to_raw(fields, slice)
+                  end
+                end
+                cached_responses = []
               end
+            rescue GRPC::Aborted
+              if @execute_options
+                @enum = @service.streaming_execute_sql \
+                  @session_path, @sql,
+                  @execute_options.merge(resume_token: resume_token)
+              else
+                @enum = @service.streaming_read_table \
+                  @session_path, @table, @columns,
+                  @read_options.merge(resume_token: resume_token)
+              end
+              cached_responses = []
             rescue StopIteration
               break
             end
+          end
+
+          # clear out any remaining values left over
+          cached_responses.each do |resp|
+            if chunked_value
+              resp.values.unshift merge(chunked_value, resp.values.shift)
+              chunked_value = nil
+            end
+            to_iterate = values + Array(resp.values)
+            chunked_value = to_iterate.pop if resp.chunked_value
+            values = to_iterate.pop(to_iterate.count % fields.count)
+            to_iterate.each_slice(fields.count) do |slice|
+              yield Convert.row_to_raw(fields, slice)
+            end
+          end
+          values.each_slice(fields.count) do |slice|
+            yield Convert.row_to_raw(fields, slice)
           end
 
           # If we get this far then we can release the session
@@ -143,13 +179,41 @@ module Google
         end
 
         # @private
-        def self.from_enum enum
+        def self.from_enum enum, service
           grpc = enum.peek
-          results = new
-          results.instance_variable_set :@metadata,   grpc.metadata
-          results.instance_variable_set :@stats,      grpc.stats
-          results.instance_variable_set :@enum,       enum
-          results
+          new.tap do |results|
+            results.instance_variable_set :@metadata, grpc.metadata
+            results.instance_variable_set :@stats,    grpc.stats
+            results.instance_variable_set :@enum,     enum
+            results.instance_variable_set :@service,  service
+          end
+        end
+
+        # @private
+        def self.execute service, session_path, sql, params: nil,
+                         transaction: nil
+          execute_options = { transaction: transaction, params: params }
+          enum = service.streaming_execute_sql session_path, sql,
+                                               execute_options
+          from_enum(enum, service).tap do |results|
+            results.instance_variable_set :@session_path,    session_path
+            results.instance_variable_set :@sql,             sql
+            results.instance_variable_set :@execute_options, execute_options
+          end
+        end
+
+        # @private
+        def self.read service, session_path, table, columns, id: nil,
+                      limit: nil, transaction: nil
+          read_options = { id: id, limit: limit, transaction: transaction }
+          enum = service.streaming_read_table \
+            session_path, table, columns, read_options
+          from_enum(enum, service).tap do |results|
+            results.instance_variable_set :@session_path, session_path
+            results.instance_variable_set :@table,        table
+            results.instance_variable_set :@columns,      columns
+            results.instance_variable_set :@read_options, read_options
+          end
         end
 
         # @private

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -287,7 +287,7 @@ module Google
         end
 
         def streaming_execute_sql session_path, sql, transaction: nil,
-                                  params: nil
+                                  params: nil, resume_token: nil
           input_params = nil
           input_param_types = nil
           unless params.nil?
@@ -300,7 +300,8 @@ module Google
           execute do
             service.execute_streaming_sql \
               session_path, sql, transaction: transaction, params: input_params,
-                                 param_types: input_param_types
+                                 param_types: input_param_types,
+                                 resume_token: resume_token
           end
         end
 
@@ -322,7 +323,7 @@ module Google
         end
 
         def streaming_read_table session_path, table_name, columns, id: nil,
-                                 transaction: nil, limit: nil
+                                 transaction: nil, limit: nil, resume_token: nil
           columns.map!(&:to_s)
           key_set = Google::Spanner::V1::KeySet.new(all: true)
           unless id.nil?
@@ -334,7 +335,7 @@ module Google
           execute do
             service.streaming_read \
               session_path, table_name, columns, key_set,
-              transaction: transaction, limit: limit
+              transaction: transaction, limit: limit, resume_token: resume_token
           end
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -215,8 +215,8 @@ module Google
         def execute sql, params: nil, transaction: nil, streaming: true
           ensure_service!
           if streaming
-            Results.from_enum service.streaming_execute_sql \
-              path, sql, params: params, transaction: transaction
+            Results.execute service, path, sql,
+                            params: params, transaction: transaction
           else
             Results.from_grpc service.execute_sql \
               path, sql, params: params, transaction: transaction
@@ -277,9 +277,8 @@ module Google
                  streaming: true
           ensure_service!
           if streaming
-            Results.from_enum service.streaming_read_table \
-              path, table, columns, id: id, limit: limit,
-                                    transaction: transaction
+            Results.read service, path, table, columns,
+                         id: id, limit: limit, transaction: transaction
           else
             Results.from_grpc service.read_table \
               path, table, columns, id: id, limit: limit,

--- a/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
@@ -135,8 +135,8 @@ module Google
         def execute sql, params: nil, streaming: true
           ensure_service!
           if streaming
-            Results.from_enum service.streaming_execute_sql \
-              session_name, sql, transaction: tx_selector, params: params
+            Results.execute service, session_name, sql,
+                            params: params, transaction: tx_selector
           else
             Results.from_grpc service.execute_sql \
               session_name, sql, transaction: tx_selector, params: params
@@ -195,9 +195,8 @@ module Google
         def read table, columns, id: nil, limit: nil, streaming: true
           ensure_service!
           if streaming
-            Results.from_enum service.streaming_read_table \
-              session_name, table, columns, id: id, transaction: tx_selector,
-                                            limit: limit
+            Results.read service, session_name, table, columns,
+                         id: id, limit: limit, transaction: tx_selector
           else
             Results.from_grpc service.read_table \
               session_name, table, columns, id: id, transaction: tx_selector,

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -134,8 +134,8 @@ module Google
         def execute sql, params: nil, streaming: true
           ensure_service!
           if streaming
-            Results.from_enum service.streaming_execute_sql \
-              session_name, sql, transaction: tx_selector, params: params
+            Results.execute service, session_name, sql,
+                            params: params, transaction: tx_selector
           else
             Results.from_grpc service.execute_sql \
               session_name, sql, transaction: tx_selector, params: params
@@ -194,9 +194,8 @@ module Google
         def read table, columns, id: nil, limit: nil, streaming: true
           ensure_service!
           if streaming
-            Results.from_enum service.streaming_read_table \
-              session_name, table, columns, id: id, transaction: tx_selector,
-                                            limit: limit
+            Results.read service, session_name, table, columns,
+                         id: id, limit: limit, transaction: tx_selector
           else
             Results.from_grpc service.read_table \
               session_name, table, columns, id: id, transaction: tx_selector,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -68,7 +68,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = nil
@@ -102,7 +102,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil]
+      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -127,7 +127,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil]
+      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -145,7 +145,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil]
+      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -169,7 +169,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts]
-      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil]
+      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil]
       spanner.service.mocked_service = mock
 
       results = nil

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_retry_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,11 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Results, :from_enum, :mock_spanner do
+describe Google::Cloud::Spanner::Client, :execute, :streaming, :retry, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let :results_hash1 do
     {
       metadata: {
@@ -39,17 +43,37 @@ describe Google::Cloud::Spanner::Results, :from_enum, :mock_spanner do
     {
       values: [
         { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" }
-      ]
+        { stringValue: "Charlie" }
+      ],
+      resumeToken: Base64.strict_encode64("xyz890")
     }
   end
   let :results_hash3 do
+    {
+      values: [
+        { boolValue: true},
+        { stringValue: "29" }
+      ]
+    }
+  end
+  let :results_hash4 do
+    {
+      values: [
+        { numberValue: 0.9 },
+        { stringValue: "2017-01-02T03:04:05.060000000Z" }
+      ],
+      resumeToken: Base64.strict_encode64("abc123")
+    }
+  end
+  let :results_hash5 do
+    {
+      values: [
+        { stringValue: "1950-01-01" },
+        { stringValue: "aW1hZ2U=" },
+      ]
+    }
+  end
+  let :results_hash6 do
     {
       values: [
         { listValue: { values: [ { stringValue: "1"},
@@ -58,14 +82,41 @@ describe Google::Cloud::Spanner::Results, :from_enum, :mock_spanner do
       ]
     }
   end
-  let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json)].to_enum
+  let(:results_enum1) do
+    [
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      GRPC::Aborted,
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
+    ].to_enum
   end
-  let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
+  let(:results_enum2) do
+    [
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
+    ].to_enum
+  end
+  let(:client) { spanner.client instance_id, database_id }
 
-  it "exists" do
+  it "retries aborted responses" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
+    mock.expect :execute_streaming_sql, AbortableEnumerator.new(results_enum1), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil]
+    mock.expect :execute_streaming_sql, AbortableEnumerator.new(results_enum2), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: "abc123"]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users"
+
+    assert_results results
+
+    mock.verify
+  end
+
+  def assert_results results
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_test.rb
@@ -60,7 +60,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users"
@@ -73,7 +73,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
@@ -86,7 +86,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
@@ -114,7 +114,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
@@ -142,7 +142,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
@@ -157,7 +157,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
@@ -170,7 +170,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
@@ -183,7 +183,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }
@@ -198,7 +198,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -213,7 +213,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -228,7 +228,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_buffer_bound_test.rb
@@ -1,0 +1,230 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Client, :read, :streaming, :retry, :buffer_bound, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let :results_header do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { name: "id",          type: { code: "INT64" } },
+            { name: "name",        type: { code: "STRING" } },
+            { name: "active",      type: { code: "BOOL" } },
+            { name: "age",         type: { code: "INT64" } },
+            { name: "score",       type: { code: "FLOAT64" } },
+            { name: "updated_at",  type: { code: "TIMESTAMP" } },
+            { name: "birthday",    type: { code: "DATE"} },
+            { name: "avatar",      type: { code: "BYTES" } },
+            { name: "project_ids", type: { code: "ARRAY",
+                                           arrayElementType: { code: "INT64" } } }
+          ]
+        }
+      }
+    }
+  end
+  let :results_hash1 do
+    {
+      values: [
+        { stringValue: "1" },
+        { stringValue: "Charlie" }
+      ]
+    }
+  end
+  let :results_hash2 do
+    {
+      values: [
+        { boolValue: true},
+        { stringValue: "29" }
+      ]
+    }
+  end
+  let :results_hash3 do
+    {
+      values: [
+        { numberValue: 0.9 },
+        { stringValue: "2017-01-02T03:04:05.060000000Z" }
+      ]
+    }
+  end
+  let :results_hash4 do
+    {
+      values: [
+        { stringValue: "1950-01-01" },
+        { stringValue: "aW1hZ2U=" },
+      ]
+    }
+  end
+  let :results_hash5 do
+    {
+      values: [
+        { listValue: { values: [ { stringValue: "1"},
+                                 { stringValue: "2"},
+                                 { stringValue: "3"} ]}}
+      ]
+    }
+  end
+  let(:client) { spanner.client instance_id, database_id }
+  let(:columns) { [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids] }
+
+  it "returns all rows even when there is no resume_token" do
+    no_tokens_enum = [
+      Google::Spanner::V1::PartialResultSet.decode_json(results_header.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json)
+    ].to_enum
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
+    mock.expect :streaming_read, no_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns
+
+    assert_results results
+    rows = results.rows.to_a # grab them all from the enumerator
+    rows.count.must_equal 3
+    rows.each { |row| assert_row row }
+
+    mock.verify
+  end
+
+  it "returns all rows even when all requests have resume_token" do
+    all_tokens_enum = [
+      Google::Spanner::V1::PartialResultSet.decode_json(results_header.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.merge(resumeToken: Base64.strict_encode64("xyz123")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.merge(resumeToken: Base64.strict_encode64("xyz124")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.merge(resumeToken: Base64.strict_encode64("xyz125")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.merge(resumeToken: Base64.strict_encode64("xyz126")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.merge(resumeToken: Base64.strict_encode64("xyz127")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.merge(resumeToken: Base64.strict_encode64("xyz128")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.merge(resumeToken: Base64.strict_encode64("xyz129")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.merge(resumeToken: Base64.strict_encode64("xyz130")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.merge(resumeToken: Base64.strict_encode64("xyz131")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.merge(resumeToken: Base64.strict_encode64("xyz132")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.merge(resumeToken: Base64.strict_encode64("xyz133")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.merge(resumeToken: Base64.strict_encode64("xyz134")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.merge(resumeToken: Base64.strict_encode64("xyz135")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.merge(resumeToken: Base64.strict_encode64("xyz137")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.merge(resumeToken: Base64.strict_encode64("xyz128")).to_json)
+    ].to_enum
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
+    mock.expect :streaming_read, all_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns
+
+    assert_results results
+    rows = results.rows.to_a # grab them all from the enumerator
+    rows.count.must_equal 3
+    rows.each { |row| assert_row row }
+
+    mock.verify
+  end
+
+  it "returns buffered responses once it hits the buffer bounds, but will re-raise if there is no resume_token" do
+    bounds_with_abort_enum = [
+      Google::Spanner::V1::PartialResultSet.decode_json(results_header.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.merge(resumeToken: Base64.strict_encode64("xyz123")).to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
+      GRPC::Aborted,
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json)
+    ].to_enum
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
+    mock.expect :streaming_read, AbortableEnumerator.new(bounds_with_abort_enum), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns
+
+    assert_results results
+    row_enum = results.rows
+    # gets the first row
+    assert_row row_enum.next
+    # gets the second row
+    assert_row row_enum.next
+    # raises error getting third row, since the buffer bound has been reached
+    assert_raises Google::Cloud::AbortedError do
+      results.rows.next
+    end
+
+    mock.verify
+  end
+
+  def assert_results results
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+    results.must_be :streaming?
+
+    results.types.wont_be :nil?
+    results.types.must_be_kind_of Hash
+    results.types.keys.count.must_equal 9
+    results.types[:id].must_equal          :INT64
+    results.types[:name].must_equal        :STRING
+    results.types[:active].must_equal      :BOOL
+    results.types[:age].must_equal         :INT64
+    results.types[:score].must_equal       :FLOAT64
+    results.types[:updated_at].must_equal  :TIMESTAMP
+    results.types[:birthday].must_equal    :DATE
+    results.types[:avatar].must_equal      :BYTES
+    results.types[:project_ids].must_equal [:INT64]
+  end
+
+  def assert_row row
+    row.must_be_kind_of Hash
+    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    row[:id].must_equal 1
+    row[:name].must_equal "Charlie"
+    row[:active].must_equal true
+    row[:age].must_equal 29
+    row[:score].must_equal 0.9
+    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    row[:birthday].must_equal Date.parse("1950-01-01")
+    row[:avatar].must_be_kind_of StringIO
+    row[:avatar].read.must_equal "image"
+    row[:project_ids].must_equal [1, 2, 3]
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,11 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Results, :from_enum, :mock_spanner do
+describe Google::Cloud::Spanner::Client, :read, :streaming, :retry, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let :results_hash1 do
     {
       metadata: {
@@ -39,17 +43,37 @@ describe Google::Cloud::Spanner::Results, :from_enum, :mock_spanner do
     {
       values: [
         { stringValue: "1" },
-        { stringValue: "Charlie" },
-        { boolValue: true},
-        { stringValue: "29" },
-        { numberValue: 0.9 },
-        { stringValue: "2017-01-02T03:04:05.060000000Z" },
-        { stringValue: "1950-01-01" },
-        { stringValue: "aW1hZ2U=" }
-      ]
+        { stringValue: "Charlie" }
+      ],
+      resumeToken: Base64.strict_encode64("xyz890")
     }
   end
   let :results_hash3 do
+    {
+      values: [
+        { boolValue: true},
+        { stringValue: "29" }
+      ]
+    }
+  end
+  let :results_hash4 do
+    {
+      values: [
+        { numberValue: 0.9 },
+        { stringValue: "2017-01-02T03:04:05.060000000Z" }
+      ],
+      resumeToken: Base64.strict_encode64("abc123")
+    }
+  end
+  let :results_hash5 do
+    {
+      values: [
+        { stringValue: "1950-01-01" },
+        { stringValue: "aW1hZ2U=" },
+      ]
+    }
+  end
+  let :results_hash6 do
     {
       values: [
         { listValue: { values: [ { stringValue: "1"},
@@ -58,14 +82,43 @@ describe Google::Cloud::Spanner::Results, :from_enum, :mock_spanner do
       ]
     }
   end
-  let(:results_enum) do
-    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
-     Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json)].to_enum
+  let(:results_enum1) do
+    [
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      GRPC::Aborted,
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
+    ].to_enum
   end
-  let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
+  let(:results_enum2) do
+    [
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash1.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
+      Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
+    ].to_enum
+  end
+  let(:client) { spanner.client instance_id, database_id }
 
-  it "exists" do
+  it "retries aborted responses" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
+    mock.expect :streaming_read, AbortableEnumerator.new(results_enum1), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil]
+    mock.expect :streaming_read, AbortableEnumerator.new(results_enum2), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: "abc123"]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns
+
+    assert_results results
+
+    mock.verify
+  end
+
+  def assert_results results
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns
@@ -89,7 +89,7 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, limit: nil]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, limit: nil, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, id: [1, 2, 3]
@@ -104,7 +104,7 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: 5]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: 5, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, limit: 5
@@ -119,7 +119,7 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, limit: 1]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, limit: 1, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, id: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -67,7 +67,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id)]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil]
     spanner.service.mocked_service = mock
 
     results = nil

--- a/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
@@ -51,7 +51,7 @@ describe Google::Cloud::Spanner::Results, :from_enum, :single_response, :mock_sp
   let(:results_enum) do
     [Google::Spanner::V1::PartialResultSet.decode_json(results_hash.to_json)].to_enum
   end
-  let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum }
+  let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
 
   it "exists" do
     results.must_be_kind_of Google::Cloud::Spanner::Results

--- a/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
       { values: [{ stringValue: "ghi" }] }
     ]
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
-    results = Google::Cloud::Spanner::Results.from_enum results_enum
+    results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?
@@ -52,7 +52,7 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
       { values: [{ listValue: { values: [{ stringValue: "i" }, { stringValue: "jkl" }] }}]}
     ]
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
-    results = Google::Cloud::Spanner::Results.from_enum results_enum
+    results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?
@@ -79,7 +79,7 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
       { values: [{ listValue: { values: [{ nullValue: "NULL_VALUE" }, { stringValue: "jkl" }] }}]}
     ]
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
-    results = Google::Cloud::Spanner::Results.from_enum results_enum
+    results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?
@@ -106,7 +106,7 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
       { values: [{ listValue: { values: [{ stringValue: "" }, { stringValue: "jkl" }] }}]}
     ]
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
-    results = Google::Cloud::Spanner::Results.from_enum results_enum
+    results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?
@@ -133,7 +133,7 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
       { values: [{ listValue: { values: [{ stringValue: "ghi" }] }}]}
     ]
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
-    results = Google::Cloud::Spanner::Results.from_enum results_enum
+    results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?
@@ -160,7 +160,7 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
       { values: [{ listValue: { values: [{ nullValue: "NULL_VALUE" }, { stringValue: "5" }] }}]}
     ]
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
-    results = Google::Cloud::Spanner::Results.from_enum results_enum
+    results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?
@@ -187,7 +187,7 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
       { values: [{ listValue: { values: [{ nullValue: "NULL_VALUE" }, { numberValue: 3.0 }] }}]}
     ]
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
-    results = Google::Cloud::Spanner::Results.from_enum results_enum
+    results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?
@@ -215,7 +215,7 @@ describe Google::Cloud::Spanner::Results, :merge, :mock_spanner do
       { values: [{ stringValue: "f" }] }
     ]
     results_enum = results_hashes.map { |hash| Google::Spanner::V1::PartialResultSet.decode_json hash.to_json }.to_enum
-    results = Google::Cloud::Spanner::Results.from_enum results_enum
+    results = Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.must_be :streaming?

--- a/google-cloud-spanner/test/google/cloud/spanner/session/streaming_execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/streaming_execute_test.rb
@@ -59,7 +59,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users"
@@ -71,7 +71,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
@@ -83,7 +83,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
@@ -95,7 +95,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
@@ -109,7 +109,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
@@ -123,7 +123,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
@@ -135,7 +135,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
@@ -149,7 +149,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
@@ -161,7 +161,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
@@ -173,7 +173,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }
@@ -187,7 +187,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -201,7 +201,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -215,7 +215,7 @@ describe Google::Cloud::Spanner::Session, :execute, :streaming, :mock_spanner do
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/session/streaming_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/streaming_read_test.rb
@@ -73,7 +73,7 @@ describe Google::Cloud::Spanner::Session, :read, :streaming, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns
@@ -87,7 +87,7 @@ describe Google::Cloud::Spanner::Session, :read, :streaming, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, limit: nil]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, limit: nil, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns, id: [1, 2, 3]
@@ -101,7 +101,7 @@ describe Google::Cloud::Spanner::Session, :read, :streaming, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: 5]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: 5, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns, limit: 5
@@ -115,7 +115,7 @@ describe Google::Cloud::Spanner::Session, :read, :streaming, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, limit: 1]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, limit: 1, resume_token: nil]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns, id: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/streaming_execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/streaming_execute_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users"
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
@@ -87,7 +87,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
@@ -113,7 +113,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
@@ -127,7 +127,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
@@ -139,7 +139,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
@@ -153,7 +153,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
@@ -165,7 +165,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
@@ -177,7 +177,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }
@@ -191,7 +191,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -205,7 +205,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -219,7 +219,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/streaming_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/streaming_read_test.rb
@@ -77,7 +77,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :streaming, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns
@@ -91,7 +91,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :streaming, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, id: [1, 2, 3]
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :streaming, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, limit: 5
@@ -119,7 +119,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :streaming, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1, resume_token: nil]
     snapshot.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, id: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/streaming_execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/streaming_execute_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users"
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
@@ -87,7 +87,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
@@ -113,7 +113,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
@@ -127,7 +127,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
@@ -139,7 +139,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
@@ -153,7 +153,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
@@ -165,7 +165,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
@@ -177,7 +177,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }
@@ -191,7 +191,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -205,7 +205,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -219,7 +219,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/streaming_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/streaming_read_test.rb
@@ -77,7 +77,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :streaming, :mock_spanner d
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.read "my-table", columns
@@ -91,7 +91,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :streaming, :mock_spanner d
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, id: [1, 2, 3]
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :streaming, :mock_spanner d
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, limit: 5
@@ -119,7 +119,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :streaming, :mock_spanner d
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1, resume_token: nil]
     transaction.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, id: 1, limit: 1

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -128,3 +128,24 @@ class MockSpanner < Minitest::Spec
     OpenStruct.new page: OpenStruct.new(response: response)
   end
 end
+
+# This is used to raise errors in an enumerator
+class AbortableEnumerator
+  def initialize enum
+    @enum = enum
+  end
+
+  def next
+    v = @enum.next
+    raise v if v == GRPC::Aborted
+    v
+  end
+
+  def method_missing method, *args
+    @enum.send method, *args
+  end
+
+  def inspect
+    "<#{self.class}>"
+  end
+end


### PR DESCRIPTION
This PR adds retry to streams responses that receive an ABORTED error. Responses are buffered while waiting for a `resume_token`. Values will be returned when the buffer has reached its upper bound.

closes #1236