### PR TITLE
Spanner Read Improvements

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -181,6 +181,9 @@ module Google
         # @param [Object, Array<Object>] id A single, or list of keys to match
         #   returned data to. Values should have exactly as many elements as
         #   there are columns in the primary key.
+        # @param [String] index The name of an index to use instead of the
+        #   table's primary key when interpreting `id` and sorting result rows.
+        #   Optional.
         # @param [Integer] limit If greater than zero, no more than this number
         #   of rows will be returned. The default is no limit.
         # @param [Time, DateTime] timestamp Executes all reads at a
@@ -219,8 +222,8 @@ module Google
         #     puts "User #{row[:id]} is #{row[:name]}""
         #   end
         #
-        def read table, columns, id: nil, limit: nil, timestamp: nil,
-                 staleness: nil
+        def read table, columns, id: nil, index: nil, limit: nil,
+                 timestamp: nil, staleness: nil
           validate_single_use_args! timestamp: timestamp, staleness: staleness
           ensure_service!
 
@@ -229,7 +232,8 @@ module Google
           results = nil
           @pool.with_session do |session|
             results = session.read \
-              table, columns, id: id, limit: limit, transaction: single_use_tx
+              table, columns, id: id, index: index, limit: limit,
+                              transaction: single_use_tx
           end
           results
         end

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -428,8 +428,9 @@ module Google
         #
         # @param [String] table The name of the table in the database to be
         #   modified.
-        # @param [Array<Object>] keys One or more primary keys of the rows
-        #   within table to delete.
+        # @param [Object, Array<Object>] keys A single, or list of keys or key
+        #   ranges to match returned data to. Values should have exactly as many
+        #   elements as there are columns in the primary key.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -440,7 +441,7 @@ module Google
         #
         #   db.delete "users", [1, 2, 3]
         #
-        def delete table, *keys
+        def delete table, keys = []
           @pool.with_session do |session|
             session.delete table, keys
           end

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -19,6 +19,7 @@ require "google/cloud/spanner/pool"
 require "google/cloud/spanner/session"
 require "google/cloud/spanner/transaction"
 require "google/cloud/spanner/snapshot"
+require "google/cloud/spanner/range"
 
 module Google
   module Cloud
@@ -178,9 +179,9 @@ module Google
         #   read.
         # @param [Array<String>] columns The columns of table to be returned for
         #   each row matching this request.
-        # @param [Object, Array<Object>] id A single, or list of keys to match
-        #   returned data to. Values should have exactly as many elements as
-        #   there are columns in the primary key.
+        # @param [Object, Array<Object>] id A single, or list of keys or key
+        #   ranges to match returned data to. Values should have exactly as many
+        #   elements as there are columns in the primary key.
         # @param [String] index The name of an index to use instead of the
         #   table's primary key when interpreting `id` and sorting result rows.
         #   Optional.
@@ -543,6 +544,40 @@ module Google
             yield snp if block_given?
           end
           nil
+        end
+
+        ##
+        # Creates a Spanner Range. This can be used in place of a Ruby Range
+        # when needing to excluse the beginning value.
+        #
+        # @param [Object] beginning The object that defines the beginning of the
+        #   range.
+        # @param [Object] ending The object that defines the end of the range.
+        # @param [Boolean] exclude_begin Determines if the range excludes its
+        # beginning value. Default is `false`.
+        # @param [Boolean] exclude_end Determines if the range excludes its
+        # ending value. Default is `false`.
+        #
+        # @return [Google::Cloud::Spanner::Range]
+        #
+        # @example
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   key_range = db.range 1, 100
+        #   results = db.read "users", ["id, "name"], id: key_range
+        #
+        #   results.rows.each do |row|
+        #     puts "User #{row[:id]} is #{row[:name]}""
+        #   end
+        #
+        def range beginning, ending, exclude_begin: false, exclude_end: false
+          Range.new beginning, ending,
+                    exclude_begin: exclude_begin,
+                    exclude_end: exclude_end
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -179,7 +179,7 @@ module Google
         #   read.
         # @param [Array<String>] columns The columns of table to be returned for
         #   each row matching this request.
-        # @param [Object, Array<Object>] id A single, or list of keys or key
+        # @param [Object, Array<Object>] keys A single, or list of keys or key
         #   ranges to match returned data to. Values should have exactly as many
         #   elements as there are columns in the primary key.
         # @param [String] index The name of an index to use instead of the
@@ -223,7 +223,7 @@ module Google
         #     puts "User #{row[:id]} is #{row[:name]}""
         #   end
         #
-        def read table, columns, id: nil, index: nil, limit: nil,
+        def read table, columns, keys: nil, index: nil, limit: nil,
                  timestamp: nil, staleness: nil
           validate_single_use_args! timestamp: timestamp, staleness: staleness
           ensure_service!
@@ -233,7 +233,7 @@ module Google
           results = nil
           @pool.with_session do |session|
             results = session.read \
-              table, columns, id: id, index: index, limit: limit,
+              table, columns, keys: keys, index: index, limit: limit,
                               transaction: single_use_tx
           end
           results
@@ -428,8 +428,8 @@ module Google
         #
         # @param [String] table The name of the table in the database to be
         #   modified.
-        # @param [Array<Object>] id One or more primary keys of the rows within
-        #   table to delete.
+        # @param [Array<Object>] keys One or more primary keys of the rows
+        #   within table to delete.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -440,9 +440,9 @@ module Google
         #
         #   db.delete "users", [1, 2, 3]
         #
-        def delete table, *id
+        def delete table, *keys
           @pool.with_session do |session|
-            session.delete table, id
+            session.delete table, keys
           end
         end
 
@@ -568,7 +568,7 @@ module Google
         #   db = spanner.client "my-instance", "my-database"
         #
         #   key_range = db.range 1, 100
-        #   results = db.read "users", ["id, "name"], id: key_range
+        #   results = db.read "users", ["id, "name"], keys: key_range
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}""

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -547,6 +547,34 @@ module Google
         end
 
         ##
