### PR TITLE
Expose Commit Timestamp

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
@@ -20,8 +20,10 @@ describe "Spanner Client", :single_use, :spanner do
   let(:fields_hash) { { account_id: :INT64, username: :STRING, friends: [:INT64], active: :BOOL, reputation: :FLOAT64, avatar: :BYTES } }
 
   before do
-    db.delete "accounts"
-    db.insert "accounts", default_account_rows
+    @setup_timestamp = db.commit do |c|
+      c.delete "accounts"
+      c.insert "accounts", default_account_rows
+    end
   end
 
   after do
@@ -38,7 +40,7 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?
+    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a read with strong option" do
@@ -51,12 +53,11 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?
+    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a query with timestamp option" do
-    timestamp = Time.now
-    results = db.execute "SELECT * FROM accounts", single_use: { timestamp: timestamp }
+    results = db.execute "SELECT * FROM accounts", single_use: { timestamp: @setup_timestamp }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal fields_hash
@@ -65,12 +66,11 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to timestamp, 1
+    results.timestamp.must_be_close_to @setup_timestamp, 1
   end
 
   it "runs a read with timestamp option" do
-    timestamp = Time.now
-    results = db.read "accounts", columns, single_use: { timestamp: timestamp }
+    results = db.read "accounts", columns, single_use: { timestamp: @setup_timestamp }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal fields_hash
@@ -79,7 +79,7 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to timestamp, 1
+    results.timestamp.must_be_close_to @setup_timestamp, 1
   end
 
   it "runs a query with staleness option" do
@@ -92,7 +92,7 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?
+    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a read with staleness option" do
@@ -105,12 +105,11 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?
+    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a query with bounded_timestamp option" do
-    timestamp = Time.now
-    results = db.execute "SELECT * FROM accounts", single_use: { bounded_timestamp: timestamp }
+    results = db.execute "SELECT * FROM accounts", single_use: { bounded_timestamp: @setup_timestamp }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal fields_hash
@@ -119,12 +118,11 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to timestamp, 3 # within 3 seconds?
+    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a read with bounded_timestamp option" do
-    timestamp = Time.now
-    results = db.read "accounts", columns, single_use: { bounded_timestamp: timestamp }
+    results = db.read "accounts", columns, single_use: { bounded_timestamp: @setup_timestamp }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
     results.fields.to_h.must_equal fields_hash
@@ -133,7 +131,7 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to timestamp, 3 # within 3 seconds?
+    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a query with bounded_staleness option" do
@@ -146,7 +144,7 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?
+    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   it "runs a read with bounded_staleness option" do
@@ -159,7 +157,7 @@ describe "Spanner Client", :single_use, :spanner do
     end
 
     results.timestamp.wont_be :nil?
-    results.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?
+    results.timestamp.must_be_close_to @setup_timestamp, 3 # within 3 seconds?
   end
 
   def assert_accounts_equal expected, actual

--- a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
@@ -20,8 +20,10 @@ describe "Spanner Client", :snapshot, :spanner do
   let(:fields_hash) { { account_id: :INT64, username: :STRING, friends: [:INT64], active: :BOOL, reputation: :FLOAT64, avatar: :BYTES } }
 
   before do
-    db.delete "accounts"
-    db.insert "accounts", default_account_rows
+    @setup_timestamp = db.commit do |c|
+      c.delete "accounts"
+      c.insert "accounts", default_account_rows
+    end
   end
 
   after do
@@ -97,9 +99,8 @@ describe "Spanner Client", :snapshot, :spanner do
   end
 
   it "runs a query with timestamp option" do
-    timestamp = Time.now
     results = nil
-    db.snapshot timestamp: timestamp do |snp|
+    db.snapshot timestamp: @setup_timestamp do |snp|
       snp.transaction_id.wont_be :nil?
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?
@@ -115,9 +116,8 @@ describe "Spanner Client", :snapshot, :spanner do
   end
 
   it "runs a read with timestamp option" do
-    timestamp = Time.now
     results = nil
-    db.snapshot timestamp: timestamp do |snp|
+    db.snapshot timestamp: @setup_timestamp do |snp|
       snp.transaction_id.wont_be :nil?
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?
@@ -217,7 +217,7 @@ describe "Spanner Client", :snapshot, :spanner do
     sample_row = { account_id: first_row[:account_id], username: first_row[:username] }
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
-    db.snapshot timestamp: Time.now do |snp|
+    db.snapshot timestamp: @setup_timestamp do |snp|
       snp.transaction_id.wont_be :nil?
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?
@@ -240,7 +240,7 @@ describe "Spanner Client", :snapshot, :spanner do
     sample_row = { account_id: first_row[:account_id], username: first_row[:username] }
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
-    db.snapshot timestamp: Time.now do |snp|
+    db.snapshot timestamp: @setup_timestamp do |snp|
       snp.transaction_id.wont_be :nil?
       snp.timestamp.wont_be :nil?
       snp.timestamp.must_be_close_to Time.now, 3 # within 3 seconds?

