### PR TITLE
Spanner Session Pool

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/non_streaming/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/non_streaming/crud_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :non_streaming, :crud, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   before do
     db.transaction do |tx|

--- a/google-cloud-spanner/acceptance/spanner/client/non_streaming/execute_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/non_streaming/execute_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :non_streaming, :execute, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   it "runs a simple query" do
     results = db.execute "SELECT 42 AS num", streaming: false

--- a/google-cloud-spanner/acceptance/spanner/client/non_streaming/params_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/non_streaming/params_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :non_streaming, :params, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   it "queries and returns a string parameter" do
     results = db.execute "SELECT @value AS value", params: { value: "hello" }, streaming: false

--- a/google-cloud-spanner/acceptance/spanner/client/non_streaming/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/non_streaming/snapshot_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :non_streaming, :snapshot, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   before do
     db.transaction do |tx|

--- a/google-cloud-spanner/acceptance/spanner/client/non_streaming/transaction_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/non_streaming/transaction_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :non_streaming, :transaction, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   it "runs a simple query" do
     results = nil

--- a/google-cloud-spanner/acceptance/spanner/client/streaming/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/streaming/crud_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :streaming, :crud, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   before do
     db.transaction do |tx|

--- a/google-cloud-spanner/acceptance/spanner/client/streaming/execute_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/streaming/execute_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :streaming, :execute, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   it "runs a simple query" do
     results = db.execute "SELECT 42 AS num"

--- a/google-cloud-spanner/acceptance/spanner/client/streaming/params_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/streaming/params_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :streaming, :params, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   it "queries and returns a string parameter" do
     results = db.execute "SELECT @value AS value", params: { value: "hello" }

--- a/google-cloud-spanner/acceptance/spanner/client/streaming/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/streaming/snapshot_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :streaming, :snapshot, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   before do
     db.transaction do |tx|

--- a/google-cloud-spanner/acceptance/spanner/client/streaming/transaction_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/streaming/transaction_test.rb
@@ -15,7 +15,7 @@
 require "spanner_helper"
 
 describe "Spanner Client", :streaming, :transaction, :spanner do
-  let(:db) { spanner.client $spanner_prefix, "main" }
+  let(:db) { spanner_client }
 
   it "runs a simple streaming query" do
     results = nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -41,11 +41,12 @@ module Google
       class Client
         ##
         # @private Creates a new Spanner Project instance.
-        def initialize project, instance_id, database_id, min: 2, max: 10
+        def initialize project, instance_id, database_id, min: 2, max: 10,
+                       keepalive: 1500
           @project = project
           @instance_id = instance_id
           @database_id = database_id
-          @pool = Pool.new self, min: min, max: max
+          @pool = Pool.new self, min: min, max: max, keepalive: keepalive
         end
 
         # The Spanner project connected to.
@@ -580,6 +581,13 @@ module Google
             yield snp if block_given?
           end
           nil
+        end
+
+        ##
+        # Closes the client connection and releases resources.
+        #
+        def close
+          @pool.close
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -15,6 +15,7 @@
 
 require "google/cloud/errors"
 require "google/cloud/spanner/project"
+require "google/cloud/spanner/pool"
 require "google/cloud/spanner/session"
 require "google/cloud/spanner/transaction"
 require "google/cloud/spanner/snapshot"
@@ -40,10 +41,11 @@ module Google
       class Client
         ##
         # @private Creates a new Spanner Project instance.
-        def initialize project, instance_id, database_id
+        def initialize project, instance_id, database_id, min: 2, max: 10
           @project = project
           @instance_id = instance_id
           @database_id = database_id
+          @pool = Pool.new self, min: min, max: max
         end
 
         # The Spanner project connected to.
@@ -181,8 +183,13 @@ module Google
 
           single_use_tx = single_use_transaction timestamp: timestamp,
                                                  staleness: staleness
-          session.execute sql, params: params, transaction: single_use_tx,
-                               streaming: streaming
+          results = nil
+          @pool.with_session do |session|
+            results = session.execute \
+              sql, params: params, transaction: single_use_tx,
+                   streaming: streaming
+          end
+          results
         end
         alias_method :query, :execute
 
