### PR TITLE
Update Spanner docs

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -112,10 +112,12 @@ module Google
         #   parameter placeholders, minus the "@", are the the hash keys, and
         #   the literal values are the hash values. If the query string contains
         #   something like "WHERE id > @msg_id", then the params must contain
-        #   something like `:msg_id -> 1`.
+        #   something like `:msg_id => 1`.
         # @param [Hash] single_use Perform the read with a single-use snapshot
-        #   (read-only transaction). The snapshot can be created by providing
-        #   just one of the following options in the hash:
+        #   (read-only transaction). (See
+        #   [TransactionOptions](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#transactionoptions).)
+        #   The snapshot can be created by providing exactly one of the
+        #   following options in the hash:
         #
         #   * **Strong**
         #     * `:strong` (true, false) Read at a timestamp where all previously
@@ -224,8 +226,10 @@ module Google
         # @param [Integer] limit If greater than zero, no more than this number
         #   of rows will be returned. The default is no limit.
         # @param [Hash] single_use Perform the read with a single-use snapshot
-        #   (read-only transaction). The snapshot can be created by providing
-        #   just one of the following options in the hash:
+        #   (read-only transaction). (See
+        #   [TransactionOptions](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#transactionoptions).)
+        #   The snapshot can be created by providing exactly one of the
+        #   following options in the hash:
         #
         #   * **Strong**
         #     * `:strong` (true, false) Read at a timestamp where all previously
@@ -304,9 +308,15 @@ module Google
           results
         end
 
-        # Creates changes to be applied to rows in the database.
+        ##
+        # Creates and commits a transaction for writes that execute atomically
+        # at a single logical point in time across columns, rows, and tables in
+        # a database.
         #
-        # @yield [commit] The block for updating the data.
+        # Unlike {#transaction}, which can also perform reads, this operation
+        # accepts only mutations and makes a single API request.
+        #
+        # @yield [commit] The block for mutating the data.
         # @yieldparam [Google::Cloud::Spanner::Commit] commit The Commit object.
         #
         # @example
@@ -351,6 +361,9 @@ module Google
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
         #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
         # @example
         #   require "google/cloud/spanner"
         #
@@ -391,6 +404,9 @@ module Google
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
         #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
         # @example
         #   require "google/cloud/spanner"
         #
@@ -429,6 +445,9 @@ module Google
         #   | `TIMESTAMP` | `Time`, `DateTime` | |
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
         # @example
         #   require "google/cloud/spanner"
@@ -470,6 +489,9 @@ module Google
         #   | `TIMESTAMP` | `Time`, `DateTime` | |
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
         # @example
         #   require "google/cloud/spanner"
@@ -516,6 +538,9 @@ module Google
         # Creates a transaction for reads and writes that execute atomically at
         # a single logical point in time across columns, rows, and tables in a
         # database.
+        #
+        # Unlike {#commit}, which does not allow reads, this operation
+        # makes separate API requests to begin and commit the transaction.
         #
         # @param [Numeric] deadline The total amount of time in seconds the
         #   transaction has to succeed.
@@ -570,8 +595,11 @@ module Google
         end
 
         ##
-        # Creates a snapshot for reads that execute atomically at a single
-        # logical point in time across columns, rows, and tables in a database.
+        # Creates a snapshot read-only transaction for reads that execute
+        # atomically at a single logical point in time across columns, rows, and
+        # tables in a database. For transactions that only read, snapshot
+        # read-only transactions provide simpler semantics and are almost always
+        # faster than read-write transactions.
         #
         # @param [true, false] strong Read at a timestamp where all previously
         #   committed transactions are visible.
@@ -583,7 +611,9 @@ module Google
         #
         #   Useful for large scale consistent reads such as mapreduces, or for
         #   coordinating many reads against a consistent snapshot of the data.
-        # @param [Time, DateTime] read_timestamp Same as `timestamp`
+        #   (See
+        #   [TransactionOptions](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#transactionoptions).)
+        # @param [Time, DateTime] read_timestamp Same as `timestamp`.
         # @param [Numeric] staleness Executes all reads at a timestamp that is
         #   +staleness+ old. The timestamp is chosen soon after the read
         #   is started.
@@ -595,8 +625,9 @@ module Google
         #   timestamps.
         #
         #   Useful for reading at nearby replicas without the distributed