--- a/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
@@ -21,8 +21,10 @@ describe "Spanner Client", :transaction, :spanner do
   let(:additional_account) { { account_id: 4, username: "swcloud", reputation: 99.894, active: true, friends: [1,2] } }
 
   before do
-    db.delete "accounts"
-    db.insert "accounts", default_account_rows
+    db.commit do |c|
+      c.delete "accounts"
+      c.insert "accounts", default_account_rows
+    end
   end
 
   after do

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -372,7 +372,7 @@ module Google
         # @yield [commit] The block for mutating the data.
         # @yieldparam [Google::Cloud::Spanner::Commit] commit The Commit object.
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -419,7 +419,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -464,7 +464,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -508,7 +508,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -554,7 +554,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -582,7 +582,7 @@ module Google
         #   ranges to match returned data to. Values should have exactly as many
         #   elements as there are columns in the primary key.
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -279,7 +279,7 @@ module Google
         # @yield [commit] The block for mutating the data.
         # @yieldparam [Google::Cloud::Spanner::Commit] commit The Commit object.
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -296,8 +296,9 @@ module Google
         def commit transaction_id: nil
           commit = Commit.new
           yield commit
-          service.commit path, commit.mutations, transaction_id: transaction_id
-          true
+          commit_resp = service.commit path, commit.mutations,
+                                       transaction_id: transaction_id
+          Convert.timestamp_to_time commit_resp.commit_timestamp
         end
 
         ##
@@ -327,7 +328,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -340,10 +341,9 @@ module Google
         #                       { id: 2, name: "Harvey",  active: true }]
         #
         def upsert table, *rows, transaction_id: nil
-          commit = Commit.new
-          commit.upsert table, rows
-          service.commit path, commit.mutations, transaction_id: transaction_id
-          true
+          commit transaction_id: transaction_id do |c|
+            c.upsert table, rows
+          end
         end
         alias_method :save, :upsert
 
@@ -373,7 +373,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -386,10 +386,9 @@ module Google
         #                       { id: 2, name: "Harvey",  active: true }]
         #
         def insert table, *rows, transaction_id: nil
-          commit = Commit.new
-          commit.insert table, rows
-          service.commit path, commit.mutations, transaction_id: transaction_id
-          true
+          commit transaction_id: transaction_id do |c|
+            c.insert table, rows
+          end
         end
 
         ##
@@ -418,7 +417,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -431,10 +430,9 @@ module Google
         #                       { id: 2, name: "Harvey",  active: true }]
         #
         def update table, *rows, transaction_id: nil
-          commit = Commit.new
-          commit.update table, rows
-          service.commit path, commit.mutations, transaction_id: transaction_id
-          true
+          commit transaction_id: transaction_id do |c|
+            c.update table, rows
+          end
         end
 
         ##
@@ -465,7 +463,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -478,10 +476,9 @@ module Google
         #                        { id: 2, name: "Harvey",  active: true }]
         #
         def replace table, *rows, transaction_id: nil
-          commit = Commit.new
-          commit.replace table, rows
-          service.commit path, commit.mutations, transaction_id: transaction_id
-          true
+          commit transaction_id: transaction_id do |c|
+            c.replace table, rows
+          end
         end
 
         ##
@@ -494,7 +491,7 @@ module Google
         #   ranges to match returned data to. Values should have exactly as many
         #   elements as there are columns in the primary key.
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the operation committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -506,10 +503,9 @@ module Google
         #   db.delete "users", [1, 2, 3]
         #
         def delete table, keys = [], transaction_id: nil
-          commit = Commit.new
-          commit.delete table, keys
-          service.commit path, commit.mutations, transaction_id: transaction_id
-          true
+          commit transaction_id: transaction_id do |c|
+            c.delete table, keys
+          end
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -194,7 +194,7 @@ module Google
         # @yield [commit] The block for mutating the data.
         # @yieldparam [Google::Cloud::Spanner::Commit] commit The Commit object.
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the transaction committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -242,7 +242,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the transaction committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -287,7 +287,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the transaction committed.
         #
         # @example
         #   require "google/cloud/spanner"
@@ -331,7 +331,7 @@ module Google
         #   See [Data
         #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
         #
-        # @return [Boolean] Returns `true` if the operation succeeded.
+        # @return [Time] The timestamp at which the transaction committed.
         #
         # @example
         #   require "google/cloud/spanner"

--- a/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
@@ -20,7 +20,9 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:commit_resp) { Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new() }
+  let(:commit_time) { Time.now }
+  let(:commit_timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp commit_time }
+  let(:commit_resp) { Google::Spanner::V1::CommitResponse.new commit_timestamp: commit_timestamp }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
 