+        # Indicates the field names and types for a table.
+        #
+        # @param [String] table The name of the table in the database to
+        #   retrieve types for
+        # @param [Boolean] pairs Allow the types to be represented as a nested
+        #   Array of pairs rather than a Hash. This is useful when results have
+        #   duplicate names. The default is `false`.
+        #
+        # @return [Hash, Array] The types of the returned data. The default is a
+        #   Hash. Is a nested Array of Arrays when `pairs` is specified.
+        #
+        # @example
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   users_types = db.types_for "users"
+        #   db.insert "users", [{ id: 1, name: "Charlie", active: false },
+        #                       { id: 2, name: "Harvey",  active: true }],
+        #             types: users_types
+        #
+        def types_for table, pairs: false
+          execute("SELECT * FROM #{table} WHERE 1 = 0").types pairs: pairs
+        end
+
+        ##
         # Creates a Spanner Range. This can be used in place of a Ruby Range
         # when needing to excluse the beginning value.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
@@ -256,8 +256,8 @@ module Google
         #
         # @param [String] table The name of the table in the database to be
         #   modified.
-        # @param [Array<Object>] id One or more primary keys of the rows within
-        #   table to delete.
+        # @param [Array<Object>] keys One or more primary keys of the rows
+        #   within table to delete.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -271,8 +271,8 @@ module Google
         #   end
 
         #
-        def delete table, *id
-          keys = Array(id).flatten
+        def delete table, *keys
+          keys = Array(keys).flatten
           keys.delete_if(&:nil?)
           key_set = Google::Spanner::V1::KeySet.new(all: true)
           if keys.any?

--- a/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
@@ -262,6 +262,23 @@ module Google
 
             Time.at timestamp.seconds, Rational(timestamp.nanos, 1000)
           end
+
+          def to_key_range range
+            range_opts = {
+              start_closed: raw_to_value(Array(range.begin)).list_value,
+              end_closed: raw_to_value(Array(range.end)).list_value }
+
+            if range.respond_to?(:exclude_begin?) && range.exclude_begin?
+              range_opts[:start_open] = range_opts[:start_closed]
+              range_opts.delete :start_closed
+            end
+            if range.exclude_end?
+              range_opts[:end_open] = range_opts[:end_closed]
+              range_opts.delete :end_closed
+            end
+
+            Google::Spanner::V1::KeyRange.new range_opts
+          end
         end
 
         # rubocop:enable all

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -19,6 +19,7 @@ require "google/cloud/spanner/service"
 require "google/cloud/spanner/client"
 require "google/cloud/spanner/instance"
 require "google/cloud/spanner/database"
+require "google/cloud/spanner/range"
 
 module Google
   module Cloud

--- a/google-cloud-spanner/lib/google/cloud/spanner/range.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/range.rb
@@ -28,7 +28,7 @@ module Google
       #   db = spanner.client "my-instance", "my-database"
       #
       #   key_range = db.range 1, 100
-      #   results = db.read "users", ["id, "name"], id: key_range
+      #   results = db.read "users", ["id, "name"], keys: key_range
       #
       #   results.rows.each do |row|
       #     puts "User #{row[:id]} is #{row[:name]}""
@@ -63,7 +63,7 @@ module Google
         #   db = spanner.client "my-instance", "my-database"
         #
         #   key_range = Google::Cloud::Spanner::Range.new 1, 100
-        #   results = db.read "users", ["id, "name"], id: key_range
+        #   results = db.read "users", ["id, "name"], keys: key_range
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}""

--- a/google-cloud-spanner/lib/google/cloud/spanner/range.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/range.rb
@@ -1,0 +1,96 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Spanner
+      ##
+      # # Range
+      #
+      # @example
+      # @example
+      #   require "google/cloud/spanner"
+      #
+      #   spanner = Google::Cloud::Spanner.new
+      #
+      #   db = spanner.client "my-instance", "my-database"
+      #
+      #   key_range = db.range 1, 100
+      #   results = db.read "users", ["id, "name"], id: key_range
+      #
+      #   results.rows.each do |row|
+      #     puts "User #{row[:id]} is #{row[:name]}""
+      #   end
+      #
+      class Range
+        ##
+        # Returns the object that defines the beginning of the range.
+        attr_reader :begin
+
+        ##
+        # Returns the object that defines the end of the range.
+        attr_reader :end
+
+        ##
+        # Creates a Spanner Range. This can be used in place of a Ruby Range
+        # when needing to excluse the beginning value.
+        #
+        # @param [Object] beginning The object that defines the beginning of the
+        #   range.
+        # @param [Object] ending The object that defines the end of the range.
+        # @param [Boolean] exclude_begin Determines if the range excludes its
+        # beginning value. Default is `false`.
+        # @param [Boolean] exclude_end Determines if the range excludes its
+        # ending value. Default is `false`.
+        #
+        # @example
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   key_range = Google::Cloud::Spanner::Range.new 1, 100
+        #   results = db.read "users", ["id, "name"], id: key_range
+        #
+        #   results.rows.each do |row|
+        #     puts "User #{row[:id]} is #{row[:name]}""
+        #   end
+        #
+        def initialize beginning, ending, exclude_begin: false,
+                       exclude_end: false
+          @begin = beginning
+          @end = ending
+          @exclude_begin = exclude_begin
+          @exclude_end = exclude_end
+        end
+
+        ##
+        # Returns `true` if the range excludes its beginning value.
+        # @return [Boolean]
+        def exclude_begin?
+          @exclude_begin
+        end
+
+        ##
+        # Returns `true` if the range excludes its end value.
+        # @return [Boolean]
+        def exclude_end?
+          @exclude_end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -246,8 +246,9 @@ module Google
 
         # @private
         def self.read service, session_path, table, columns, id: nil,
-                      limit: nil, transaction: nil
-          read_options = { id: id, limit: limit, transaction: transaction }
+                      index: nil, limit: nil, transaction: nil
+          read_options = { id: id, index: index, limit: limit,
+                           transaction: transaction }
           enum = service.streaming_read_table \
             session_path, table, columns, read_options
           from_enum(enum, service).tap do |results|

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -245,9 +245,9 @@ module Google
         end
 
         # @private
-        def self.read service, session_path, table, columns, id: nil,
+        def self.read service, session_path, table, columns, keys: nil,
                       index: nil, limit: nil, transaction: nil
