### PR TITLE
Spanner Snapshot Improvements

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
@@ -33,8 +33,24 @@ describe "Spanner Client", :execute, :spanner do
     row[:num].must_equal 42
   end
 
+  it "runs a simple query using a single-use strong option" do
+    results = db.execute "SELECT 42 AS num", single_use: { strong: true }
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    results.types.must_be_kind_of Hash
+    results.types.keys.count.must_equal 1
+    results.types[:num].must_equal :INT64
+
+    rows = results.rows.to_a # grab all from the enumerator
+    rows.count.must_equal 1
+    row = rows.first
+    row.must_be_kind_of Hash
+    row.keys.must_equal [:num]
+    row[:num].must_equal 42
+  end
+
   it "runs a simple query using a single-use timestamp option" do
-    results = db.execute "SELECT 42 AS num", timestamp: (Time.now - 60)
+    results = db.execute "SELECT 42 AS num", single_use: { timestamp: (Time.now - 60) }
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
     results.types.must_be_kind_of Hash
@@ -50,7 +66,39 @@ describe "Spanner Client", :execute, :spanner do
   end
 
   it "runs a simple query using a single-use staleness option" do
-    results = db.execute "SELECT 42 AS num", staleness: 60
+    results = db.execute "SELECT 42 AS num", single_use: { staleness: 60 }
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    results.types.must_be_kind_of Hash
+    results.types.keys.count.must_equal 1
+    results.types[:num].must_equal :INT64
+
+    rows = results.rows.to_a # grab all from the enumerator
+    rows.count.must_equal 1
+    row = rows.first
+    row.must_be_kind_of Hash
+    row.keys.must_equal [:num]
+    row[:num].must_equal 42
+  end
+
+  it "runs a simple query using a single-use bounded_timestamp option" do
+    results = db.execute "SELECT 42 AS num", single_use: { bounded_timestamp: (Time.now - 60) }
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    results.types.must_be_kind_of Hash
+    results.types.keys.count.must_equal 1
+    results.types[:num].must_equal :INT64
+
+    rows = results.rows.to_a # grab all from the enumerator
+    rows.count.must_equal 1
+    row = rows.first
+    row.must_be_kind_of Hash
+    row.keys.must_equal [:num]
+    row[:num].must_equal 42
+  end
+
+  it "runs a simple query using a single-use bounded_staleness option" do
+    results = db.execute "SELECT 42 AS num", single_use: { bounded_staleness: 60 }
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
     results.types.must_be_kind_of Hash

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -110,44 +110,52 @@ module Google
         #   (read-only transaction). The snapshot can be created by providing
         #   just one of the following options in the hash:
         #
-        #   * `:strong` (true, false) Read at a timestamp where all previously
-        #     committed transactions are visible.
-        #   * `:timestamp` (Time, DateTime) Executes all reads at the given
-        #     timestamp. Unlike other modes, reads at a specific timestamp are
-        #     repeatable; the same read at the same timestamp always returns the
-        #     same data. If the timestamp is in the future, the read will block
-        #     until the specified timestamp, modulo the read's deadline.
+        #   * **Strong**
+        #     * `:strong` (true, false) Read at a timestamp where all previously
+        #       committed transactions are visible.
+        #   * **Exact**
+        #     * `:timestamp`/`:read_timestamp` (Time, DateTime) Executes all
+        #       reads at the given timestamp. Unlike other modes, reads at a
+        #       specific timestamp are repeatable; the same read at the same
+        #       timestamp always returns the same data. If the timestamp is in
+        #       the future, the read will block until the specified timestamp,
+        #       modulo the read's deadline.
         #
-        #     Useful for large scale consistent reads such as mapreduces, or for
-        #     coordinating many reads against a consistent snapshot of the data.
-        #   * `:staleness` (Numeric) Executes all reads at a timestamp that is
-        #     exactly the number of seconds provided old. The timestamp is
-        #     chosen soon after the read is started.
+        #       Useful for large scale consistent reads such as mapreduces, or
+        #       for coordinating many reads against a consistent snapshot of the
+        #       data.
+        #     * `:staleness`/`:exact_staleness` (Numeric) Executes all reads at
+        #       a timestamp that is exactly the number of seconds provided old.
+        #       The timestamp is chosen soon after the read is started.
         #