-        #   timestamp negotiation overhead of single-use +staleness+.
-        # @param [Numeric] exact_staleness Same as `staleness`
+        #   timestamp negotiation overhead of single-use +staleness+. (See
+        #   [TransactionOptions](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#transactionoptions).)
+        # @param [Numeric] exact_staleness Same as `staleness`.
         #
         # @yield [snapshot] The block for reading and writing data.
         # @yieldparam [Google::Cloud::Spanner::Snapshot] snapshot The Snapshot
@@ -635,7 +666,7 @@ module Google
         end
 
         ##
-        # Indicates the field names and types for a table.
+        # Executes a query to retrieve the field names and types for a table.
         #
         # @param [String] table The name of the table in the database to
         #   retrieve types for
@@ -664,7 +695,7 @@ module Google
 
         ##
         # Creates a Spanner Range. This can be used in place of a Ruby Range
-        # when needing to excluse the beginning value.
+        # when needing to exclude the beginning value.
         #
         # @param [Object] beginning The object that defines the beginning of the
         #   range.

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -27,21 +27,28 @@ module Google
       ##
       # # Client
       #
-      # ...
+      # A client is used to read and/or modify data in a Cloud Spanner database.
       #
-      # See {Google::Cloud#spanner}
+      # See {Google::Cloud::Spanner::Project#client}.
       #
       # @example
       #   require "google/cloud"
       #
-      #   gcloud = Google::Cloud.new
-      #   spanner = gcloud.spanner
+      #   spanner = Google::Cloud::Spanner.new
       #
-      #   # ...
+      #   db = spanner.client "my-instance", "my-database"
+      #
+      #   db.transaction do |tx|
+      #     results = tx.execute "SELECT * FROM users"
+      #
+      #     results.rows.each do |row|
+      #       puts "User #{row[:id]} is #{row[:name]}""
+      #     end
+      #   end
       #
       class Client
         ##
-        # @private Creates a new Spanner Project instance.
+        # @private Creates a new Spanner Client instance.
         def initialize project, instance_id, database_id, min: 2, max: 10,
                        keepalive: 1500
           @project = project

--- a/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
@@ -21,7 +21,9 @@ module Google
       ##
       # # Commit
       #
-      # Creates changes to be applied to rows in the database.
+      # Accepts mutations for execution within a transaction. All writes will
+      # execute atomically at a single logical point in time across columns,
+      # rows, and tables in a database.
       #
       # @example
       #   require "google/cloud/spanner"
@@ -65,6 +67,9 @@ module Google
         #   | `TIMESTAMP` | `Time`, `DateTime` | |
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
         # @example
         #   require "google/cloud/spanner"
@@ -118,6 +123,9 @@ module Google
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
         #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
         # @example
         #   require "google/cloud/spanner"
         #
@@ -168,6 +176,9 @@ module Google
         #   | `TIMESTAMP` | `Time`, `DateTime` | |
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
         # @example
         #   require "google/cloud/spanner"
@@ -221,6 +232,9 @@ module Google
         #   | `TIMESTAMP` | `Time`, `DateTime` | |
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
         # @example
         #   require "google/cloud/spanner"

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -95,23 +95,23 @@ module Google
         # rubocop:enable LineLength
 
         ##
-        # The current database state.
+        # The current database state. Possible values are `:CREATING` and
+        # `:READY`.
         # @return [Symbol]
         def state
           @grpc.state
         end
 
         ##
-        # The database is still being created. Resources may not be available
-        # yet, and operations such as database creation may not work.
+        # The database is still being created. Operations on the database may
+        # fail with `FAILED_PRECONDITION` in this state.
         # @return [Boolean]
         def creating?
           state == :CREATING
         end
 
         ##
-        # The database is fully created and ready to do work such as creating
-        # databases.
+        # The database is fully created and ready for use.
         # @return [Boolean]
         def ready?
           state == :READY

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -23,17 +23,33 @@ module Google
       ##
       # # Database
       #
-      # ...
+      # Represents a Cloud Spanner database. To use Cloud Spanner's read and
+      # write operations, you must first create a database. A database belongs
+      # to a {Instance} and contains tables and indexes. You may create multiple
+      # databases in an {Instance}.
       #
-      # See {Google::Cloud#spanner}
+      # See {Google::Cloud::Spanner::Instance#databases},
+      # {Google::Cloud::Spanner::Instance#database}, and
+      # {Google::Cloud::Spanner::Instance#create_database}.
+      #
+      # To read and/or modify data in a Cloud Spanner database, use an instance
+      # of {Google::Cloud::Spanner::Client}. See
+      # {Google::Cloud::Spanner::Project#client}.
       #
       # @example
       #   require "google/cloud"
       #
