### PR TITLE
Add acceptance tests for concurrent transactions

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 require "spanner_helper"
+require "concurrent"
 
 describe "Spanner Client", :transaction, :spanner do
   let(:db) { spanner_client }
   let(:columns) { [:account_id, :username, :friends, :active, :reputation, :avatar] }
   let(:fields_hash) { { account_id: :INT64, username: :STRING, friends: [:INT64], active: :BOOL, reputation: :FLOAT64, avatar: :BYTES } }
   let(:additional_account) { { account_id: 4, username: "swcloud", reputation: 99.894, active: true, friends: [1,2] } }
+  let(:query_reputation) { "SELECT reputation FROM accounts WHERE account_id = 1 LIMIT 1" }
 
   before do
     db.commit do |c|
@@ -122,6 +124,86 @@ describe "Spanner Client", :transaction, :spanner do
     results.fields.to_h.must_equal fields_hash
     results.rows.zip(default_account_rows).each do |expected, actual|
       assert_accounts_equal expected, actual
+    end
+  end
+
+  it "supports tx isolation with read and update" do
+    results = db.read "accounts", [:reputation], keys: 1, limit: 1
+    original_val = results.rows.first[:reputation]
+    begin
+      read_latch = Concurrent::CountDownLatch.new 1
+      commit_latch = Concurrent::CountDownLatch.new 1
+      thr_1 = Thread.new do
+        db.transaction do |tx|
+          tx_results = tx.read "accounts", [:reputation], keys: 1, limit: 1
+          tx_val = tx_results.rows.first[:reputation]
+          # puts "read 1: #{tx_val}"
+          read_latch.count_down # Let thread 2 read now
+          commit_latch.wait # Let thread 2 read second but write and commit first
+          new_val = tx_val + 1
+          tx.update "accounts", [{ account_id: 1, reputation: new_val }]
+          # puts "write 1"
+        end
+        # puts "commit 1"
+      end
+      thr_2 = Thread.new do
+        db.transaction do |tx|
+          read_latch.wait # Let thread 1 read first
+          tx_results = tx.read "accounts", [:reputation], keys: 1, limit: 1
+          tx_val = tx_results.rows.first[:reputation]
+          # puts "read 2: #{tx_val}"
+          new_val = tx_val + 1
+          tx.update "accounts", [{ account_id: 1, reputation: new_val }]
+          # puts "write 2"
+        end # Thread 2 commits now
+        commit_latch.count_down # Let thread 1 commit now
+        # puts "commit 2"
+      end
+    ensure
+      thr_1.join
+      thr_2.join
+    end
+
+    results = db.read "accounts", [:reputation], keys: 1, limit: 1
+    results.rows.first[:reputation].must_equal original_val + 2
+  end
+
+  it "supports tx isolation with query and update" do
+    results = db.execute query_reputation
+    original_val = results.rows.first[:reputation]
+    begin
+      thr_1 = Thread.new do
+        query_and_update db
+      end
+      thr_2 = Thread.new do
+        query_and_update db
+      end
+    ensure
+      thr_1.join
+      thr_2.join
+    end
+
+    results = db.execute query_reputation
+    results.rows.first[:reputation].must_equal original_val + 2
+  end
+
+  def read_and_update db
+    db.transaction do |tx|
+      tx_results = tx.read "accounts", [:reputation], keys: 1, limit: 1
+      tx_val = tx_results.rows.first[:reputation]
+      sleep 1 # ensure that both threads would have read same value if not read locked
+      new_val = tx_val + 1
+      tx.update "accounts", [{ account_id: 1, reputation: new_val }]
+    end
+  end
+
+  def query_and_update db
+    db.transaction do |tx|
+      tx_results = tx.execute query_reputation
+      tx_val = tx_results.rows.first[:reputation]
+      sleep 1 # ensure that both threads would have read same value if not read locked
+      new_val = tx_val + 1
+      tx.update "accounts", [{ account_id: 1, reputation: new_val }]
     end
   end
 


### PR DESCRIPTION
Add test coverage for multiple concurrent transactions.

These tests add a total of 4 seconds of sleep time. If that is unacceptable, let me know and I'll remove it.

[closes #1484]