### PR TITLE
Spanner Transaction Improvements

### DIFF
--- a/google-cloud-spanner/.rubocop.yml
+++ b/google-cloud-spanner/.rubocop.yml
@@ -44,3 +44,5 @@ Style/TrivialAccessors:
   Enabled: false
 Style/FileName:
   Enabled: false # for lib/google-cloud-spanner.rb file
+Lint/HandleExceptions:
+  Enabled: false

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -446,6 +446,9 @@ module Google
         # a single logical point in time across columns, rows, and tables in a
         # database.
         #
+        # @param [Numeric] deadline The total amount of time in seconds the
+        #   transaction has to succeed.
+        #
         # @yield [transaction] The block for reading and writing data.
         # @yieldparam [Google::Cloud::Spanner::Transaction] transaction The
         #   Transaction object.
@@ -464,17 +467,24 @@ module Google
         #     end
         #   end
         #
-        def transaction &block
+        def transaction deadline: 120, &block
           ensure_service!
+
+          deadline = validate_deadline deadline
+          backoff = 1.0
+          start_time = current_time
+
           @pool.with_session do |session|
-            tx_grpc = @project.service.begin_transaction session.path
-            tx = Transaction.from_grpc(tx_grpc, session)
+            tx = create_transaction! session
             begin
               block.call tx
             rescue Google::Cloud::AbortedError => err
-              sleep delay_from_aborted(err)
-              tx_grpc = @project.service.begin_transaction session.path
-              tx = Transaction.from_grpc(tx_grpc, session)
+              # Re-raise if deadline has passed
+              raise err if current_time - start_time > deadline
+              # Sleep the amount from RetryDelay, or incremental backoff
+              sleep(delay_from_aborted(err) || backoff *= 1.3)
+              # Create new transaction and retry the block
+              tx = create_transaction! session
               retry
             end
           end
@@ -567,6 +577,11 @@ module Google
           fail "Must have active connection to service" unless @project.service
         end
 
+        def create_transaction! session
+          tx_grpc = @project.service.begin_transaction session.path
+          Transaction.from_grpc(tx_grpc, session)
+        end
+
         ##
         # Check for valid snapshot arguments
         def validate_single_use_args! timestamp: nil, staleness: nil
@@ -599,10 +614,22 @@ module Google
                "(strong, timestamp, staleness)"
         end
 
+        def validate_deadline deadline
+          return 120 unless deadline.is_a? Numeric
+          return 120 if deadline < 0
+          deadline
+        end
+
+        ##
+        # Defer to this method so we have something to mock for tests
+        def current_time
+          Time.now
+        end
+
         ##
         # Retrieves the delay value from Google::Cloud::AbortedError
         def delay_from_aborted err
-          return 0 if err.nil?
+          return nil if err.nil?
           if err.respond_to?(:metadata) && err.metadata["retryDelay"]
             # a correct metadata will look like this:
             # "{\"retryDelay\":{\"seconds\":60}}"
@@ -614,8 +641,8 @@ module Google
           # No metadata? Try the inner error
           delay_from_aborted(err.cause)
         rescue
-          # Any error gets the default delay, which is 0
-          return 0
+          # Any error indicates the backoff should be handled elsewhere
+          return nil
         end
       end
     end

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -488,6 +488,11 @@ module Google
               retry
             rescue RollbackError
               # Transaction block was interrupted, allow to continue
+            rescue => err
+              # Rollback transaction when handling unexpeced error
+              # Don't use Transaction#rollback since it raises
+              session.rollback tx.send(:transaction_id)
+              raise err
             end
           end
           nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-require "google/cloud/errors"
+require "google/cloud/spanner/errors"
 require "google/cloud/spanner/project"
 require "google/cloud/spanner/pool"
 require "google/cloud/spanner/session"
@@ -486,6 +486,8 @@ module Google
               # Create new transaction and retry the block
               tx = create_transaction! session
               retry
+            rescue RollbackError
+              # Transaction block was interrupted, allow to continue
             end
           end
           nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/errors.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/errors.rb
@@ -1,0 +1,29 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/errors"
+
+module Google
+  module Cloud
+    module Spanner
+      ##
+      # # TransactionError
+      #
+      # General error for Transaction problems.
+      class RollbackError < Google::Cloud::Error
+      end
+    end
+  end
+end

--- a/google-cloud-spanner/lib/google/cloud/spanner/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/policy.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-require "google/cloud/errors"
+require "google/cloud/spanner/errors"
 
 module Google
   module Cloud

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-require "google/cloud/errors"
+require "google/cloud/spanner/errors"
 require "google/cloud/env"
 require "google/cloud/spanner/service"
 require "google/cloud/spanner/client"

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -14,7 +14,7 @@
 
 
 require "google/cloud/spanner/convert"
-require "google/cloud/errors"
+require "google/cloud/spanner/errors"
 
 module Google
   module Cloud

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-require "google/cloud/errors"
+require "google/cloud/spanner/errors"
 require "google/cloud/spanner/credentials"
 require "google/cloud/spanner/version"
 require "google/cloud/spanner/v1"