@@ -259,9 +266,13 @@ module Google
 
           single_use_tx = single_use_transaction timestamp: timestamp,
                                                  staleness: staleness
-          session.read table, columns, id: id, limit: limit,
-                                       transaction: single_use_tx,
-                                       streaming: streaming
+          results = nil
+          @pool.with_session do |session|
+            results = session.read \
+              table, columns, id: id, limit: limit, transaction: single_use_tx,
+                              streaming: streaming
+          end
+          results
         end
 
         # Creates changes to be applied to rows in the database.
@@ -282,7 +293,9 @@ module Google
         #   end
         #
         def commit &block
-          session.commit(&block)
+          @pool.with_session do |session|
+            session.commit(&block)
+          end
         end
 
         ##
@@ -320,7 +333,9 @@ module Google
         #                       { id: 2, name: "Harvey",  active: true }]
         #
         def upsert table, *rows
-          session.upsert table, rows
+          @pool.with_session do |session|
+            session.upsert table, rows
+          end
         end
         alias_method :save, :upsert
 
@@ -358,7 +373,9 @@ module Google
         #                       { id: 2, name: "Harvey",  active: true }]
         #
         def insert table, *rows
-          session.insert table, rows
+          @pool.with_session do |session|
+            session.insert table, rows
+          end
         end
 
         ##
@@ -395,7 +412,9 @@ module Google
         #                       { id: 2, name: "Harvey",  active: true }]
         #
         def update table, *rows
-          session.update table, rows
+          @pool.with_session do |session|
+            session.update table, rows
+          end
         end
 
         ##
@@ -434,7 +453,9 @@ module Google
         #                        { id: 2, name: "Harvey",  active: true }]
         #
         def replace table, *rows
-          session.replace table, rows
+          @pool.with_session do |session|
+            session.replace table, rows
+          end
         end
 
         ##
@@ -456,7 +477,9 @@ module Google
         #   db.delete "users", [1, 2, 3]
         #
         def delete table, *id
-          session.delete table, id
+          @pool.with_session do |session|
+            session.delete table, id
+          end
         end
 
         ##
@@ -484,17 +507,18 @@ module Google
         #
         def transaction &block
           ensure_service!
-          tx_session = session
-          tx_grpc = @project.service.begin_transaction tx_session.path
-          tx = Transaction.from_grpc(tx_grpc, tx_session)
-          begin
-            block.call tx
-          rescue Google::Cloud::AbortedError
-            # TODO: retrieve delay from ABORTED error
-            # Retry the entire transaction
-            tx2_grpc = @project.service.begin_transaction tx_session.path
-            tx2 = Transaction.from_grpc(tx2_grpc, tx_session)
-            block.call tx2
+          @pool.with_session do |session|
+            tx_grpc = @project.service.begin_transaction session.path
+            tx = Transaction.from_grpc(tx_grpc, session)
+            begin
+              block.call tx
+            rescue Google::Cloud::AbortedError
+              # TODO: retrieve delay from ABORTED error
+              # Retry the entire transaction
+              tx2_grpc = @project.service.begin_transaction session.path
+              tx2 = Transaction.from_grpc(tx2_grpc, session)
+              block.call tx2
+            end
           end
           nil
         end
@@ -530,8 +554,6 @@ module Google
         # @yieldparam [Google::Cloud::Spanner::Snapshot] snapshot The Snapshot
         #   object.
         #
-        # @return [Google::Cloud::Spanner::Snapshot]
-        #
         # @example
         #   require "google/cloud/spanner"
         #
@@ -550,13 +572,25 @@ module Google
           validate_snapshot_args! strong: strong, timestamp: timestamp,
                                   staleness: staleness
           ensure_service!
-          snp_session = session
-          snp_grpc = @project.service.create_snapshot \
-            snp_session.path, strong: strong, timestamp: timestamp,
-                              staleness: staleness
-          snp = Snapshot.from_grpc(snp_grpc, snp_session)
-          yield snp if block_given?
-          snp
+          @pool.with_session do |session|
+            snp_grpc = @project.service.create_snapshot \
+              session.path, strong: strong, timestamp: timestamp,
+                            staleness: staleness
+            snp = Snapshot.from_grpc(snp_grpc, session)
+            yield snp if block_given?
+          end
+          nil
+        end
+
+        ##
+        # @private
+        # Creates a new session object every time.
+        def create_new_session
+          ensure_service!
+          grpc = @project.service.create_session \
+            Admin::Database::V1::DatabaseAdminClient.database_path(
+              project_id, instance_id, database_id)
+          Session.from_grpc(grpc, @project.service)
         end
 
         protected