-      #   gcloud = Google::Cloud.new
-      #   spanner = gcloud.spanner
+      #   spanner = Google::Cloud::Spanner.new
+      #   instance = spanner.instance "my-instance"
       #
-      #   # ...
+      #   job = instance.create_database "my-new-database"
+      #
+      #   job.done? #=> false
+      #   job.reload! # API call
+      #   job.done? #=> true
+      #
+      #   database = instance.database "my-new-database"
+      #
       class Database
         ##
         # @private The gRPC Service object.
@@ -315,7 +331,20 @@ module Google
         #
         #   The permissions that can be checked on a database are:
         #
-        #   * TODO
+        #   * pubsub.databases.create
+        #   * pubsub.databases.list
+        #   * pubsub.databases.update
+        #   * pubsub.databases.updateDdl
+        #   * pubsub.databases.get
+        #   * pubsub.databases.getDdl
+        #   * pubsub.databases.getIamPolicy
+        #   * pubsub.databases.setIamPolicy
+        #   * pubsub.databases.beginReadOnlyTransaction
+        #   * pubsub.databases.beginOrRollbackReadWriteTransaction
+        #   * pubsub.databases.read
+        #   * pubsub.databases.select
+        #   * pubsub.databases.write
+        #   * pubsub.databases.drop
         #
         # @return [Array<Strings>] The permissions that have access.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/database/job.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database/job.rb
@@ -20,8 +20,8 @@ module Google
         ##
         # # Job
         #
-        # A resource represents the long-running, asynchronous processing of an
-        # database create or update operation. The job can be refreshed to
+        # A resource representing the long-running, asynchronous processing of
+        # a database create or update operation. The job can be refreshed to
         # retrieve the database object once the operation has been completed.
         #
         # See {Project#create_database} and {Database#update}.
@@ -59,7 +59,7 @@ module Google
           end
 
           ##
-          # The database.
+          # The database that is the object of the operation.
           #
           # @return [Google::Cloud::Spanner::Database, nil] Returns `nil`
           #   if operation is not complete.
@@ -121,7 +121,7 @@ module Google
 
           ##
           # Reloads the job with current data from the long-running,
-          # asynchronous processing of an database operation.
+          # asynchronous processing of a database operation.
           #
           # @example
           #   require "google/cloud/spanner"

--- a/google-cloud-spanner/lib/google/cloud/spanner/database/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database/list.rb
@@ -100,7 +100,7 @@ module Google
           #
           #   databases = spanner.databases "my-instance"
           #   databases.all do |database|
-          #     puts database.name
+          #     puts database.database_id
           #   end
           #
           # @example Using the enumerator by not passing a block:
@@ -110,7 +110,7 @@ module Google
           #
           #   databases = spanner.databases "my-instance"
           #   all_database_ids = databases.all.map do |database|
-          #     database.name
+          #     database.database_id
           #   end
           #
           # @example Limit the number of API calls made:
@@ -120,7 +120,7 @@ module Google
           #
           #   databases = spanner.databases "my-instance"
           #   databases.all(request_limit: 10) do |database|
-          #     puts database.name
+          #     puts database.database_id
           #   end
           #
           def all request_limit: nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
@@ -25,17 +25,36 @@ module Google
       ##
       # # Instance
       #
-      # ...
+      # Represents a Cloud Spanner instance. Instances are dedicated Cloud
+      # Spanner serving and storage resources to be used by Cloud Spanner
+      # databases. Instances offer isolation: problems with databases in one
+      # instance will not affect other instances. However, within an instance
+      # databases can affect each other. For example, if one database in an
+      # instance receives a lot of requests and consumes most of the instance
+      # resources, fewer resources are available for other databases in that
+      # instance, and their performance may suffer.
       #
-      # See {Google::Cloud#spanner}
+      # See {Google::Cloud::Spanner::Project#instances},
+      # {Google::Cloud::Spanner::Project#instance}, and
+      # {Google::Cloud::Spanner::Project#create_instance}.
       #
       # @example
-      #   require "google/cloud"
+      #   require "google/cloud/spanner"
       #
-      #   gcloud = Google::Cloud.new
-      #   spanner = gcloud.spanner
+      #   spanner = Google::Cloud::Spanner.new
       #
-      #   # ...
+      #   job = spanner.create_instance "my-new-instance",
+      #                                 name: "My New Instance",
+      #                                 config: "regional-us-central1",
+      #                                 nodes: 5,
+      #                                 labels: { production: :env }
+      #
+      #   job.done? #=> false
+      #   job.reload! # API call
+      #   job.done? #=> true
+      #
+      #   instance = spanner.instance "my-new-instance"
+      #
       class Instance
         ##
         # @private The gRPC Service object.
