### PR TITLE
Send trace field from standard logger object

### DIFF
--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -246,7 +246,8 @@ describe Google::Cloud::Logging, :logging do
     end
 
     def entries_via_backoff type
-      filter = "log_name = projects/#{logging.project}/logs/#{log_name}-#{type}"
+      filter = "resource.type = \"gce_instance\" AND " +
+        "log_name = \"projects/#{logging.project}/logs/#{log_name}-#{type}\""
       entries = logging.entries filter: filter
       if entries.count < 6 && @sleep < 5
         @sleep += 1
@@ -364,7 +365,8 @@ describe Google::Cloud::Logging, :logging do
     end
 
     def entries_via_backoff type
-      filter = "log_name = projects/#{logging.project}/logs/#{log_name}-#{type}"
+      filter = "resource.type = \"gce_instance\" AND " +
+        "log_name = \"projects/#{logging.project}/logs/#{log_name}-#{type}\""
       entries = logging.entries filter: filter
       if entries.count < 6 && @sleep < 5
         @sleep += 1


### PR DESCRIPTION
Teach the Logger object to set the `trace` field in the LogEntry proto. This is apparently the new preferred way to associate logs with traces. See internal issue b/36130996.

Of note for review: This adds a `project` attribute on the Logger object, since the project ID is needed to format the trace field correctly. Normally, a Logger can obtain this value from the writer passed to it (since that is normally either a Project or an AsyncWriter).

The changes to acceptance/logging/logging_test.rb improve the reliability of those acceptance tests by making the queries run a lot faster if the project has lots of logs for other resources.