@@ -566,17 +600,6 @@ module Google
         # available.
         def ensure_service!
           fail "Must have active connection to service" unless @project.service
-        end
-
-        ##
-        # Creates a new session object every time.
-        # No pooling, no reuse. That will come later...
-        def session
-          ensure_service!
-          grpc = @project.service.create_session \
-            Admin::Database::V1::DatabaseAdminClient.database_path(
-              project_id, instance_id, database_id)
-          Session.from_grpc(grpc, @project.service)
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -1,0 +1,75 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/spanner/session"
+
+module Google
+  module Cloud
+    module Spanner
+      ##
+      # @private
+      #
+      # # Pool
+      #
+      # ...
+      class Pool
+        attr_accessor :min, :max, :pool, :queue
+
+        def initialize client, min: 2, max: 10
+          @client = client
+          @min = min
+          @max = max
+
+          # initialize pool and availability queue
+          @pool = []
+          @queue = []
+          @min.times { new_session! }
+        end
+
+        def with_session
+          session = checkout
+          yield session
+          checkin session
+        end
+
+        def checkout
+          if queue.empty?
+            fail "No available sessions" if pool.size >= @max
+            new_session!
+          end
+          queue.shift
+        end
+
+        def checkin session
+          fail "Cannot checkin session" unless pool.include? session
+
+          # Do we ever delete sessions if the queue is *too* full?
+          queue.push session
+
+          nil
+        end
+
+        private
+
+        def new_session!
+          session = @client.create_new_session
+          pool << session
+          queue << session
+          session
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -393,8 +393,8 @@ module Google
         #
         #   ...
         #
-        def client instance_id, database_id
-          Client.new self, instance_id, database_id
+        def client instance_id, database_id, min: 2, max: 10
+          Client.new self, instance_id, database_id, min: min, max: max
         end
 
         protected

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -393,8 +393,9 @@ module Google
         #
         #   ...
         #
-        def client instance_id, database_id, min: 2, max: 10
-          Client.new self, instance_id, database_id, min: min, max: max
+        def client instance_id, database_id, min: 2, max: 10, keepalive: 1500
+          Client.new self, instance_id, database_id, min: min, max: max,
+                                                     keepalive: keepalive
         end
 
         protected

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -494,6 +494,22 @@ module Google
         end
 
         ##
+        # @private
+        # Keeps the session alive by calling SELECT 1
+        def keepalive!
+          ensure_service!
+          execute "SELECT 1"
+          return true
+        rescue Google::Cloud::NotFoundError
+          @grpc = service.create_session \
+            Admin::Database::V1::DatabaseAdminClient.database_path(
+              project_id, instance_id, database_id)
+          self
+          execute "SELECT 1"
+          return false
+        end
+
+        ##
         # @private Creates a new Session instance from a
         # Google::Spanner::V1::Session.
         def self.from_grpc grpc, service

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -303,10 +303,10 @@ module Google
         #     c.insert "users", [{ id: 2, name: "Harvey",  active: true }]
         #   end
         #
-        def commit
+        def commit transaction_id: nil
           commit = Commit.new
           yield commit
-          service.commit path, commit.mutations
+          service.commit path, commit.mutations, transaction_id: transaction_id
         end
 
         ##
@@ -343,10 +343,10 @@ module Google
         #   db.upsert "users", [{ id: 1, name: "Charlie", active: false },
         #                       { id: 2, name: "Harvey",  active: true }]
         #
-        def upsert table, *rows
+        def upsert table, *rows, transaction_id: nil
           commit = Commit.new
           commit.upsert table, rows
-          service.commit path, commit.mutations
+          service.commit path, commit.mutations, transaction_id: transaction_id
         end
         alias_method :save, :upsert
 