@@ -412,7 +431,13 @@ module Google
         #
         #   The permissions that can be checked on a instance are:
         #
-        #   * TODO
+        #   * pubsub.instances.create
+        #   * pubsub.instances.list
+        #   * pubsub.instances.get
+        #   * pubsub.instances.getIamPolicy
+        #   * pubsub.instances.update
+        #   * pubsub.instances.setIamPolicy
+        #   * pubsub.instances.delete
         #
         # @return [Array<Strings>] The permissions that have access.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
@@ -236,7 +236,7 @@ module Google
         #   instance = spanner.instance "my-instance"
         #   databases = instance.databases
         #   databases.each do |database|
-        #     puts database.name
+        #     puts database.database_id
         #   end
         #
         # @example Retrieve all: (See {Instance::Config::List::List#all})
@@ -247,7 +247,7 @@ module Google
         #   instance = spanner.instance "my-instance"
         #   databases = instance.databases
         #   databases.all do |database|
-        #     puts database.name
+        #     puts database.database_id
         #   end
         #
         def databases token: nil, max: nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
@@ -98,7 +98,7 @@ module Google
         alias_method :display_name, :name
 
         ##
-        # The instance config resource.
+        # The instance configuration resource.
         # @return [Instance::Config]
         def config
           ensure_service!
@@ -133,7 +133,8 @@ module Google
         alias_method :node_count=, :nodes=
 
         ##
-        # The current instance state.
+        # The current instance state. Possible values are `:CREATING` and
+        # `:READY`.
         # @return [Symbol]
         def state
           @grpc.state
@@ -218,7 +219,7 @@ module Google
         end
 
         ##
-        # Retrieves the list of databases for the given project.
+        # Retrieves the list of databases for the given instance.
         #
         # @param [String] token The `token` value returned by the last call to
         #   `databases`; indicates that this is a continuation of a call,
@@ -257,7 +258,7 @@ module Google
         end
 
         ##
-        # Retrieves database by name.
+        # Retrieves a database belonging to the instance by identifier.
         #
         # @param [String] database_id The unique identifier for the database.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/config.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/config.rb
@@ -22,17 +22,23 @@ module Google
         ##
         # # Instance Config
         #
-        # ...
+        # Represents a Cloud Spanner instance configuration. Instance
+        # configurations define the geographic placement of nodes and their
+        # replication.
         #
-        # See {Google::Cloud#spanner}
+        # See {Google::Cloud::Spanner::Project#instance_configs} and
+        # {Google::Cloud::Spanner::Project#instance_config}.
         #
         # @example
-        #   require "google/cloud"
+        #   require "google/cloud/spanner"
         #
-        #   gcloud = Google::Cloud.new
-        #   spanner = gcloud.spanner
+        #   spanner = Google::Cloud::Spanner.new
         #
-        #   # ...
+        #   instance_configs = spanner.instance_configs
+        #   instance_configs.each do |config|
+        #     puts config.name
+        #   end
+        #
         class Config
           ##
           # @private Creates a new Instance::Config instance.

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/config.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/config.rb
@@ -36,7 +36,7 @@ module Google
         #
         #   instance_configs = spanner.instance_configs
         #   instance_configs.each do |config|
-        #     puts config.name
+        #     puts config.instance_config_id
         #   end
         #
         class Config

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/config/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/config/list.rb
@@ -101,7 +101,7 @@ module Google
             #   spanner = Google::Cloud::Spanner.new
             #
             #   spanner.instance_configs.all do |config|
-            #     puts config.name
+            #     puts config.instance_config_id
             #   end
             #
             # @example Using the enumerator by not passing a block:
@@ -110,7 +110,7 @@ module Google
             #   spanner = Google::Cloud::Spanner.new
             #
             #   all_config_ids = spanner.instance_configs.all.map do |config|
-            #     config.name
+            #     config.instance_config_id
             #   end
             #
             # @example Limit the number of API calls made:
@@ -119,7 +119,7 @@ module Google
             #   spanner = Google::Cloud::Spanner.new
             #
             #   spanner.instance_configs.all(request_limit: 10) do |config|
-            #     puts config.name
+            #     puts config.instance_config_id
             #   end
             #
             def all request_limit: nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/job.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/job.rb
@@ -20,8 +20,8 @@ module Google
         ##
         # # Job
         #