@@ -359,6 +359,13 @@ module Google
               session_name, mutations,
               transaction_id: transaction_id, single_use_transaction: tx_opts,
               options: opts
+          end
+        end
+
+        def rollback session_name, transaction_id
+          opts = default_options_from_session session_name
+          execute do
+            service.rollback session_name, transaction_id, options: opts
           end
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -443,6 +443,12 @@ module Google
         end
 
         ##
+        # Rolls back the transaction, releasing any locks it holds.
+        def rollback transaction_id
+          service.rollback path, transaction_id
+        end
+
+        ##
         # @private
         # Keeps the session alive by calling SELECT 1
         def keepalive!

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+require "google/cloud/spanner/errors"
 require "google/cloud/spanner/results"
 require "google/cloud/spanner/commit"
 
@@ -354,6 +355,26 @@ module Google
         def delete table, *id
           ensure_session!
           session.delete table, id, transaction_id: transaction_id
+        end
+
+        ##
+        # Rolls back the transaction, releasing any locks it holds. It is a good
+        # idea to call this for any transaction that includes one or more `read`
+        # or `execute` requests and ultimately decides not to commit.
+        #
+        # @example
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.transaction { |tx| tx.rollback }
+        #
+        def rollback
+          ensure_session!
+          session.rollback transaction_id
+          # Raise RollbackError so the client can stop the transaction.
+          fail RollbackError
         end
 
         ##

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -70,7 +70,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     client.close
   end
 