@@ -383,10 +383,10 @@ module Google
         #   db.insert "users", [{ id: 1, name: "Charlie", active: false },
         #                       { id: 2, name: "Harvey",  active: true }]
         #
-        def insert table, *rows
+        def insert table, *rows, transaction_id: nil
           commit = Commit.new
           commit.insert table, rows
-          service.commit path, commit.mutations
+          service.commit path, commit.mutations, transaction_id: transaction_id
         end
 
         ##
@@ -422,10 +422,10 @@ module Google
         #   db.update "users", [{ id: 1, name: "Charlie", active: false },
         #                       { id: 2, name: "Harvey",  active: true }]
         #
-        def update table, *rows
+        def update table, *rows, transaction_id: nil
           commit = Commit.new
           commit.update table, rows
-          service.commit path, commit.mutations
+          service.commit path, commit.mutations, transaction_id: transaction_id
         end
 
         ##
@@ -463,10 +463,10 @@ module Google
         #   db.replace "users", [{ id: 1, name: "Charlie", active: false },
         #                        { id: 2, name: "Harvey",  active: true }]
         #
-        def replace table, *rows
+        def replace table, *rows, transaction_id: nil
           commit = Commit.new
           commit.replace table, rows
-          service.commit path, commit.mutations
+          service.commit path, commit.mutations, transaction_id: transaction_id
         end
 
         ##
@@ -487,10 +487,10 @@ module Google
         #
         #   db.delete "users", [1, 2, 3]
         #
-        def delete table, *id
+        def delete table, *id, transaction_id: nil
           commit = Commit.new
           commit.delete table, id
-          service.commit path, commit.mutations
+          service.commit path, commit.mutations, transaction_id: transaction_id
         end
 
         ##

--- a/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
@@ -1,0 +1,42 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:client) { spanner.client instance_id, database_id, min: 0, max: 4 }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+
+  before do
+    p = client.instance_variable_get :@pool
+    p.pool = [session]
+    p.queue = [session]
+  end
+
+  it "deletes sessions" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
+    session.service.mocked_service = mock
+
+    client.close
+
+    mock.verify
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -24,6 +24,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client) { spanner.client instance_id, database_id, min: 0 }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "commits using a block" do
     mutations = [
       Google::Spanner::V1::Mutation.new(

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   let(:commit_resp) { Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new() }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
 
   it "commits using a block" do
     mutations = [

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
@@ -59,6 +59,12 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
   let(:results_grpc) { Google::Spanner::V1::ResultSet.decode_json results_json }
   let(:client) { spanner.client instance_id, database_id, min: 0 }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
@@ -57,7 +57,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
   end
   let(:results_json) { results_hash.to_json }
   let(:results_grpc) { Google::Spanner::V1::ResultSet.decode_json results_json }
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -59,6 +59,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   let(:results_grpc) { Google::Spanner::V1::ResultSet.decode_json results_json }
   let(:client) { spanner.client instance_id, database_id, min: 0 }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "can read all rows" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -57,7 +57,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   end
   let(:results_json) { results_hash.to_json }
   let(:results_grpc) { Google::Spanner::V1::ResultSet.decode_json results_json }
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
 
   it "can read all rows" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -61,7 +61,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
   let(:results_json) { results_hash.to_json }
   let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
   let(:results_enum) { Array(results_grpc).to_enum }
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
   let(:snp_opts) { Google::Spanner::V1::TransactionOptions::ReadOnly.new return_read_timestamp: true }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new read_only: snp_opts }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -65,6 +65,12 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
   let(:snp_opts) { Google::Spanner::V1::TransactionOptions::ReadOnly.new return_read_timestamp: true }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new read_only: snp_opts }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "can execute a simple query without any options" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_retry_test.rb
@@ -101,7 +101,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :retry, :mock_spa
       Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
     ].to_enum
   end
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
 
   it "retries aborted responses" do
     mock = Minitest::Mock.new

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_retry_test.rb
@@ -103,6 +103,12 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :retry, :mock_spa
   end
   let(:client) { spanner.client instance_id, database_id, min: 0 }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "retries aborted responses" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
   let(:results_json) { results_hash.to_json }
   let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
   let(:results_enum) { Array(results_grpc).to_enum }
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_execute_test.rb
@@ -58,6 +58,12 @@ describe Google::Cloud::Spanner::Client, :execute, :streaming, :mock_spanner do
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, min: 0 }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_buffer_bound_test.rb
@@ -84,6 +84,12 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :retry, :buffer_boun
   let(:client) { spanner.client instance_id, database_id, min: 0 }
   let(:columns) { [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids] }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "returns all rows even when there is no resume_token" do
     no_tokens_enum = [
       Google::Spanner::V1::PartialResultSet.decode_json(results_header.to_json),

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_buffer_bound_test.rb
@@ -81,7 +81,7 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :retry, :buffer_boun
       ]
     }
   end
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
   let(:columns) { [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids] }
 
   it "returns all rows even when there is no resume_token" do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_test.rb
