### PR TITLE
Update gem spec homepage links

### DIFF
--- a/gcloud/gcloud.gemspec
+++ b/gcloud/gcloud.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "gcloud is the legacy support library for the new google-cloud library."
   gem.summary       = "API Client library for Google Cloud"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/gcloud"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-bigquery is the official library for Google BigQuery."
   gem.summary       = "API Client library for Google BigQuery"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-bigquery"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-core/google-cloud-core.gemspec
+++ b/google-cloud-core/google-cloud-core.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-core is the internal shared library for google-cloud-ruby."
   gem.summary       = "Internal shared library for google-cloud-ruby"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-core"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-datastore is the official library for Google Cloud Datastore."
   gem.summary       = "API Client library for Google Cloud Datastore"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-datastore"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["hexiong@google.com"]
   gem.description   = "google-cloud-debugger is the official library for Stackdriver Debugger."
   gem.summary       = "API Client and instrumentation library for Stackdriver Debugger"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-debugger"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/* ext/*`.split("\n") +

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-dns is the official library for Google Cloud DNS."
   gem.summary       = "API Client library for Google Cloud DNS"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-dns"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-env/google-cloud-env.gemspec
+++ b/google-cloud-env/google-cloud-env.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["dazuma@google.com"]
   gem.description   = "google-cloud-env provides information on the Google Cloud Platform hosting environment. Applications can use this library to determine hosting context information such as the project ID, whether App Engine is running, what tags are set on the VM instance, and much more."
   gem.summary       = "Google Cloud Platform hosting environment information."
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-env"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["googleapis-packages@google.com"]
   gem.description   = "google-cloud-error_reporting is the official library for Stackdriver Error Reporting."
   gem.summary       = "API Client library for Stackdriver Error Reporting"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-error_reporting"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-language is the official library for Google Cloud Natural Language API."
   gem.summary       = "API Client library for Google Cloud Natural Language API"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-language"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-logging is the official library for Stackdriver Logging."
   gem.summary       = "API Client library for Stackdriver Logging"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-logging"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["googleapis-packages@google.com"]
   gem.description   = "google-cloud-monitoring is the official library for Stackdriver Monitoring."
   gem.summary       = "API Cient library for Stackdriver Monitoring"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-monitoring"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-pubsub is the official library for Google Cloud Pub/Sub."
   gem.summary       = "API Client library for Google Cloud Pub/Sub"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-pubsub"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
+++ b/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-resource_manager is the official library for Google Cloud Resource Manager."
   gem.summary       = "API Client library for Google Cloud Resource Manager"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-resource_manager"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-spanner is the official library for Google Cloud Spanner API."
   gem.summary       = "API Client library for Google Cloud Spanner API"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-spanner"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n")

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-speech is the official library for Google Cloud Speech API."
   gem.summary       = "API Client library for Google Cloud Speech API"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-speech"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-storage is the official library for Google Cloud Storage."
   gem.summary       = "API Client library for Google Cloud Storage"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-storage"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["dazuma@google.com"]
   gem.description   = "google-cloud-trace is the official library for Stackdriver Trace."
   gem.summary       = "Application Instrumentation and API Client library for Stackdriver Trace"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-trace"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/google-cloud-translate/google-cloud-translate.gemspec
+++ b/google-cloud-translate/google-cloud-translate.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-translate is the official library for Google Cloud Translation API."
   gem.summary       = "API Client library for Google Cloud Translation API"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-translate"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud-vision is the official library for Google Cloud Vision API."
   gem.summary       = "API Client library for Google Cloud Vision API"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-vision"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/google-cloud/google-cloud.gemspec
+++ b/google-cloud/google-cloud.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "google-cloud is the official library for Google Cloud Platform APIs."
   gem.summary       = "API Client library for Google Cloud"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/stackdriver-core/stackdriver-core.gemspec
+++ b/stackdriver-core/stackdriver-core.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["dazuma@google.com"]
   gem.description   = "stackdriver-core is an internal shared library for the Ruby Stackdriver integration libraries."
   gem.summary       = "Internal shared library for Ruby Stackdriver integration"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/stackdriver-core"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["hxiong388@gmail.com"]
   gem.description   = "stackdriver is the official library for Google Stackdriver APIs."
   gem.summary       = "API Client library for Google Stackdriver"
-  gem.homepage      = "http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver"
+  gem.homepage      = "https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/stackdriver"
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +


### PR DESCRIPTION
For each gem, set the Homepage link to the directory in the shared GitHub repo. (e.g. [Datastore](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-datastore))

[refs #1444]