### PR TITLE
Standardize Stackdriver instrumentation configuration story

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -399,19 +399,19 @@ namespace :jsondoc do
 
   desc "Generates the jsondoc for master branch for all gems, updates google-cloud with all gems' master branch, publishes."
   task :master do
-    unless ENV["GH_OAUTH_TOKEN"]
-      # only check this if we are not running on travis
-      branch = `git symbolic-ref --short HEAD`.chomp
-      if "master" != branch
-        puts "You are on the #{branch} branch. You must be on the master branch to run this rake task."
-        exit
-      end
-
-      unless `git status --porcelain`.chomp.empty?
-        puts "The master branch is not clean. Unable to update gh-pages."
-        exit
-      end
-    end
+    # unless ENV["GH_OAUTH_TOKEN"]
+    #   # only check this if we are not running on travis
+    #   branch = `git symbolic-ref --short HEAD`.chomp
+    #   if "master" != branch
+    #     puts "You are on the #{branch} branch. You must be on the master branch to run this rake task."
+    #     exit
+    #   end
+    #
+    #   unless `git status --porcelain`.chomp.empty?
+    #     puts "The master branch is not clean. Unable to update gh-pages."
+    #     exit
+    #   end
+    # end
 
     gh_pages_dir = "all-master-gh-pages"
 
@@ -424,7 +424,7 @@ namespace :jsondoc do
     end
     Rake::Task["jsondoc:google_cloud"].invoke("master", gh_pages_dir)
     Rake::Task["jsondoc:stackdriver"].invoke("master", gh_pages_dir)
-    Rake::Task["jsondoc:publish"].invoke("master", gh_pages_dir)
+    # Rake::Task["jsondoc:publish"].invoke("master", gh_pages_dir)
   end
 
   # Usage: rake jsondoc:package["google-cloud-vision/v0.21.1"]

--- a/Rakefile
+++ b/Rakefile
@@ -399,19 +399,19 @@ namespace :jsondoc do
 
   desc "Generates the jsondoc for master branch for all gems, updates google-cloud with all gems' master branch, publishes."
   task :master do
-    # unless ENV["GH_OAUTH_TOKEN"]
-    #   # only check this if we are not running on travis
-    #   branch = `git symbolic-ref --short HEAD`.chomp
-    #   if "master" != branch
-    #     puts "You are on the #{branch} branch. You must be on the master branch to run this rake task."
-    #     exit
-    #   end
-    #
-    #   unless `git status --porcelain`.chomp.empty?
-    #     puts "The master branch is not clean. Unable to update gh-pages."
-    #     exit
-    #   end
-    # end
+    unless ENV["GH_OAUTH_TOKEN"]
+      # only check this if we are not running on travis
+      branch = `git symbolic-ref --short HEAD`.chomp
+      if "master" != branch
+        puts "You are on the #{branch} branch. You must be on the master branch to run this rake task."
+        exit
+      end
+
+      unless `git status --porcelain`.chomp.empty?
+        puts "The master branch is not clean. Unable to update gh-pages."
+        exit
+      end
+    end
 
     gh_pages_dir = "all-master-gh-pages"
 
@@ -424,7 +424,7 @@ namespace :jsondoc do
     end
     Rake::Task["jsondoc:google_cloud"].invoke("master", gh_pages_dir)
     Rake::Task["jsondoc:stackdriver"].invoke("master", gh_pages_dir)
-    # Rake::Task["jsondoc:publish"].invoke("master", gh_pages_dir)
+    Rake::Task["jsondoc:publish"].invoke("master", gh_pages_dir)
   end
 
   # Usage: rake jsondoc:package["google-cloud-vision/v0.21.1"]

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
+gem "stackdriver-core", path: "../stackdriver-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"

--- a/google-cloud-debugger/docs/instrumentation.md
+++ b/google-cloud-debugger/docs/instrumentation.md
@@ -58,7 +58,7 @@ you want to run on a non Google Cloud environment or you want to customize
 the default behavior.
 
 See the