-        # A resource represents the long-running, asynchronous processing of an
-        # instance create or update operation. The job can be refreshed to
+        # A resource representing the long-running, asynchronous processing of
+        # an instance create or update operation. The job can be refreshed to
         # retrieve the instance object once the operation has been completed.
         #
         # See {Project#create_instance} and {Instance#update}.
@@ -62,7 +62,7 @@ module Google
           end
 
           ##
-          # The instance.
+          # The instance that is the object of the operation.
           #
           # @return [Google::Cloud::Spanner::Instance, nil] Returns `nil`
           #   if operation is not complete.

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/list.rb
@@ -99,7 +99,7 @@ module Google
           #   spanner = Google::Cloud::Spanner.new
           #
           #   spanner.instances.all do |instance|
-          #     puts instance.name
+          #     puts instance.instance_id
           #   end
           #
           # @example Using the enumerator by not passing a block:
@@ -108,7 +108,7 @@ module Google
           #   spanner = Google::Cloud::Spanner.new
           #
           #   all_instance_ids = spanner.instances.all.map do |instance|
-          #     instance.name
+          #     instance.instance_id
           #   end
           #
           # @example Limit the number of API calls made:
@@ -117,7 +117,7 @@ module Google
           #   spanner = Google::Cloud::Spanner.new
           #
           #   spanner.instances.all(request_limit: 10) do |instance|
-          #     puts instance.name
+          #     puts instance.instance_id
           #   end
           #
           def all request_limit: nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -23,7 +23,9 @@ module Google
       #
       # # Pool
       #
-      # ...
+      # Implements a pool for managing and reusing
+      # {Google::Cloud::Spanner::Session} instances.
+      #
       class Pool
         attr_accessor :min, :max, :pool, :queue
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -100,7 +100,7 @@ module Google
         #
         #   instances = spanner.instances
         #   instances.each do |instance|
-        #     puts instance.name
+        #     puts instance.instance_id
         #   end
         #
         # @example Retrieve all: (See {Instance::Config::List::List#all})
@@ -110,7 +110,7 @@ module Google
         #
         #   instances = spanner.instances
         #   instances.all do |instance|
-        #     puts instance.name
+        #     puts instance.instance_id
         #   end
         #
         def instances token: nil, max: nil
@@ -225,7 +225,7 @@ module Google
         #
         #   instance_configs = spanner.instance_configs
         #   instance_configs.each do |config|
-        #     puts config.name
+        #     puts config.instance_config_id
         #   end
         #
         # @example Retrieve all: (See {Instance::Config::List::List#all})
@@ -235,7 +235,7 @@ module Google
         #
         #   instance_configs = spanner.instance_configs
         #   instance_configs.all do |config|
-        #     puts config.name
+        #     puts config.instance_config_id
         #   end
         #
         def instance_configs token: nil, max: nil
@@ -293,7 +293,7 @@ module Google
         #
         #   databases = spanner.databases "my-instance"
         #   databases.each do |database|
-        #     puts database.name
+        #     puts database.database_id
         #   end
         #
         # @example Retrieve all: (See {Instance::Config::List::List#all})
@@ -303,7 +303,7 @@ module Google
         #
         #   databases = spanner.databases "my-instance"
         #   databases.all do |database|
-        #     puts database.name
+        #     puts database.database_id
         #   end
         #
         def databases instance_id, token: nil, max: nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -32,18 +32,38 @@ module Google
       # Cloud Spanner data. Each project has a friendly name and a unique ID.
       #
       # Google::Cloud::Spanner::Project is the main object for interacting with
-      # Cloud Spanner. {Google::Cloud::Spanner::Instance} and
+      # Cloud Spanner.
+      #
+      # {Google::Cloud::Spanner::Instance} and
       # {Google::Cloud::Spanner::Database} objects are created,
       # accessed, and managed by Google::Cloud::Spanner::Project.
       #
+      # A {Google::Cloud::Spanner::Client} obtained from a project can be used
+      # to read and/or modify data in a Cloud Spanner database.
+      #
       # See {Google::Cloud::Spanner.new} and {Google::Cloud#spanner}.
       #
-      # @example
+      # @example Obtaining an instance and a database from a project.
       #   require "google/cloud"
       #
       #   spanner = Google::Cloud::Spanner.new
       #   instance = spanner.instance "my-instance"
       #   database = instance.database "my-database"