-        #     Guarantees that all writes that have committed more than the
-        #     specified number of seconds ago are visible. Because Cloud Spanner
-        #     chooses the exact timestamp, this mode works even if the client's
-        #     local clock is substantially skewed from Cloud Spanner commit
-        #     timestamps.
+        #       Guarantees that all writes that have committed more than the
+        #       specified number of seconds ago are visible. Because Cloud
+        #       Spanner chooses the exact timestamp, this mode works even if the
+        #       client's local clock is substantially skewed from Cloud Spanner
+        #       commit timestamps.
         #
-        #     Useful for reading at nearby replicas without the distributed
-        #     timestamp negotiation overhead of single-use `bounded_staleness`.
-        #   * `:bounded_timestamp` (Time, DateTime) Executes all reads at a
-        #     timestamp greater than the value provided.
+        #       Useful for reading at nearby replicas without the distributed
+        #       timestamp negotiation overhead of single-use
+        #       `bounded_staleness`.
+        #   * **Bounded**
+        #     * `:bounded_timestamp`/`:min_read_timestamp` (Time, DateTime)
+        #       Executes all reads at a timestamp greater than the value
+        #       provided.
         #
-        #     This is useful for requesting fresher data than some previous
-        #     read, or data that is fresh enough to observe the effects of some
-        #     previously committed transaction whose timestamp is known.
-        #   * `:bounded_staleness` (Numeric) Read data at a timestamp greater
-        #     than or equal to the number of seconds provided. Guarantees that
-        #     all writes that have committed more than the specified number of
-        #     seconds ago are visible. Because Cloud Spanner chooses the exact
-        #     timestamp, this mode works even if the client's local clock is
-        #     substantially skewed from Cloud Spanner commit timestamps.
+        #       This is useful for requesting fresher data than some previous
+        #       read, or data that is fresh enough to observe the effects of
+        #       some previously committed transaction whose timestamp is known.
+        #     * `:bounded_staleness`/`:max_staleness` (Numeric) Read data at a
+        #       timestamp greater than or equal to the number of seconds
+        #       provided. Guarantees that all writes that have committed more
+        #       than the specified number of seconds ago are visible. Because
+        #       Cloud Spanner chooses the exact timestamp, this mode works even
+        #       if the client's local clock is substantially skewed from Cloud
+        #       Spanner commit timestamps.
         #
-        #     Useful for reading the freshest data available at a nearby
-        #     replica, while bounding the possible staleness if the local
-        #     replica has fallen behind.
+        #       Useful for reading the freshest data available at a nearby
+        #       replica, while bounding the possible staleness if the local
+        #       replica has fallen behind.
         #
         # @return [Google::Cloud::Spanner::Results]
         #
@@ -212,44 +220,52 @@ module Google
         #   (read-only transaction). The snapshot can be created by providing
         #   just one of the following options in the hash:
         #
-        #   * `:strong` (true, false) Read at a timestamp where all previously
-        #     committed transactions are visible.
-        #   * `:timestamp` (Time, DateTime) Executes all reads at the given
-        #     timestamp. Unlike other modes, reads at a specific timestamp are
-        #     repeatable; the same read at the same timestamp always returns the
-        #     same data. If the timestamp is in the future, the read will block
-        #     until the specified timestamp, modulo the read's deadline.
+        #   * **Strong**
+        #     * `:strong` (true, false) Read at a timestamp where all previously
+        #       committed transactions are visible.
+        #   * **Exact**
+        #     * `:timestamp`/`:read_timestamp` (Time, DateTime) Executes all
+        #       reads at the given timestamp. Unlike other modes, reads at a
+        #       specific timestamp are repeatable; the same read at the same
+        #       timestamp always returns the same data. If the timestamp is in
+        #       the future, the read will block until the specified timestamp,
+        #       modulo the read's deadline.
         #
-        #     Useful for large scale consistent reads such as mapreduces, or for
-        #     coordinating many reads against a consistent snapshot of the data.
-        #   * `:staleness` (Numeric) Executes all reads at a timestamp that is
-        #     exactly the number of seconds provided old. The timestamp is
-        #     chosen soon after the read is started.
+        #       Useful for large scale consistent reads such as mapreduces, or
+        #       for coordinating many reads against a consistent snapshot of the
+        #       data.
+        #     * `:staleness`/`:exact_staleness` (Numeric) Executes all reads at
+        #       a timestamp that is exactly the number of seconds provided old.
+        #       The timestamp is chosen soon after the read is started.
         #
