### PR TITLE
Bigquery billing options

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -596,6 +596,15 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
+        # @param [Integer] maximum_billing_tier Limits the billing tier for this
+        #   job. Queries that have resource usage beyond this tier will fail
+        #   (without incurring a charge). Optional. If unspecified, this will be
+        #   set to your project default. For more information, see [High-Compute
+        #   queries](https://cloud.google.com/bigquery/pricing#high-compute).
+        # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
+        #   job. Queries that will have bytes billed beyond this limit will fail
+        #   (without incurring a charge). Optional. If unspecified, this will be
+        #   set to your project default.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -666,11 +675,14 @@ module Google
         #
         def query_job query, params: nil, priority: "INTERACTIVE", cache: true,
                       table: nil, create: nil, write: nil, standard_sql: nil,
-                      legacy_sql: nil, large_results: nil, flatten: nil
+                      legacy_sql: nil, large_results: nil, flatten: nil,
+                      maximum_billing_tier: nil, maximum_bytes_billed: nil
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
                       legacy_sql: legacy_sql, standard_sql: standard_sql,
+                      maximum_billing_tier: maximum_billing_tier,
+                      maximum_bytes_billed: maximum_bytes_billed,
                       params: params }
           options[:dataset] ||= self
           ensure_service!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -155,6 +155,8 @@ module Google
         #   * `append` - BigQuery appends the data to the table.
         #   * `empty` - A 'duplicate' error is returned in the job result if the
         #     table exists and contains data.
+        # @param [Dataset, String] dataset The default dataset to use for
+        #   unqualified table names in the query. Optional.
         # @param [Boolean] large_results If `true`, allows the query to produce
         #   arbitrarily large result tables at a slight cost in performance.
         #   Requires `table` parameter to be set.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -180,6 +180,15 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
+        # @param [Integer] maximum_billing_tier Limits the billing tier for this
+        #   job. Queries that have resource usage beyond this tier will fail
+        #   (without incurring a charge). Optional. If unspecified, this will be
+        #   set to your project default. For more information, see [High-Compute
+        #   queries](https://cloud.google.com/bigquery/pricing#high-compute).
+        # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
+        #   job. Queries that will have bytes billed beyond this limit will fail
+        #   (without incurring a charge). Optional. If unspecified, this will be
+        #   set to your project default.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -75,6 +75,22 @@ module Google
         end
 
         ##
+        # Limits the billing tier for this job.
+        # For more information, see [High-Compute
+        # queries](https://cloud.google.com/bigquery/pricing#high-compute).
+        def maximum_billing_tier
+          @gapi.configuration.query.maximum_billing_tier
+        end
+
+        ##
+        # Limits the bytes billed for this job.
+        def maximum_bytes_billed
+          Integer @gapi.configuration.query.maximum_bytes_billed
+        rescue
+          nil
+        end
+
+        ##
         # Checks if the query results are from the query cache.
         def cache_hit?
           @gapi.statistics.query.cache_hit

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -20,6 +20,10 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
+  let(:table_id) { "my_table" }
+  let(:table_gapi) { random_table_gapi dataset_id, table_id }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+                                                  bigquery.service }
 
   it "queries the data with default dataset option set" do
     mock = Minitest::Mock.new
@@ -33,6 +37,38 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
     job = dataset.query_job query
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with table options" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi(query)
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+      project_id: project,
+      dataset_id: dataset_id
+    )
+    job_gapi.configuration.query.destination_table = Google::Apis::BigqueryV2::TableReference.new(
+      project_id: project,
+      dataset_id: dataset_id,
+      table_id:   table_id
+    )
+    job_gapi.configuration.query.create_disposition = "CREATE_NEVER"
+    job_gapi.configuration.query.write_disposition = "WRITE_TRUNCATE"
+    job_gapi.configuration.query.allow_large_results = true
+    job_gapi.configuration.query.flatten_results = false
+    job_gapi.configuration.query.maximum_billing_tier = 2
+    job_gapi.configuration.query.maximum_bytes_billed = 12345678901234
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = dataset.query_job query, table: table,
+                            create: :never, write: :truncate,
+                            large_results: true, flatten: false,
+                            maximum_billing_tier: 2,
+                            maximum_bytes_billed: 12345678901234
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -67,11 +67,15 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job_gapi.configuration.query.write_disposition = "WRITE_TRUNCATE"
     job_gapi.configuration.query.allow_large_results = true
     job_gapi.configuration.query.flatten_results = false
+    job_gapi.configuration.query.maximum_billing_tier = 2
+    job_gapi.configuration.query.maximum_bytes_billed = 12345678901234
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
     job = bigquery.query_job query, table: table,
                                 create: :never, write: :truncate,
-                                large_results: true, flatten: false
+                                large_results: true, flatten: false,
+                                maximum_billing_tier: 2,
+                                maximum_bytes_billed: 12345678901234
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_query_results_test.rb
@@ -202,6 +202,8 @@ describe Google::Cloud::Bigquery::QueryJob, :query_results, :mock_bigquery do
       "useQueryCache" => true,
       "flattenResults" => true,
       "useLegacySql" => false,
+      "maximumBillingTier" => nil,
+      "maximumBytesBilled" => nil
     }
     hash
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -47,6 +47,8 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     job.must_be :flatten?
     job.wont_be :legacy_sql?
     job.must_be :standard_sql?
+    job.maximum_billing_tier.must_equal 2
+    job.maximum_bytes_billed.must_equal 12345678901234
   end
 
   it "knows its statistics data" do
@@ -85,7 +87,9 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
       "allowLargeResults" => true,
       "useQueryCache" => true,
       "flattenResults" => true,
-      "useLegacySql" => false
+      "useLegacySql" => false,
+      "maximumBillingTier" => 2,
+      "maximumBytesBilled" => 12345678901234 # Long
     }
     hash["statistics"]["query"] = {
       "cacheHit" => false,


### PR DESCRIPTION
Follow-up to #1432 adding docs, tests, and the new attributes where needed. Also adds missing docs for `dataset` option docs to `Project#query_job`.

[closes #1482]