@@ -103,6 +103,12 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :retry, :mock_spanne
   end
   let(:client) { spanner.client instance_id, database_id, min: 0 }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "retries aborted responses" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_retry_test.rb
@@ -101,7 +101,7 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :retry, :mock_spanne
       Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
     ].to_enum
   end
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
 
   it "retries aborted responses" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_test.rb
@@ -70,6 +70,12 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :mock_spanner do
   end
   let(:client) { spanner.client instance_id, database_id, min: 0 }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "can read all rows" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/streaming_read_test.rb
@@ -68,7 +68,7 @@ describe Google::Cloud::Spanner::Client, :read, :streaming, :mock_spanner do
      Google::Spanner::V1::PartialResultSet.decode_json(results_hash2.to_json),
      Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json)].to_enum
   end
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
 
   it "can read all rows" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -61,7 +61,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   let(:results_json) { results_hash.to_json }
   let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
   let(:results_enum) { Array(results_grpc).to_enum }
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
 
   it "retries aborted transactions" do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -64,6 +64,12 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   let(:client) { spanner.client instance_id, database_id, min: 0 }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "retries aborted transactions" do
     mutations = [
       Google::Spanner::V1::Mutation.new(

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -64,6 +64,12 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
   let(:client) { spanner.client instance_id, database_id, min: 0 }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -61,7 +61,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
   let(:results_json) { results_hash.to_json }
   let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
   let(:results_enum) { Array(results_grpc).to_enum }
-  let(:client) { spanner.client instance_id, database_id }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
 
   it "can execute a simple query" do

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
@@ -1,0 +1,48 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Pool, :close, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:client) { spanner.client instance_id, database_id, min: 0, max: 4 }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:pool) do
+    p = client.instance_variable_get :@pool
+    p.pool = [session]
+    p.queue = [session]
+    p
+  end
+
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
+  it "deletes sessions" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
+    session.service.mocked_service = mock
+
+    pool.close
+
+    mock.verify
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_test.rb
@@ -1,0 +1,82 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Pool, :keepalive, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:client) { spanner.client instance_id, database_id, min: 0, max: 4 }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:pool) do
+    p = client.instance_variable_get :@pool
+    p.pool = [session]
+    p.queue = [session]
+    p
+  end
+  let :results_hash do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { type: { code: "INT64" } }
+          ]
+        }
+      },
+      values: [
+        { stringValue: "1" }
+      ]
+    }
+  end
+  let(:results_json) { results_hash.to_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_enum) { Array(results_grpc).to_enum }
+
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
+  it "calls keepalive on all sessions" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT 1", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    pool.keepalive!
+
+    mock.verify
+  end
+
+  it "calls keepalive on all sessions and sleeps" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT 1", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    # stub out the sleep method so the test doesn't actually block
+    mock.expect :sleep, nil, [1500]
+    pool.define_singleton_method :sleep do |count|
+      # call the mock to satisfy the expectation
+      mock.sleep count
+    end
+
+    pool.keepalive_and_sleep!
+
+    mock.verify
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -30,6 +30,12 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     p
   end
 
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
   it "can checkout and checkin a session" do
     pool.pool.size.must_equal 1
     pool.queue.size.must_equal 1

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -1,0 +1,113 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Pool, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:client) { spanner.client instance_id, database_id, min: 0, max: 4 }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:pool) do
+    p = client.instance_variable_get :@pool
+    p.pool = [session]
+    p.queue = [session]
+    p
+  end
+
+  it "can checkout and checkin a session" do
+    pool.pool.size.must_equal 1
+    pool.queue.size.must_equal 1
+
+    s = pool.checkout
+
+    pool.pool.size.must_equal 1
+    pool.queue.size.must_equal 0
+
+    pool.checkin s
+
+    pool.pool.size.must_equal 1
+    pool.queue.size.must_equal 1
+  end
+
+  it "creates new sessions when needed" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    spanner.service.mocked_service = mock
+
+    pool.pool.size.must_equal 1
+    pool.queue.size.must_equal 1
+
+    s1 = pool.checkout
+    s2 = pool.checkout
+
+    pool.pool.size.must_equal 2
+    pool.queue.size.must_equal 0
+
+    pool.checkin s1
+    pool.checkin s2
+
+    pool.pool.size.must_equal 2
+    pool.queue.size.must_equal 2
+
+    mock.verify
+  end
+
+  it "raises when checking out more than MAX sessions" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    spanner.service.mocked_service = mock
+
+    pool.pool.size.must_equal 1
+    pool.queue.size.must_equal 1
+
+    s1 = pool.checkout
+    s2 = pool.checkout
+    s3 = pool.checkout
+    s4 = pool.checkout
+
+    checkout_error = assert_raises RuntimeError do
+      pool.checkout
+    end
+    checkout_error.message.must_equal "No available sessions"
+
+    pool.pool.size.must_equal 4
+    pool.queue.size.must_equal 0
+
+    pool.checkin s1
+    pool.checkin s2
+    pool.checkin s3
+    pool.checkin s4
+
+    pool.pool.size.must_equal 4
+    pool.queue.size.must_equal 4
+
+    mock.verify
+  end
+
+  it "raises when checking in a session that does not belong" do
+    outside_session = Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service
+
+    checkin_error = assert_raises RuntimeError do
+      pool.checkin outside_session
+    end
+    checkin_error.message.must_equal "Cannot checkin session"
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
@@ -1,0 +1,51 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let :results_hash do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { type: { code: "INT64" } }
+          ]
+        }
+      },
+      values: [
+        { stringValue: "1" }
+      ]
+    }
+  end
+  let(:results_json) { results_hash.to_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_enum) { Array(results_grpc).to_enum }
+
+  it "can call keepalive" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT 1", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    session.keepalive!
+
+    mock.verify
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
@@ -65,8 +65,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users", streaming: false
 