-        #     Guarantees that all writes that have committed more than the
-        #     specified number of seconds ago are visible. Because Cloud Spanner
-        #     chooses the exact timestamp, this mode works even if the client's
-        #     local clock is substantially skewed from Cloud Spanner commit
-        #     timestamps.
+        #       Guarantees that all writes that have committed more than the
+        #       specified number of seconds ago are visible. Because Cloud
+        #       Spanner chooses the exact timestamp, this mode works even if the
+        #       client's local clock is substantially skewed from Cloud Spanner
+        #       commit timestamps.
         #
-        #     Useful for reading at nearby replicas without the distributed
-        #     timestamp negotiation overhead of single-use `bounded_staleness`.
-        #   * `:bounded_timestamp` (Time, DateTime) Executes all reads at a
-        #     timestamp greater than the value provided.
+        #       Useful for reading at nearby replicas without the distributed
+        #       timestamp negotiation overhead of single-use
+        #       `bounded_staleness`.
+        #   * **Bounded**
+        #     * `:bounded_timestamp`/`:min_read_timestamp` (Time, DateTime)
+        #       Executes all reads at a timestamp greater than the value
+        #       provided.
         #
-        #     This is useful for requesting fresher data than some previous
-        #     read, or data that is fresh enough to observe the effects of some
-        #     previously committed transaction whose timestamp is known.
-        #   * `:bounded_staleness` (Numeric) Read data at a timestamp greater
-        #     than or equal to the number of seconds provided. Guarantees that
-        #     all writes that have committed more than the specified number of
-        #     seconds ago are visible. Because Cloud Spanner chooses the exact
-        #     timestamp, this mode works even if the client's local clock is
-        #     substantially skewed from Cloud Spanner commit timestamps.
+        #       This is useful for requesting fresher data than some previous
+        #       read, or data that is fresh enough to observe the effects of
+        #       some previously committed transaction whose timestamp is known.
+        #     * `:bounded_staleness`/`:max_staleness` (Numeric) Read data at a
+        #       timestamp greater than or equal to the number of seconds
+        #       provided. Guarantees that all writes that have committed more
+        #       than the specified number of seconds ago are visible. Because
+        #       Cloud Spanner chooses the exact timestamp, this mode works even
+        #       if the client's local clock is substantially skewed from Cloud
+        #       Spanner commit timestamps.
         #
-        #     Useful for reading the freshest data available at a nearby
-        #     replica, while bounding the possible staleness if the local
-        #     replica has fallen behind.
+        #       Useful for reading the freshest data available at a nearby
+        #       replica, while bounding the possible staleness if the local
+        #       replica has fallen behind.
         #
         # @return [Google::Cloud::Spanner::Results]
         #
@@ -560,6 +576,7 @@ module Google
         #
         #   Useful for large scale consistent reads such as mapreduces, or for
         #   coordinating many reads against a consistent snapshot of the data.
+        # @param [Time, DateTime] read_timestamp Same as `timestamp`
         # @param [Numeric] staleness Executes all reads at a timestamp that is
         #   +staleness+ old. The timestamp is chosen soon after the read
         #   is started.
@@ -572,6 +589,7 @@ module Google
         #
         #   Useful for reading at nearby replicas without the distributed
         #   timestamp negotiation overhead of single-use +staleness+.
+        # @param [Numeric] exact_staleness Same as `staleness`
         #
         # @yield [snapshot] The block for reading and writing data.
         # @yieldparam [Google::Cloud::Spanner::Snapshot] snapshot The Snapshot
@@ -591,14 +609,18 @@ module Google
         #     end
         #   end
         #
-        def snapshot strong: nil, timestamp: nil, staleness: nil
+        def snapshot strong: nil, timestamp: nil, read_timestamp: nil,
+                     staleness: nil, exact_staleness: nil
           validate_snapshot_args! strong: strong, timestamp: timestamp,
-                                  staleness: staleness
+                                  read_timestamp: read_timestamp,
+                                  staleness: staleness,
+                                  exact_staleness: exact_staleness
           ensure_service!
           @pool.with_session do |session|
             snp_grpc = @project.service.create_snapshot \