-          read_options = { id: id, index: index, limit: limit,
+          read_options = { keys: keys, index: index, limit: limit,
                            transaction: transaction }
           enum = service.streaming_read_table \
             session_path, table, columns, read_options

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -310,7 +310,7 @@ module Google
           end
         end
 
-        def read_table session_name, table_name, columns, id: nil,
+        def read_table session_name, table_name, columns, id: nil, index: nil,
                        transaction: nil, limit: nil
           columns.map!(&:to_s)
           key_set = Google::Spanner::V1::KeySet.new(all: true)
@@ -324,12 +324,14 @@ module Google
           execute do
             service.read \
               session_name, table_name, columns, key_set,
-              transaction: transaction, limit: limit, options: opts
+              transaction: transaction, index: index, limit: limit,
+              options: opts
           end
         end
 
         def streaming_read_table session_name, table_name, columns, id: nil,
-                                 transaction: nil, limit: nil, resume_token: nil
+                                 index: nil, transaction: nil, limit: nil,
+                                 resume_token: nil
           columns.map!(&:to_s)
           key_set = Google::Spanner::V1::KeySet.new(all: true)
           unless id.nil?
@@ -342,7 +344,7 @@ module Google
           execute do
             service.streaming_read \
               session_name, table_name, columns, key_set,
-              transaction: transaction, limit: limit,
+              transaction: transaction, index: index, limit: limit,
               resume_token: resume_token, options: opts
           end
         end

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -313,17 +313,10 @@ module Google
         def read_table session_name, table_name, columns, id: nil, index: nil,
                        transaction: nil, limit: nil
           columns.map!(&:to_s)
-          key_set = Google::Spanner::V1::KeySet.new(all: true)
-          unless id.nil?
-            key_list = Array(id).map do |i|
-              Convert.raw_to_value(Array(i)).list_value
-            end
-            key_set = Google::Spanner::V1::KeySet.new(keys: key_list)
-          end
           opts = default_options_from_session session_name
           execute do
             service.read \
-              session_name, table_name, columns, key_set,
+              session_name, table_name, columns, key_set(id),
               transaction: transaction, index: index, limit: limit,
               options: opts
           end
@@ -333,17 +326,10 @@ module Google
                                  index: nil, transaction: nil, limit: nil,
                                  resume_token: nil
           columns.map!(&:to_s)
-          key_set = Google::Spanner::V1::KeySet.new(all: true)
-          unless id.nil?
-            key_list = Array(id).map do |i|
-              Convert.raw_to_value(Array(i)).list_value
-            end
-            key_set = Google::Spanner::V1::KeySet.new(keys: key_list)
-          end
           opts = default_options_from_session session_name
           execute do
             service.streaming_read \
-              session_name, table_name, columns, key_set,
+              session_name, table_name, columns, key_set(id),
               transaction: transaction, index: index, limit: limit,
               resume_token: resume_token, options: opts
           end
@@ -393,6 +379,30 @@ module Google
         end
 
         protected
+
+        def key_set keys
+          return Google::Spanner::V1::KeySet.new(all: true) if keys.nil?
+          if keys_are_ranges? keys
+            keys = [keys] unless keys.is_a? Array
+            key_ranges = keys.map do |r|
+              Convert.to_key_range(r)
+            end
+            return Google::Spanner::V1::KeySet.new(ranges: key_ranges)
+          end
+          key_list = Array(keys).map do |i|
+            Convert.raw_to_value(Array(i)).list_value
+          end
+          Google::Spanner::V1::KeySet.new keys: key_list
+        end
+
+        def keys_are_ranges? keys
+          keys = [keys] unless keys.is_a? Array
+          keys.each do |key|
+            return true if key.is_a? ::Range
+            return true if key.is_a? Google::Cloud::Spanner::Range
+          end
+          false
+        end
 
         def default_options_from_session session_name
           default_prefix = session_name.split("/sessions/").first

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -310,26 +310,26 @@ module Google
           end
         end
 
-        def read_table session_name, table_name, columns, id: nil, index: nil,
+        def read_table session_name, table_name, columns, keys: nil, index: nil,
                        transaction: nil, limit: nil
           columns.map!(&:to_s)
           opts = default_options_from_session session_name
           execute do
             service.read \
-              session_name, table_name, columns, key_set(id),
+              session_name, table_name, columns, key_set(keys),
               transaction: transaction, index: index, limit: limit,
               options: opts
           end
         end
 
-        def streaming_read_table session_name, table_name, columns, id: nil,
+        def streaming_read_table session_name, table_name, columns, keys: nil,
                                  index: nil, transaction: nil, limit: nil,
                                  resume_token: nil
           columns.map!(&:to_s)
           opts = default_options_from_session session_name
           execute do
             service.streaming_read \
-              session_name, table_name, columns, key_set(id),
+              session_name, table_name, columns, key_set(keys),
               transaction: transaction, index: index, limit: limit,
               resume_token: resume_token, options: opts
           end

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -382,6 +382,8 @@ module Google
 
         def key_set keys
           return Google::Spanner::V1::KeySet.new(all: true) if keys.nil?
+          keys = [keys] unless keys.is_a? Array
+          return Google::Spanner::V1::KeySet.new(all: true) if keys.empty?
           if keys_are_ranges? keys
             keys = [keys] unless keys.is_a? Array
             key_ranges = keys.map do |r|
@@ -396,7 +398,6 @@ module Google
         end
 
         def keys_are_ranges? keys
-          keys = [keys] unless keys.is_a? Array
           keys.each do |key|
             return true if key.is_a? ::Range
             return true if key.is_a? Google::Cloud::Spanner::Range

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -208,6 +208,9 @@ module Google
         # @param [Object, Array<Object>] id A single, or list of keys to match
         #   returned data to. Values should have exactly as many elements as
         #   there are columns in the primary key.
+        # @param [String] index The name of an index to use instead of the
+        #   table's primary key when interpreting `id` and sorting result rows.
+        #   Optional.
         # @param [Integer] limit If greater than zero, no more than this number
         #   of rows will be returned. The default is no limit.
         # @param [Google::Spanner::V1::TransactionSelector] transaction The
@@ -229,10 +232,12 @@ module Google
         #     puts "User #{row[:id]} is #{row[:name]}""
         #   end
         #
-        def read table, columns, id: nil, limit: nil, transaction: nil
+        def read table, columns, id: nil, index: nil, limit: nil,
+                 transaction: nil
           ensure_service!
           Results.read service, path, table, columns,
-                       id: id, limit: limit, transaction: transaction
+                       id: id, index: index, limit: limit,
+                       transaction: transaction
         end
 
         # Creates changes to be applied to rows in the database.

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -205,7 +205,7 @@ module Google
         #   read.
         # @param [Array<String>] columns The columns of table to be returned for
         #   each row matching this request.
-        # @param [Object, Array<Object>] id A single, or list of keys or key
+        # @param [Object, Array<Object>] keys A single, or list of keys or key
         #   ranges to match returned data to. Values should have exactly as many
         #   elements as there are columns in the primary key.
         # @param [String] index The name of an index to use instead of the
@@ -232,11 +232,11 @@ module Google
         #     puts "User #{row[:id]} is #{row[:name]}""
         #   end
         #
-        def read table, columns, id: nil, index: nil, limit: nil,
+        def read table, columns, keys: nil, index: nil, limit: nil,
                  transaction: nil
           ensure_service!
           Results.read service, path, table, columns,
-                       id: id, index: index, limit: limit,
+                       keys: keys, index: index, limit: limit,
                        transaction: transaction
         end
 
@@ -429,8 +429,8 @@ module Google
         #
         # @param [String] table The name of the table in the database to be
         #   modified.
-        # @param [Array<Object>] id One or more primary keys of the rows within
-        #   table to delete.
+        # @param [Array<Object>] keys One or more primary keys of the rows
+        #   within table to delete.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -441,9 +441,9 @@ module Google
         #
         #   db.delete "users", [1, 2, 3]
         #
-        def delete table, *id, transaction_id: nil
+        def delete table, *keys, transaction_id: nil
           commit = Commit.new
-          commit.delete table, id
+          commit.delete table, keys
           service.commit path, commit.mutations, transaction_id: transaction_id
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -205,9 +205,9 @@ module Google
         #   read.
         # @param [Array<String>] columns The columns of table to be returned for
         #   each row matching this request.
-        # @param [Object, Array<Object>] id A single, or list of keys to match
-        #   returned data to. Values should have exactly as many elements as
-        #   there are columns in the primary key.
+        # @param [Object, Array<Object>] id A single, or list of keys or key
+        #   ranges to match returned data to. Values should have exactly as many
+        #   elements as there are columns in the primary key.
         # @param [String] index The name of an index to use instead of the
         #   table's primary key when interpreting `id` and sorting result rows.
         #   Optional.

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -429,8 +429,9 @@ module Google
         #
         # @param [String] table The name of the table in the database to be
         #   modified.
-        # @param [Array<Object>] keys One or more primary keys of the rows
-        #   within table to delete.
+        # @param [Object, Array<Object>] keys A single, or list of keys or key
+        #   ranges to match returned data to. Values should have exactly as many
+        #   elements as there are columns in the primary key.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -441,7 +442,7 @@ module Google
         #
         #   db.delete "users", [1, 2, 3]
         #
-        def delete table, *keys, transaction_id: nil
+        def delete table, keys = [], transaction_id: nil
           commit = Commit.new
           commit.delete table, keys
           service.commit path, commit.mutations, transaction_id: transaction_id

--- a/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
@@ -121,9 +121,9 @@ module Google
         #   read.
         # @param [Array<String>] columns The columns of table to be returned for
         #   each row matching this request.
-        # @param [Object, Array<Object>] id A single, or list of keys to match
-        #   returned data to. Values should have exactly as many elements as
-        #   there are columns in the primary key.
+        # @param [Object, Array<Object>] id A single, or list of keys or key
+        #   ranges to match returned data to. Values should have exactly as many
+        #   elements as there are columns in the primary key.
         # @param [String] index The name of an index to use instead of the
         #   table's primary key when interpreting `id` and sorting result rows.
         #   Optional.
@@ -150,6 +150,41 @@ module Google
           ensure_session!
           session.read table, columns, id: id, index: index, limit: limit,
                                        transaction: tx_selector
+        end
+
+        ##
+        # Creates a Spanner Range. This can be used in place of a Ruby Range
+        # when needing to excluse the beginning value.
+        #
+        # @param [Object] beginning The object that defines the beginning of the
+        #   range.
+        # @param [Object] ending The object that defines the end of the range.
+        # @param [Boolean] exclude_begin Determines if the range excludes its
+        # beginning value. Default is `false`.
+        # @param [Boolean] exclude_end Determines if the range excludes its
+        # ending value. Default is `false`.
+        #
+        # @return [Google::Cloud::Spanner::Range]
+        #
+        # @example
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.snapshot do |snp|
+        #     key_range = db.range 1, 100
+        #     results = snp.read "users", ["id, "name"], id: key_range
+        #
+        #     results.rows.each do |row|
+        #       puts "User #{row[:id]} is #{row[:name]}""
+        #     end
+        #   end
+        #
+        def range beginning, ending, exclude_begin: false, exclude_end: false
+          Range.new beginning, ending,
+                    exclude_begin: exclude_begin,
+                    exclude_end: exclude_end
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
@@ -124,6 +124,9 @@ module Google
         # @param [Object, Array<Object>] id A single, or list of keys to match
         #   returned data to. Values should have exactly as many elements as
         #   there are columns in the primary key.
+        # @param [String] index The name of an index to use instead of the
+        #   table's primary key when interpreting `id` and sorting result rows.
+        #   Optional.
         # @param [Integer] limit If greater than zero, no more than this number
         #   of rows will be returned. The default is no limit.
         #
@@ -143,9 +146,9 @@ module Google
         #     end
         #   end
         #
-        def read table, columns, id: nil, limit: nil
+        def read table, columns, id: nil, index: nil, limit: nil
           ensure_session!
-          session.read table, columns, id: id, limit: limit,
+          session.read table, columns, id: id, index: index, limit: limit,
                                        transaction: tx_selector
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
@@ -121,7 +121,7 @@ module Google
         #   read.
         # @param [Array<String>] columns The columns of table to be returned for
         #   each row matching this request.
-        # @param [Object, Array<Object>] id A single, or list of keys or key
+        # @param [Object, Array<Object>] keys A single, or list of keys or key
         #   ranges to match returned data to. Values should have exactly as many
         #   elements as there are columns in the primary key.
         # @param [String] index The name of an index to use instead of the
@@ -146,9 +146,9 @@ module Google
         #     end
         #   end
         #
-        def read table, columns, id: nil, index: nil, limit: nil
+        def read table, columns, keys: nil, index: nil, limit: nil
           ensure_session!
-          session.read table, columns, id: id, index: index, limit: limit,
+          session.read table, columns, keys: keys, index: index, limit: limit,
                                        transaction: tx_selector
         end
 
@@ -174,7 +174,7 @@ module Google
         #
         #   db.snapshot do |snp|
         #     key_range = db.range 1, 100
-        #     results = snp.read "users", ["id, "name"], id: key_range
+        #     results = snp.read "users", ["id, "name"], keys: key_range
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}""

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -124,6 +124,9 @@ module Google
         # @param [Object, Array<Object>] id A single, or list of keys to match
         #   returned data to. Values should have exactly as many elements as
         #   there are columns in the primary key.
