### PR TITLE
Retry Streaming Results on UNAVAILABLE

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -122,11 +122,11 @@ module Google
                 # Flush the buffered responses now that they are all handled
                 buffered_responses = []
               end
-            rescue GRPC::Aborted => aborted
+            rescue GRPC::Unavailable => err
               if resume_token.nil? || resume_token.empty?
                 # Re-raise if the resume_token is not a valid value.
                 # This can happen if the buffer was flushed.
-                raise Google::Cloud::Error.from_error(aborted)
+                raise Google::Cloud::Error.from_error(err)
               end
 
               # Resume the stream from the last known resume_token

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Client, :execute, :retry, :mock_spanner do
+describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -90,7 +90,7 @@ describe Google::Cloud::Spanner::Client, :execute, :retry, :mock_spanner do
       Google::Spanner::V1::PartialResultSet.decode_json(results_hash3.to_json),
       Google::Spanner::V1::PartialResultSet.decode_json(results_hash4.to_json),
       Google::Spanner::V1::PartialResultSet.decode_json(results_hash5.to_json),
-      GRPC::Aborted,
+      GRPC::Unavailable,
       Google::Spanner::V1::PartialResultSet.decode_json(results_hash6.to_json)
     ].to_enum
   end
@@ -109,14 +109,16 @@ describe Google::Cloud::Spanner::Client, :execute, :retry, :mock_spanner do
     client.close
   end
 
-  it "retries aborted responses" do
+  it "resumes broken response streams" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :execute_streaming_sql, AbortableEnumerator.new(results_enum1), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    mock.expect :execute_streaming_sql, AbortableEnumerator.new(results_enum2), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: "abc123", options: default_options]
+    mock.expect :streaming_read, UnavailableEnumerator.new(results_enum1), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, UnavailableEnumerator.new(results_enum2), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: "abc123", options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.execute "SELECT * FROM users"
+    results = client.read "my-table", columns
 
     assert_results results
 

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -130,14 +130,14 @@ class MockSpanner < Minitest::Spec
 end
 
 # This is used to raise errors in an enumerator
-class AbortableEnumerator
+class UnavailableEnumerator
   def initialize enum
     @enum = enum
   end
 
   def next
     v = @enum.next
-    raise v if v == GRPC::Aborted
+    raise v if v == GRPC::Unavailable
     v
   end
 


### PR DESCRIPTION
Streaming results should handle UNAVAILABLE errors, not ABORTED.

Transactions will still be retried on ABORTED errors.