-              session.path, strong: strong, timestamp: timestamp,
-                            staleness: staleness
+              session.path, strong: strong,
+                            timestamp: (timestamp || read_timestamp),
+                            staleness: (staleness || exact_staleness)
             snp = Snapshot.from_grpc(snp_grpc, session)
             yield snp if block_given?
           end
@@ -703,8 +725,9 @@ module Google
         # Check for valid snapshot arguments
         def validate_single_use_args! opts = {}
           return true if opts.nil? || opts.empty?
-          valid_keys = [:strong, :timestamp, :staleness, :bounded_timestamp,
-                        :bounded_staleness]
+          valid_keys = [:strong, :timestamp, :read_timestamp, :staleness,
+                        :exact_staleness, :bounded_timestamp,
+                        :min_read_timestamp, :bounded_staleness, :max_staleness]
           if opts.keys.count == 1 && valid_keys.include?(opts.keys.first)
             return true
           end
@@ -718,10 +741,14 @@ module Google
         def single_use_transaction opts = {}
           return nil if opts.nil? || opts.empty?
 
-          exact_timestamp = Convert.time_to_timestamp opts[:timestamp]
-          exact_staleness = Convert.number_to_duration opts[:staleness]
-          bnded_timestamp = Convert.time_to_timestamp opts[:bounded_timestamp]
-          bnded_staleness = Convert.number_to_duration opts[:bounded_staleness]
+          exact_timestamp = Convert.time_to_timestamp \
+            opts[:timestamp] || opts[:read_timestamp]
+          exact_staleness = Convert.number_to_duration \
+            opts[:staleness] || opts[:exact_staleness]
+          bounded_timestamp = Convert.time_to_timestamp \
+            opts[:bounded_timestamp] || opts[:min_read_timestamp]
+          bounded_staleness = Convert.number_to_duration \
+            opts[:bounded_staleness] || opts[:max_staleness]
 
           Google::Spanner::V1::TransactionSelector.new(single_use:
             Google::Spanner::V1::TransactionOptions.new(read_only:
@@ -729,21 +756,23 @@ module Google
                 strong: opts[:strong],
                 read_timestamp: exact_timestamp,
                 exact_staleness: exact_staleness,
-                min_read_timestamp: bnded_timestamp,
-                max_staleness: bnded_staleness,
+                min_read_timestamp: bounded_timestamp,
+                max_staleness: bounded_staleness,
                 return_read_timestamp: true
               }.delete_if { |_, v| v.nil? })))
         end
 
         ##
         # Check for valid snapshot arguments
-        def validate_snapshot_args! strong: nil, timestamp: nil, staleness: nil
-          remaining_args = { strong: strong, timestamp: timestamp,
-                             staleness: staleness }.delete_if { |_, v| v.nil? }
-          return true if remaining_args.keys.count <= 1
+        def validate_snapshot_args! strong: nil,
+                                    timestamp: nil, read_timestamp: nil,
+                                    staleness: nil, exact_staleness: nil
+          valid_args_count = [strong, timestamp, read_timestamp, staleness,
+                              exact_staleness].compact.count
+          return true if valid_args_count <= 1
           fail ArgumentError,
                "Can only provide one of the following arguments: " \
-               "(strong, timestamp, staleness)"
+               "(strong, timestamp, read_timestamp, staleness, exact_staleness)"
         end
 
         def validate_deadline deadline

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -220,6 +220,24 @@ module Google
 
         # rubocop:enable all
 
+        ##
+        # Identifier of the transaction results were run in. Single-use
+        # read-only transactions do not have IDs, because single-use
+        # transactions do not support multiple requests.
+        # @return [String] The transaction id.
+        def transaction
+          return nil if @metadata.nil? || @metadata.transaction.nil?
+          @metadata.transaction.id
+        end
+
+        ##
+        # The read timestamp chosen for snapshots.
+        # @return [Time] The chosen timestamp.
+        def timestamp
+          return nil if @metadata.nil? || @metadata.transaction.nil?
+          Convert.timestamp_to_time @metadata.transaction.read_timestamp
+        end
+
         # @private
         def self.from_enum enum, service
           grpc = enum.peek

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
@@ -109,6 +109,27 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
+  it "executes with read_timestamp" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          read_timestamp: timestamp, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users", single_use: { read_timestamp: time_obj }
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "executes with staleness" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
@@ -124,6 +145,27 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { staleness: 120 }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "executes with exact_staleness" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          exact_staleness: duration, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users", single_use: { exact_staleness: 120 }
 
     mock.verify
 