@@ -65,13 +67,14 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.commit do |c|
+    timestamp = session.commit do |c|
       c.update "users", [{ id: 1, name: "Charlie", active: false }]
       c.insert "users", [{ id: 2, name: "Harvey",  active: true }]
       c.upsert "users", [{ id: 3, name: "Marley",  active: false }]
       c.replace "users", [{ id: 4, name: "Henry",  active: true }]
       c.delete "users", [1, 2, 3, 4, 5]
     end
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -90,7 +93,8 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.update "users", [{ id: 1, name: "Charlie", active: false }]
+    timestamp = session.update "users", [{ id: 1, name: "Charlie", active: false }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -109,7 +113,8 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.insert "users", [{ id: 2, name: "Harvey",  active: true }]
+    timestamp = session.insert "users", [{ id: 2, name: "Harvey",  active: true }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -128,7 +133,8 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.upsert "users", [{ id: 3, name: "Marley",  active: false }]
+    timestamp = session.upsert "users", [{ id: 3, name: "Marley",  active: false }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -147,7 +153,8 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.save "users", [{ id: 3, name: "Marley",  active: false }]
+    timestamp = session.save "users", [{ id: 3, name: "Marley",  active: false }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -166,7 +173,8 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.replace "users", [{ id: 4, name: "Henry",  active: true }]
+    timestamp = session.replace "users", [{ id: 4, name: "Henry",  active: true }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -188,7 +196,8 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.delete "users", [1, 2, 3, 4, 5]
+    timestamp = session.delete "users", [1, 2, 3, 4, 5]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -208,7 +217,8 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.delete "users", 1..100
+    timestamp = session.delete "users", 1..100
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -230,7 +240,8 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.delete "users", 5
+    timestamp = session.delete "users", 5
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -248,7 +259,8 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session.path, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     session.service.mocked_service = mock
 
-    session.delete "users"
+    timestamp = session.delete "users"
+    timestamp.must_equal commit_time
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/commit_test.rb
@@ -24,7 +24,9 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
   let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
-  let(:commit_resp) { Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new() }
+  let(:commit_time) { Time.now }
+  let(:commit_timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp commit_time }
+  let(:commit_resp) { Google::Spanner::V1::CommitResponse.new commit_timestamp: commit_timestamp }
 
   it "commits using a block" do
     mutations = [
@@ -67,13 +69,14 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.commit do |c|
+    timestamp = transaction.commit do |c|
       c.update "users", [{ id: 1, name: "Charlie", active: false }]
       c.insert "users", [{ id: 2, name: "Harvey",  active: true }]
       c.upsert "users", [{ id: 3, name: "Marley",  active: false }]
       c.replace "users", [{ id: 4, name: "Henry",  active: true }]
       c.delete "users", [1, 2, 3, 4, 5]
     end
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -92,7 +95,8 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.update "users", [{ id: 1, name: "Charlie", active: false }]
+    timestamp = transaction.update "users", [{ id: 1, name: "Charlie", active: false }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -111,7 +115,8 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.insert "users", [{ id: 2, name: "Harvey",  active: true }]
+    timestamp = transaction.insert "users", [{ id: 2, name: "Harvey",  active: true }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -130,7 +135,8 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.upsert "users", [{ id: 3, name: "Marley",  active: false }]
+    timestamp = transaction.upsert "users", [{ id: 3, name: "Marley",  active: false }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -149,7 +155,8 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.save "users", [{ id: 3, name: "Marley",  active: false }]
+    timestamp = transaction.save "users", [{ id: 3, name: "Marley",  active: false }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -168,7 +175,8 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.replace "users", [{ id: 4, name: "Henry",  active: true }]
+    timestamp = transaction.replace "users", [{ id: 4, name: "Henry",  active: true }]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -190,7 +198,8 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.delete "users", [1, 2, 3, 4, 5]
+    timestamp = transaction.delete "users", [1, 2, 3, 4, 5]
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -210,7 +219,8 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.delete "users", 1..100
+    timestamp = transaction.delete "users", 1..100
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -232,7 +242,8 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.delete "users", 5
+    timestamp = transaction.delete "users", 5
+    timestamp.must_equal commit_time
 
     mock.verify
   end
@@ -250,7 +261,8 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     session.service.mocked_service = mock
 
-    transaction.delete "users"
+    timestamp = transaction.delete "users"
+    timestamp.must_equal commit_time
 
     mock.verify
   end


### PR DESCRIPTION
This PR adds timestamp as a return value for methods that will modify data. Previously, these methods returned `true`, but will now return a `Time` value returned from Spanner in `Google::Spanner::V1::CommitResponse.commit_timestamp`.