### PR TITLE
Add missing gems to integration sample apps

### DIFF
--- a/integration/rails4_app/Gemfile
+++ b/integration/rails4_app/Gemfile
@@ -45,10 +45,11 @@ group :development do
   gem 'spring'
 end
 
+gem "google-cloud-bigquery", path: "../../google-cloud-bigquery"
 gem "google-cloud-core", path: "../../google-cloud-core"
 gem "google-cloud-env", path: "../../google-cloud-env"
-gem "google-cloud-bigquery", path: "../../google-cloud-bigquery"
 gem "google-cloud-datastore", path: "../../google-cloud-datastore"
+gem "google-cloud-debugger", path: "../../google-cloud-debugger"
 gem "google-cloud-dns", path: "../../google-cloud-dns"
 gem "google-cloud-error_reporting", path: "../../google-cloud-error_reporting"
 gem "google-cloud-language", path: "../../google-cloud-language"
@@ -58,8 +59,10 @@ gem "google-cloud-pubsub", path: "../../google-cloud-pubsub"
 gem "google-cloud-resource_manager", path: "../../google-cloud-resource_manager"
 gem "google-cloud-speech", path: "../../google-cloud-speech"
 gem "google-cloud-storage", path: "../../google-cloud-storage"
+gem "google-cloud-trace", path: "../../google-cloud-trace"
 gem "google-cloud-translate", path: "../../google-cloud-translate"
 gem "google-cloud-vision", path: "../../google-cloud-vision"
 gem "google-cloud", path: "../../google-cloud"
 gem "gcloud", path: "../../gcloud"
 gem "stackdriver", path: "../../stackdriver"
+gem "stackdriver-core", path: "../../stackdriver-core"

--- a/integration/rails5_app/Gemfile
+++ b/integration/rails5_app/Gemfile
@@ -48,10 +48,11 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+gem "google-cloud-bigquery", path: "../../google-cloud-bigquery"
 gem "google-cloud-core", path: "../../google-cloud-core"
 gem "google-cloud-env", path: "../../google-cloud-env"
-gem "google-cloud-bigquery", path: "../../google-cloud-bigquery"
 gem "google-cloud-datastore", path: "../../google-cloud-datastore"
+gem "google-cloud-debugger", path: "../../google-cloud-debugger"
 gem "google-cloud-dns", path: "../../google-cloud-dns"
 gem "google-cloud-error_reporting", path: "../../google-cloud-error_reporting"
 gem "google-cloud-language", path: "../../google-cloud-language"
@@ -61,8 +62,10 @@ gem "google-cloud-pubsub", path: "../../google-cloud-pubsub"
 gem "google-cloud-resource_manager", path: "../../google-cloud-resource_manager"
 gem "google-cloud-speech", path: "../../google-cloud-speech"
 gem "google-cloud-storage", path: "../../google-cloud-storage"
+gem "google-cloud-trace", path: "../../google-cloud-trace"
 gem "google-cloud-translate", path: "../../google-cloud-translate"
 gem "google-cloud-vision", path: "../../google-cloud-vision"
 gem "google-cloud", path: "../../google-cloud"
 gem "gcloud", path: "../../gcloud"
 gem "stackdriver", path: "../../stackdriver"
+gem "stackdriver-core", path: "../../stackdriver-core"


### PR DESCRIPTION
The integration tests are failing because the sample apps aren't referencing some of the google-cloud-ruby gems from source. This PR fixes that.