@@ -151,6 +193,27 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     assert_results results
   end
 
+  it "executes with min_read_timestamp" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          min_read_timestamp: timestamp, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users", single_use: { min_read_timestamp: time_obj }
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "executes with bounded_staleness" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
@@ -166,6 +229,27 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { bounded_staleness: 120 }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "executes with max_staleness" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          max_staleness: duration, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users", single_use: { max_staleness: 120 }
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
@@ -1,0 +1,207 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let :results_hash do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { name: "id",          type: { code: "INT64" } },
+            { name: "name",        type: { code: "STRING" } },
+            { name: "active",      type: { code: "BOOL" } },
+            { name: "age",         type: { code: "INT64" } },
+            { name: "score",       type: { code: "FLOAT64" } },
+            { name: "updated_at",  type: { code: "TIMESTAMP" } },
+            { name: "birthday",    type: { code: "DATE"} },
+            { name: "avatar",      type: { code: "BYTES" } },
+            { name: "project_ids", type: { code: "ARRAY",
+                                           arrayElementType: { code: "INT64" } } }
+          ]
+        }
+      },
+      values: [
+        { stringValue: "1" },
+        { stringValue: "Charlie" },
+        { boolValue: true},
+        { stringValue: "29" },
+        { numberValue: 0.9 },
+        { stringValue: "2017-01-02T03:04:05.060000000Z" },
+        { stringValue: "1950-01-01" },
+        { stringValue: "aW1hZ2U=" },
+        { listValue: { values: [ { stringValue: "1"},
+                                 { stringValue: "2"},
+                                 { stringValue: "3"} ]}}
+      ]
+    }
+  end
+  let(:results_json) { results_hash.to_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_enum) { Array(results_grpc).to_enum }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
+  let(:time_obj) { Time.parse "2014-10-02T15:01:23.045123456Z" }
+  let(:timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp time_obj }
+  let(:duration) { Google::Cloud::Spanner::Convert.number_to_duration 120 }
+
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
+  it "executes with strong" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          strong: true, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users", single_use: { strong: true }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "executes with timestamp" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          read_timestamp: timestamp, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users", single_use: { timestamp: time_obj }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "executes with staleness" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          exact_staleness: duration, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users", single_use: { staleness: 120 }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "executes with bounded_timestamp" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          min_read_timestamp: timestamp, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users", single_use: { bounded_timestamp: time_obj }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "executes with bounded_staleness" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          max_staleness: duration, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.execute "SELECT * FROM users", single_use: { bounded_staleness: 120 }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  def assert_results results
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    results.types.wont_be :nil?
+    results.types.must_be_kind_of Hash
+    results.types.keys.count.must_equal 9
+    results.types[:id].must_equal          :INT64
+    results.types[:name].must_equal        :STRING
+    results.types[:active].must_equal      :BOOL
+    results.types[:age].must_equal         :INT64
+    results.types[:score].must_equal       :FLOAT64
+    results.types[:updated_at].must_equal  :TIMESTAMP
+    results.types[:birthday].must_equal    :DATE
+    results.types[:avatar].must_equal      :BYTES
+    results.types[:project_ids].must_equal [:INT64]
+
+    rows = results.rows.to_a # grab them all from the enumerator
+    rows.count.must_equal 1
+    row = rows.first
+    row.must_be_kind_of Hash
+    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    row[:id].must_equal 1
+    row[:name].must_equal "Charlie"
+    row[:active].must_equal true
+    row[:age].must_equal 29
+    row[:score].must_equal 0.9
+    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    row[:birthday].must_equal Date.parse("1950-01-01")
+    row[:avatar].must_be_kind_of StringIO
+    row[:avatar].read.must_equal "image"
+    row[:project_ids].must_equal [1, 2, 3]
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -110,6 +110,27 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     assert_results results
   end
 