@@ -77,8 +77,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute sql using the query alias" do
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.query "SELECT * FROM users", streaming: false
 
@@ -89,8 +89,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE active = @active", params: { active: true }, streaming: false
 
@@ -101,8 +101,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }, streaming: false
 
@@ -113,8 +113,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }, streaming: false
 
@@ -127,8 +127,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }, streaming: false
 
@@ -141,8 +141,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }, streaming: false
 
@@ -153,8 +153,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }, streaming: false
 
@@ -167,8 +167,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }, streaming: false
 
@@ -179,8 +179,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }, streaming: false
 
@@ -191,8 +191,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, streaming: false
 
@@ -205,8 +205,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }, streaming: false
 
@@ -219,8 +219,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }, streaming: false
 
@@ -233,8 +233,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_sql, results_grpc, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }, streaming: false
 

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -67,8 +67,8 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :read, results_grpc, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :read, results_grpc, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, streaming: false
 
@@ -81,8 +81,8 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :read, results_grpc, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :read, results_grpc, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, id: [1, 2, 3], streaming: false
 
@@ -95,8 +95,8 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :read, results_grpc, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :read, results_grpc, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, limit: 5, streaming: false
 
@@ -109,8 +109,8 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :read, results_grpc, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :read, results_grpc, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, id: 1, limit: 1, streaming: false
 

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/streaming_execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/streaming_execute_test.rb
@@ -64,8 +64,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users"
 
@@ -76,8 +76,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
 
@@ -88,8 +88,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
@@ -100,8 +100,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
@@ -114,8 +114,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
@@ -128,8 +128,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
@@ -140,8 +140,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
@@ -154,8 +154,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
@@ -166,8 +166,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
@@ -178,8 +178,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }
 