-  it "retries aborted transactions" do
+  it "retries aborted transactions without retry metadata" do
     mutations = [
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
@@ -84,10 +84,10 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # mock.expect :commit, ->{ raise GRPC::Aborted }, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
+
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # mock.expect :commit, Google::Spanner::V1::CommitResponse.new(commit_timestamp: Google::Protobuf::Timestamp.new()), [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_selector, options: default_options]
+
     def mock.commit *args
       # first time called this will raise
       if @called == nil
@@ -99,7 +99,175 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       # second call will return correct response
       Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
     end
+    mock.expect :sleep, nil, [0]
     spanner.service.mocked_service = mock
+
+    client.define_singleton_method :sleep do |count|
+      # call the mock to satisfy the expectation
+      mock.sleep count
+    end
+
+    results = nil
+    client.transaction do |tx|
+      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      results = tx.execute "SELECT * FROM users"
+      tx.update "users", [{ id: 1, name: "Charlie", active: false }]
+    end
+
+    assert_results results
+
+    mock.verify
+  end
+
+  it "retries aborted transactions with retry metadata seconds" do
+    skip "Can't get trailing metadata on Ruby 2.0" unless Exception.instance_methods.include? :cause
+
+    mutations = [
+      Google::Spanner::V1::Mutation.new(
+        update: Google::Spanner::V1::Mutation::Write.new(
+          table: "users", columns: %w(id name active),
+          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+
+    def mock.commit *args
+      # first time called this will raise
+      if @called == nil
+        @called = true
+        gax_error = Google::Gax::GaxError.new "aborted"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(10, "aborted", {"retryDelay"=>{"seconds"=>60}})
+        raise gax_error
+      end
+      # second call will return correct response
+      Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
+    end
+    mock.expect :sleep, nil, [60]
+    spanner.service.mocked_service = mock
+
+    client.define_singleton_method :sleep do |count|
+      # call the mock to satisfy the expectation
+      mock.sleep count
+    end
+
+    results = nil
+    client.transaction do |tx|
+      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      results = tx.execute "SELECT * FROM users"
+      tx.update "users", [{ id: 1, name: "Charlie", active: false }]
+    end
+
+    assert_results results
+
+    mock.verify
+  end
+
+  it "retries aborted transactions with retry metadata seconds and nanos" do
+    skip "Can't get trailing metadata on Ruby 2.0" unless Exception.instance_methods.include? :cause
+
+    mutations = [
+      Google::Spanner::V1::Mutation.new(
+        update: Google::Spanner::V1::Mutation::Write.new(
+          table: "users", columns: %w(id name active),
+          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+
+    def mock.commit *args
+      # first time called this will raise
+      if @called == nil
+        @called = true
+        gax_error = Google::Gax::GaxError.new "aborted"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(10, "aborted", {"retryDelay"=>{"seconds"=>123, "nanos"=>456000000}})
+        raise gax_error
+      end
+      # second call will return correct response
+      Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
+    end
+    mock.expect :sleep, nil, [123.456]
+    spanner.service.mocked_service = mock
+
+    client.define_singleton_method :sleep do |count|
+      # call the mock to satisfy the expectation
+      mock.sleep count
+    end
+
+    results = nil
+    client.transaction do |tx|
+      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      results = tx.execute "SELECT * FROM users"
+      tx.update "users", [{ id: 1, name: "Charlie", active: false }]
+    end
+
+    assert_results results
+
+    mock.verify
+  end
+
+  it "retries multiple aborted transactions" do
+    skip "Can't get trailing metadata on Ruby 2.0" unless Exception.instance_methods.include? :cause
+
+    mutations = [
+      Google::Spanner::V1::Mutation.new(
+        update: Google::Spanner::V1::Mutation::Write.new(
+          table: "users", columns: %w(id name active),
+          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    def mock.commit *args
+      # first time called this will raise
+      if @called == nil
+        @called = false
+        gax_error = Google::Gax::GaxError.new "aborted"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(10, "aborted")
+        raise gax_error
+      end
+      if @called == false
+        @called = true
+        gax_error = Google::Gax::GaxError.new "aborted"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(10, "aborted", {"retryDelay"=>{"seconds"=>30}})
+        raise gax_error
+      end
+      # third call will return correct response
+      Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
+    end
+    mock.expect :sleep, nil, [0]
+    mock.expect :sleep, nil, [30]
+    spanner.service.mocked_service = mock
+
+    client.define_singleton_method :sleep do |count|
+      # call the mock to satisfy the expectation
+      mock.sleep count
+    end
 
     results = nil
     client.transaction do |tx|

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -1,0 +1,128 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:transaction_id) { "tx789" }
+  let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
+  let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
+  let(:tx_selector) { Google::Spanner::V1::TransactionSelector.new id: transaction_id }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let :results_hash do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { name: "id",          type: { code: "INT64" } },
+            { name: "name",        type: { code: "STRING" } },
+            { name: "active",      type: { code: "BOOL" } },
+            { name: "age",         type: { code: "INT64" } },
+            { name: "score",       type: { code: "FLOAT64" } },
+            { name: "updated_at",  type: { code: "TIMESTAMP" } },
+            { name: "birthday",    type: { code: "DATE"} },
+            { name: "avatar",      type: { code: "BYTES" } },
+            { name: "project_ids", type: { code: "ARRAY",
+                                           arrayElementType: { code: "INT64" } } }
+          ]
+        }
+      },
+      values: [
+        { stringValue: "1" },
+        { stringValue: "Charlie" },
+        { boolValue: true},
+        { stringValue: "29" },
+        { numberValue: 0.9 },
+        { stringValue: "2017-01-02T03:04:05.060000000Z" },
+        { stringValue: "1950-01-01" },
+        { stringValue: "aW1hZ2U=" },
+        { listValue: { values: [ { stringValue: "1"},
+                                 { stringValue: "2"},
+                                 { stringValue: "3"} ]}}
+      ]
+    }
+  end
+  let(:results_json) { results_hash.to_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_enum) { Array(results_grpc).to_enum }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
+  let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
+
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
+  it "can rollback a transaction and not continue code in the block" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = nil
+    client.transaction do |tx|
+      tx.must_be_kind_of Google::Cloud::Spanner::Transaction
+      results = tx.execute "SELECT * FROM users"
+      # Rollback, RollbackError is handled by the client.
+      tx.rollback
+      # This code will never be run, so no mocks for it.
+      tx.update "users", [{ id: 1, name: "Charlie", active: false }]
+    end
+
+    mock.verify
+
+    assert_results results
+  end
+
+  def assert_results results
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    results.types.wont_be :nil?
+    results.types.must_be_kind_of Hash
+    results.types.keys.count.must_equal 9
+    results.types[:id].must_equal          :INT64
+    results.types[:name].must_equal        :STRING
+    results.types[:active].must_equal      :BOOL
+    results.types[:age].must_equal         :INT64
+    results.types[:score].must_equal       :FLOAT64
+    results.types[:updated_at].must_equal  :TIMESTAMP
+    results.types[:birthday].must_equal    :DATE
+    results.types[:avatar].must_equal      :BYTES
+    results.types[:project_ids].must_equal [:INT64]
+
+    rows = results.rows.to_a # grab them all from the enumerator
+    rows.count.must_equal 1
+    row = rows.first
+    row.must_be_kind_of Hash
+    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    row[:id].must_equal 1
+    row[:name].must_equal "Charlie"
+    row[:active].must_equal true
+    row[:age].must_equal 29
+    row[:score].must_equal 0.9
+    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    row[:birthday].must_equal Date.parse("1950-01-01")
+    row[:avatar].must_be_kind_of StringIO
+    row[:avatar].read.must_equal "image"
+    row[:project_ids].must_equal [1, 2, 3]
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/rollback_test.rb
@@ -1,0 +1,39 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:transaction_id) { "tx789" }
+  let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
+  let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+
+  it "rolls itself back" do
+    mock = Minitest::Mock.new
+    mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
+    session.service.mocked_service = mock
+
+    assert_raises Google::Cloud::Spanner::RollbackError do
+      transaction.rollback
+    end
+
+    mock.verify
+  end
+end


### PR DESCRIPTION
This PR makes the following changes to Transaction:

- [x] Add `Transaction#rollback`
- [x] Retry aborted transactions as many times as needed.
- [x] Add `deadline` to control how long a transaction can take to complete.