### PR TITLE
Spanner Transaction Retry

### DIFF
--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
+describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }


### PR DESCRIPTION
Transaction failing with an ABORTED status it needs to be retried. This PR does not include retrieving the backoff value from the RetryInfo object, as we are unsure how to get this value from the GRPC error.

(refs #1234)