+        # @param [String] index The name of an index to use instead of the
+        #   table's primary key when interpreting `id` and sorting result rows.
+        #   Optional.
         # @param [Integer] limit If greater than zero, no more than this number
         #   of rows will be returned. The default is no limit.
         #
@@ -143,9 +146,9 @@ module Google
         #     end
         #   end
         #
-        def read table, columns, id: nil, limit: nil
+        def read table, columns, id: nil, index: nil, limit: nil
           ensure_session!
-          session.read table, columns, id: id, limit: limit,
+          session.read table, columns, id: id, index: index, limit: limit,
                                        transaction: tx_selector
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -121,9 +121,9 @@ module Google
         #   read.
         # @param [Array<String>] columns The columns of table to be returned for
         #   each row matching this request.
-        # @param [Object, Array<Object>] id A single, or list of keys to match
-        #   returned data to. Values should have exactly as many elements as
-        #   there are columns in the primary key.
+        # @param [Object, Array<Object>] id A single, or list of keys or key
+        #   ranges to match returned data to. Values should have exactly as many
+        #   elements as there are columns in the primary key.
         # @param [String] index The name of an index to use instead of the
         #   table's primary key when interpreting `id` and sorting result rows.
         #   Optional.
@@ -357,6 +357,41 @@ module Google
         def delete table, *id
           ensure_session!
           session.delete table, id, transaction_id: transaction_id
