### PR TITLE
Remove Spanner from google-cloud toc.json

### DIFF
--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -396,56 +396,6 @@
       ]
     },
     {
-      "title": "Spanner",
-      "type": "google/cloud/spanner",
-      "patterns": ["\/spanner", "google\/iam", "google\/protobuf", "google\/rpc"],
-      "nav": [
-        {
-          "title": "Client",
-          "type": "google/cloud/spanner/client"
-        },
-        {
-          "title": "Results",
-          "type": "google/cloud/spanner/results"
-        },
-        {
-          "title": "Project",
-          "type": "google/cloud/spanner/project"
-        },
-        {
-          "title": "Instance",
-          "type": "google/cloud/spanner/instance"
-        },
-        {
-          "title": "Database",
-          "type": "google/cloud/spanner/database"
-        },
-        {
-          "title": "V1",
-          "type": "google/cloud/spanner/v1",
-          "patterns": ["\/spanner\/v1", "google\/iam", "google\/protobuf", "google\/rpc"],
-          "nav": [
-            {
-              "title": "SpannerClient",
-              "type": "google/cloud/spanner/v1/spannerclient"
-            },
-            {
-              "title": "InstanceAdminClient",
-              "type": "google/cloud/spanner/admin/instance/v1/instanceadminclient"
-            },
-            {
-              "title": "DatabaseAdminClient",
-              "type": "google/cloud/spanner/admin/database/v1/databaseadminclient"
-            },
-            {
-              "title": "Data Types",
-              "type": "google/spanner/v1/datatypes"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "title": "Speech",
       "type": "google/cloud/speech",
       "nav": [


### PR DESCRIPTION
Spanner was added prematurely to the meta package, and needs to be removed for now.

I have verified that after this change, there no occurrences of 'spanner' (case insensitive) in directory `google-cloud`, nor is it whitelisted in the `jsondoc:google_cloud` rake task.