+      #
+      # @example Obtaining a client for use with a database.
+      #   require "google/cloud/spanner"
+      #
+      #   spanner = Google::Cloud::Spanner.new
+      #
+      #   db = spanner.client "my-instance", "my-database"
+      #
+      #   db.transaction do |tx|
+      #     results = tx.execute "SELECT * FROM users"
+      #
+      #     results.rows.each do |row|
+      #       puts "User #{row[:id]} is #{row[:name]}""
+      #     end
+      #   end
       #
       class Project
         ##
@@ -56,7 +76,8 @@ module Google
           @service = service
         end
 
-        # The Spanner project connected to.
+        ##
+        # The identifier for the Cloud Spanner project.
         #
         # @example
         #   require "google/cloud"
@@ -83,7 +104,7 @@ module Google
         end
 
         ##
-        # Retrieves the list of instances for the given project.
+        # Retrieves the list of Cloud Spanner instances for the project.
         #
         # @param [String] token The `token` value returned by the last call to
         #   `instances`; indicates that this is a continuation of a call,
@@ -120,7 +141,7 @@ module Google
         end
 
         ##
-        # Retrieves instance by name.
+        # Retrieves a Cloud Spanner instance by unique identifier.
         #
         # @param [String] instance_id The unique identifier for the instance.
         #
@@ -148,7 +169,8 @@ module Google
         end
 
         ##
-        # Creates an instance and starts preparing it to begin serving.
+        # Creates a Cloud Spanner instance and starts preparing it to begin
+        # serving.
         #
         # See {Instance::Job}.
         #
@@ -208,7 +230,7 @@ module Google
         end
 
         ##
-        # Retrieves a list of instance configuration for the given project.
+        # Retrieves the list of instance configurations for the project.
         #
         # @param [String] token The `token` value returned by the last call to
         #   `instance_configs`; indicates that this is a continuation of a call,
@@ -245,7 +267,7 @@ module Google
         end
 
         ##
-        # Retrieves instance configuration by name.
+        # Retrieves an instance configuration by unique identifier.
         #
         # @param [String] instance_config_id The instance configuration
         #   identifier. Values can be the `instance_config_id`, or the full
@@ -275,7 +297,7 @@ module Google
         end
 
         ##
-        # Retrieves the list of databases for the given project.
+        # Retrieves the list of databases for the project.
         #
         # @param [String] instance_id The unique identifier for the instance.
         # @param [String] token The `token` value returned by the last call to
@@ -313,7 +335,7 @@ module Google
         end
 
         ##
-        # Retrieves database by name.
+        # Retrieves a database by unique identifier.
         #
         # @param [String] instance_id The unique identifier for the instance.
         # @param [String] database_id The unique identifier for the database.
@@ -381,8 +403,8 @@ module Google
         end
 
         ##
-        # Creates a Spanner Client. A client is used to read and/or modify data
-        # in a Cloud Spanner database.
+        # Creates a Cloud Spanner client. A client is used to read and/or modify
+        # data in a Cloud Spanner database.
         #
         # @param [String] instance_id The unique identifier for the instance.
         #   Required.

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -27,17 +27,23 @@ module Google
       ##
       # # Project
       #
-      # ...
+      # Projects are top-level containers in Google Cloud Platform. They store
+      # information about billing and authorized users, and they contain
+      # Cloud Spanner data. Each project has a friendly name and a unique ID.
       #
-      # See {Google::Cloud#spanner}
+      # Google::Cloud::Spanner::Project is the main object for interacting with
+      # Cloud Spanner. {Google::Cloud::Spanner::Instance} and
+      # {Google::Cloud::Spanner::Database} objects are created,
+      # accessed, and managed by Google::Cloud::Spanner::Project.
+      #
+      # See {Google::Cloud::Spanner.new} and {Google::Cloud#spanner}.
       #
       # @example
       #   require "google/cloud"
       #
-      #   gcloud = Google::Cloud.new
-      #   spanner = gcloud.spanner
-      #
-      #   # ...
+      #   spanner = Google::Cloud::Spanner.new
+      #   instance = spanner.instance "my-instance"
+      #   database = instance.database "my-database"
       #
       class Project
         ##
@@ -390,9 +396,15 @@ module Google
         #
         #   spanner = Google::Cloud::Spanner.new
         #
-        #   db = spanner.client "my-instance", "my-new-database"
+        #   db = spanner.client "my-instance", "my-database"
         #
-        #   ...
+        #   db.transaction do |tx|
+        #     results = tx.execute "SELECT * FROM users"
+        #
+        #     results.rows.each do |row|
+        #       puts "User #{row[:id]} is #{row[:name]}""
+        #     end
+        #   end
         #
         def client instance_id, database_id, min: 2, max: 10, keepalive: 1500
           Client.new self, instance_id, database_id, min: min, max: max,