-[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
 for full configuration parameters.
 
 ### Using instrumentation with Ruby on Rails

--- a/google-cloud-debugger/docs/instrumentation.md
+++ b/google-cloud-debugger/docs/instrumentation.md
@@ -50,6 +50,17 @@ are finished being evaluated. Be aware the more breakpoints are created,
 or the harder to reach the breakpoints, the more resource the debugger
 agent would need to consume.
 
+### Configuration
+
+The default configuration enables Stackdriver instrumentation features to run on
+Google Cloud Platform. You can easily configure the instrumentation library if 
+you want to run on a non Google Cloud environment or you want to customize 
+the default behavior.
+
+See the
+[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+for full configuration parameters.
+
 ### Using instrumentation with Ruby on Rails
 
 To install application instrumentation in your Ruby on Rails app, add this
@@ -61,28 +72,7 @@ require "google/cloud/debugger/rails"
 ```
 
 This will load a Railtie that automatically integrates with the Rails
-framework by injecting a Rack middleware. The Railtie also takes in the
-following Rails configuration as parameter of the debugger agent
-initialization:
-
-```ruby
-# Explicitly enable or disable Stackdriver Debugger Agent
-config.google_cloud.use_debugger = true
-# Shared Google Cloud Platform project identifier
-config.google_cloud.project_id = "gcloud-project"
-# Google Cloud Platform project identifier for Stackdriver Debugger only
-config.google_cloud.debugger.project_id = "debugger-project"
-# Shared Google Cloud authentication json file
-config.google_cloud.keyfile = "/path/to/keyfile.json"
-# Google Cloud authentication json file for Stackdriver Debugger only
-config.google_cloud.debugger.keyfile = "/path/to/debugger/keyfile.json"
-# Stackdriver Debugger Agent module name identifier
-config.google_cloud.debugger.module_name = "my-ruby-app"
-# Stackdriver Debugger Agent module version identifier
-config.google_cloud.debugger.module_version = "v1"
-```
-
-See the Google::Cloud::Debugger::Railtie class for more information.
+framework by injecting a Rack middleware. 
 
 ### Using instrumentation with Sinatra
 
@@ -96,15 +86,6 @@ use Google::Cloud::Debugger::Middleware
 ```
 
 This will install the debugger middleware in your application.
-
-Configuration parameters may also be passed in as arguments to Middleware.
-```ruby
-require "google/cloud/debugger"
-use Google::Cloud::Debugger::Middleware project: "debugger-project-id",
-                                        keyfile: "/path/to/keyfile.json",
-                                        module_name: "my-ruby-app",
-                                        module_version: "v1"
-```
 
 ### Using instrumentation with other Rack-based frameworks
 

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "binding_of_caller", "~> 0.7"
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "google-gax", "~> 0.8.0"
+  gem.add_dependency "stackdriver-core", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -387,7 +387,7 @@ module Google
       # Configure the Stackdriver Debugger agent.
       #
       # See the [Configuration
-      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # for full configuration parameters.
       #
       # @return [Stackdriver::Core::Configuration] The configuration object

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -15,6 +15,7 @@
 
 require "google-cloud-debugger"
 require "google/cloud/debugger/project"
+require "stackdriver/core"
 
 module Google
   module Cloud
@@ -319,6 +320,12 @@ module Google
     # See {Google::Cloud::Debugger::V2::Debugger2Client} for details.
     #
     module Debugger
+      # Initialize :error_reporting as a nested Configuration under
+      # Google::Cloud if haven't already
+      unless Google::Cloud.configure.option? :debugger
+        Google::Cloud.configure.add_nested :debugger
+      end
+
       ##
       # Creates a new debugger object for instrumenting Stackdriver Debugger for
       # an application. Each call creates a new debugger agent with independent
@@ -373,6 +380,25 @@ module Google
           module_name: module_name,
           module_version: module_version
         )
+      end
+
+
+      ##
+      # Configure the Stackdriver Debugger agent.
+      #
+      # Possible configuration parameters:
+      #   * `project_id`: The Google Cloud Project ID. Automatically discovered
+      #                   when running from GCP environments.
+      #   * `keyfile`: The service account JSON file path. Automatically
+      #                discovered when running from GCP environments.
+      #
+      # @return [Stackdriver::Core::Configuration] The configuration object
+      #   the Google::Cloud::ErrorReporting module uses.
+      #
+      def self.configure
+        yield Google::Cloud.configure.debugger if block_given?
+
+        Google::Cloud.configure.debugger
       end
     end
   end

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -386,11 +386,9 @@ module Google
       ##
       # Configure the Stackdriver Debugger agent.
       #
-      # Possible configuration parameters:
-      #   * `project_id`: The Google Cloud Project ID. Automatically discovered
-      #                   when running from GCP environments.
-      #   * `keyfile`: The service account JSON file path. Automatically
-      #                discovered when running from GCP environments.
+      # See the [Configuration
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # for full configuration parameters.
       #
       # @return [Stackdriver::Core::Configuration] The configuration object
       #   the Google::Cloud::ErrorReporting module uses.

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -323,7 +323,7 @@ module Google
       # Initialize :error_reporting as a nested Configuration under
       # Google::Cloud if haven't already
       unless Google::Cloud.configure.option? :debugger
-        Google::Cloud.configure.add_nested :debugger
+        Google::Cloud.configure.add_options :debugger
       end
 
       ##

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -29,22 +29,22 @@ module Google
         # @param [Google::Cloud::Debugger::Project] debugger A debugger to be
         #   used by this middleware. If not given, will construct a new one
         #   using the other parameters.
-        # @param [String] project_id Project identifier for the Stackdriver
-        #   Debugger service. Optional if a debugger is given.
-        # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud:
-        #   either the JSON data or the path to a readable file. Optional if
-        #   a debugger is given.
+        # @param [Hash] *kwargs Hash of configuration settings. Used for
+        #   backward API compatibility reason. See the [Configuration
+        #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
+        #   for the prefered way to set configuration parameters.
         #
         # @return [Google::Cloud::Debugger::Middleware] A new
         #   Google::Cloud::Debugger::Middleware instance
         #
-        def initialize app, debugger: nil, project_id: nil, keyfile: nil
+        def initialize app, debugger: nil, **kwargs
           @app = app
-          load_config project_id: project_id, keyfile: keyfile
+
+          load_config kwargs
 
           @debugger = debugger ||
-                      Debugger.new(project: @project_id,
-                                   keyfile: @keyfile,
+                      Debugger.new(project: configuration.project_id,
+                                   keyfile: configuration.keyfile,
                                    module_name: configuration.module_name,
                                    module_version: configuration.module_version)
           # Immediately start the debugger agent
@@ -78,22 +78,30 @@ module Google
         # instrumentation config parameters to default values if not set
         # already.
         #
-        def load_config project_id: nil, keyfile: nil
-          @project_id = project_id ||
-                        configuration.project_id ||
-                        Cloud.configure.project_id ||
-                        Debugger::Project.default_project
-          @keyfile = keyfile || configuration.keyfile || Cloud.configure.keyfile
+        def load_config **kwargs
+          configuration.project_id = kwargs[:project_id] ||
+                                     configuration.project_id
+          configuration.keyfile = kwargs[:keyfile] ||
+                                  configuration.keyfile
 
-          # Set defaults
-          configuration.module_name ||=
-            Debugger::Project.default_module_name
+          configuration.module_name = kwargs[:module_name] ||
+                                      configuration.module_name
+          configuration.module_version = kwargs[:module_version] ||
+                                         configuration.module_version
+
+          init_default_config
+        end
+
+        ##
+        # Fallback to default configuration values if not defined already
+        def init_default_config
+          configuration.project_id ||= Cloud.configure.project_id ||
+                                       Debugger::Project.default_project
+          configuration.keyfile ||= Cloud.configure.keyfile
+
+          configuration.module_name ||= Debugger::Project.default_module_name
           configuration.module_version ||=
             Debugger::Project.default_module_version
-
-          # Ensure instrumentation configurations are aligned
-          configuration.project_id = @project_id
-          configuration.keyfile = @keyfile
         end
 
         ##

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -79,7 +79,8 @@ module Google
         # already.
         #
         def load_config **kwargs
-          configuration.project_id = kwargs[:project_id] ||
+          configuration.project_id = kwargs[:project] ||
+                                     kwargs[:project_id] ||
                                      configuration.project_id
           configuration.keyfile = kwargs[:keyfile] ||
                                   configuration.keyfile

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -30,7 +30,7 @@ module Google
         #   used by this middleware. If not given, will construct a new one
         #   using the other parameters.
         # @param [Hash] *kwargs Hash of configuration settings. Used for
-        #   backward API compatibility reason. See the [Configuration
+        #   backward API compatibility. See the [Configuration
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
         #   for the prefered way to set configuration parameters.
         #

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -29,26 +29,25 @@ module Google
         # @param [Google::Cloud::Debugger::Project] debugger A debugger to be
         #   used by this middleware. If not given, will construct a new one
         #   using the other parameters.
-        # @param [String] project Project identifier for the Stackdriver
+        # @param [String] project_id Project identifier for the Stackdriver
         #   Debugger service. Optional if a debugger is given.
         # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud:
         #   either the JSON data or the path to a readable file. Optional if
         #   a debugger is given.
-        # @param [String] module_name Name for the debuggee application.
-        #   Optional if a debugger is given.
-        # @param [String] module_version Version identifier for the debuggee
-        #   application. Optiona if a debugger is given.
         #
         # @return [Google::Cloud::Debugger::Middleware] A new
         #   Google::Cloud::Debugger::Middleware instance
         #
-        def initialize app, debugger: nil, module_name:nil, module_version: nil,
-                       project: nil, keyfile: nil
+        def initialize app, debugger: nil, project_id: nil, keyfile: nil
           @app = app
-          @debugger = debugger || Debugger.new(project: project,
-                                               keyfile: keyfile,
-                                               module_name: module_name,
-                                               module_version: module_version)
+          load_config project_id: project_id, keyfile: keyfile
+
+          @debugger = debugger ||
+                      Debugger.new(project: @project_id,
+                                   keyfile: @keyfile,
+                                   module_name: configuration.module_name,
+                                   module_version: configuration.module_version)
+          # Immediately start the debugger agent
           @debugger.start
         end
 
@@ -70,6 +69,37 @@ module Google
         ensure
           # Stop breakpoints tracing beyond this point
           @debugger.agent.tracer.disable_traces_for_thread
+        end
+
+        private
+
+        ##
+        # Consolidate configurations from various sources. Also set
+        # instrumentation config parameters to default values if not set
+        # already.
+        #
+        def load_config project_id: nil, keyfile: nil
+          @project_id = project_id ||
+                        configuration.project_id ||
+                        Cloud.configure.project_id ||
+                        Debugger::Project.default_project
+          @keyfile = keyfile || configuration.keyfile || Cloud.configure.keyfile
+
+          # Set defaults
+          configuration.module_name ||=
+            Debugger::Project.default_module_name
+          configuration.module_version ||=
+            Debugger::Project.default_module_version
+
+          # Ensure instrumentation configurations are aligned
+          configuration.project_id = @project_id
+          configuration.keyfile = @keyfile
+        end
+
+        ##
+        # @private Get Google::Cloud::Debugger.configure
+        def configuration
+          Google::Cloud::Debugger.configure
         end
       end
     end

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -31,23 +31,9 @@ module Google
       # to the application code.
       #
       # The Railtie should also initialize a debugger to be used by the
-      # middleware. The debugger can be configured using the following Rails
-      # configuration:
-      # @example
-      #   # Explicitly enable or disable Stackdriver Debugger Agent
-      #   config.google_cloud.use_debugger = true
-      #   # Shared Google Cloud Platform project identifier
-      #   config.google_cloud.project_id = "gcloud-project"
-      #   # Google Cloud Platform project identifier for Stackdriver Debugger
-      #   config.google_cloud.debugger.project_id = "debugger-project"
-      #   # Share Google Cloud authentication json file
-      #   config.google_cloud.keyfile = "/path/to/keyfile.json"
-      #   # Google Cloud authentication json file for Stackdriver Debugger only
-      #   config.google_cloud.debugger.keyfile = "/path/to/keyfile.json"
-      #   # Stackdriver Debugger Agent module name identifier
-      #   config.google_cloud.debugger.module_name = "my-ruby-app"
-      #   # Stackdriver Debugger Agent module version identifier
-      #   config.google_cloud.debugger.module_version = "v1"
+      # Middleware. See the [Configuration
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # on how to configure the Railtie and Middleware.
       #
       class Railtie < ::Rails::Railtie
         config.google_cloud = ::ActiveSupport::OrderedOptions.new unless
@@ -84,12 +70,7 @@ module Google
         def self.consolidate_rails_config config
           merge_rails_config config
 
-          Debugger.configure.project_id ||= Debugger::Project.default_project
-          Debugger.configure.module_name ||=
-            Debugger::Project.default_module_name
-          Debugger.configure.module_version ||=
-            Debugger::Project.default_module_version
-
+          init_default_config
 
           # Done if Google::Cloud.configure.use_debugger is explicitly
           # false
@@ -125,6 +106,15 @@ module Google
         end
 
         ##
+        # Fallback to default config values if config parameters not provided.
+        def self.init_default_config
+          config = Debugger.configure
+          config.project_id ||= Debugger::Project.default_project
+          config.module_name ||= Debugger::Project.default_module_name
+          config.module_version ||= Debugger::Project.default_module_version
+        end
+
+        ##
         # @private Verify credentials
         def self.valid_credentials? project_id, keyfile
           begin
@@ -145,6 +135,7 @@ module Google
         end
 
         private_class_method :merge_rails_config,
+                             :init_default_config,
                              :valid_credentials?
       end
     end

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -58,84 +58,94 @@ module Google
         end
 
         initializer "Stackdriver.Debugger" do |app|
-          if self.class.use_debugger? app.config
-            debugger_config = Railtie.parse_rails_config config
+          self.class.consolidate_rails_config app.config
 
-            project_id = debugger_config[:project_id]
-            keyfile = debugger_config[:keyfile]
-            module_name = debugger_config[:module_name]
-            module_version = debugger_config[:module_version]
-
-            debugger =
-              Google::Cloud::Debugger.new project: project_id,
-                                          keyfile: keyfile,
-                                          module_name: module_name,
-                                          module_version: module_version
-
-            app.middleware.insert_after Rack::ETag,
-                                        Google::Cloud::Debugger::Middleware,
-                                        debugger: debugger
-          end
+          self.class.init_middleware app if Cloud.configure.use_debugger
         end
 
         ##
-        # Determine whether to use Stackdriver Debugger or not.
-        #
-        # Returns true if valid GCP project_id is provided and underneath API is
-        # able to authenticate. Also either Rails needs to be in "production"
-        # environment or config.stackdriver.use_debugger is explicitly true.
+        # @private Init Debugger integration for Rails. Setup configuration and
+        # insert the Middleware.
+        def self.init_middleware app
+          app.middleware.insert_after Rack::ETag,
+                                      Google::Cloud::Debugger::Middleware
+        end
+
+        ##
+        # @private Consolidate Rails configuration into Debugger instrumentation
+        # configuration. Also consolidate the `use_debugger` setting by
+        # verifying credentials and Rails environment. The `use_debugger`
+        # setting will be true if credentials are valid, and the setting is
+        # manually set to true or Rails is in production environment.
         #
         # @param [Rails::Railtie::Configuration] config The
         #   Rails.application.config
         #
-        # @return [Boolean] Whether to use Stackdriver Debugger
-        #
-        def self.use_debugger? config
-          debugger_config = parse_rails_config config
+        def self.consolidate_rails_config config
+          merge_rails_config config
 
-          # Return false if config.stackdriver.use_debugger is explicitly false
-          use_debugger = debugger_config[:use_debugger]
-          return false if !use_debugger.nil? && !use_debugger
+          Debugger.configure.project_id ||= Debugger::Project.default_project
+          Debugger.configure.module_name ||=
+            Debugger::Project.default_module_name
+          Debugger.configure.module_version ||=
+            Debugger::Project.default_module_version
 
-          # Try authenticate authorize client API. Return false if unable to
-          # authorize.
+
+          # Done if Google::Cloud.configure.use_debugger is explicitly
+          # false
+          return if Google::Cloud.configure.use_debugger == false
+
+          # Verify credentials and set use_debugger to false if
+          # credentials are invalid
+          unless valid_credentials? Debugger.configure.project_id,
+                                    Debugger.configure.keyfile
+            Cloud.configure.use_debugger = false
+            return
+          end
+
+          # Otherwise set use_debugger to true if Rails is running in
+          # production
+          Google::Cloud.configure.use_debugger ||= Rails.env.production?
+        end
+
+        ##
+        # @private Merge Rails configuration into Debugger instrumentation
+        # configuration.
+        def self.merge_rails_config rails_config
+          gcp_config = rails_config.google_cloud
+          dbg_config = gcp_config.debugger
+
+          Cloud.configure.use_debugger ||= gcp_config.use_debugger
+          Debugger.configure do |config|
+            config.project_id ||= dbg_config.project_id || gcp_config.project_id
+            config.keyfile ||= dbg_config.keyfile || gcp_config.keyfile
+            config.module_name ||= dbg_config.module_name
+            config.module_version ||= dbg_config.module_version
+          end
+        end
+
+        ##
+        # @private Verify credentials
+        def self.valid_credentials? project_id, keyfile
           begin
-            Google::Cloud::Debugger::Credentials.credentials_with_scope(
-              debugger_config[:keyfile])
+            Debugger::Credentials.credentials_with_scope keyfile
           rescue => e
             STDOUT.puts "Note: Google::Cloud::Debugger is disabled because " \
               "it failed to authorize with the service. (#{e.message})"
             return false
           end
 
-          project_id = debugger_config[:project_id] ||
-                       Google::Cloud::Debugger::Project.default_project
           if project_id.to_s.empty?
             STDOUT.puts "Note: Google::Cloud::Debugger is disabled because " \
               "the project ID could not be determined."
             return false
           end
 
-          # Otherwise default to true if Rails is running in production or
-          # config.stackdriver.use_debugger is true
-          Rails.env.production? || use_debugger
+          true
         end
 
-        ##
-        # @private Helper method to parse rails config into a flattened hash
-        def self.parse_rails_config config
-          gcp_config = config.google_cloud
-          debugger_config = gcp_config[:debugger]
-          use_debugger =
-            gcp_config.key?(:use_debugger) ? gcp_config.use_debugger : nil
-          {
-            project_id: debugger_config.project_id || gcp_config.project_id,
-            keyfile: debugger_config.keyfile || gcp_config.keyfile,
-            module_name: debugger_config.module_name,
-            module_version: debugger_config.module_version,
-            use_debugger: use_debugger
-          }
-        end
+        private_class_method :merge_rails_config,
+                             :valid_credentials?
       end
     end
   end

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -32,7 +32,7 @@ module Google
       #
       # The Railtie should also initialize a debugger to be used by the
       # Middleware. See the [Configuration
-      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # on how to configure the Railtie and Middleware.
       #
       class Railtie < ::Rails::Railtie

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
@@ -124,6 +124,8 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "allows .at" do
+      skip if RUBY_VERSION.to_f < 2.4
+
       expression_must_be_kind_of "Time.at 0", Time
     end
   end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
@@ -338,13 +338,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     it "doesn't allow #`" do
       result = evaluator.readonly_eval_expression binding, "`ls`"
 
-      # ActiveSupport overloads Kernel, injects additional code into the
-      # execution path
-      if defined? Rails
-        result.must_match "Mutation detected"
-      else
-        result.must_match "Invalid operation detected"
-      end
+      result.must_match "Invalid operation detected"
     end
 
     it "doesn't allow #eval" do

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
@@ -338,7 +338,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     it "doesn't allow #`" do
       result = evaluator.readonly_eval_expression binding, "`ls`"
 
-      result.match?("Mutation detected|Invalid operation detected").must_equal true
+      result.match("Mutation detected|Invalid operation detected").wont_be_nil
     end
 
     it "doesn't allow #eval" do

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
@@ -338,7 +338,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     it "doesn't allow #`" do
       result = evaluator.readonly_eval_expression binding, "`ls`"
 
-      result.must_match "Invalid operation detected"
+      result.match?("Mutation detected|Invalid operation detected").must_equal true
     end
 
     it "doesn't allow #eval" do

--- a/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
@@ -25,6 +25,11 @@ describe Google::Cloud::Debugger::Middleware, :mock_debugger do
     Google::Cloud::Debugger::Middleware.new rack_app, debugger: debugger
   }
 
+  after {
+    Google::Cloud::Debugger.configure.instance_variable_get(:@configs).clear
+    Google::Cloud.configure.delete :use_debugger
+  }
+
   describe "#call" do
     it "calls Tracer#start and Tracer#disable_traces_for_thread for each request" do
       mocked_tracer = Minitest::Mock.new

--- a/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
@@ -1,0 +1,103 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "rails"
+require "rails/railtie"
+require "active_support/ordered_options"
+require "google/cloud/debugger/rails"
+
+describe Google::Cloud::Debugger::Railtie do
+  let(:rails_config) do
+    config = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud.debugger = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud.project_id = "test-project"
+    config.google_cloud.keyfile = "test/keyfile"
+    config.google_cloud.debugger.module_name = "test-module"
+    config.google_cloud.debugger.module_version = "test-version"
+    config
+  end
+
+  after {
+    Google::Cloud::Debugger.configure.clear
+    Google::Cloud.configure.delete :use_debugger
+  }
+
+  describe ".consolidate_rails_config" do
+    it "merges configs from Rails configuration" do
+      STDOUT.stub :puts, nil do
+        Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
+
+        Google::Cloud::Debugger.configure do |config|
+          config.project_id.must_equal "test-project"
+          config.keyfile.must_equal "test/keyfile"
+          config.module_name.must_equal "test-module"
+          config.module_version.must_equal "test-version"
+        end
+      end
+    end
+
+    it "doesn't override instrumentation configs" do
+      Google::Cloud::Debugger.configure do |config|
+        config.project_id = "another-test-project"
+        config.keyfile = "/another/test/keyfile"
+        config.module_name = "another-test-module"
+        config.module_version = "another-test-version"
+      end
+
+      STDOUT.stub :puts, nil do
+        Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
+
+        Google::Cloud::Debugger.configure do |config|
+          config.project_id.must_equal "another-test-project"
+          config.keyfile.must_equal "/another/test/keyfile"
+          config.module_name.must_equal "another-test-module"
+          config.module_version.must_equal "another-test-version"
+        end
+      end
+    end
+
+    it "Set use_debugger to false if credentials aren't valid" do
+      Google::Cloud.configure.use_debugger = true
+
+      Google::Cloud::Debugger::Railtie.stub :valid_credentials?, false do
+        Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
+        Google::Cloud.configure.use_debugger.must_equal false
+      end
+    end
+
+    it "Set use_debugger to true if Rails is in production" do
+      Google::Cloud::Debugger::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, true do
+          Google::Cloud.configure.use_debugger.must_be_nil
+          Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_debugger.must_equal true
+        end
+      end
+    end
+
+    it "returns true if use_debugger is explicitly true even Rails is not in production" do
+      rails_config.google_cloud.use_debugger = true
+
+      Google::Cloud::Debugger::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, false do
+          Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_debugger.must_equal true
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
@@ -31,6 +31,11 @@ describe Google::Cloud::Debugger::Railtie do
     config
   end
 
+  before {
+    Google::Cloud::Debugger.configure.clear
+    Google::Cloud.configure.delete :use_debugger
+  }
+
   after {
     Google::Cloud::Debugger.configure.clear
     Google::Cloud.configure.delete :use_debugger

--- a/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
@@ -31,13 +31,8 @@ describe Google::Cloud::Debugger::Railtie do
     config
   end
 
-  before {
-    Google::Cloud::Debugger.configure.clear
-    Google::Cloud.configure.delete :use_debugger
-  }
-
   after {
-    Google::Cloud::Debugger.configure.clear
+    Google::Cloud::Debugger.configure.instance_variable_get(:@configs).clear
     Google::Cloud.configure.delete :use_debugger
   }
 

--- a/google-cloud-debugger/test/google/cloud/debugger_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger_test.rb
@@ -137,6 +137,16 @@ describe Google::Cloud do
     end
   end
 
+  describe ".configure" do
+    it "has Google::Cloud.configure.debugger initialized already" do
+      Google::Cloud.configure.option?(:debugger).must_equal true
+    end
+
+    it "operates on the same Configuration object as Google::Cloud.configure.debugger" do
+      Google::Cloud::Debugger.configure.must_equal Google::Cloud.configure.debugger
+    end
+  end
+
   describe "Debugger.new" do
     let(:default_credentials) { OpenStruct.new empty: true }
     let(:default_module_name) { "default-utest-service" }

--- a/google-cloud-error_reporting/.rubocop.yml
+++ b/google-cloud-error_reporting/.rubocop.yml
@@ -36,7 +36,7 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 10
 Metrics/AbcSize:
-  Max: 20
+  Max: 25
 Metrics/MethodLength:
   Max: 20
   Exclude:

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -59,7 +59,7 @@ namespace :integration do
   desc "Run integration tests against GAE"
   task :gae, :project_uri do |t, args|
     fail "You must provide a project_uri. e.g. rake " \
-      "integration:gae[http://my-project.appspot.com]" if args[:project_uri].nil?
+      "integration:gae[http://my-project.appspot-preview.com]" if args[:project_uri].nil?
 
     ENV["TEST_GOOGLE_CLOUD_PROJECT_URI"] = args[:project_uri]
 

--- a/google-cloud-error_reporting/docs/instrumentation.md
+++ b/google-cloud-error_reporting/docs/instrumentation.md
@@ -26,7 +26,7 @@ if you want to run on a non Google Cloud environment or you want to customize
 the default behavior.
 
 See the 
-[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
 for full configuration parameters.
 
 ## Rack Middleware and Railtie

--- a/google-cloud-error_reporting/docs/instrumentation.md
+++ b/google-cloud-error_reporting/docs/instrumentation.md
@@ -3,12 +3,6 @@
 The google-cloud-error_reporting gem provides framework instrumentation features
 to make it easy to report exceptions from your application.
 
-## Installation
-
-```
-$ gem install google-cloud-error_reporting
-```
-
 ## Quick Start
 
 ```ruby
@@ -26,56 +20,14 @@ end
 ```
 
 ## Configuration
-The default configuration enables Stackdriver instrumentation features for most 
-applications running on Google Cloud Platform. If you want to run on a non 
-Google Cloud environment or you want to customize the instrumentation behavior,
-you can modify the Stackdriver configuration through a single interface:
+The default configuration enables Stackdriver instrumentation features to run
+on Google Cloud Platform. You can easily configure the instrumentation library 
+if you want to run on a non Google Cloud environment or you want to customize 
+the default behavior.
 
-```ruby
-require "google/cloud/error_reporting"
- 
-Google::Cloud.configure do |config|
-  # Sharing authentication parameters
-  config.project_id = "my-project"
-  config.keyfile    = "/path/to/keyfile.json"
-  # Or more specificly for ErrorReporting
-  config.error_reporting.project_id = "my-error_reporting-project"
-  config.error_reporting.keyfile    = "/path/error_reporting/keyfile.json"
-  
-  # Explicitly enable or disable ErrorReporting
-  config.use_error_reporting = true
- 
-  # Set Stackdriver Error Reporting service context
-  config.error_reporting.service_name = "my-app-name"
-  config.error_reporting.service_version = "my-app-version"
-end
-```
-
-Configuration specific to Stackdriver Error Reporting can also be
-configured through its own interface:
-
-```ruby
-require "google/cloud/error_reporting"
- 
-# These two blocks code are functionally identical
-Google::Cloud::ErrorReporting do |config|
-  config.project_id      = "my-project"
-  config.keyfile         = "/path/to/keyfile.json"
-  config.service_name    = "my-app-name"
-  config.service_version = "my-app-version"
-end
- 
-Google::Cloud.configure do |config|
-  config.error_reporting.project_id      = "my-project"
-  config.error_reporting.keyfile         = "/path/to/keyfile.json"
-  config.error_reporting.service_name    = "my-app-name"
-  config.error_reporting.service_version = "my-app-version"
-end
-```
-
-These configuration parameters will be applied to both of the 
-`Google::Cloud::ErrorReporting::Middleware` and the 
-`Google::Cloud::ErrorReporting.report` interface.
+See the 
+[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+for full configuration parameters.
 
 ## Rack Middleware and Railtie
 The google-cloud-error_reporting gem provides a Rack Middleware class that can 
@@ -93,29 +45,6 @@ simply add this line to config/application.rb:
 
 ```ruby
 require "google/cloud/error_reporting/rails"
-```
-
-Then the instrumentation library can also be configured using Rails 
-configuration interface:
-
-```ruby
-# In config/environments/*.rb
- 
-Rails.application.configure do
-    # Sharing authentication parameters
-    config.google_cloud.project_id = "gcp-project-id"
-    config.google_cloud.keyfile = "/path/to/gcp/secret.json"
-    # Or more specificly for ErrorReporting
-    config.google_cloud.error_reporting.project_id = "gcp-project-id"
-    config.google_cloud.error_reporting.keyfile = "/path/to/gcp/sercret.json"
-     
-    # Explicitly enable or disable ErrorReporting
-    config.google_cloud.use_error_reporting = true
-     
-    # Set Stackdriver Error Reporting service context
-    config.google_cloud.error_reporting.service_name = "my-app-name"
-    config.google_cloud.error_reporting.service_version = "my-app-version"
-end
 ```
 
 Alternatively, check out the 

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -137,20 +137,9 @@ module Google
       # client, allows the {.report} public method to reuse these
       # configured parameters.
       #
-      # Possible configuration parameters:
-      #   * `project_id`: The Google Cloud Project ID. Automatically discovered
-      #                   when running from GCP environments.
-      #   * `keyfile`: The service account JSON file path. Automatically
-      #                discovered when running from GCP environments.
-      #   * `service_name`: An identifier for the running service. Optional,
-      #                     automatically discovered when running from Google
-      #                     App Engine Flex. Otherwise default to "ruby".
-      #   * `service_version`: A version identifier for the running service.
-      #                        Optional, automatically discovered when running
-      #                        from Google App Engine Flex.
-      #
-      # Note the project_id and keyfile configuration changes won't be picked up
-      # after the first {.report} call.
+      # See the [Configuration
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # for full configuration parameters.
       #
       # @example
       #   # in app.rb

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -74,7 +74,7 @@ module Google
       # Initialize :error_reporting as a nested Configuration under
       # Google::Cloud if haven't already
       unless Google::Cloud.configure.option? :error_reporting
-        Google::Cloud.configure.add_nested :error_reporting
+        Google::Cloud.configure.add_options :error_reporting
       end
 
       ##

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -138,7 +138,7 @@ module Google
       # configured parameters.
       #
       # See the [Configuration
-      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # for full configuration parameters.
       #
       # @example

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -71,19 +71,10 @@ module Google
     # for more examples.
     #
     module ErrorReporting
-      ##
-      # @private Instrumentation library configuration options
-      CONFIG_OPTIONS = %I{
-        project_id
-        keyfile
-        service_name
-        service_version
-      }
-
       # Initialize :error_reporting as a nested Configuration under
       # Google::Cloud if haven't already
       unless Google::Cloud.configure.option? :error_reporting
-        Google::Cloud.configure.add_options error_reporting: CONFIG_OPTIONS
+        Google::Cloud.configure.add_nested :error_reporting
       end
 
       ##

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -190,8 +190,8 @@ module Google
         # Sync Middleware configuration parameters from multiple sources. The
         # sources take precedence in following order: explicit parameters,
         # Google::Cloud::ErrorReporting.configure, Google::Cloud.configure,
-        # then Google::Cloud::ErrorReporting::Project#defaults. This methods
-        # sets final parameters as Middleware instance varaibles, then set
+        # then Google::Cloud::ErrorReporting::Project#defaults. This method
+        # sets final parameters as Middleware instance varaibles, then sets
         # the same parameters back into Google::Cloud::ErrorReporting, to ensure
         # the Middleware and the simple API configuration are consistent.
         #

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -58,8 +58,7 @@ module Google
           require "rack"
           require "rack/request"
           @app = app
-          load_config project_id: project_id,
-                      keyfile: keyfile
+          load_config project_id: project_id, keyfile: keyfile
 
           @error_reporting = error_reporting ||
                              ErrorReporting.new(project: @project_id,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -36,7 +36,7 @@ module Google
         #   Google::Cloud::ErrorReporting::Project client for reporting
         #   exceptions
         # @param [Hash] *kwargs Hash of configuration settings. Used for
-        #   backward API compatibility reason. See the [Configuration
+        #   backward API compatibility. See the [Configuration
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
         #   for the prefered way to set configuration parameters.
         #

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -60,7 +60,6 @@ module Google
           @app = app
           load_config project_id: project_id,
                       keyfile: keyfile
-          fail ArgumentError, "project_id is required" if @project_id.nil?
 
           @error_reporting = error_reporting ||
                              ErrorReporting.new(project: @project_id,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -168,15 +168,21 @@ module Google
           @keyfile = keyfile || configuration.keyfile || Cloud.configure.keyfile
 
           # Set defaults
+          init_default_config
+
+          # Ensure instrumentation configurations are aligned
+          configuration.project_id = @project_id
+          configuration.keyfile = @keyfile
+        end
+
+        ##
+        # Fallback to default configuration values if not defined already
+        def init_default_config
           configuration.service_name ||=
             ErrorReporting::Project.default_service_name
           configuration.service_version ||=
             ErrorReporting::Project.default_service_version
           configuration.ignore_classes = Array(configuration.ignore_classes)
-
-          # Ensure instrumentation configurations are aligned
-          configuration.project_id = @project_id
-          configuration.keyfile = @keyfile
         end
 
         ##

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -44,6 +44,8 @@ module Google
       #   config.google_cloud.error_reporting.keyfile = "/path/to/secret.json"
       #   config.google_cloud.error_reporting.service_name = "my-service-name"
       #   config.google_cloud.error_reporting.service_version = "v1"
+      #   config.google_cloud.error_reporting.ignore_classes =
+      #     [ActiveRecord::Exception]
       #
       class Railtie < ::Rails::Railtie
         config.google_cloud = ActiveSupport::OrderedOptions.new unless
@@ -51,70 +53,95 @@ module Google
         config.google_cloud.error_reporting = ActiveSupport::OrderedOptions.new
 
         initializer "Google.Cloud.ErrorReporting" do |app|
-          use_error_reporting = self.class.use_error_reporting? app.config
-          if use_error_reporting
-            er_config = Railtie.parse_rails_config app.config
+          consolidate_rails_config app.config
 
-            project_id = er_config[:project_id]
-            keyfile = er_config[:keyfile]
-            service_name = er_config[:service_name]
-            service_version = er_config[:service_version]
-
-            # In later versions of Rails, ActionDispatch::DebugExceptions is
-            # responsible for catching exceptions. But it didn't exist until
-            # Rails 3.2. So we use ShowExceptions as pivot for earlier Rails.
-            rails_exception_middleware =
-              if defined? ::ActionDispatch::DebugExceptions
-                ::ActionDispatch::DebugExceptions
-              else
-                ::ActionDispatch::ShowExceptions
-              end
-
-            error_reporting = ErrorReporting.new project: project_id,
-                                                 keyfile: keyfile
-
-            app.middleware.insert_after rails_exception_middleware,
-                                        Middleware,
-                                        project_id: project_id,
-                                        keyfile: keyfile,
-                                        error_reporting: error_reporting,
-                                        service_name: service_name,
-                                        service_version: service_version
-          end
-
-          Google::Cloud.configure.use_error_reporting = use_error_reporting
+          self.class.init_middleware app if Cloud.configure.use_error_reporting
         end
 
         ##
-        # Determine whether to use Stackdriver Error Reporting or not.
-        #
-        # Returns true if valid GCP project_id and keyfile are provided and
-        # either Rails is in "production" environment or \
-        # config.google_cloud.use_error_reporting is explicitly true. Otherwise
-        # false.
+        # @private Init Error Reporting integration for Rails. Setup
+        # configuration and insert the Middleware.
+        def self.init_middleware app
+          project_id = ErrorReporting.configure.project_id
+          keyfile = ErrorReporting.configure.keyfile
+
+          # In later versions of Rails, ActionDispatch::DebugExceptions is
+          # responsible for catching exceptions. But it didn't exist until
+          # Rails 3.2. So we use ShowExceptions as pivot for earlier Rails.
+          rails_exception_middleware =
+            if defined? ::ActionDispatch::DebugExceptions
+              ::ActionDispatch::DebugExceptions
+            else
+              ::ActionDispatch::ShowExceptions
+            end
+
+          error_reporting = ErrorReporting.new project: project_id,
+                                               keyfile: keyfile
+
+          app.middleware.insert_after rails_exception_middleware,
+                                      Middleware,
+                                      project_id: project_id,
+                                      keyfile: keyfile,
+                                      error_reporting: error_reporting
+        end
+
+        ##
+        # @private Consolidate Rails configuration into Error Reporting
+        # instrumentation configuration. Also consolidate the
+        # `use_error_reporting` setting by verifying credentials and Rails
+        # environment. The `use_error_reporting` setting will be true if
+        # credentials are valid, and the setting is manually set to true or
+        # Rails is in production environment.
         #
         # @param [Rails::Railtie::Configuration] config The
         #   Rails.application.config
         #
-        # @return [Boolean] Whether to use Stackdriver Error Reporting
-        #
-        def self.use_error_reporting? config
-          er_config = Railtie.parse_rails_config config
+        def self.consolidate_rails_config config
+          merge_rails_config config
 
-          # Return false if config.google_cloud.use_error_reporting is
-          # explicitly false
-          use_error_reporting = er_config[:use_error_reporting]
-          return false if use_error_reporting == false
+          ErrorReporting.configure.project_id ||=
+            ErrorReporting::Project.default_project
 
-          project_id = er_config[:project_id] ||
-                       ErrorReporting::Project.default_project
-          keyfile = er_config[:keyfile]
+          # Done if Google::Cloud.configure.use_error_reporting is explicitly
+          # false
+          return if Google::Cloud.configure.use_error_reporting == false
 
-          # Check credentialing. Returns false if authorization errors are
-          # rescued.
+          # Verify credentials and set use_error_reporting to false if
+          # credentials are invalid
+          unless valid_credentials? ErrorReporting.configure.project_id,
+                                    ErrorReporting.configure.keyfile
+            Cloud.configure.use_error_reporting = false
+            return
+          end
+
+          # Otherwise set use_error_reporting to true if Rails is running in
+          # production
+          Google::Cloud.configure.use_error_reporting ||= Rails.env.production?
+        end
+
+        ##
+        # @private Merge Rails configuration into Error Reporting
+        # instrumentation configuration.
+        def self.merge_rails_config rails_config
+          gcp_config = rails_config.google_cloud
+          er_config = gcp_config.error_reporting
+
+          Cloud.configure.use_error_reporting ||= gcp_config.use_error_reporting
+          ErrorReporting.configure do |config|
+            config.project_id ||= er_config.project_id || gcp_config.project_id
+            config.keyfile ||= er_config.keyfile || gcp_config.keyfile
+            config.service_name ||= er_config.service_name
+            config.service_version ||= er_config.service_version
+            config.ignore_classes ||= er_config.ignore_classes
+          end
+        end
+
+        ##
+        # @private Verify credentials
+        def self.valid_credentials? project_id, keyfile
           begin
             ErrorReporting::Credentials.credentials_with_scope keyfile
-          rescue StandardError => e
+          rescue => e
             STDOUT.puts "Note: Google::Cloud::ErrorReporting is disabled " \
               "because it failed to authorize with the service. (#{e.message})"
             return false
@@ -126,30 +153,12 @@ module Google
             return false
           end
 
-          # Otherwise return true if Rails is running in production or
-          # config.google_cloud.use_error_reporting is explicitly true
-          Rails.env.production? || use_error_reporting || false
+          true
         end
 
-        ##
-        # @private Helper method to parse rails config into a flattened hash.
-        def self.parse_rails_config config
-          gcp_config = config.google_cloud
-          er_config = gcp_config.error_reporting
-          if gcp_config.key? :use_error_reporting
-            use_error_reporting = gcp_config.use_error_reporting
-          else
-            use_error_reporting = nil
-          end
-
-          {
-            project_id: er_config.project_id || gcp_config.project_id,
-            keyfile: er_config.keyfile || gcp_config.keyfile,
-            service_name: er_config.service_name,
-            service_version: er_config.service_version,
-            use_error_reporting: use_error_reporting
-          }
-        end
+        private_class_method :consolidate_rails_config,
+                             :merge_rails_config,
+                             :valid_credentials?
       end
     end
   end

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -31,8 +31,9 @@ module Google
       #
       # When loaded, the {Google::Cloud::ErrorReporting::Middleware} will be
       # inserted after ActionDispatch::DebugExceptions or
-      # ActionDispatch::ShowExceptions Middleware, which
-      # allows it to actually rescue all Exceptions and re-throw them back up.
+      # ActionDispatch::ShowExceptions Middleware, which allows it to intercept
+      # and handle all Exceptions without interfering with Rails's normal error
+      # pages.
       # See the [Configuration
       # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # on how to configure the Railtie and Middleware.
@@ -54,7 +55,7 @@ module Google
         def self.init_middleware app
           # In later versions of Rails, ActionDispatch::DebugExceptions is
           # responsible for catching exceptions. But it didn't exist until
-          # Rails 3.2. So we use ShowExceptions as pivot for earlier Rails.
+          # Rails 3.2. So we use ShowExceptions as fallback for earlier Rails.
           rails_exception_middleware =
             if defined? ::ActionDispatch::DebugExceptions
               ::ActionDispatch::DebugExceptions

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -32,7 +32,7 @@ module Google
       # When loaded, the {Google::Cloud::ErrorReporting::Middleware} will be
       # inserted after ActionDispatch::DebugExceptions or
       # ActionDispatch::ShowExceptions Middleware, which
-      # allows it to actually rescue all Exceptions and throw it back up.
+      # allows it to actually rescue all Exceptions and re-throw them back up.
       # See the [Configuration
       # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # on how to configure the Railtie and Middleware.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -34,7 +34,7 @@ module Google
       # ActionDispatch::ShowExceptions Middleware, which
       # allows it to actually rescue all Exceptions and throw it back up.
       # See the [Configuration
-      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # on how to configure the Railtie and Middleware.
       #
       class Railtie < ::Rails::Railtie

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -67,10 +67,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
 
   after {
     # Clear configuration values between each test
-    config_hash = Google::Cloud::ErrorReporting.configure.instance_variable_get(:@configs)
-    config_hash.each do |k, _|
-      config_hash[k] = nil
-    end
+    Google::Cloud::ErrorReporting.configure.clear
   }
 
   describe "#initialize" do

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -59,7 +59,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
 
   after {
     # Clear configuration values between each test
-    Google::Cloud::ErrorReporting.configure.clear
+    Google::Cloud::ErrorReporting.configure.instance_variable_get(:@configs).clear
     Google::Cloud.configure.delete :use_error_reporting
   }
 

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -77,44 +77,6 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
       end
     end
 
-    it "uses Google::Cloud::ErrorReporting.configure if parameters not given" do
-      stubbed_config = OpenStruct.new project_id: "another-project-id",
-                                      keyfile: "another-keyfile",
-                                      service_name: nil, service_version: nil
-
-      Google::Cloud::ErrorReporting::Project.stub :default_project, nil do
-        Google::Cloud::ErrorReporting.stub :new, "A default error_reporting" do
-          Google::Cloud::ErrorReporting.stub :configure, stubbed_config do
-            ENV.stub :[], nil do
-              midware = Google::Cloud::ErrorReporting::Middleware.new nil
-              midware.project_id.must_equal "another-project-id"
-              midware.keyfile.must_equal "another-keyfile"
-            end
-          end
-        end
-      end
-    end
-
-    it "uses Google::Cloud.configure if parameters not given and " do
-      stubbed_er_config = OpenStruct.new project_id: nil, keyfile: nil, service_name: nil, service_version: nil
-      stubbed_gcloud_config = OpenStruct.new project_id: "gcloud-project-id",
-                                             keyfile: "gcloud-keyfile"
-
-      Google::Cloud::ErrorReporting::Project.stub :default_project, nil do
-        Google::Cloud::ErrorReporting.stub :new, "A default error_reporting" do
-          Google::Cloud.stub :configure, stubbed_gcloud_config do
-            Google::Cloud::ErrorReporting.stub :configure, stubbed_er_config do
-              ENV.stub :[], nil do
-                midware = Google::Cloud::ErrorReporting::Middleware.new nil
-                midware.project_id.must_equal "gcloud-project-id"
-                midware.keyfile.must_equal "gcloud-keyfile"
-              end
-            end
-          end
-        end
-      end
-    end
-
     it "sets Google::Cloud::ErrorReporting\#@@default_client" do
       middleware
       Google::Cloud::ErrorReporting.class_variable_get(:@@default_client).object_id.must_equal error_reporting.object_id

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -77,23 +77,6 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
       end
     end
 
-    it "raises ArgumentError if empty project_id provided" do
-      stubbed_config = OpenStruct.new project_id: nil, keyfile: nil, service_name: nil, service_version: nil
-
-      assert_raises ArgumentError do
-        # Prevent return of actual project in any environment including GCE, etc.
-        Google::Cloud::ErrorReporting::Project.stub :default_project, nil do
-          Google::Cloud::ErrorReporting.stub :new, "A default error_reporting" do
-            Google::Cloud::ErrorReporting.stub :configure, stubbed_config do
-              ENV.stub :[], nil do
-                Google::Cloud::ErrorReporting::Middleware.new nil
-              end
-            end
-          end
-        end
-      end
-    end
-
     it "uses Google::Cloud::ErrorReporting.configure if parameters not given" do
       stubbed_config = OpenStruct.new project_id: "another-project-id",
                                       keyfile: "another-keyfile",

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -45,29 +45,22 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
     end
     app
   }
-  # let(:error_reporting) {
-  #   obj = OpenStruct.new report: Proc.new {}
-  #   obj.define_singleton_method(:report_error_event) do end
-  #   obj
-  # }
   let(:middleware) {
+    Google::Cloud::ErrorReporting.configure do |config|
+      config.ignore_classes = [IgnoredError]
+      config.service_name = service_name
+      config.service_version = service_version
+    end
     Google::Cloud::ErrorReporting::Middleware.new rack_app,
                                                   error_reporting: error_reporting,
                                                   project_id: project_id,
-                                                  keyfile: keyfile,
-                                                  service_name: service_name,
-                                                  service_version: service_version,
-                                                  ignore_classes: [IgnoredError]
-  }
-  let(:default_middleware) {
-    Google::Cloud::ErrorReporting::Middleware.new rack_app,
-                                                  error_reporting: error_reporting,
-                                                  project_id: project_id
+                                                  keyfile: keyfile
   }
 
   after {
     # Clear configuration values between each test
     Google::Cloud::ErrorReporting.configure.clear
+    Google::Cloud.configure.delete :use_error_reporting
   }
 
   describe "#initialize" do

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::ErrorReporting::Railtie do
   end
 
   after {
-    Google::Cloud::ErrorReporting.configure.clear
+    Google::Cloud::ErrorReporting.configure.instance_variable_get(:@configs).clear
     Google::Cloud.configure.delete :use_error_reporting
   }
 

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
@@ -24,33 +24,82 @@ describe Google::Cloud::ErrorReporting::Railtie do
     config = ::ActiveSupport::OrderedOptions.new
     config.google_cloud = ::ActiveSupport::OrderedOptions.new
     config.google_cloud.error_reporting = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud.project_id = "test-project"
+    config.google_cloud.keyfile = "test/keyfile"
+    config.google_cloud.error_reporting.service_name = "test-service"
+    config.google_cloud.error_reporting.service_version = "test-version"
+    config.google_cloud.error_reporting.ignore_classes = "test class"
     config
   end
 
-  describe ".use_error_reporting?" do
-    it "returns false if config.google_cloud.use_error_reporting is explicitly false" do
-      rails_config.google_cloud.use_error_reporting = false
+  after {
+    Google::Cloud::ErrorReporting.configure.clear
+    Google::Cloud.configure.delete :use_error_reporting
+  }
 
-      Google::Cloud::ErrorReporting::Railtie.use_error_reporting?(rails_config).must_equal false
-    end
+  describe ".consolidate_rails_config" do
+    it "merges configs from Rails configuration" do
+      STDOUT.stub :puts, nil do
+        Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
 
-    it "returns false if empty project_id provided" do
-      Google::Cloud::ErrorReporting::Credentials.stub :credentials_with_scope, nil do
-        ENV.stub :[], nil do
-          STDOUT.stub :puts, nil do
-            Google::Cloud::ErrorReporting::Railtie.use_error_reporting?(rails_config).must_equal false
-          end
+        Google::Cloud::ErrorReporting.configure do |config|
+          config.project_id.must_equal "test-project"
+          config.keyfile.must_equal "test/keyfile"
+          config.service_name.must_equal "test-service"
+          config.service_version.must_equal "test-version"
+          config.ignore_classes.must_equal "test class"
         end
       end
     end
 
-    it "returns true if config.google_cloud.use_error_reporting is explicitly true even Rails is not in production" do
-      rails_config.google_cloud.error_reporting.project_id = "test-project"
+    it "doesn't override instrumentation configs" do
+      Google::Cloud::ErrorReporting.configure do |config|
+        config.project_id = "another-test-project"
+        config.keyfile = "/another/test/keyfile"
+        config.service_name = "another-test-service"
+        config.service_version = "another-test-version"
+        config.ignore_classes = "another test class"
+      end
+
+      STDOUT.stub :puts, nil do
+        Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
+
+        Google::Cloud::ErrorReporting.configure do |config|
+          config.project_id.must_equal "another-test-project"
+          config.keyfile.must_equal "/another/test/keyfile"
+          config.service_name.must_equal "another-test-service"
+          config.service_version.must_equal "another-test-version"
+          config.ignore_classes.must_equal "another test class"
+        end
+      end
+    end
+
+    it "Set use_error_reporting to false if credentials aren't valid" do
+      Google::Cloud.configure.use_error_reporting = true
+
+      Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, false do
+        Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
+        Google::Cloud.configure.use_error_reporting.must_equal false
+      end
+    end
+
+    it "Set use_error_reporting to true if Rails is in production" do
+      Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, true do
+          Google::Cloud.configure.use_error_reporting.must_be_nil
+          Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_error_reporting.must_equal true
+        end
+      end
+    end
+
+    it "returns true if use_error_reporting is explicitly true even Rails is not in production" do
       rails_config.google_cloud.use_error_reporting = true
 
-      Google::Cloud::ErrorReporting::Credentials.stub :credentials_with_scope, nil do
-        Rails.env.stub :production?, nil do
-          Google::Cloud::ErrorReporting::Railtie.use_error_reporting?(rails_config).must_equal true
+      Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, false do
+          Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_error_reporting.must_equal true
         end
       end
     end

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
@@ -67,19 +67,12 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
   end
 
   describe ".configure" do
-    it "initializes Google::Cloud.configure.error_reporting once" do
-      error_reporting_config = Google::Cloud.configure.error_reporting
-      Google::Cloud::ErrorReporting.configure
-      Google::Cloud.configure.error_reporting.must_equal error_reporting_config
+    it "has Google::Cloud.configure.error_reporting initialized already" do
+      Google::Cloud.configure.option?(:error_reporting).must_equal true
     end
 
     it "operates on the same Configuration object as Google::Cloud.configure.error_reporting" do
       Google::Cloud::ErrorReporting.configure.must_equal Google::Cloud.configure.error_reporting
-    end
-
-    it "initialies ErrorReporting Configuration with all the valid operations" do
-      Google::Cloud::ErrorReporting.configure.instance_variable_get(:@configs).keys.must_equal Google::Cloud::ErrorReporting::CONFIG_OPTIONS
-      Google::Cloud.configure.error_reporting.instance_variable_get(:@configs).keys.must_equal Google::Cloud::ErrorReporting::CONFIG_OPTIONS
     end
   end
 

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -106,7 +106,7 @@ namespace :integration do
   desc "Run integration tests against GAE"
   task :gae, :project_uri do |t, args|
     raise "You must provide a project_uri. e.g. rake " \
-      "integration:gae[http://my-project.appspot.com]" if args[:project_uri].nil?
+      "integration:gae[http://my-project.appspot-preview.com]" if args[:project_uri].nil?
 
     ENV["TEST_GOOGLE_CLOUD_PROJECT_URI"] = args[:project_uri]
 

--- a/google-cloud-logging/docs/instrumentation.md
+++ b/google-cloud-logging/docs/instrumentation.md
@@ -9,6 +9,16 @@ to the Stackdriver Logging service.
 On top of that, the google-cloud-logging also implements a Railtie class that 
 automatically enables the Rack Middleware in Rails applications when used.
 
+## Configuration
+The default configuration enables Stackdriver instrumentation features to run
+on Google Cloud Platform. You can easily configure the instrumentation library 
+if you want to run on a non Google Cloud environment or you want to customize 
+the default behavior.
+
+See the 
+[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+for full configuration parameters.
+
 ## Using instrumentation with Ruby on Rails
 
 To install application instrumentation in your Ruby on Rails app, add this
@@ -18,27 +28,8 @@ add the following line to your `config/application.rb` file:
 require "google/cloud/logging/rails"
 ```
 This will load a Railtie that automatically integrates with the Rails
-framework by injecting a Rack middleware. The logging instrumentation can be 
-configured with the following Rails configuration:
-```ruby
-# Sharing authentication parameters
-config.google_cloud.project_id = "gcp-project-id"
-config.google_cloud.keyfile = "/path/to/gcp/secret.json"
-# Or more specificly for Logging
-config.google_cloud.logging.project_id = "gcp-project-id"
-config.google_cloud.logging.keyfile = "/path/to/gcp/sercret.json"
- 
-# Explicitly enable or disable Logging
-config.google_cloud.use_logging = true
- 
-# Set Stackdriver Logging log name
-config.google_cloud.logging.log_name = "my-app-log"
- 
-# Override default monitored resource if needed. E.g. used on AWS
-config.google_cloud.logging.monitored_resource.type = "aws_ec2_instance"
-config.google_cloud.logging.monitored_resource.labels.instance_id = "ec2-instance-id"
-config.google_cloud.logging.monitored_resource.labels.aws_account = "AWS account number"
-```
+framework by injecting a Rack middleware.
+
 ## Using instrumentation with Sinatra
 
 To install application instrumentation in your Sinatra app, add this gem,
@@ -52,17 +43,6 @@ use Google::Cloud::Logging::Middleware
 
 This will install the logging middleware in your application.
 
-You may customize the logging instrumention by providing your own
-Google::Cloud::Logging::Logger:
-```ruby
-require "google/cloud/logging"
- 
-logging = Google::Cloud::Logging.new
-resource = Google::Cloud::Logging::Middleware.build_monitored_resource
-logger = logging.logger "my-log-name",
-                        resource
-use Google::Cloud::Logging::Middleware, logger: logger
-```
 ### Using instrumentation with other Rack-based frameworks
 
 To install application instrumentation in an app using another Rack-based

--- a/google-cloud-logging/docs/instrumentation.md
+++ b/google-cloud-logging/docs/instrumentation.md
@@ -16,7 +16,7 @@ if you want to run on a non Google Cloud environment or you want to customize
 the default behavior.
 
 See the 
-[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
 for full configuration parameters.
 
 ## Using instrumentation with Ruby on Rails

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -332,7 +332,7 @@ module Google
       # Initialize :error_reporting as a nested Configuration under
       # Google::Cloud if haven't already
       unless Google::Cloud.configure.option? :logging
-        Google::Cloud.configure.add_nested logging: {
+        Google::Cloud.configure.add_options logging: {
           monitored_resource: :labels
         }
       end

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -393,18 +393,9 @@ module Google
       # Configure the Google::Cloud::Logging::Middleware when used in a
       # Rack-based application.
       #
-      # Possible configuration parameters:
-      #   * `project_id`: The Google Cloud Project ID. Automatically discovered
-      #       when running from GCP environments.
-      #   * `keyfile`: The service account JSON file path. Automatically
-      #       discovered when running from GCP environments.
-      #   * `log_name`: A name for the log.
-      #   * `monitored_resource.type`: Identifier for monitored resource.
-      #       Optional. See [Monitored Resource
-      #       Doc](https://cloud.google.com/logging/docs/api/v2/resource-list)
-      #       for full list.
-      #   * `monitored_resource.labels`: Hash of custom labels for Monitored
-      #       Resource.
+      # See the [Configuration
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # for full configuration parameters.
       #
       # @return [Stackdriver::Core::Configuration] The configuration object
       #   the Google::Cloud::Logging module uses.

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -394,7 +394,7 @@ module Google
       # Rack-based application.
       #
       # See the [Configuration
-      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # for full configuration parameters.
       #
       # @return [Stackdriver::Core::Configuration] The configuration object

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -332,9 +332,7 @@ module Google
       # Initialize :error_reporting as a nested Configuration under
       # Google::Cloud if haven't already
       unless Google::Cloud.configure.option? :logging
-        Google::Cloud.configure.add_options logging: {
-          monitored_resource: :labels
-        }
+        Google::Cloud.configure.add_options logging: :monitored_resource
       end
 
       ##

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -50,6 +50,10 @@ module Google
         #   file path the file must be readable. Used to create a default logger
         #   if one isn't specified and a service account is used for
         #   authentication. Optional.
+        # @param [String] log_name The name of the log to use. Use default
+        #   log name if nil.
+        # @param [String] resource_type The name of Logging Monitored Resource.
+        #   Defaults to
         # @param [Hash] log_name_map A map from URI path to log name override.
         #   The path may be a string or regex. If a request path matches an
         #   entry in this map, the log name is set accordingly, otherwise the
@@ -59,17 +63,26 @@ module Google
         #   Google::Cloud::Logging::Middleware instance
         #
         def initialize app, logger: nil, project_id: nil, keyfile: nil,
-                       log_name_map: DEFAULT_LOG_NAME_MAP
+                       log_name: nil, log_name_map: DEFAULT_LOG_NAME_MAP,
+                       resource_type: nil, resource_labels: nil
           @app = app
+          @log_name_map = log_name_map
+
+          load_config project_id: project_id,
+                      keyfile: keyfile,
+                      log_name: log_name,
+                      resource_type: resource_type,
+                      resource_labels: resource_labels
+
           if logger
             @logger = logger
           else
-            logging = Google::Cloud::Logging.new project: project_id,
-                                                 keyfile: keyfile
-            resource = Middleware.build_monitored_resource
-            @logger = logging.logger DEFAULT_LOG_NAME, resource
+            logging = Google::Cloud::Logging.new project: @project_id,
+                                                 keyfile: @keyfile
+            resource = Middleware.build_monitored_resource @resource_type,
+                                                           @resource_labels
+            @logger = logging.logger @log_name, resource
           end
-          @log_name_map = log_name_map
         end
 
         ##
@@ -249,6 +262,34 @@ module Google
         end
 
         private_class_method :default_monitored_resource
+
+        private
+
+        ##
+        # @private Sync Middleware configuration parameters from multiple
+        # sources. The sources take precendence in the following order:
+        # explicit parameters; Google::Cloud::Logging.configure;
+        # Google::Cloud.configure; and finally the defaults.
+        def load_config project_id: nil, keyfile: nil, log_name: nil,
+                        resource_type: nil, resource_labels: nil
+          gcloud_config = Google::Cloud.configure
+          logging_config = gcloud_config.logging
+
+          @project_id = project_id ||
+                        logging_config.project_id ||
+                        gcloud_config.project_id ||
+                        Logging::Project.default_project
+          @keyfile = keyfile || logging_config.keyfile || gcloud_config.keyfile
+          @log_name = log_name || logging_config.log_name || DEFAULT_LOG_NAME
+          @resource_type = resource_type || logging_config.resource_type
+          @resource_labels = resource_labels || logging_config.resource_labels
+
+          logging_config.project_id = @project_id
+          logging_config.keyfile = @keyfile
+          logging_config.log_name = @log_name
+          logging_config.resource_type = @resource_type
+          logging_config.resource_labels = @resource_labels
+        end
       end
     end
   end

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -43,7 +43,7 @@ module Google
         #   env["rack.logger"] to this assigned logger for accessing. If not
         #   specified, a default logger with be used.
         # @param [Hash] *kwargs Hash of configuration settings. Used for
-        #   backward API compatibility reason. See the [Configuration
+        #   backward API compatibility. See the [Configuration
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
         #   for the prefered way to set configuration parameters.
         #

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -72,12 +72,13 @@ module Google
           if logger
             @logger = logger
           else
+            log_name = configuration.log_name
             logging = Google::Cloud::Logging.new project: @project_id,
                                                  keyfile: @keyfile
             resource = Middleware.build_monitored_resource(
               configuration.monitored_resource.type,
               configuration.monitored_resource.labels)
-            @logger = logging.logger @log_name, resource
+            @logger = logging.logger log_name, resource
           end
         end
 

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -36,7 +36,7 @@ module Google
       # before the `Rails::Rack::Logger Middleware`, which allows it to set the
       # `env['rack.logger']` in place of Rails's default logger.
       # See the [Configuration
-      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # on how to configure the Railtie and Middleware.
       #
       class Railtie < ::Rails::Railtie

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -64,68 +64,91 @@ module Google
           ::ActiveSupport::OrderedOptions.new
 
         initializer "Stackdriver.Logging", before: :initialize_logger do |app|
-          use_logging = self.class.use_logging? app.config
-          if use_logging
-            logging_config = Railtie.parse_rails_config app.config
+          consolidate_rails_config app.config
 
-            project_id = logging_config[:project_id]
-            keyfile = logging_config[:keyfile]
-            resource_type = logging_config[:resource_type]
-            resource_labels = logging_config[:resource_labels]
-            log_name = logging_config[:log_name]
-
-            logging = Google::Cloud::Logging.new project: project_id,
-                                                 keyfile: keyfile
-            resource =
-              Logging::Middleware.build_monitored_resource resource_type,
-                                                           resource_labels
-
-            app.config.logger = logging.logger log_name, resource
-            app.middleware.insert_before Rails::Rack::Logger,
-                                         Google::Cloud::Logging::Middleware,
-                                         logger: app.config.logger,
-                                         project_id: project_id,
-                                         keyfile: keyfile,
-                                         log_name: log_name,
-                                         resource_type: resource_type,
-                                         resource_labels: resource_labels
-          end
-
-          Google::Cloud.configure.use_logging = use_logging
+          self.class.init_middleware app if Cloud.configure.use_logging
         end
 
         ##
-        # Determine whether to use Stackdriver Logging or not.
-        #
-        # Returns `true` if Stackdriver Logging is enabled for this application.
-        # That is, if all of the following are true:
-        #
-        # * A valid GCP `project_id` is available, either because the
-        #   application is hosted on Google Cloud or because it is set in the
-        #   configuration.
-        # * The API is able to authenticate, again either because the
-        #   application is hosted on Google Cloud or because an appropriate
-        #   keyfile is provided in the configuration.
-        # * Either the Rails environment is set to `production` or the
-        #   `config.google_cloud.use_logging` configuration is explicitly set to
-        #   `true`.
+        # @private Init Logging integration for Rails. Setup configuration and
+        # insert the Middleware.
+        def self.init_middleware app
+          project_id = Logging.configure.project_id
+          keyfile = Logging.configure.keyfile
+          resource_type = Logging.configure.resource_type
+          resource_labels = Logging.configure.resource_labels
+          log_name = Logging.configure.log_name
+
+          logging = Google::Cloud::Logging.new project: project_id,
+                                               keyfile: keyfile
+          resource =
+            Logging::Middleware.build_monitored_resource resource_type,
+                                                         resource_labels
+
+          app.config.logger = logging.logger log_name, resource
+          app.middleware.insert_before Rails::Rack::Logger,
+                                       Google::Cloud::Logging::Middleware,
+                                       logger: app.config.logger,
+                                       project_id: project_id,
+                                       keyfile: keyfile
+        end
+
+        ##
+        # @private Consolidate Rails configuration into Logging instrumentation
+        # configuration. Also consolidate the `use_logging` setting by verifying
+        # credentials and Rails environment. The `use_logging` setting will be
+        # true if credentials are valid, and the setting is manually set to true
+        # or Rails is in production environment.
         #
         # @param [Rails::Railtie::Configuration] config The
-        #   `Rails.application.config`
+        #   Rails.application.config
         #
-        # @return [Boolean] Whether to use Stackdriver Logging
-        #
-        def self.use_logging? config
-          logging_config = Railtie.parse_rails_config config
+        def self.consolidate_rails_config config
+          merge_rails_config config
 
-          # Return false if config.google_cloud.use_logging is explicitly false
-          use_logging = logging_config[:use_logging]
-          return false if use_logging == false
+          # Fallback to default config values if config parameters not provided.
+          Logging.configure.project_id ||= Logging::Project.default_project
+          Logging.configure.log_name ||= Middleware::DEFAULT_LOG_NAME
 
-          project_id = logging_config[:project_id] ||
-                       Google::Cloud::Logging::Project.default_project
-          keyfile = logging_config[:keyfile]
+          # Done if Google::Cloud.configure.use_logging is explicitly false
+          return if Google::Cloud.configure.use_logging == false
 
+          # Verify credentials and set use_error_reporting to false if
+          # credentials are invalid
+          unless valid_credentials? Logging.configure.project_id,
+                                    Logging.configure.keyfile
+            Cloud.configure.use_logging = false
+            return
+          end
+
+          # Otherwise set use_logging to true if Rails is running in production
+          Google::Cloud.configure.use_logging ||= Rails.env.production?
+        end
+
+        ##
+        # @private Merge Rails configuration into Logging instrumentation
+        # configuration.
+        def self.merge_rails_config rails_config
+          gcp_config = rails_config.google_cloud
+          logging_config = gcp_config.logging
+
+          Cloud.configure.use_logging ||= gcp_config.use_logging
+          Logging.configure do |config|
+            config.project_id ||= logging_config.project_id ||
+                                  gcp_config.project_id
+            config.keyfile ||= logging_config.keyfile || gcp_config.keyfile
+            config.log_name ||= logging_config.log_name
+            config.log_name_map ||= logging_config.log_name_map
+            config.monitored_resource.type ||=
+              logging_config.monitored_resource.type
+            config.monitored_resource.labels.merge!(
+              logging_config.monitored_resource.labels)
+          end
+        end
+
+        ##
+        # @private Verify credentials
+        def self.valid_credentials? project_id, keyfile
           # Try authenticate authorize client API. Return false if unable to
           # authorize.
           begin
@@ -144,27 +167,12 @@ module Google
             return false
           end
 
-          # Otherwise default to true if Rails is running in production or
-          # config.google_cloud.use_logging is true
-          Rails.env.production? || use_logging
+          true
         end
 
-        ##
-        # @private Helper method to parse rails config into a flattened hash
-        def self.parse_rails_config config
-          gcp_config = config.google_cloud
-          logging_config = gcp_config.logging
-          use_logging =
-            gcp_config.key?(:use_logging) ? gcp_config.use_logging : nil
-          {
-            project_id: logging_config.project_id || gcp_config.project_id,
-            keyfile: logging_config.keyfile || gcp_config.keyfile,
-            resource_type: logging_config.monitored_resource.type,
-            resource_labels: logging_config.monitored_resource.labels,
-            log_name: logging_config.log_name || Middleware::DEFAULT_LOG_NAME,
-            use_logging: use_logging
-          }
-        end
+        private_class_method :consolidate_rails_config,
+                             :merge_rails_config,
+                             :valid_credentials?
       end
     end
   end

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -73,9 +73,7 @@ module Google
           app.config.logger = logging.logger log_name, resource
           app.middleware.insert_before Rails::Rack::Logger,
                                        Google::Cloud::Logging::Middleware,
-                                       logger: app.config.logger,
-                                       project_id: project_id,
-                                       keyfile: keyfile
+                                       logger: app.config.logger
         end
 
         ##
@@ -124,8 +122,8 @@ module Google
             config.log_name_map ||= logging_config.log_name_map
             config.monitored_resource.type ||=
               logging_config.monitored_resource.type
-            config.monitored_resource.labels.merge!(
-              logging_config.monitored_resource.labels)
+            config.monitored_resource.labels ||=
+              logging_config.monitored_resource.labels.to_h
           end
         end
 

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -64,7 +64,7 @@ module Google
           ::ActiveSupport::OrderedOptions.new
 
         initializer "Stackdriver.Logging", before: :initialize_logger do |app|
-          consolidate_rails_config app.config
+          self.class.consolidate_rails_config app.config
 
           self.class.init_middleware app if Cloud.configure.use_logging
         end
@@ -170,8 +170,7 @@ module Google
           true
         end
 
-        private_class_method :consolidate_rails_config,
-                             :merge_rails_config,
+        private_class_method :merge_rails_config,
                              :valid_credentials?
       end
     end

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -53,8 +53,8 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
     Google::Cloud::Logging.configure.delete :log_name
     Google::Cloud::Logging.configure.delete :log_name_map
     Google::Cloud::Logging.configure.monitored_resource.delete :type
-    Google::Cloud::Logging.configure.monitored_resource.labels.clear
-    Google::Cloud.configure.delete :use_logging
+    Google::Cloud::Logging.configure.monitored_resource.delete :labels
+    Google::Cloud.configure.instance_variable_get(:@configs).delete :use_logging
   }
 
   describe "#initialize" do

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -42,7 +42,19 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
   let(:labels) { { "env" => "production" } }
   let(:logger) { Google::Cloud::Logging::Logger.new logging, log_name, resource, labels }
   let(:middleware) {
-    Google::Cloud::Logging::Middleware.new rack_app, logger: logger
+    Google::Cloud::Logging::Middleware.new rack_app, logger: logger,
+                                                     project_id: project
+  }
+
+  after {
+    # Clear configuration values between each test
+    Google::Cloud::Logging.configure.delete :project_id
+    Google::Cloud::Logging.configure.delete :keyfile
+    Google::Cloud::Logging.configure.delete :log_name
+    Google::Cloud::Logging.configure.delete :log_name_map
+    Google::Cloud::Logging.configure.monitored_resource.delete :type
+    Google::Cloud::Logging.configure.monitored_resource.labels.clear
+    Google::Cloud.configure.delete :use_logging
   }
 
   describe "#initialize" do

--- a/google-cloud-logging/test/google/cloud/logging/rails_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/rails_test.rb
@@ -20,37 +20,94 @@ require "active_support/ordered_options"
 require "google/cloud/logging/rails"
 
 describe Google::Cloud::Logging::Railtie do
-  describe ".use_logging?" do
-    before do
-      @rails_config = ::ActiveSupport::OrderedOptions.new
-      @rails_config.google_cloud = ::ActiveSupport::OrderedOptions.new
-      @rails_config.google_cloud.logging = ::ActiveSupport::OrderedOptions.new
-      @rails_config.google_cloud.logging.monitored_resource = ::ActiveSupport::OrderedOptions.new
+  let(:rails_config) do
+    config = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud.logging = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud.logging.monitored_resource = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud.project_id = "test-project"
+    config.google_cloud.keyfile = "test/keyfile"
+    config.google_cloud.logging.log_name = "test-log-name"
+    config.google_cloud.logging.log_name_map = { "test-path" => "log-name" }
+    config.google_cloud.logging.monitored_resource.type = "test-type"
+    config.google_cloud.logging.monitored_resource.labels = { test: "label" }
+    config
+  end
+
+  after {
+    Google::Cloud::Logging.configure.delete :project_id
+    Google::Cloud::Logging.configure.delete :keyfile
+    Google::Cloud::Logging.configure.delete :log_name
+    Google::Cloud::Logging.configure.delete :log_name_map
+    Google::Cloud::Logging.configure.monitored_resource.delete :type
+    Google::Cloud::Logging.configure.monitored_resource.labels.clear
+    Google::Cloud.configure.delete :use_logging
+  }
+
+  describe ".consolidate_rails_config?" do
+    it "merges configs from Rails configuration" do
+      STDOUT.stub :puts, nil do
+        Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
+
+        Google::Cloud::Logging.configure do |config|
+          config.project_id.must_equal "test-project"
+          config.keyfile.must_equal "test/keyfile"
+          config.log_name.must_equal "test-log-name"
+          config.log_name_map.must_equal "test-path" => "log-name"
+          config.monitored_resource.type.must_equal "test-type"
+          config.monitored_resource.labels.must_equal test: "label"
+        end
+      end
     end
 
-    it "returns false if config.google_cloud.use_logging is explicitly false" do
-      @rails_config.google_cloud.use_logging = false
+    it "doesn't override instrumentation configs" do
+      Google::Cloud::Logging.configure do |config|
+        config.project_id = "another-test-project"
+        config.keyfile = "/another/test/keyfile"
+        config.log_name = "another-test-log-name"
+        config.log_name_map = {"test-path" => "another-log-name"}
+        config.monitored_resource.type = "another-test-type"
+      end
 
-      Google::Cloud::Logging::Railtie.use_logging?(@rails_config).must_equal false
+      STDOUT.stub :puts, nil do
+        Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
+
+        Google::Cloud::Logging.configure do |config|
+          config.project_id.must_equal "another-test-project"
+          config.keyfile.must_equal "/another/test/keyfile"
+          config.log_name.must_equal  "another-test-log-name"
+          config.log_name_map.must_equal "test-path" => "another-log-name"
+          config.monitored_resource.type.must_equal "another-test-type"
+        end
+      end
     end
 
-    it "returns false if can't find non-empty project_id" do
-      Google::Cloud::Logging::Credentials.stub :default, nil do
-        Google::Cloud::Logging::Project.stub :default_project, nil do
-          STDOUT.stub :puts, nil do
-            Google::Cloud::Logging::Railtie.use_logging?(@rails_config).must_equal false
-          end
+    it "Set use_logging to false if credentials aren't valid" do
+      Google::Cloud.configure.use_logging = true
+
+      Google::Cloud::Logging::Railtie.stub :valid_credentials?, false do
+        Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
+        Google::Cloud.configure.use_logging.must_equal false
+      end
+    end
+
+    it "Set use_logging to true if Rails is in production" do
+      Google::Cloud::Logging::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, true do
+          Google::Cloud.configure.use_logging.must_be_nil
+          Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_logging.must_equal true
         end
       end
     end
 
     it "returns true if config.google_cloud.use_logging is explicitly true even Rails is not in production" do
-      @rails_config.google_cloud.logging.project_id = "test-project"
-      @rails_config.google_cloud.use_logging = true
+      rails_config.google_cloud.use_logging = true
 
-      Google::Cloud::Logging::Credentials.stub :default, nil do
+      Google::Cloud::Logging::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, false do
-          Google::Cloud::Logging::Railtie.use_logging?(@rails_config).must_equal true
+          Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_logging.must_equal true
         end
       end
     end

--- a/google-cloud-logging/test/google/cloud/logging/rails_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/rails_test.rb
@@ -37,7 +37,7 @@ describe Google::Cloud::Logging::Railtie do
     it "returns false if can't find non-empty project_id" do
       Google::Cloud::Logging::Credentials.stub :default, nil do
         Google::Cloud::Logging::Project.stub :default_project, nil do
-          $stderr.stub :write, nil do
+          STDOUT.stub :puts, nil do
             Google::Cloud::Logging::Railtie.use_logging?(@rails_config).must_equal false
           end
         end

--- a/google-cloud-logging/test/google/cloud/logging/rails_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/rails_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::Logging::Railtie do
     Google::Cloud::Logging.configure.delete :log_name
     Google::Cloud::Logging.configure.delete :log_name_map
     Google::Cloud::Logging.configure.monitored_resource.delete :type
-    Google::Cloud::Logging.configure.monitored_resource.labels.clear
+    Google::Cloud::Logging.configure.monitored_resource.delete :labels
     Google::Cloud.configure.delete :use_logging
   }
 

--- a/google-cloud-logging/test/google/cloud/logging_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging_test.rb
@@ -166,4 +166,14 @@ describe Google::Cloud do
       end
     end
   end
+
+  describe ".configure" do
+    it "has Google::Cloud.configure.logging initialized already" do
+      Google::Cloud.configure.option?(:logging).must_equal true
+    end
+
+    it "operates on the same Configuration object as Google::Cloud.configure.logging" do
+      Google::Cloud::Logging.configure.must_equal Google::Cloud.configure.logging
+    end
+  end
 end

--- a/google-cloud-trace/docs/instrumentation.md
+++ b/google-cloud-trace/docs/instrumentation.md
@@ -4,32 +4,21 @@ Then google-cloud-trace gem provides a Rack Middleware class that integrates wit
 
 Additionally, the google-cloud-trace gem provides a Railtie class that automatically enables the Rack Middleware in Rails applications when used.
 
+## Configuration
+The default configuration enables Stackdriver instrumentation features to run
+on Google Cloud Platform. You can easily configure the instrumentation library 
+if you want to run on a non Google Cloud environment or you want to customize 
+the default behavior.
+
+See the 
+[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+for full configuration parameters.
+
 ## Rails Integration
 
 To use the Stackdriver Logging Railtie for Ruby on Rails applications, simply add this line to config/application.rb:
 ```ruby
 require "google/cloud/trace/rails"
-```
-
-Then the library can be configured through this set of Rails parameters in config/environments/*.rb:
-```ruby
-# Sharing authentication parameters
-config.google_cloud.project_id = "gcp-project-id"
-config.google_cloud.keyfile = "/path/to/gcp/secret.json"
-# Or more specificly for Logging
-config.google_cloud.logging.project_id = "gcp-project-id"
-config.google_cloud.logging.keyfile = "/path/to/gcp/sercret.json"
-
-# Explicitly enable or disable Trace
-config.google_cloud.use_trace = true
-
-# Choose ActiveRecord notifications to trace
-config.google_cloud.trace.notifications =
-  Google::Cloud::Trace::Railtie::DEFAULT_NOTIFICATIONS +
-  ["render_partial.action_view"]
-
-# Specify whether to capture call stacks
-config.google_cloud.trace.capture_stack = true
 ```
 
 Alternatively, check out the [stackdriver](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver) gem, which enables this Railtie by default.

--- a/google-cloud-trace/docs/instrumentation.md
+++ b/google-cloud-trace/docs/instrumentation.md
@@ -11,7 +11,7 @@ if you want to run on a non Google Cloud environment or you want to customize
 the default behavior.
 
 See the 
-[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+[Configuration Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
 for full configuration parameters.
 
 ## Rails Integration

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -346,7 +346,7 @@ module Google
       # Configure the Stackdriver Trace instrumentation Middleware.
       #
       # See the [Configuration
-      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # for full configuration parameters.
       #
       # @return [Stackdriver::Core::Configuration] The configuration object

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -194,7 +194,7 @@ module Google
       # Initialize :error_reporting as a nested Configuration under
       # Google::Cloud if haven't already
       unless Google::Cloud.configure.option? :trace
-        Google::Cloud.configure.add_nested :trace
+        Google::Cloud.configure.add_options :trace
       end
 
       ##

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-require "stackdriver/core/trace_context"
 require "google-cloud-trace"
 require "google/cloud/trace/version"
 require "google/cloud/trace/credentials"
@@ -28,11 +27,12 @@ require "google/cloud/trace/span_kind"
 require "google/cloud/trace/time_sampler"
 require "google/cloud/trace/trace_record"
 require "google/cloud/trace/utils"
+require "stackdriver/core"
 
 module Google
   module Cloud
     ##
-    # # Stackdriver Trace
+    # # Trace
     #
     # The Stackdriver Trace service collects and stores latency data from your
     # application and displays it in the Google Cloud Platform Console, giving
@@ -191,6 +191,12 @@ module Google
     module Trace
       THREAD_KEY = :__stackdriver_trace_span__
 
+      # Initialize :error_reporting as a nested Configuration under
+      # Google::Cloud if haven't already
+      unless Google::Cloud.configure.option? :trace
+        Google::Cloud.configure.add_nested :trace
+      end
+
       ##
       # Creates a new object for connecting to the Stackdriver Trace service.
       # Each call creates a new connection.
@@ -334,6 +340,32 @@ module Google
         else
           yield nil
         end
+      end
+
+      ##
+      # Configure the Stackdriver Trace instrumentation Middleware.
+      #
+      # Possible configuration parameters:
+      #   * `project_id`: The Google Cloud Project ID. Automatically discovered
+      #       when running from GCP environments.
+      #   * `keyfile`: The service account JSON file path. Automatically
+      #       discovered when running from GCP environments.
+      #   * `notifications`: A list of ActiveSupport notification type Strings
+      #       to override the default notifications the Trace Middleware
+      #       subscribes.
+      #   * `max_data_length`: The maximum length of span properties recorded
+      #       with ActiveSupport notification events. Any property value larger
+      #       than this length is truncated.
+      #   * `capture_stack`: Boolean. Whether to capture the call stack with
+      #       each trace span. Default is false.
+      #
+      # @return [Stackdriver::Core::Configuration] The configuration object
+      #   the Google::Cloud::ErrorReporting module uses.
+      #
+      def self.configure
+        yield Google::Cloud.configure.trace if block_given?
+
+        Google::Cloud.configure.trace
       end
     end
   end

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -345,19 +345,9 @@ module Google
       ##
       # Configure the Stackdriver Trace instrumentation Middleware.
       #
-      # Possible configuration parameters:
-      #   * `project_id`: The Google Cloud Project ID. Automatically discovered
-      #       when running from GCP environments.
-      #   * `keyfile`: The service account JSON file path. Automatically
-      #       discovered when running from GCP environments.
-      #   * `notifications`: A list of ActiveSupport notification type Strings
-      #       to override the default notifications the Trace Middleware
-      #       subscribes.
-      #   * `max_data_length`: The maximum length of span properties recorded
-      #       with ActiveSupport notification events. Any property value larger
-      #       than this length is truncated.
-      #   * `capture_stack`: Boolean. Whether to capture the call stack with
-      #       each trace span. Default is false.
+      # See the [Configuration
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # for full configuration parameters.
       #
       # @return [Stackdriver::Core::Configuration] The configuration object
       #   the Google::Cloud::ErrorReporting module uses.

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -115,7 +115,7 @@ module Google
         # @param [Google::Cloud::Trace::Service] service The service object.
         #     Optional if running on GCE.
         # @param [Hash] *kwargs Hash of configuration settings. Used for
-        #   backward API compatibility reason. See the [Configuration
+        #   backward API compatibility. See the [Configuration
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
         #   for the prefered way to set configuration parameters.
         #

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -119,8 +119,7 @@ module Google
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
         #   for the prefered way to set configuration parameters.
         #
-        def initialize app,
-                       service: nil, **kwargs
+        def initialize app, service: nil, **kwargs
           @app = app
 
           load_config kwargs

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -114,11 +114,6 @@ module Google
         # @param [Rack Application] app Rack application
         # @param [Google::Cloud::Trace::Service] service The service object.
         #     Optional if running on GCE.
-        # @param [Boolean] capture_stack Whether to capture stack traces for
-        #     each span. Default is false.
-        # @param [Proc] sampler A sampler to use, or `nil` to use the default.
-        #     See {Google::Cloud::Trace::TimeSampler}. Note that the sampler
-        #     may be any Proc that implements the sampling contract.
         #
         def initialize app,
                        service: nil

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -124,13 +124,15 @@ module Google
                        service: nil
           @app = app
 
-          Google::Cloud::Trace.configure.capture_stack ||= false
+          load_config
 
           if service
             @service = service
           else
-            project_id = Google::Cloud::Trace::Project.default_project
-            @service = Google::Cloud::Trace.new.service if project_id
+            project_id = configuration.project_id
+            if project_id
+              @service = Google::Cloud::Trace.new(project: project_id).service
+            end
           end
         end
 
@@ -352,6 +354,18 @@ module Google
         end
 
         private
+
+        ##
+        # Consolidate configurations from various sources. Also set
+        # instrumentation config parameters to default values if not set
+        # already.
+        #
+        def load_config
+          # Set defaults
+          configuration.project_id ||= Cloud.configure.project_id ||
+                                       Trace::Project.default_project
+          Google::Cloud::Trace.configure.capture_stack ||= false
+        end
 
         ##
         # @private Get Google::Cloud::Trace.configure

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -135,7 +135,7 @@ module Google
           Google::Cloud::Trace::Notifications::DEFAULT_MAX_DATA_LENGTH
 
         initializer "Google.Cloud.Trace" do |app|
-          consolidate_rails_config app.config
+          self.class.consolidate_rails_config app.config
 
           self.class.init_middleware app if Cloud.configure.use_trace
         end
@@ -157,8 +157,7 @@ module Google
           app.middleware.insert_before \
             Rack::Runtime,
             Google::Cloud::Trace::Middleware,
-            service: tracer.service,
-            capture_stack: trace_config.capture_stack
+            service: tracer.service
 
           trace_config.notifications.each do |type|
             Google::Cloud::Trace::Notifications.instrument \
@@ -239,8 +238,7 @@ module Google
           true
         end
 
-        private_class_method :consolidate_rails_config,
-                             :merge_rails_config,
+        private_class_method :merge_rails_config,
                              :valid_credentials?
       end
     end

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -44,7 +44,7 @@ module Google
       # ## Configuration
       #
       # See the [Configuration
-      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
       # on how to configure the Railtie and Middleware.
       #
       # ## Measuring custom functionality

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -43,59 +43,9 @@ module Google
       #
       # ## Configuration
       #
-      # The following Rails configuration options are recognized.
-      #
-      # ```ruby
-      # config.google_cloud.use_trace = true | false
-      # ```
-      #
-      # Normally, tracing is activated when `RAILS_ENV` is set to `production`
-      # and credentials are available. You can override this and enable tracing
-      # in other environments by setting `use_trace` explicitly.
-      #
-      # ```ruby
-      # config.google_cloud.keyfile = "path/to/file"
-      # ```
-      #
-      # If your application is running on Google Cloud Platform, it will
-      # automatically use credentials available to your project. However, if
-      # you are running an application locally or on a different hosting
-      # provider, you may provide a path to your credentials file using this
-      # configuration.
-      #
-      # ```ruby
-      # config.google_cloud.project_id = "my-project-id"
-      # ```
-      #
-      # If your application is running on Google Cloud Platform, it will
-      # automatically select the project under which it is running. However, if
-      # you are running an application locally or on a different hosting
-      # provider, or if you want to log traces to a different project than you
-      # are using to host your application, you may provide the project ID.
-      #
-      # ```ruby
-      # config.google_cloud.trace.notifications = ["event1", "event2"]
-      # ```
-      #
-      # By default, this Railtie subscribes to ActiveSupport notifications
-      # emitted by ActiveRecord queries, rendering, and emailing functions.
-      # See {DEFAULT_NOTIFICATIONS}. If you want to customize the list of
-      # notification types, edit the notifications configuration.
-      #
-      # ```ruby
-      # config.google_cloud.trace.max_data_length = 1024
-      # ```
-      #
-      # The maximum length of span properties recorded with ActiveSupport
-      # notification events. Any property value larger than this length is
-      # truncated.
-      #
-      # ```ruby
-      # config.google_cloud.trace.capture_stack = true | false
-      # ```
-      #
-      # Whether to capture the call stack with each trace span. Default is
-      # false.
+      # See the [Configuration
+      # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriverguides/instrumentation_configuration)
+      # on how to configure the Railtie and Middleware.
       #
       # ## Measuring custom functionality
       #
@@ -180,8 +130,7 @@ module Google
         def self.consolidate_rails_config config
           merge_rails_config config
 
-          Trace.configure.project_id ||=
-            Trace::Project.default_project
+          init_default_config
 
           # Done if Google::Cloud.configure.use_trace is explicitly false
           return if Google::Cloud.configure.use_trace == false
@@ -219,6 +168,12 @@ module Google
         end
 
         ##
+        # Fallback to default config values if config parameters not provided.
+        def self.init_default_config
+          Trace.configure.project_id ||= Trace::Project.default_project
+        end
+
+        ##
         # @private Verify credentials
         def self.valid_credentials? project_id, keyfile
           begin
@@ -239,6 +194,7 @@ module Google
         end
 
         private_class_method :merge_rails_config,
+                             :init_default_config,
                              :valid_credentials?
       end
     end

--- a/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
@@ -69,9 +69,18 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
     ::Proc.new { my_span_id }
   }
   let(:base_middleware) {
-    Google::Cloud::Trace::Middleware.new base_app,
-                                         sampler: sampler,
-                                         span_id_generator: mock_span_id_generator
+    Google::Cloud::Trace.configure do |config|
+      config.sampler = sampler
+      config.span_id_generator = mock_span_id_generator
+    end
+    Google::Cloud::Trace::Middleware.new base_app
+                                         # sampler: sampler,
+                                         # span_id_generator: mock_span_id_generator
+  }
+
+  after {
+    Google::Cloud.configure.delete :use_trace
+    Google::Cloud::Trace.configure.clear
   }
 
   def base_app(&block)
@@ -160,11 +169,13 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
       tracer.service.mocked_lowlevel_client = mock
 
       env = rack_env sample: true, span_id: nil
+      Google::Cloud::Trace.configure do |config|
+        config.sampler = sampler
+        config.span_id_generator = mock_span_id_generator
+      end
       middleware = Google::Cloud::Trace::Middleware.new \
         base_app,
-        sampler: sampler,
-        service: tracer.service,
-        span_id_generator: mock_span_id_generator
+        service: tracer.service
       result = ::Time.stub :now, start_time do
         middleware.call env
       end
@@ -183,16 +194,19 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
         Google::Cloud::Trace.get.span_id.must_equal my_span_id
         ["200", {}, "Hello, world!\n"]
       end
+
+      Google::Cloud::Trace.configure do |config|
+        config.sampler = sampler
+        config.span_id_generator = mock_span_id_generator
+      end
       middleware = Google::Cloud::Trace::Middleware.new \
         base_app(&myapp),
-        sampler: sampler,
-        service: tracer.service,
-        span_id_generator: mock_span_id_generator
-      result = ::Time.stub :now, start_time do
+        service: tracer.service
+      ::Time.stub :now, start_time do
         middleware.call env
       end
 
-      mock.verify
+      # mock.verify
     end
   end
 end

--- a/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
@@ -74,13 +74,11 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
       config.span_id_generator = mock_span_id_generator
     end
     Google::Cloud::Trace::Middleware.new base_app
-                                         # sampler: sampler,
-                                         # span_id_generator: mock_span_id_generator
   }
 
   after {
     Google::Cloud.configure.delete :use_trace
-    Google::Cloud::Trace.configure.clear
+    Google::Cloud::Trace.configure.instance_variable_get(:@configs).clear
   }
 
   def base_app(&block)
@@ -206,7 +204,7 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
         middleware.call env
       end
 
-      # mock.verify
+      mock.verify
     end
   end
 end

--- a/google-cloud-trace/test/google/cloud/trace/rails_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/rails_test.rb
@@ -19,36 +19,94 @@ require "active_support/ordered_options"
 require "google/cloud/trace/rails"
 
 describe Google::Cloud::Trace::Railtie do
-  describe ".use_trace?" do
-    before do
-      @rails_config = ::ActiveSupport::OrderedOptions.new
-      @rails_config.google_cloud = ::ActiveSupport::OrderedOptions.new
-      @rails_config.google_cloud.trace = ::ActiveSupport::OrderedOptions.new
-    end
+  let(:rails_config) do
+    config = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud.trace = ::ActiveSupport::OrderedOptions.new
+    config.google_cloud.project_id = "test-project"
+    config.google_cloud.keyfile = "test/keyfile"
+    config.google_cloud.trace.capture_stack = "true"
+    config.google_cloud.trace.notifications = ["foo", "boo"]
+    config.google_cloud.trace.max_data_length = 123
+    config.google_cloud.trace.sampler = "test-sampler"
+    config.google_cloud.trace.span_id_generator = "test-generator"
+    config
+  end
 
-    it "returns false if config.google_cloud.use_trace is explicitly false" do
-      @rails_config.google_cloud.use_trace = false
+  after {
+    Google::Cloud.configure.delete :use_trace
+    Google::Cloud::Trace.configure.clear
+  }
 
-      Google::Cloud::Trace::Railtie.use_trace?(@rails_config).must_equal false
-    end
+  describe ".consolidate_rails_config" do
+    it "merges configs from Rails configuration" do
+      STDOUT.stub :puts, nil do
+        Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
 
-    it "returns false if can't find non-empty project_id" do
-      Google::Cloud::Trace::Credentials.stub :default, nil do
-        Google::Cloud::Trace::Project.stub :default_project, nil do
-          $stderr.stub :write, nil do
-            Google::Cloud::Trace::Railtie.use_trace?(@rails_config).must_equal false
-          end
+        Google::Cloud::Trace.configure do |config|
+          config.project_id.must_equal "test-project"
+          config.keyfile.must_equal "test/keyfile"
+          config.capture_stack.must_equal "true"
+          config.notifications.must_equal ["foo", "boo"]
+          config.max_data_length.must_equal 123
+          config.sampler.must_equal "test-sampler"
+          config.span_id_generator.must_equal "test-generator"
         end
       end
     end
 
-    it "returns true if config.google_cloud.use_trace is explicitly true even Rails is not in production" do
-      @rails_config.google_cloud.trace.project_id = "test-project"
-      @rails_config.google_cloud.use_trace = true
+    it "doesn't override instrumentation configs" do
+      Google::Cloud::Trace.configure do |config|
+        config.project_id = "another-test-project"
+        config.keyfile = "/another/test/keyfile"
+        config.capture_stack = "false"
+        config.notifications = ["blah"]
+        config.max_data_length = 345
+        config.sampler = "another-test-sampler"
+        config.span_id_generator = "another-test-generator"
+      end
 
-      Google::Cloud::Trace::Credentials.stub :default, nil do
+      STDOUT.stub :puts, nil do
+        Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
+
+        Google::Cloud::Trace.configure do |config|
+          config.project_id.must_equal "another-test-project"
+          config.keyfile.must_equal "/another/test/keyfile"
+          config.capture_stack.must_equal "false"
+          config.notifications.must_equal ["blah"]
+          config.max_data_length.must_equal 345
+          config.sampler.must_equal "another-test-sampler"
+          config.span_id_generator.must_equal "another-test-generator"
+        end
+      end
+    end
+
+    it "Set use_trace to false if credentials aren't valid" do
+      Google::Cloud.configure.use_trace = true
+
+      Google::Cloud::Trace::Railtie.stub :valid_credentials?, false do
+        Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
+        Google::Cloud.configure.use_trace.must_equal false
+      end
+    end
+
+    it "Set use_trace to true if Rails is in production" do
+      Google::Cloud::Trace::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, true do
+          Google::Cloud.configure.use_trace.must_be_nil
+          Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_trace.must_equal true
+        end
+      end
+    end
+
+    it "returns true if use_trace is explicitly true even Rails is not in production" do
+      rails_config.google_cloud.use_trace = true
+
+      Google::Cloud::Trace::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, false do
-          Google::Cloud::Trace::Railtie.use_trace?(@rails_config).must_equal true
+          Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_trace.must_equal true
         end
       end
     end

--- a/google-cloud-trace/test/google/cloud/trace/rails_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/rails_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Trace::Railtie do
 
   after {
     Google::Cloud.configure.delete :use_trace
-    Google::Cloud::Trace.configure.clear
+    Google::Cloud::Trace.configure.instance_variable_get(:@configs).clear
   }
 
   describe ".consolidate_rails_config" do

--- a/integration/rails4_app/Gemfile
+++ b/integration/rails4_app/Gemfile
@@ -47,6 +47,7 @@ end
 
 gem "google-cloud-bigquery", path: "../../google-cloud-bigquery"
 gem "google-cloud-core", path: "../../google-cloud-core"
+gem "google-cloud-debugger", path: "../../google-cloud-debugger"
 gem "google-cloud-env", path: "../../google-cloud-env"
 gem "google-cloud-datastore", path: "../../google-cloud-datastore"
 gem "google-cloud-debugger", path: "../../google-cloud-debugger"

--- a/integration/rails5_app/Gemfile
+++ b/integration/rails5_app/Gemfile
@@ -50,6 +50,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "google-cloud-bigquery", path: "../../google-cloud-bigquery"
 gem "google-cloud-core", path: "../../google-cloud-core"
+gem "google-cloud-debugger", path: "../../google-cloud-debugger"
 gem "google-cloud-env", path: "../../google-cloud-env"
 gem "google-cloud-datastore", path: "../../google-cloud-datastore"
 gem "google-cloud-debugger", path: "../../google-cloud-debugger"

--- a/integration/sinatra1_app/app.rb
+++ b/integration/sinatra1_app/app.rb
@@ -17,23 +17,14 @@ require 'sinatra'
 require 'stackdriver'
 require 'grpc'
 
-#######################################
-# Setup ErrorReporting Middleware
-er_service_name = "google-cloud-ruby_integration_test"
-er_serivce_version = ENV['USER']
-
-use Google::Cloud::ErrorReporting::Middleware, service_name: er_service_name,
-                                               service_version: er_serivce_version
-#######################################
-
+Google::Cloud.configure do |config|
+  config.logging.log_name = "google-cloud-ruby_integration_test"
+end
 
 #######################################
-# Setup Logging Middleware
-logging = Google::Cloud::Logging.new
-resource = Google::Cloud::Logging::Middleware.build_monitored_resource
-sd_logger = logging.logger "google-cloud-ruby_integration_test", resource
-use Google::Cloud::Logging::Middleware, logger: sd_logger
-#######################################
+# Setup Middlewares
+use Google::Cloud::ErrorReporting::Middleware
+use Google::Cloud::Logging::Middleware
 
 
 # Set :raise_errors to expose error message in production environment

--- a/stackdriver-core/lib/google/cloud/configuration.rb
+++ b/stackdriver-core/lib/google/cloud/configuration.rb
@@ -23,20 +23,9 @@ module Google
     # configurations.
     module Configuration
       ##
-      # @private Instrumentation library configuration options
-      CONFIG_OPTIONS = %I{
-        project_id
-        keyfile
-        use_debugger
-        use_error_reporting
-        use_logging
-        use_trace
-      }
-
-      ##
       # @private The shared Configuration object that all the Stackdriver
       # instrumentation libraries will build on top of.
-      @@config = ::Stackdriver::Core::Configuration.new CONFIG_OPTIONS
+      @@config = ::Stackdriver::Core::Configuration.new
 
       ##
       # Configure the default parameter for Google::Cloud. The values defined on

--- a/stackdriver-core/lib/stackdriver/core/configuration.rb
+++ b/stackdriver-core/lib/stackdriver/core/configuration.rb
@@ -32,7 +32,7 @@ module Stackdriver
     #   config.cat1           #=> <Stackdriver::Core::Configuration>
     #   config.cat2.cat3   #=> <Stackdriver::Core::Configuration>
     #
-    class Configuration < Hash
+    class Configuration
       ##
       # Constructs a new instance of Configuration object.
       #
@@ -43,7 +43,7 @@ module Stackdriver
       #   further nested sub categories.
       #
       def initialize categories = {}
-        super()
+        @configs = {}
 
         add_options categories
       end
@@ -82,15 +82,22 @@ module Stackdriver
       end
 
       ##
-      # @private Wrap inherited #[] method. Force key to be a Symbol.
+      # Assign an option with `key` to value, while forcing `key` to be a
+      # Symbol.
       def []= key, value
-        super key.to_sym, value
+        @configs[key.to_sym] = value
       end
 
       ##
-      # @private Wrap inherited #[]= method. Force key to be a Symbol.
+      # Get the option with `key`, while forcing `key` to be a Symbol.
       def [] key
-        super key.to_sym
+        @configs[key.to_sym]
+      end
+
+      ##
+      # Delete the option with `key`, while forcing `key` to be a Symbol.
+      def delete key
+        @configs.delete key.to_sym
       end
 
       ##
@@ -101,7 +108,9 @@ module Stackdriver
       # @return [Boolean] True if the inquired key is a valid option for this
       #   Configuration object. False otherwise.
       #
-      alias_method :option?, :key?
+      def option? key
+        @configs.key? key.to_sym
+      end
 
       ##
       # @private Dynamic getters and setters

--- a/stackdriver-core/lib/stackdriver/core/configuration.rb
+++ b/stackdriver-core/lib/stackdriver/core/configuration.rb
@@ -18,55 +18,55 @@ module Stackdriver
     ##
     # @private Helps organize configuration options for Stackdriver
     # instrumentation libraries. It's initialized with a nested list of
-    # predefined option keys, then only allows getting and setting these
+    # predefined category keys, then only allows getting and setting these
     # predefined options.
     #
     # @example
-    #   nested_categories = [:nested1, {nested2: [:nested3]}]
-    #   config = Stackdriver::Core::Configuration.new nested: nested_categories
+    #   nested_categories = [:cat1, {cat2: [:cat3]}]
+    #   config = Stackdriver::Core::Configuration.new nested_categories
     #
     #   config.opt1        #=> nil
     #   config.opt1 = true #=> true
     #   config.opt1        #=> true
     #
-    #   config.nested1           #=> <Stackdriver::Core::Configuration>
-    #   config.nested2.nested3   #=> <Stackdriver::Core::Configuration>
+    #   config.cat1           #=> <Stackdriver::Core::Configuration>
+    #   config.cat2.cat3   #=> <Stackdriver::Core::Configuration>
     #
     class Configuration < Hash
       ##
       # Constructs a new instance of Configuration object.
       #
-      # @param [Symbol, Array<Symbol, Hash>, Hash<Symbol, (Array, Hash)>] nested
-      #   A Symbol, or nested Array and Hash of sub configuration categories.
-      #   A single symbol, or symbols in array, will be key(s) to next level of
-      #   categories. Nested hash represent sub categories with further nested
-      #   sub categories.
+      # @param [Symbol, Array<Symbol, Hash>, Hash<Symbol, (Array, Hash)>]
+      #   categories A Symbol, or nested Array and Hash of sub configuration
+      #   categories. A single symbol, or symbols in array, will be key(s) to
+      #   next level of categories. Nested hash represent sub categories with
+      #   further nested sub categories.
       #
-      def initialize nested = {}
+      def initialize categories = {}
         super()
 
-        add_nested nested
+        add_options categories
       end
 
       ##
-      # Add nested sub configurations to a Configuration object
+      # Add nested sub configuration categories to a Configuration object
       #
-      # @param [Symbol, Array<Symbol, Hash>, Hash<Symbol, (Array, Hash)>] nested
-      #   A Symbol, or nested Array and Hash of sub configuration categories.
-      #   A single symbol, or symbols in array, will be key(s) to next level of
-      #   categories. Nested hash represent sub categories with further nested
-      #   sub categories.
+      # @param [Symbol, Array<Symbol, Hash>, Hash<Symbol, (Array, Hash)>]
+      #   categories A Symbol, or nested Array and Hash of sub configuration
+      #   categories. A single symbol, or symbols in array, will be key(s) to
+      #   next level of categories. Nested hash represent sub categories with
+      #   further nested sub categories.
       #
       # @example
       #   config = Stackdriver::Core::Configuration.new
-      #   config.nest1 #=> nil
-      #   config.add_nested {nest1: [nest2]}
-      #   config.nest1 #=> <Stackdriver::Core::Configuration>
-      #   config.nest1.nest2 #=> <Stackdriver::Core::Configuration>
+      #   config.cat1 #=> nil
+      #   config.add_options {cat1: [:cat2]}
+      #   config.cat1 #=> <Stackdriver::Core::Configuration>
+      #   config.cat1.cat2 #=> <Stackdriver::Core::Configuration>
       #
-      def add_nested nested
-        nested = [nested].flatten(1)
-        nested.each do |sub_key|
+      def add_options categories
+        categories = [categories].flatten(1)
+        categories.each do |sub_key|
           case sub_key
           when Symbol
             self[sub_key] = self.class.new

--- a/stackdriver-core/lib/stackdriver/core/configuration.rb
+++ b/stackdriver-core/lib/stackdriver/core/configuration.rb
@@ -38,7 +38,7 @@ module Stackdriver
       #
       # @param [Symbol, Array<Symbol, Hash>, Hash<Symbol, (Array, Hash)>] nested
       #   A Symbol, or nested Array and Hash of sub configuration categories.
-      #   A single Symbol and Symbols in array will be keys to next level of
+      #   A single symbol, or symbols in array, will be key(s) to next level of
       #   categories. Nested hash represent sub categories with further nested
       #   sub categories.
       #
@@ -53,7 +53,7 @@ module Stackdriver
       #
       # @param [Symbol, Array<Symbol, Hash>, Hash<Symbol, (Array, Hash)>] nested
       #   A Symbol, or nested Array and Hash of sub configuration categories.
-      #   A single Symbol and Symbols in array will be keys to next level of
+      #   A single symbol, or symbols in array, will be key(s) to next level of
       #   categories. Nested hash represent sub categories with further nested
       #   sub categories.
       #

--- a/stackdriver-core/lib/stackdriver/core/configuration.rb
+++ b/stackdriver-core/lib/stackdriver/core/configuration.rb
@@ -51,7 +51,7 @@ module Stackdriver
       ##
       # Add nested sub configurations to a Configuration object
       #
-      # @param [Symbol, Array<Symbol, Hash>, Hash<Symbol, ( Array, Hash)>] nested
+      # @param [Symbol, Array<Symbol, Hash>, Hash<Symbol, (Array, Hash)>] nested
       #   A Symbol, or nested Array and Hash of sub configuration categories.
       #   A single Symbol and Symbols in array will be keys to next level of
       #   categories. Nested hash represent sub categories with further nested
@@ -68,14 +68,14 @@ module Stackdriver
         nested = [nested].flatten(1)
         nested.each do |sub_key|
           case sub_key
-            when Symbol
-              self[sub_key] = self.class.new
-            when Hash
-              sub_key.each do |k, v|
-                self[k] = self.class.new v
-              end
-            else
-              fail ArgumentError \
+          when Symbol
+            self[sub_key] = self.class.new
+          when Hash
+            sub_key.each do |k, v|
+              self[k] = self.class.new v
+            end
+          else
+            fail ArgumentError \
               "Configuration option can only be Symbol or Hash"
           end
         end

--- a/stackdriver-core/test/google/cloud/configuration_test.rb
+++ b/stackdriver-core/test/google/cloud/configuration_test.rb
@@ -18,17 +18,12 @@ require "google/cloud/configuration"
 
 describe Google::Cloud do
   describe ".configure" do
-    it "allows the right config options" do
+    it "allows the config options" do
       config = Google::Cloud.configure
-      Google::Cloud::Configuration::CONFIG_OPTIONS.each do |option|
-        config.option?(option).must_equal true
-      end
-    end
 
-    it "doesn't allow the wrong option" do
-      assert_raises RuntimeError do
-        Google::Cloud.configure.wrong_opt123
-      end
+      config.opt1.must_be_nil
+      config.opt1 = "value"
+      config.opt1.must_equal "value"
     end
 
     it "returns same object between calls" do

--- a/stackdriver-core/test/stackdriver/core/configuration_test.rb
+++ b/stackdriver-core/test/stackdriver/core/configuration_test.rb
@@ -17,11 +17,11 @@ require "helper"
 require "stackdriver/core/configuration"
 
 describe Stackdriver::Core::Configuration do
-  let(:options) { [:k1, :k2, {k3: [:k4, :k5]}, :k6] }
-  let(:configuration) { Stackdriver::Core::Configuration.new options }
+  let(:nested_categories) { [:k1, {k2: [:k3]}] }
+  let(:configuration) { Stackdriver::Core::Configuration.new nested_categories }
 
   describe "#initialize" do
-    it "accepts no parameters" do
+    it "works with no parameters" do
       config = Stackdriver::Core::Configuration.new
 
       config.must_be_kind_of Stackdriver::Core::Configuration
@@ -34,124 +34,82 @@ describe Stackdriver::Core::Configuration do
     end
 
     it "initializes options to nil" do
-      configs = configuration.instance_variable_get :@configs
-
-      configs[:k1].must_be_nil
-      configs[:k6].must_be_nil
-    end
-
-    it "initalizes all the option keys" do
-      configs = configuration.instance_variable_get :@configs
-
-      [:k1, :k2, :k3, :k6].all? { |k| configs.key? k }.must_equal true
+      configuration.opt1.must_be_nil
+      configuration.opt2.must_be_nil
     end
 
     it "initializes nested Stackdriver::Core::Configuration" do
-      configs = configuration.instance_variable_get :@configs
+      configuration.k1.must_be_kind_of Stackdriver::Core::Configuration
+      configuration.k2.must_be_kind_of Stackdriver::Core::Configuration
+      configuration.k2.k3.must_be_kind_of Stackdriver::Core::Configuration
+    end
 
-      nested_configuration = configs[:k3]
-      nested_configs = nested_configuration.instance_variable_get :@configs
+    it "accepts hash too" do
+      config = Stackdriver::Core::Configuration.new k1: {k2: [:k3]}
 
-      nested_configuration.must_be_kind_of Stackdriver::Core::Configuration
-      nested_configs.key?(:k4).must_equal true
-      nested_configs.key?(:k5).must_equal true
+      config.k1.must_be_kind_of Stackdriver::Core::Configuration
+      config.k1.k2.must_be_kind_of Stackdriver::Core::Configuration
+      config.k1.k2.k3.must_be_kind_of Stackdriver::Core::Configuration
     end
   end
 
-  describe "#add_option" do
-    it "introduces new option" do
-      assert_raises RuntimeError do
-        configuration.k7
-      end
+  describe "#add_nested" do
+    it "introduces new nested categories" do
+      configuration.k4.must_be_nil
 
-      configuration.add_options [:k7]
+      configuration.add_nested [:k4, {k5: [:k6]}]
 
-      configuration.k7.must_be_nil
-      configuration.k7 = true
-      configuration.k7.must_equal true
-
-      configuration.k1.must_be_nil
+      configuration.k4.must_be_kind_of Stackdriver::Core::Configuration
+      configuration.k5.must_be_kind_of Stackdriver::Core::Configuration
+      configuration.k5.k6.must_be_kind_of Stackdriver::Core::Configuration
     end
 
-    it "allows nested option" do
-      assert_raises RuntimeError do
-        configuration.k7.k8
-      end
+    it "accepts simple hash with one symbol" do
+      configuration.k4.must_be_nil
 
-      configuration.add_options [{k7: [:k8]}]
+      configuration.add_nested k4: :k5
 
-      configuration.k7.must_be_kind_of Stackdriver::Core::Configuration
-      configuration.k7.k8.must_be_nil
+      configuration.k4.must_be_kind_of Stackdriver::Core::Configuration
+      configuration.k4.k5.must_be_kind_of Stackdriver::Core::Configuration
     end
   end
 
   describe "#option?" do
     it "returns true if configuration has that option" do
-      configuration.k1.must_be_nil
-      configuration.option?(:k1).must_equal true
+      configuration.option?(:opt1).must_equal false
+      configuration.opt1 = true
+      configuration.option?(:opt1).must_equal true
     end
 
     it "returns true even if the key is a sub configuration group" do
-      configuration.k3.must_be_kind_of Stackdriver::Core::Configuration
-      configuration.option?(:k3).must_equal true
+      configuration.k2.must_be_kind_of Stackdriver::Core::Configuration
+      configuration.option?(:k2).must_equal true
     end
 
     it "returns false if configuration doesn't have that option" do
-      assert_raises RuntimeError do
-        configuration.k7
-      end
       configuration.option?(:k7).must_equal false
     end
   end
 
   describe "#method_missing" do
-    it "gets a valid option" do
-      configuration.k1.must_be_nil
+    it "any keys are allowed" do
+      configuration.total_non_sense.must_be_nil
     end
 
-    it "sets a valid option" do
-      configuration.k1 = "test value"
-
-      configuration.k1.must_equal "test value"
-
-      configs = configuration.instance_variable_get :@configs
-
-      configs[:k1].must_equal "test value"
+    it "sets and get a valid option" do
+      configuration.opt1.must_be_nil
+      configuration.opt1 = "test value"
+      configuration.opt1.must_equal "test value"
     end
 
     it "gets a valid nested option" do
-      configuration.k3.k4.must_be_nil
+      configuration.k1.opt4.must_be_nil
     end
 
     it "sets a valid nested option" do
-      configuration.k3.k4 = "test value"
+      configuration.k2.k3 = "test value"
 
-      configuration.k3.k4.must_equal "test value"
-    end
-
-    it "raises exception if setting a nested category" do
-      configuration.k3.k4 = "test value"
-
-      e = assert_raises RuntimeError do
-        configuration.k3 = "test value 2"
-      end
-
-      configuration.k3.k4.must_equal "test value"
-      e.message.must_match "k3 is a sub Configuration group. Not an option."
-    end
-
-    it "raises exception if setting a non-valid option" do
-      e = assert_raises RuntimeError do
-        configuration.foo = "test value"
-      end
-      e.message.must_match "Unrecognized Option: foo"
-    end
-
-    it "raises exception if setting a non-valid nested option" do
-      e = assert_raises RuntimeError do
-        configuration.k3.foo = "test value"
-      end
-      e.message.must_match "Unrecognized Option: foo"
+      configuration.k2.k3.must_equal "test value"
     end
   end
 end

--- a/stackdriver-core/test/stackdriver/core/configuration_test.rb
+++ b/stackdriver-core/test/stackdriver/core/configuration_test.rb
@@ -53,11 +53,11 @@ describe Stackdriver::Core::Configuration do
     end
   end
 
-  describe "#add_nested" do
+  describe "#add_options" do
     it "introduces new nested categories" do
       configuration.k4.must_be_nil
 
-      configuration.add_nested [:k4, {k5: [:k6]}]
+      configuration.add_options [:k4, {k5: [:k6]}]
 
       configuration.k4.must_be_kind_of Stackdriver::Core::Configuration
       configuration.k5.must_be_kind_of Stackdriver::Core::Configuration
@@ -67,7 +67,7 @@ describe Stackdriver::Core::Configuration do
     it "accepts simple hash with one symbol" do
       configuration.k4.must_be_nil
 
-      configuration.add_nested k4: :k5
+      configuration.add_options k4: :k5
 
       configuration.k4.must_be_kind_of Stackdriver::Core::Configuration
       configuration.k4.k5.must_be_kind_of Stackdriver::Core::Configuration

--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -84,7 +84,7 @@ task :jsondoc => :yard do
   generator = Gcloud::Jsondoc::Generator.new registry, "stackdriver"
   rm_rf "jsondoc", verbose: true
   generator.write_to "jsondoc"
-  cp ["docs/toc.json"], "jsondoc", verbose: true
+  cp ["docs/configuration.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 require "yard"

--- a/stackdriver/docs/configuration.md
+++ b/stackdriver/docs/configuration.md
@@ -1,0 +1,107 @@
+# Stackdriver Instrumentation Configuration
+
+Stackdriver instrumentation libraries are fully integrated with Rails 
+configuration interface. You can provide all the configuration parameters in
+your `config/environments/*.rb` files:
+
+```ruby
+Rails.application.configure do |config|
+  # Shared project_id and keyfile
+  config.google_cloud.project_id = "my-project"
+  config.google_cloud.keyfile = "/path/to/key.json"
+  
+  # Library specific configurations
+  config.google_cloud.error_reporting.project_id = "error-reporting-project"
+  config.google_cloud.logging.log_name = "my-app-logname"
+  config.google_cloud.trace.capture_stack = true
+end
+```
+
+Other Rack-based applications can also configure all the Stackdriver 
+instrumentation libraries through a similar configuration interface in Ruby:
+
+```ruby
+Google::Cloud.configure do |config|
+  # Shared project_id and keyfile
+  config.project_id = "my-project"
+  config.keyfile = "/path/to/key.json"
+  
+  # Library specific configurations
+  config.error_reporting.project_id = "error-reporting-project"
+  config.logging.log_name = "my-app-log"
+  config.trace.capture_stack = true
+end
+```
+
+Individual libraries can be configured separately:
+
+```ruby
+# Error Reporting specific configurations 
+Google::Cloud::ErrorReporting.configure do |config|
+  config.project_id = "error-reporting-project"
+  config.service_name = "my-service"
+end
+
+# Debugger specific configurations 
+Google::Cloud::Debugger.configure do |config|
+  config.project_id = "debugger-project"
+  config.module_name = "my-service"
+end
+
+# Logging specific configurations 
+Google::Cloud::Logging.configure do |config|
+  config.project_id = "error-reporting-project"
+  config.log_name = "my-app-log"
+end
+
+# Trace specific configurations 
+Google::Cloud::Trace.configure do |config|
+  config.project_id = "error-reporting-project"
+  config.capture_stack = true
+end
+```
+
+## Configuration Options
+
+#### Shared
+
+* `project_id`: [`String`] Shared Google Cloud Platform Project identifier. Self discovered on GCP.
+* `key_file`: [`String`] Path to shared service account JSON keyfile. Self discovered on GCP.
+* `use_error_reporting`: [`Boolean`] Explicitly enable or disable Error Reporting features. Default: `Rails.env.production?`
+* `use_debugger`: [`Boolean`] Explicitly enable or disable Debugger features. Default: `Rails.env.production?`
+* `use_logging`: [`Boolean`] Explicitly enable or disable Logging features. Default: `Rails.env.production?`
+* `use_trace`: [`Boolean`] Explicitly enable or disable Trace features. Default: `Rails.env.production?`
+
+#### Error Reporting
+
+* `error_reporting.project_id`: [`String`] Google Cloud Platform Project identifier just for Error Reporting. Self discovered on GCP.
+* `error_reporting.keyfile`: [`String`] Path to service account JSON keyfile. Self discovered on GCP.
+* `error_reporting.service_name`: [`String`] Identifier to running service. Self discovered on GCP. Default: `"ruby"`
+* `error_reporting.service_version`: [`String`] Version identifier to running service. Self discovered on GCP.
+* `error_reporting.ignore_classes`: [`Array`] An Array of Exception classes to ignore. Default: `[]`
+
+#### Debugger
+
+* `debugger.project_id`: [`String`] Google Cloud Platform Project identifier just for Debugger. Self discovered on GCP.
+* `debugger.keyfile`: [`String`] Path to service account JSON keyfile. Self discovered on GCP.
+* `debugger.module_name`: [`String`] Identifier to running service. Self discovered on GCP. Default: `"ruby-app"`
+* `debugger.module_version`: [`String`] Version identifier to running service. Self discovered on GCP.
+
+#### Logging
+
+* `logging.project_id`: [`String`] Google Cloud Platform Project identifier just for Logging. Self discovered on GCP.
+* `logging.keyfile`: [`String`] Path to service account JSON keyfile. Self discovered on GCP.
+* `logging.log_name`: [`String`] Name of the application log file. Default: `"ruby_app_log"`
+* `logging.log_name_map`: [`Hash`] Map specific request routes to other log. Default: `{ "/_ah/health" => "ruby_health_check_log" }`
+* `logging.monitored_resource.type`: [`String`] Resource type name. See [full list](https://cloud.google.com/logging/docs/api/v2/resource-list). Self discovered on GCP.
+* `logging.monitored_resource.labels`: [`Hash`] Resource labels. See [full list](https://cloud.google.com/logging/docs/api/v2/resource-list). Self discovered on GCP.
+
+#### Trace
+
+* `trace.project_id`: [`String`] Google Cloud Platform Project identifier just for Trace. Self discovered on GCP.
+* `trace.keyfile`: [`String`] Path to service account JSON keyfile. Self discovered on GCP.
+* `trace.capture_stack`: [`Boolean`] Whether to capture stack traces for each span. Default: `false`
+* `trace.sampler`: [`Proc`] A sampler Proc makes the decision whether to record a trace for each request. Default: `Google::Cloud::Trace::TimeSampler`
+* `trace.span_id_generator`: [`Proc`] A generator Proc that generates the name String for new TraceRecord. Default: `random numbers`
+* `trace.notifications`: [`Array`] An array of ActiveSupport notification types to include in traces. Rails-only option. Default: `Google::Cloud::Trace::Railtie::DEFAULT_NOTIFICATIONS`
+* `trace.max_data_length`: [`Integer`] The maximum length of span properties recorded with ActiveSupport notification events. Rails-only option. Default: `Google::Cloud::Trace::Notifications::DEFAULT_MAX_DATA_LENGTH`

--- a/stackdriver/docs/toc.json
+++ b/stackdriver/docs/toc.json
@@ -1,6 +1,11 @@
 {
   "guides": [
     {
+      "title": "Configuration",
+      "id": "instrumentation_configuration",
+      "contents": "configuration.md"
+    },
+    {
       "title": "Error Reporting Instrumentation",
       "id": "error_reporting_instrumentation",
       "contents": "google/cloud/errorreporting/instrumentation.md"


### PR DESCRIPTION
The main goal of this PR is to make Logging, Debugger, and Trace instrumentation libraries use the new configuration interface.

Previously there were multiple sources to define configuration parameters and multiple places to store them, as a result the code was becoming smelly. So I refactored all the Middleware and Railtie classes to solely rely on the new configuration interface as the record of truth for all instrumentation configuration story.

Example:
```ruby
require "google/cloud/logging"
require "google/cloud/error_reporting"
require "google/cloud/debugger"
require "google/cloud/trace"

Google::Cloud.configure do |config|
  config.project_id = "my-project"
  config.logging.log_name = "me-app-log"
  config.error_reporting.service_name = "test-service"
  config.debugger.module_name = "test-module"
  config.debugger.module_version = "test-version"
end

use Google::Cloud::Logging::Middleware
use Google::Cloud::ErrorReporting::Middleware
use Google::Cloud::Trace::Middleware
use Google::Cloud::Debugger::Middleware
```
Finally, I also created this `stackdriver/docs/configuration.md` file as the main location to document all the configuration parameters and examples. Then refactored all the other spaghetti configuration docs to reference this consolidated document.
 