### PR TITLE
Fix sinatra integration tests

### DIFF
--- a/integration/sinatra1_app/app.rb
+++ b/integration/sinatra1_app/app.rb
@@ -17,29 +17,12 @@ require 'sinatra'
 require 'stackdriver'
 require 'grpc'
 
-keyfile = ENV["GOOGLE_APPLICATION_CREDENTIALS"]
-
 #######################################
 # Setup ErrorReporting Middleware
-er_scopes = Google::Cloud::ErrorReporting::V1beta1::ReportErrorsServiceClient::ALL_SCOPES
-er_credentials = if keyfile.nil?
-                Google::Cloud::Credentials.default(
-                  scope: er_scopes)
-              else
-                Google::Cloud::Credentials.new(
-                  keyfile, scope: er_scopes)
-              end
-er_channel_cred = GRPC::Core::ChannelCredentials.new.compose \
-            GRPC::Core::CallCredentials.new er_credentials.client.updater_proc
-er_chan = GRPC::Core::Channel.new Google::Cloud::ErrorReporting::V1beta1::ReportErrorsServiceClient::SERVICE_ADDRESS,
-                                               nil, er_channel_cred
 er_service_name = "google-cloud-ruby_integration_test"
 er_serivce_version = ENV['USER']
 
-error_reporting = Google::Cloud::ErrorReporting::V1beta1::ReportErrorsServiceClient.new channel: er_chan
-
-use Google::Cloud::ErrorReporting::Middleware, error_reporting: error_reporting,
-                                               service_name: er_service_name,
+use Google::Cloud::ErrorReporting::Middleware, service_name: er_service_name,
                                                service_version: er_serivce_version
 #######################################
 


### PR DESCRIPTION
Follow up PR to #1479 and #1487 to fix integration tests. The Error Reporting instrumentation Middleware has been revamped. This integrate Sinatra app can now load the Error Reporting Middleware the easy way.