### PR TITLE
Fix translator code to check retry error reason

### DIFF
--- a/google-cloud-translate/lib/google/cloud/translate/service.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/service.rb
@@ -178,7 +178,7 @@ module Google
           end
 
           def retry_error_reason? response #:nodoc:
-            result = JSON.parse(response.body)["data"]
+            result = JSON.parse(response.body)
             if result &&
                result["error"] &&
                result["error"]["errors"]

--- a/google-cloud-translate/test/google/cloud/translate/service_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/service_test.rb
@@ -1,0 +1,109 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Translate::Service, :service do
+  let(:project) { "test" }
+  let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
+  let(:service) { Google::Cloud::Translate::Service.new(project, credentials, retries: 1) }
+  let(:mock_http) { MockHttp.new }
+
+  it "does not retry on other errors" do
+    body = {
+      "error" => {
+        "errors" => [
+          {
+            "reason" => "otherError"
+          }
+        ]
+      }
+    }.to_json
+    mock_http.stub_response(403, body)
+
+    service.stub(:http, mock_http) do
+      begin
+        service.detect('hello')
+      rescue Google::Cloud::PermissionDeniedError; end
+    end
+
+    mock_http.request_count.must_equal(1)
+  end
+
+  it "retries when there is rateLimitExceeded error" do
+    body = {
+      "error" => {
+        "errors" => [
+          {
+            "reason" => "rateLimitExceeded"
+          }
+        ]
+      }
+    }.to_json
+    mock_http.stub_response(403, body)
+
+    service.stub(:http, mock_http) do
+      begin
+        service.detect('hello')
+      rescue Google::Cloud::PermissionDeniedError; end
+    end
+
+    mock_http.request_count.must_equal(2)
+  end
+
+  it "retries when there is userRateLimitExceeded error" do
+    body = {
+      "error" => {
+        "errors" => [
+          {
+            "reason" => "userRateLimitExceeded"
+          }
+        ]
+      }
+    }.to_json
+    mock_http.stub_response(403, body)
+
+    service.stub(:http, mock_http) do
+      begin
+        service.detect('hello')
+      rescue Google::Cloud::PermissionDeniedError; end
+    end
+
+    mock_http.request_count.must_equal(2)
+  end
+
+  it "retries when the response status 500" do
+    mock_http.stub_response(500, '')
+
+    service.stub(:http, mock_http) do
+      begin
+        service.detect('hello')
+      rescue Google::Cloud::InternalError; end
+    end
+
+    mock_http.request_count.must_equal(2)
+  end
+
+  it "retries when the response status 503" do
+    mock_http.stub_response(503, '')
+
+    service.stub(:http, mock_http) do
+      begin
+        service.detect('hello')
+      rescue Google::Cloud::UnavailableError; end
+    end
+
+    mock_http.request_count.must_equal(2)
+  end
+end

--- a/google-cloud-translate/test/helper.rb
+++ b/google-cloud-translate/test/helper.rb
@@ -31,3 +31,23 @@ class MockTranslate < Minitest::Spec
     addl.include? :mock_translate
   end
 end
+
+class MockHttp
+  attr_reader :request_count
+
+  def initialize
+    @request_count = 0
+  end
+
+  def stub_response(status, body)
+    @stub_status = status
+    @stub_body = body
+  end
+
+  def post(*_)
+    @request_count += 1
+    Faraday::Response.new.tap do |response|
+      response.finish(status: @stub_status, body: @stub_body)
+    end
+  end
+end


### PR DESCRIPTION
The error response from translator api
```
{
  "error": {
    "code": 403,
    "message": "User Rate Limit Exceeded",
    "errors": [
      {
        "message": "User Rate Limit Exceeded",
        "domain": "usageLimits",
        "reason": "userRateLimitExceeded"
      }
    ]
  }
}
```
As can be seen its not contained inside a "data" key