+        end
+
+        ##
+        # Creates a Spanner Range. This can be used in place of a Ruby Range
+        # when needing to excluse the beginning value.
+        #
+        # @param [Object] beginning The object that defines the beginning of the
+        #   range.
+        # @param [Object] ending The object that defines the end of the range.
+        # @param [Boolean] exclude_begin Determines if the range excludes its
+        # beginning value. Default is `false`.
+        # @param [Boolean] exclude_end Determines if the range excludes its
+        # ending value. Default is `false`.
+        #
+        # @return [Google::Cloud::Spanner::Range]
+        #
+        # @example
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.transaction do |tx|
+        #     key_range = tx.range 1, 100
+        #     results = tx.read "users", ["id, "name"], id: key_range
+        #
+        #     results.rows.each do |row|
+        #       puts "User #{row[:id]} is #{row[:name]}""
+        #     end
+        #   end
+        #
+        def range beginning, ending, exclude_begin: false, exclude_end: false
+          Range.new beginning, ending,
+                    exclude_begin: exclude_begin,
+                    exclude_end: exclude_end
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -360,6 +360,35 @@ module Google
         end
 
         ##
+        # Indicates the field names and types for a table.
+        #
+        # @param [String] table The name of the table in the database to
+        #   retrieve types for
+        # @param [Boolean] pairs Allow the types to be represented as a nested
+        #   Array of pairs rather than a Hash. This is useful when results have
+        #   duplicate names. The default is `false`.
+        #
+        # @return [Hash, Array] The types of the returned data. The default is a
+        #   Hash. Is a nested Array of Arrays when `pairs` is specified.
+        #
+        # @example
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.transaction do |tx|
+        #     users_types = rx.types_for "users"
+        #     tx.insert "users", [{ id: 1, name: "Charlie", active: false },
+        #                         { id: 2, name: "Harvey",  active: true }],
+        #               types: users_types
+        #   end
+        #
+        def types_for table, pairs: false
+          execute("SELECT * FROM #{table} WHERE 1 = 0").types pairs: pairs
+        end
+
+        ##
         # Creates a Spanner Range. This can be used in place of a Ruby Range
         # when needing to excluse the beginning value.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -121,7 +121,7 @@ module Google
         #   read.
         # @param [Array<String>] columns The columns of table to be returned for
         #   each row matching this request.
-        # @param [Object, Array<Object>] id A single, or list of keys or key
+        # @param [Object, Array<Object>] keys A single, or list of keys or key
         #   ranges to match returned data to. Values should have exactly as many
         #   elements as there are columns in the primary key.
         # @param [String] index The name of an index to use instead of the
@@ -146,9 +146,9 @@ module Google
         #     end
         #   end
         #
-        def read table, columns, id: nil, index: nil, limit: nil
+        def read table, columns, keys: nil, index: nil, limit: nil
           ensure_session!
-          session.read table, columns, id: id, index: index, limit: limit,
+          session.read table, columns, keys: keys, index: index, limit: limit,
                                        transaction: tx_selector
         end
 
@@ -343,8 +343,8 @@ module Google
         #
         # @param [String] table The name of the table in the database to be
         #   modified.
-        # @param [Array<Object>] id One or more primary keys of the rows within
-        #   table to delete.
+        # @param [Array<Object>] keys One or more primary keys of the rows
+        #   within table to delete.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -354,9 +354,9 @@ module Google
         #
         #   db.transaction { |tx| tx.delete "users", [1, 2, 3] }
         #
-        def delete table, *id
+        def delete table, *keys
           ensure_session!
-          session.delete table, id, transaction_id: transaction_id
+          session.delete table, keys, transaction_id: transaction_id
         end
 
         ##
@@ -381,7 +381,7 @@ module Google
         #
         #   db.transaction do |tx|
         #     key_range = tx.range 1, 100
-        #     results = tx.read "users", ["id, "name"], id: key_range
+        #     results = tx.read "users", ["id, "name"], keys: key_range
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}""

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -343,8 +343,9 @@ module Google
         #
         # @param [String] table The name of the table in the database to be
         #   modified.