@@ -192,8 +192,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
@@ -206,8 +206,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
@@ -220,8 +220,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :streaming, :mock_spanner d
     skip "Spanner does not accept STRUCT values in query parameters"
 
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/streaming_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/streaming_read_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns
 
@@ -93,7 +93,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, id: [1, 2, 3]
 
@@ -107,7 +107,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, limit: 5
 
@@ -121,7 +121,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :streaming, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1, resume_token: nil, options: default_options]
-    snapshot.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, id: 1, limit: 1
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/commit_test.rb
@@ -65,7 +65,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     transaction.commit do |c|
       c.update "users", [{ id: 1, name: "Charlie", active: false }]
@@ -90,7 +90,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     transaction.update "users", [{ id: 1, name: "Charlie", active: false }]
 
@@ -109,7 +109,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     transaction.insert "users", [{ id: 2, name: "Harvey",  active: true }]
 
@@ -128,7 +128,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     transaction.upsert "users", [{ id: 3, name: "Marley",  active: false }]
 
@@ -147,7 +147,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     transaction.save "users", [{ id: 3, name: "Marley",  active: false }]
 
@@ -166,7 +166,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     transaction.replace "users", [{ id: 4, name: "Henry",  active: true }]
 
@@ -188,7 +188,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     transaction.delete "users", [1, 2, 3, 4, 5]
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     transaction.delete "users", 5
 
@@ -228,7 +228,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     transaction.delete "users"
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users", streaming: false
 
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   it "can execute sql using the query alias" do
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.query "SELECT * FROM users", streaming: false
 
@@ -90,7 +90,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE active = @active", params: { active: true }, streaming: false
 
@@ -102,7 +102,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }, streaming: false
 
@@ -114,7 +114,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }, streaming: false
 
@@ -128,7 +128,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }, streaming: false
 
@@ -142,7 +142,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }, streaming: false
 
@@ -154,7 +154,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }, streaming: false
 
@@ -168,7 +168,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }, streaming: false
 
@@ -180,7 +180,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }, streaming: false
 
@@ -192,7 +192,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, streaming: false
 
@@ -206,7 +206,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }, streaming: false
 
@@ -220,7 +220,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }, streaming: false
 
@@ -234,7 +234,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :execute_sql, results_grpc, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }, streaming: false
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -68,7 +68,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :read, results_grpc, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, streaming: false
 
@@ -82,7 +82,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :read, results_grpc, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, id: [1, 2, 3], streaming: false
 
@@ -96,7 +96,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :read, results_grpc, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, limit: 5, streaming: false
 
@@ -110,7 +110,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :read, results_grpc, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, id: 1, limit: 1, streaming: false
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/streaming_execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/streaming_execute_test.rb
@@ -65,7 +65,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users"
 
@@ -77,7 +77,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
 
@@ -89,7 +89,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
@@ -101,7 +101,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
@@ -115,7 +115,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
@@ -141,7 +141,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
@@ -155,7 +155,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
@@ -167,7 +167,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
@@ -179,7 +179,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }
 
@@ -193,7 +193,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
@@ -207,7 +207,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
@@ -221,7 +221,7 @@ describe Google::Cloud::Spanner::Transaction, :execute, :streaming, :mock_spanne
 
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/streaming_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/streaming_read_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :streaming, :mock_spanner d
 
     mock = Minitest::Mock.new
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns
 
@@ -93,7 +93,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :streaming, :mock_spanner d
 
     mock = Minitest::Mock.new
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, id: [1, 2, 3]
 
@@ -107,7 +107,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :streaming, :mock_spanner d
 
     mock = Minitest::Mock.new
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, limit: 5
 
@@ -121,7 +121,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :streaming, :mock_spanner d
 
     mock = Minitest::Mock.new
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1, resume_token: nil, options: default_options]
-    transaction.service.mocked_service = mock
+    session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, id: 1, limit: 1
 


### PR DESCRIPTION
Implements a session pool with the following features

* Configure minimum sessions
* Configure maximum sessions
* Configure keep alive setting

The session pool does not pre-create transactions. And trying to use more sessions than the pool has configured will raise an error. There is no configuration to have the pool block until a session becomes available.

(closes #1235)