+  it "reads with read_timestamp" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          read_timestamp: timestamp, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, single_use: { read_timestamp: time_obj }
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "reads with staleness" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
@@ -125,6 +146,27 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { staleness: 120 }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "reads with exact_staleness" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          exact_staleness: duration, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, single_use: { exact_staleness: 120 }
 
     mock.verify
 
@@ -152,6 +194,27 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     assert_results results
   end
 
+  it "reads with min_read_timestamp" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          min_read_timestamp: timestamp, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, single_use: { min_read_timestamp: time_obj }
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "reads with bounded_staleness" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
@@ -167,6 +230,27 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { bounded_staleness: 120 }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "reads with max_staleness" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          max_staleness: duration, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, single_use: { max_staleness: 120 }
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -1,0 +1,208 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let :results_hash do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { name: "id",          type: { code: "INT64" } },
+            { name: "name",        type: { code: "STRING" } },
+            { name: "active",      type: { code: "BOOL" } },
+            { name: "age",         type: { code: "INT64" } },
+            { name: "score",       type: { code: "FLOAT64" } },
+            { name: "updated_at",  type: { code: "TIMESTAMP" } },
+            { name: "birthday",    type: { code: "DATE"} },
+            { name: "avatar",      type: { code: "BYTES" } },
+            { name: "project_ids", type: { code: "ARRAY",
+                                           arrayElementType: { code: "INT64" } } }
+          ]
+        }
+      },
+      values: [
+        { stringValue: "1" },
+        { stringValue: "Charlie" },
+        { boolValue: true},
+        { stringValue: "29" },
+        { numberValue: 0.9 },
+        { stringValue: "2017-01-02T03:04:05.060000000Z" },
+        { stringValue: "1950-01-01" },
+        { stringValue: "aW1hZ2U=" },
+        { listValue: { values: [ { stringValue: "1"},
+                                 { stringValue: "2"},
+                                 { stringValue: "3"} ]}}
+      ]
+    }
+  end
+  let(:results_enum) do
+    [Google::Spanner::V1::PartialResultSet.decode_json(results_hash.to_json)].to_enum
+  end
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
+  let(:columns) { [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids] }
+  let(:time_obj) { Time.parse "2014-10-02T15:01:23.045123456Z" }
+  let(:timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp time_obj }
+  let(:duration) { Google::Cloud::Spanner::Convert.number_to_duration 120 }
+
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
+  it "reads with strong" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          strong: true, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, single_use: { strong: true }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "reads with timestamp" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          read_timestamp: timestamp, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, single_use: { timestamp: time_obj }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "reads with staleness" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          exact_staleness: duration, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, single_use: { staleness: 120 }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "reads with bounded_timestamp" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          min_read_timestamp: timestamp, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, single_use: { bounded_timestamp: time_obj }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "reads with bounded_staleness" do
+    transaction = Google::Spanner::V1::TransactionSelector.new(
+      single_use: Google::Spanner::V1::TransactionOptions.new(
+        read_only: Google::Spanner::V1::TransactionOptions::ReadOnly.new(
+          max_staleness: duration, return_read_timestamp: true
+        )
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, single_use: { bounded_staleness: 120 }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  def assert_results results
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    results.types.wont_be :nil?
+    results.types.must_be_kind_of Hash
+    results.types.keys.count.must_equal 9
+    results.types[:id].must_equal          :INT64
+    results.types[:name].must_equal        :STRING
+    results.types[:active].must_equal      :BOOL
+    results.types[:age].must_equal         :INT64
+    results.types[:score].must_equal       :FLOAT64
+    results.types[:updated_at].must_equal  :TIMESTAMP
+    results.types[:birthday].must_equal    :DATE
+    results.types[:avatar].must_equal      :BYTES
+    results.types[:project_ids].must_equal [:INT64]
+
+    rows = results.rows.to_a # grab them all from the enumerator
+    rows.count.must_equal 1
+    row = rows.first
+    row.must_be_kind_of Hash
+    row.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    row[:id].must_equal 1
+    row[:name].must_equal "Charlie"
+    row[:active].must_equal true
+    row[:age].must_equal 29
+    row[:score].must_equal 0.9
+    row[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    row[:birthday].must_equal Date.parse("1950-01-01")
+    row[:avatar].must_be_kind_of StringIO
+    row[:avatar].read.must_equal "image"
+    row[:project_ids].must_equal [1, 2, 3]
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -148,6 +148,24 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       assert_results results
     end
 
+    it "can execute a simple query with the read_timestamp option (Time)" do
+      mock = Minitest::Mock.new
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      spanner.service.mocked_service = mock
+
+      results = nil
+      client.snapshot read_timestamp: snapshot_time do |snp|
+        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        results = snp.execute "SELECT * FROM users"
+      end
+
+      mock.verify
+
+      assert_results results
+    end
+
     it "can execute a simple query with the timestamp option (DateTime)" do
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
@@ -157,6 +175,24 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
       results = nil
       client.snapshot timestamp: snapshot_datetime do |snp|
+        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        results = snp.execute "SELECT * FROM users"
+      end
+
+      mock.verify
+
+      assert_results results
+    end
+
+    it "can execute a simple query with the read_timestamp option (DateTime)" do
+      mock = Minitest::Mock.new
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      spanner.service.mocked_service = mock
+
+      results = nil
+      client.snapshot read_timestamp: snapshot_datetime do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute "SELECT * FROM users"
       end
@@ -181,6 +217,24 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
       results = nil
       client.snapshot staleness: snapshot_staleness do |snp|
+        snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
+        results = snp.execute "SELECT * FROM users"
+      end
+
+      mock.verify
+
+      assert_results results
+    end
+
+    it "can execute a simple query with the exact_staleness option" do
+      mock = Minitest::Mock.new
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+      mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      spanner.service.mocked_service = mock
+
+      results = nil
+      client.snapshot exact_staleness: snapshot_staleness do |snp|
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute "SELECT * FROM users"
       end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/emtpy_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/emtpy_test.rb
@@ -52,6 +52,9 @@ describe Google::Cloud::Spanner::Results, :empty, :mock_spanner do
   it "defaults to hashes" do
     results.must_be_kind_of Google::Cloud::Spanner::Results
 
+    results.transaction.must_be :nil?
+    results.timestamp.must_be :nil?
+
     types = results.types
     types.wont_be :nil?
     types.must_be_kind_of Hash
@@ -67,6 +70,9 @@ describe Google::Cloud::Spanner::Results, :empty, :mock_spanner do
 
   it "can return an array of pairs" do
     results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    results.transaction.must_be :nil?
+    results.timestamp.must_be :nil?
 
     types = results.types pairs: true
     types.wont_be :nil?

--- a/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
@@ -1,0 +1,49 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Results, :empty, :mock_spanner do
+  let(:time_obj) { Time.parse "2014-10-02T15:01:23.045123456Z" }
+  let(:timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp time_obj }
+  let :results_types do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { type: { code: "INT64" } },
+            { type: { code: "INT64" } },
+            { type: { code: "INT64" } },
+            { type: { code: "INT64" } }
+          ]
+        },
+        transaction: {
+          id: Base64.strict_encode64("tx123"),
+          read_timestamp: JSON.parse(timestamp.to_json)
+        }
+      }
+    }
+  end
+  let(:results_enum) do
+    [Google::Spanner::V1::PartialResultSet.decode_json(results_types.to_json)].to_enum
+  end
+  let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
+
+  it "knows it has a timestamp" do
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    results.transaction.must_equal "tx123"
+    results.timestamp.must_equal time_obj
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/transaction_test.rb
@@ -1,0 +1,46 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Results, :transaction, :mock_spanner do
+  let :results_types do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { type: { code: "INT64" } },
+            { type: { code: "INT64" } },
+            { type: { code: "INT64" } },
+            { type: { code: "INT64" } }
+          ]
+        },
+        transaction: {
+          id: Base64.strict_encode64("tx123")
+        }
+      }
+    }
+  end
+  let(:results_enum) do
+    [Google::Spanner::V1::PartialResultSet.decode_json(results_types.to_json)].to_enum
+  end
+  let(:results) { Google::Cloud::Spanner::Results.from_enum results_enum, spanner.service }
+
+  it "knows it is in a transaction" do
+    results.must_be_kind_of Google::Cloud::Spanner::Results
+
+    results.transaction.must_equal "tx123"
+    results.timestamp.must_be :nil?
+  end
+end


### PR DESCRIPTION
This PR adds the `single_use` argument to `Client#read` and `Client#execute` for specifying the single-use read-only transaction type. It also adds `Results#timestamp`.