-        # @param [Array<Object>] keys One or more primary keys of the rows
-        #   within table to delete.
+        # @param [Object, Array<Object>] keys A single, or list of keys or key
+        #   ranges to match returned data to. Values should have exactly as many
+        #   elements as there are columns in the primary key.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -354,7 +355,7 @@ module Google
         #
         #   db.transaction { |tx| tx.delete "users", [1, 2, 3] }
         #
-        def delete table, *keys
+        def delete table, keys = []
           ensure_session!
           session.delete table, keys, transaction_id: transaction_id
         end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -183,7 +183,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock.verify
   end
 
-  it "deletes multiple rows directly" do
+  it "deletes multiple rows of keys directly" do
     mutations = [
       Google::Spanner::V1::Mutation.new(
         delete: Google::Spanner::V1::Mutation::Delete.new(
@@ -202,6 +202,27 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     client.delete "users", [1, 2, 3, 4, 5]
+
+    mock.verify
+  end
+
+  it "deletes multiple rows of key rangess directly" do
+    mutations = [
+      Google::Spanner::V1::Mutation.new(
+        delete: Google::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Spanner::V1::KeySet.new(
+            ranges: [Google::Cloud::Spanner::Convert.to_key_range(1..100)]
+          )
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    spanner.service.mocked_service = mock
+
+    client.delete "users", 1..100
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
@@ -1,0 +1,72 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Client, :range, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:commit_resp) { Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new() }
+  let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
+
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
+  it "creates an inclusive range" do
+    range = client.range 1, 100
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.wont_be :exclude_begin?
+    range.wont_be :exclude_end?
+  end
+
+  it "creates an exclusive range" do
+    range = client.range 1, 100, exclude_begin: true, exclude_end: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.must_be :exclude_begin?
+    range.must_be :exclude_end?
+  end
+
+  it "creates a range that excludes beginning" do
+    range = client.range 1, 100, exclude_begin: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.must_be :exclude_begin?
+    range.wont_be :exclude_end?
+  end
+
+  it "creates a range that excludes ending" do
+    range = client.range 1, 100, exclude_end: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.wont_be :exclude_begin?
+    range.must_be :exclude_end?
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
@@ -112,7 +112,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, no_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, no_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns
@@ -147,7 +147,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, all_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, all_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns
@@ -183,7 +183,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, UnavailableEnumerator.new(bounds_with_abort_enum), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, UnavailableEnumerator.new(bounds_with_abort_enum), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -114,8 +114,8 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, UnavailableEnumerator.new(results_enum1), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil, options: default_options]
-    mock.expect :streaming_read, UnavailableEnumerator.new(results_enum2), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: "abc123", options: default_options]
+    mock.expect :streaming_read, UnavailableEnumerator.new(results_enum1), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, UnavailableEnumerator.new(results_enum2), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: "abc123", options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.read "my-table", columns, id: [1, 2, 3]
+    results = client.read "my-table", columns, keys: [1, 2, 3]
 
     mock.verify
 
@@ -114,7 +114,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.read "my-table", columns, id: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
+    results = client.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -130,7 +130,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     lookup_range = client.range [1,1], [3,3]
-    results = client.read "my-table", columns, id: lookup_range, index: "MyTableCompositeKey"
+    results = client.read "my-table", columns, keys: lookup_range, index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -160,7 +160,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
-    results = client.read "my-table", columns, id: 1, limit: 1
+    results = client.read "my-table", columns, keys: 1, limit: 1
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -81,7 +81,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns
@@ -96,10 +96,25 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, id: [1, 2, 3]
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can read rows with index" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", columns, id: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -111,7 +126,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: 5, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: 5, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, limit: 5
@@ -126,7 +141,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, limit: 1, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, id: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/client/types_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/types_for_test.rb
@@ -1,0 +1,81 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Client, :types_for, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let :results_hash do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { name: "id",          type: { code: "INT64" } },
+            { name: "name",        type: { code: "STRING" } },
+            { name: "active",      type: { code: "BOOL" } },
+            { name: "age",         type: { code: "INT64" } },
+            { name: "score",       type: { code: "FLOAT64" } },
+            { name: "updated_at",  type: { code: "TIMESTAMP" } },
+            { name: "birthday",    type: { code: "DATE"} },
+            { name: "avatar",      type: { code: "BYTES" } },
+            { name: "project_ids", type: { code: "ARRAY",
+                                           arrayElementType: { code: "INT64" } } }
+          ]
+        }
+      }
+    }
+  end
+  let(:results_json) { results_hash.to_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_enum) { Array(results_grpc).to_enum }
+  let(:client) { spanner.client instance_id, database_id, min: 0 }
+
+  after do
+    # Close the client and release the keepalive thread
+    client.instance_variable_get(:@pool).pool = []
+    client.close
+  end
+
+  it "can get a table's types" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    types = client.types_for "users"
+
+    mock.verify
+
+    assert_types types
+  end
+
+  def assert_types types
+    types.wont_be :nil?
+    types.must_be_kind_of Hash
+    types.keys.count.must_equal 9
+    types[:id].must_equal          :INT64
+    types[:name].must_equal        :STRING
+    types[:active].must_equal      :BOOL
+    types[:age].must_equal         :INT64
+    types[:score].must_equal       :FLOAT64
+    types[:updated_at].must_equal  :TIMESTAMP
+    types[:birthday].must_equal    :DATE
+    types[:avatar].must_equal      :BYTES
+    types[:project_ids].must_equal [:INT64]
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
@@ -1,0 +1,88 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Convert, :to_key_range, :mock_spanner do
+  # This tests is a sanity check on the implementation of the conversion method.
+  # We are testing the private method. This functionality is also covered elsewhere,
+  # but it was thought that since this conversion is so important we might as well
+  # also test it apart from the other tests.
+
+  it "creates an inclusive Spanner::Range" do
+    range = Google::Cloud::Spanner::Range.new 1, 100
+    key_range = Google::Cloud::Spanner::Convert.to_key_range range
+
+    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
+    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.start_open.must_be :nil?
+    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+    key_range.end_open.must_be :nil?
+  end
+
+  it "creates an exclusive Spanner::Range" do
+    range = Google::Cloud::Spanner::Range.new 1, 100, exclude_begin: true, exclude_end: true
+    key_range = Google::Cloud::Spanner::Convert.to_key_range range
+
+    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
+    key_range.start_closed.must_be :nil?
+    key_range.start_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.end_closed.must_be :nil?
+    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+  end
+
+  it "creates a Spanner::Range that excludes beginning" do
+    range = Google::Cloud::Spanner::Range.new 1, 100, exclude_begin: true
+    key_range = Google::Cloud::Spanner::Convert.to_key_range range
+
+    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
+    key_range.start_closed.must_be :nil?
+    key_range.start_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+    key_range.end_open.must_be :nil?
+  end
+
+  it "creates a Spanner::Range that excludes ending" do
+    range = Google::Cloud::Spanner::Range.new 1, 100, exclude_end: true
+    key_range = Google::Cloud::Spanner::Convert.to_key_range range
+
+    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
+    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.start_open.must_be :nil?
+    key_range.end_closed.must_be :nil?
+    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+  end
+
+  it "creates an inclusive Range" do
+    range = 1..100
+    key_range = Google::Cloud::Spanner::Convert.to_key_range range
+
+    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
+    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.start_open.must_be :nil?
+    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+    key_range.end_open.must_be :nil?
+  end
+
+  it "creates a Range that excludes ending" do
+    range = 1...100
+    key_range = Google::Cloud::Spanner::Convert.to_key_range range
+
+    key_range.must_be_kind_of Google::Spanner::V1::KeyRange
+    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.start_open.must_be :nil?
+    key_range.end_closed.must_be :nil?
+    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/range_test.rb
@@ -1,0 +1,57 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Range do
+  it "creates an inclusive range" do
+    range = Google::Cloud::Spanner::Range.new 1, 100
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.wont_be :exclude_begin?
+    range.wont_be :exclude_end?
+  end
+
+  it "creates an exclusive range" do
+    range = Google::Cloud::Spanner::Range.new 1, 100, exclude_begin: true, exclude_end: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.must_be :exclude_begin?
+    range.must_be :exclude_end?
+  end
+
+  it "creates a range that excludes beginning" do
+    range = Google::Cloud::Spanner::Range.new 1, 100, exclude_begin: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.must_be :exclude_begin?
+    range.wont_be :exclude_end?
+  end
+
+  it "creates a range that excludes ending" do
+    range = Google::Cloud::Spanner::Range.new 1, 100, exclude_end: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.wont_be :exclude_begin?
+    range.must_be :exclude_end?
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
@@ -171,7 +171,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.verify
   end
 
