### PR TITLE
Fix several ErrorReporting initialization cases

### DIFF
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 
-require "rack"
-require "rack/request"
-
 module Google
   module Cloud
     module ErrorReporting
@@ -82,6 +79,9 @@ module Google
         def initialize app, error_reporting: nil, project_id: nil, keyfile: nil,
                        service_name: nil, service_version: nil,
                        ignore_classes: nil
+          require "rack"
+          require "rack/request"
+
           @app = app
           load_config project_id: project_id,
                       keyfile: keyfile,

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -20,8 +20,7 @@ gem "google-cloud-trace"
 
 require "google/cloud/logging"
 require "google/cloud/trace"
-
-require "google/cloud/error_reporting/middleware" if defined? ::Rack
+require "google/cloud/error_reporting"
 
 if defined? ::Rails::Railtie
   require "google/cloud/error_reporting/rails"


### PR DESCRIPTION
* Requiring "google/cloud/error_reporting" failed if the Rack gem wasn't present. Fixed.
* Stackdriver gem wasn't requiring the correct error reporting entrypoint. Fixed.

These items are breaking our internal integration tests.