### PR TITLE
Add pairs argument to Spanner Results

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
@@ -137,11 +137,14 @@ module Google
             end
           end
 
-          def row_to_raw row_types, row
-            # this calls to_ruby on the value objects.
-            Hash[row_types.zip(row).map do |field, value|
+          def row_to_pairs row_types, row
+            row_types.zip(row).map do |field, value|
               [field.name.to_sym, value_to_raw(value, field.type)]
-            end]
+            end
+          end
+
+          def row_to_raw row_types, row
+            Hash[row_to_pairs(row_types, row)]
           end
 
           def value_to_raw value, type

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
@@ -1,0 +1,83 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Results, :duplicate, :mock_spanner do
+  let :results_types do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { name: "num", type: { code: "INT64" } },
+            { name: "str", type: { code: "INT64" } },
+            { name: "num", type: { code: "STRING" } },
+            { name: "str", type: { code: "STRING" } }
+          ]
+        }
+      }
+    }
+  end
+  let :results_values do
+    {
+      values: [
+        { stringValue: "1" },
+        { stringValue: "2" },
+        { stringValue: "hello" },
+        { stringValue: "world" },
+        { stringValue: "3" },
+        { stringValue: "4" },
+        { stringValue: "hola" },
+        { stringValue: "mundo" }
+      ]
+    }
+  end
+  let(:results_enum) do
+    [Google::Spanner::V1::PartialResultSet.decode_json(results_types.to_json),
+     Google::Spanner::V1::PartialResultSet.decode_json(results_values.to_json)].to_enum
+  end
+  let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
+
+  it "defaults to hashes" do
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    types = results.types
+    types.wont_be :nil?
+    types.must_be_kind_of Hash
+    types.must_equal({:"num" => :STRING, :"str" => :STRING})
+
+    rows = results.rows.to_a # grab them all from the enumerator
+    rows.count.must_equal 2
+    rows.first.must_be_kind_of Hash
+    rows.first.must_equal({num: "hello", str: "world"})
+    rows.last.must_be_kind_of Hash
+    rows.last.must_equal({num: "hola", str: "mundo"})
+  end
+
+  it "can return an array of pairs" do
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    types = results.types pairs: true
+    types.wont_be :nil?
+    types.must_be_kind_of Array
+    types.must_equal [[:num, :INT64], [:str, :INT64], [:num, :STRING], [:str, :STRING]]
+
+    rows = results.rows(pairs: true).to_a # grab them all from the enumerator
+    rows.count.must_equal 2
+    rows.first.must_be_kind_of Array
+    rows.first.must_equal [[:num, 1], [:str, 2], [:num, "hello"], [:str, "world"]]
+    rows.last.must_be_kind_of Array
+    rows.last.must_equal [[:num, 3], [:str, 4], [:num, "hola"], [:str, "mundo"]]
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/emtpy_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/emtpy_test.rb
@@ -1,0 +1,83 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Results, :empty, :mock_spanner do
+  let :results_types do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { type: { code: "INT64" } },
+            { type: { code: "INT64" } },
+            { type: { code: "INT64" } },
+            { type: { code: "INT64" } }
+          ]
+        }
+      }
+    }
+  end
+  let :results_values do
+    {
+      values: [
+        { stringValue: "1" },
+        { stringValue: "2" },
+        { stringValue: "3" },
+        { stringValue: "4" },
+        { stringValue: "5" },
+        { stringValue: "6" },
+        { stringValue: "7" },
+        { stringValue: "8" }
+      ]
+    }
+  end
+  let(:results_enum) do
+    [Google::Spanner::V1::PartialResultSet.decode_json(results_types.to_json),
+     Google::Spanner::V1::PartialResultSet.decode_json(results_values.to_json)].to_enum
+  end
+  let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
+
+  it "defaults to hashes" do
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    types = results.types
+    types.wont_be :nil?
+    types.must_be_kind_of Hash
+    types.must_equal({:"" => :INT64})
+
+    rows = results.rows.to_a # grab them all from the enumerator
+    rows.count.must_equal 2
+    rows.first.must_be_kind_of Hash
+    rows.first.must_equal({:"" => 4})
+    rows.last.must_be_kind_of Hash
+    rows.last.must_equal({:"" => 8})
+  end
+
+  it "can return an array of pairs" do
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    types = results.types pairs: true
+    types.wont_be :nil?
+    types.must_be_kind_of Array
+    types.must_equal [[:"", :INT64], [:"", :INT64], [:"", :INT64], [:"", :INT64]]
+
+    rows = results.rows(pairs: true).to_a # grab them all from the enumerator
+    rows.count.must_equal 2
+    rows.first.must_be_kind_of Array
+    rows.first.must_equal [[:"", 1], [:"", 2], [:"", 3], [:"", 4]]
+    rows.last.must_be_kind_of Array
+    rows.last.must_equal [[:"", 5], [:"", 6], [:"", 7], [:"", 8]]
+  end
+end


### PR DESCRIPTION
The pair method argument allows rows and types to be returned as a nested Array of pairs rather than a Hash. This will be useful for when users have rows that have duplicate names. The values can be
represented in a data structure that allows for duplicate keys, while being familiar to Rubyists.