-  it "deletes multiple rows directly" do
+  it "deletes multiple rows of keys directly" do
     mutations = [
       Google::Spanner::V1::Mutation.new(
         delete: Google::Spanner::V1::Mutation::Delete.new(
@@ -189,6 +189,26 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     session.delete "users", [1, 2, 3, 4, 5]
+
+    mock.verify
+  end
+
+  it "deletes multiple rows of key ranges directly" do
+    mutations = [
+      Google::Spanner::V1::Mutation.new(
+        delete: Google::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Spanner::V1::KeySet.new(
+            ranges: [Google::Cloud::Spanner::Convert.to_key_range(1..100)]
+          )
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    session.service.mocked_service = mock
+
+    session.delete "users", 1..100
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
@@ -91,7 +91,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = session.read "my-table", columns, id: [1, 2, 3]
+    results = session.read "my-table", columns, keys: [1, 2, 3]
 
     mock.verify
 
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = session.read "my-table", columns, id: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
+    results = session.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -120,7 +120,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     lookup_range = [1,1]..[3,3]
-    results = session.read "my-table", columns, id: lookup_range, index: "MyTableCompositeKey"
+    results = session.read "my-table", columns, keys: lookup_range, index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -148,7 +148,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = session.read "my-table", columns, id: 1, limit: 1
+    results = session.read "my-table", columns, keys: 1, limit: 1
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
@@ -112,6 +112,21 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     assert_results results
   end
 
+  it "can read rows with index and range" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
+    mock = Minitest::Mock.new
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(ranges: [Google::Cloud::Spanner::Convert.to_key_range([1,1]..[3,3])]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    lookup_range = [1,1]..[3,3]
+    results = session.read "my-table", columns, id: lookup_range, index: "MyTableCompositeKey"
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "can read rows with limit" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 

--- a/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
@@ -74,7 +74,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns
@@ -88,10 +88,24 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns, id: [1, 2, 3]
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can read rows with index" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
+    mock = Minitest::Mock.new
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    results = session.read "my-table", columns, id: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -102,7 +116,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, limit: 5, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: 5, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns, limit: 5
@@ -116,7 +130,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, limit: 1, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns, id: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/range_test.rb
@@ -1,0 +1,66 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Snapshot, :range, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:transaction_id) { "tx789" }
+  let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
+  let(:snapshot) { Google::Cloud::Spanner::Snapshot.from_grpc transaction_grpc, session }
+
+  it "creates an inclusive range" do
+    range = snapshot.range 1, 100
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.wont_be :exclude_begin?
+    range.wont_be :exclude_end?
+  end
+
+  it "creates an exclusive range" do
+    range = snapshot.range 1, 100, exclude_begin: true, exclude_end: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.must_be :exclude_begin?
+    range.must_be :exclude_end?
+  end
+
+  it "creates a range that excludes beginning" do
+    range = snapshot.range 1, 100, exclude_begin: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.must_be :exclude_begin?
+    range.wont_be :exclude_end?
+  end
+
+  it "creates a range that excludes ending" do
+    range = snapshot.range 1, 100, exclude_end: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.wont_be :exclude_begin?
+    range.must_be :exclude_end?
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -116,6 +116,21 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     assert_results results
   end
 
+  it "can read rows with index and range" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
+    mock = Minitest::Mock.new
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(ranges: [Google::Cloud::Spanner::Convert.to_key_range([1,1]..[3,3])]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    lookup_range = snapshot.range [1,1], [3,3]
+    results = snapshot.read "my-table", columns, id: lookup_range, index: "MyTableCompositeKey"
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "can read rows with limit" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns
@@ -92,10 +92,24 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, id: [1, 2, 3]
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can read rows with index" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
+    mock = Minitest::Mock.new
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    results = snapshot.read "my-table", columns, id: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -106,7 +120,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, index: nil, limit: 5, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, limit: 5
@@ -120,7 +134,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, id: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = snapshot.read "my-table", columns, id: [1, 2, 3]
+    results = snapshot.read "my-table", columns, keys: [1, 2, 3]
 
     mock.verify
 
@@ -109,7 +109,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = snapshot.read "my-table", columns, id: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
+    results = snapshot.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -124,7 +124,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     lookup_range = snapshot.range [1,1], [3,3]
-    results = snapshot.read "my-table", columns, id: lookup_range, index: "MyTableCompositeKey"
+    results = snapshot.read "my-table", columns, keys: lookup_range, index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -152,7 +152,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = snapshot.read "my-table", columns, id: 1, limit: 1
+    results = snapshot.read "my-table", columns, keys: 1, limit: 1
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/commit_test.rb
@@ -173,7 +173,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.verify
   end
 
-  it "deletes multiple rows directly" do
+  it "deletes multiple rows of keys directly" do
     mutations = [
       Google::Spanner::V1::Mutation.new(
         delete: Google::Spanner::V1::Mutation::Delete.new(
@@ -191,6 +191,26 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     transaction.delete "users", [1, 2, 3, 4, 5]
+
+    mock.verify
+  end
+
+  it "deletes multiple rows of key ranges directly" do
+    mutations = [
+      Google::Spanner::V1::Mutation.new(
+        delete: Google::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Spanner::V1::KeySet.new(
+            ranges: [Google::Cloud::Spanner::Convert.to_key_range(1..100)]
+          )
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    transaction.delete "users", 1..100
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/range_test.rb
@@ -1,0 +1,66 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Transaction, :range, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:transaction_id) { "tx789" }
+  let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
+  let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
+
+  it "creates an inclusive range" do
+    range = transaction.range 1, 100
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.wont_be :exclude_begin?
+    range.wont_be :exclude_end?
+  end
+
+  it "creates an exclusive range" do
+    range = transaction.range 1, 100, exclude_begin: true, exclude_end: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.must_be :exclude_begin?
+    range.must_be :exclude_end?
+  end
+
+  it "creates a range that excludes beginning" do
+    range = transaction.range 1, 100, exclude_begin: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.must_be :exclude_begin?
+    range.wont_be :exclude_end?
+  end
+
+  it "creates a range that excludes ending" do
+    range = transaction.range 1, 100, exclude_end: true
+
+    range.begin.must_equal 1
+    range.end.must_equal 100
+
+    range.wont_be :exclude_begin?
+    range.must_be :exclude_end?
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.read "my-table", columns, id: [1, 2, 3]
+    results = transaction.read "my-table", columns, keys: [1, 2, 3]
 
     mock.verify
 
@@ -109,7 +109,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.read "my-table", columns, id: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
+    results = transaction.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -124,7 +124,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     session.service.mocked_service = mock
 
     lookup_range = transaction.range [1,1], [3,3]
-    results = transaction.read "my-table", columns, id: lookup_range, index: "MyTableCompositeKey"
+    results = transaction.read "my-table", columns, keys: lookup_range, index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -152,7 +152,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
-    results = transaction.read "my-table", columns, id: 1, limit: 1
+    results = transaction.read "my-table", columns, keys: 1, limit: 1
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -116,6 +116,21 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     assert_results results
   end
 
+  it "can read rows with index and range" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
+    mock = Minitest::Mock.new
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(ranges: [Google::Cloud::Spanner::Convert.to_key_range([1,1]..[3,3])]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    lookup_range = transaction.range [1,1], [3,3]
+    results = transaction.read "my-table", columns, id: lookup_range, index: "MyTableCompositeKey"
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "can read rows with limit" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns
@@ -92,10 +92,24 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, limit: nil, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, id: [1, 2, 3]
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can read rows with index" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
+    mock = Minitest::Mock.new
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    results = transaction.read "my-table", columns, id: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
 
     mock.verify
 
@@ -106,7 +120,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, limit: 5, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: tx_selector, index: nil, limit: 5, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, limit: 5
@@ -120,7 +134,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, limit: 1, resume_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, id: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/types_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/types_for_test.rb
@@ -1,0 +1,78 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Transaction, :types_for, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:transaction_id) { "tx789" }
+  let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
+  let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
+  let(:tx_selector) { Google::Spanner::V1::TransactionSelector.new id: transaction_id }
+  let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let :results_hash do
+    {
+      metadata: {
+        rowType: {
+          fields: [
+            { name: "id",          type: { code: "INT64" } },
+            { name: "name",        type: { code: "STRING" } },
+            { name: "active",      type: { code: "BOOL" } },
+            { name: "age",         type: { code: "INT64" } },
+            { name: "score",       type: { code: "FLOAT64" } },
+            { name: "updated_at",  type: { code: "TIMESTAMP" } },
+            { name: "birthday",    type: { code: "DATE"} },
+            { name: "avatar",      type: { code: "BYTES" } },
+            { name: "project_ids", type: { code: "ARRAY",
+                                           arrayElementType: { code: "INT64" } } }
+          ]
+        }
+      }
+    }
+  end
+  let(:results_json) { results_hash.to_json }
+  let(:results_grpc) { Google::Spanner::V1::PartialResultSet.decode_json results_json }
+  let(:results_enum) { Array(results_grpc).to_enum }
+
+  it "can get a table's types" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    types = transaction.types_for "users"
+
+    mock.verify
+
+    assert_types types
+  end
+
+  def assert_types types
+    types.wont_be :nil?
+    types.must_be_kind_of Hash
+    types.keys.count.must_equal 9
+    types[:id].must_equal          :INT64
+    types[:name].must_equal        :STRING
+    types[:active].must_equal      :BOOL
+    types[:age].must_equal         :INT64
+    types[:score].must_equal       :FLOAT64
+    types[:updated_at].must_equal  :TIMESTAMP
+    types[:birthday].must_equal    :DATE
+    types[:avatar].must_equal      :BYTES
+    types[:project_ids].must_equal [:INT64]
+  end
+end


### PR DESCRIPTION
This PR adds the following features to the `read` method.

- [x] Add `index` argument to `#read`
- [x] Rename `keys` argument from `id`
- [x] Allow `keys` to contain a list of keys, _or_ a list of key ranges
- [x] Add Spanner::Range to add the `exclude_begin?` feature which is not present in Ruby's `Range`