--- a/google-cloud-spanner/lib/google/cloud/spanner/range.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/range.rb
@@ -19,7 +19,10 @@ module Google
       ##
       # # Range
       #
-      # @example
+      # Represents a range of rows in a table or index. A range has a start key
+      # and an end key. These keys can be open or closed, indicating if the
+      # range includes rows with that key.
+      #
       # @example
       #   require "google/cloud/spanner"
       #
@@ -45,7 +48,7 @@ module Google
 
         ##
         # Creates a Spanner Range. This can be used in place of a Ruby Range
-        # when needing to excluse the beginning value.
+        # when needing to exclude the beginning value.
         #
         # @param [Object] beginning The object that defines the beginning of the
         #   range.

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -22,9 +22,27 @@ module Google
       ##
       # # Results
       #
+      # Represents the result set from an operation returning data.
+      #
+      # See {Google::Cloud::Spanner::Client#execute} and
+      # {Google::Cloud::Spanner::Client#read}.
+      #
+      # @example
+      #   require "google/cloud/spanner"
+      #
+      #   spanner = Google::Cloud::Spanner.new
+      #
+      #   db = spanner.client "my-instance", "my-database"
+      #
+      #   results = db.execute "SELECT * FROM users"
+      #
+      #   results.types.each do |name, type|
+      #     puts "Column #{name} is type {type}"
+      #   end
+      #
       class Results
         ##
-        # Indicates the field names and types for the rows in the returned data.
+        # Returns the field names and types for the rows in the returned data.
         #
         # @param [Boolean] pairs Allow the types to be represented as a nested
         #   Array of pairs rather than a Hash. This is useful when results have
@@ -46,7 +64,7 @@ module Google
         #     puts "Column #{name} is type {type}"
         #   end
         #
-        # @example Can return an array of array pairs instead of a hash
+        # @example Returning an array of array pairs instead of a hash:
         #   require "google/cloud/spanner"
         #
         #   spanner = Google::Cloud::Spanner.new
@@ -99,7 +117,7 @@ module Google
         #     puts "User #{row[:id]} is #{row[:name]}""
         #   end
         #
-        # @example Can returns an array of array pairs instead of a hash
+        # @example Returning an array of array pairs instead of a hash:
         #   require "google/cloud/spanner"
         #
         #   spanner = Google::Cloud::Spanner.new

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -159,7 +159,7 @@ module Google
         #   parameter placeholders, minus the "@", are the the hash keys, and
         #   the literal values are the hash values. If the query string contains
         #   something like "WHERE id > @msg_id", then the params must contain
-        #   something like `:msg_id -> 1`.
+        #   something like `:msg_id => 1`.
         # @param [Google::Spanner::V1::TransactionSelector] transaction The
         #   transaction selector value to send. Only used for single-use
         #   transactions.
@@ -243,9 +243,13 @@ module Google
                        transaction: transaction
         end
 
+        ##
         # Creates changes to be applied to rows in the database.
         #
-        # @yield [commit] The block for updating the data.
+        # @param [String] transaction_id The identifier of previously-started
+        #   transaction to be used instead of starting a new transaction.
+        #   Optional.
+        # @yield [commit] The block for mutating the data.
         # @yieldparam [Google::Cloud::Spanner::Commit] commit The Commit object.
         #
         # @example
@@ -290,6 +294,9 @@ module Google
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
         #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
         # @example
         #   require "google/cloud/spanner"
         #
@@ -330,6 +337,9 @@ module Google
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
         #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
         # @example
         #   require "google/cloud/spanner"
         #
@@ -368,6 +378,9 @@ module Google
         #   | `TIMESTAMP` | `Time`, `DateTime` | |
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
         # @example
         #   require "google/cloud/spanner"
@@ -409,6 +422,9 @@ module Google
         #   | `TIMESTAMP` | `Time`, `DateTime` | |
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
         # @example
         #   require "google/cloud/spanner"

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -24,17 +24,20 @@ module Google
       #
       # # Session
       #
-      # ...
+      # A session can be used to perform transactions that read and/or modify
+      # data in a Cloud Spanner database. Sessions are meant to be reused for
+      # many consecutive transactions.
       #
-      # See {Google::Cloud#spanner}
+      # Sessions can only execute one transaction at a time. To execute multiple
+      # concurrent read-write/write-only transactions, create multiple sessions.
+      # Note that standalone reads and queries use a transaction internally, and
+      # count toward the one transaction limit.
       #
