### PR TITLE
Remove monitoring from stackdriver

### DIFF
--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -7,7 +7,6 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-error_reporting", path: "../google-cloud-error_reporting"
 gem "google-cloud-logging", path: "../google-cloud-logging"
-gem "google-cloud-monitoring", path: "../google-cloud-monitoring"
 gem "google-cloud-trace", path: "../google-cloud-trace"
 gem "stackdriver-core", path: "../stackdriver-core"
 

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -5,7 +5,6 @@ This gem instruments a Ruby web application for Stackdriver diagnostics. When lo
 Specifically, this gem is a convenience package that loads and automatically activates the instrumentation features of the following gems:
 - [google-cloud-logging](../google-cloud-logging)
 - [google-cloud-error_reporting](../google-cloud-error_reporting)
-- [google-cloud-monitoring](../google-cloud-monitoring)
 - [google-cloud-trace](../google-cloud-trace)
 
 Please see the top-level project [README](../README.md) for more information about the individual Stackdriver google-cloud-ruby gems.

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -15,7 +15,6 @@
 
 gem "google-cloud-error_reporting"
 gem "google-cloud-logging"
-gem "google-cloud-monitoring"
 gem "google-cloud-trace"
 
 require "google/cloud/logging"
@@ -42,7 +41,6 @@ require "legacy_stackdriver"
 # Specifically, this gem is a convenience package that loads the following gems:
 # - [google-cloud-logging](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging)
 # - [google-cloud-error_reporting](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-error_reporting)
-# - [google-cloud-monitoring](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-monitoring)
 # - [google-cloud-trace](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-trace)
 #
 # On top of that, stackdriver gem automatically activates the following

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "google-cloud-error_reporting", "~> 0.24.0"
   gem.add_runtime_dependency "google-cloud-logging", "~> 1.0"
-  gem.add_runtime_dependency "google-cloud-monitoring", "~> 0.24.0"
   gem.add_runtime_dependency "google-cloud-trace", "~> 0.24.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
@@ -31,5 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
+  gem.add_development_dependency "yard-doctest", "~> 0.1.6"
   gem.add_development_dependency "railties", "~> 4.0"
 end


### PR DESCRIPTION
Remove Monitoring from the `stackdriver` gem for now, since it doesn't have instrumentation features and its APIs aren't consistent with the other four libraries.

Internal task ref: b/37484953