-      # @example
-      #   require "google/cloud"
+      # Cloud Spanner limits the number of sessions that can exist at any given
+      # time; thus, it is a good idea to delete idle and/or unneeded sessions.
+      # Aside from explicit deletes, Cloud Spanner can delete sessions for which
+      # no operations are sent for more than an hour.
       #
-      #   gcloud = Google::Cloud.new
-      #   spanner = gcloud.spanner
-      #
-      #   # ...
       class Session
         ##
         # @private The Google::Spanner::V1::Session object

--- a/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
@@ -74,7 +74,7 @@ module Google
         #   parameter placeholders, minus the "@", are the the hash keys, and
         #   the literal values are the hash values. If the query string contains
         #   something like "WHERE id > @msg_id", then the params must contain
-        #   something like `:msg_id -> 1`.
+        #   something like `:msg_id => 1`.
         # @return [Google::Cloud::Spanner::Results]
         #
         # @example
@@ -153,8 +153,8 @@ module Google
         end
 
         ##
-        # Creates a Spanner Range. This can be used in place of a Ruby Range
-        # when needing to excluse the beginning value.
+        # Creates a Cloud Spanner Range. This can be used in place of a Ruby
+        # Range when needing to exclude the beginning value.
         #
         # @param [Object] beginning The object that defines the beginning of the
         #   range.

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -76,7 +76,7 @@ module Google
         #   parameter placeholders, minus the "@", are the the hash keys, and
         #   the literal values are the hash values. If the query string contains
         #   something like "WHERE id > @msg_id", then the params must contain
-        #   something like `:msg_id -> 1`.
+        #   something like `:msg_id => 1`.
         # @return [Google::Cloud::Spanner::Results]
         #
         # @example
@@ -153,9 +153,10 @@ module Google
                                        transaction: tx_selector
         end
 
-        # Creates changes to be applied to rows in the database.
+        ##
+        # Commits the transaction. Accepts an optional block for mutations.
         #
-        # @yield [commit] The block for updating the data.
+        # @yield [commit] The block for mutating the data.
         # @yieldparam [Google::Cloud::Spanner::Commit] commit The Commit object.
         #
         # @example
@@ -165,10 +166,9 @@ module Google
         #   db = spanner.client "my-instance", "my-database"
         #
         #   db.transaction do |tx|
-        #     tx.commit do |c|
-        #       c.update "users", [{ id: 1, name: "Charlie", active: false }]
-        #       c.insert "users", [{ id: 2, name: "Harvey",  active: true }]
-        #     end
+        #     tx.update "users", [{ id: 1, name: "Charlie", active: false }]
+        #     tx.insert "users", [{ id: 2, name: "Harvey",  active: true }]
+        #     tx.commit
         #   end
         #
         def commit
@@ -201,6 +201,9 @@ module Google
         #   | `TIMESTAMP` | `Time`, `DateTime` | |
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
         # @example
         #   require "google/cloud/spanner"
@@ -242,6 +245,9 @@ module Google
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
         #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
         # @example
         #   require "google/cloud/spanner"
         #
@@ -280,6 +286,9 @@ module Google
         #   | `TIMESTAMP` | `Time`, `DateTime` | |
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
         # @example
         #   require "google/cloud/spanner"
@@ -322,6 +331,9 @@ module Google
         #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
         #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
         #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
         # @example
         #   require "google/cloud/spanner"
         #
@@ -362,7 +374,7 @@ module Google
         end
 
         ##
-        # Indicates the field names and types for a table.
+        # Returns the field names and types for a table.
         #
         # @param [String] table The name of the table in the database to
         #   retrieve types for
@@ -391,8 +403,8 @@ module Google
         end
 
         ##
-        # Creates a Spanner Range. This can be used in place of a Ruby Range
-        # when needing to excluse the beginning value.
+        # Creates a Cloud Spanner Range. This can be used in place of a Ruby
+        # Range when needing to exclude the beginning value.
         #
         # @param [Object] beginning The object that defines the beginning of the
         #   range.
@@ -428,7 +440,8 @@ module Google
         ##
         # Rolls back the transaction, releasing any locks it holds. It is a good
         # idea to call this for any transaction that includes one or more `read`
-        # or `execute` requests and ultimately decides not to commit.
+        # or `execute` requests and for which the decision has been made not to
+        # commit.
         #
         # @example
         #   require "google/cloud/spanner"


### PR DESCRIPTION
This PR updates the Cloud Spanner documentation for a number of minor omissions and errors. Later PRs will cover examples testing (doctest) and the guide.