### PR TITLE
Spanner pool updates

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
@@ -18,74 +18,85 @@ describe "Spanner Client", :crud, :spanner do
   let(:db) { spanner_client }
 
   before do
-    db.transaction do |tx|
-      existing_ids = tx.read("accounts", ["account_id"]).rows.map { |row| row[:account_id] }
-      tx.delete "accounts", existing_ids
-    end
-  end
-
-  after do
-    db.transaction do |tx|
-      existing_ids = tx.read("accounts", ["account_id"]).rows.map { |row| row[:account_id] }
-      tx.delete "accounts", existing_ids
-    end
+    @setup_timestamp = db.delete "accounts"
   end
 
   it "inserts, updates, upserts, reads, and deletes records" do
-    db.read("accounts", ["account_id"]).rows.count.must_equal 0
+    results = db.read "accounts", ["account_id"], single_use: { timestamp: @setup_timestamp }
+    results.rows.count.must_equal 0
+    results.timestamp.wont_be :nil?
 
     db.insert "accounts", default_account_rows[0]
     db.upsert "accounts", default_account_rows[1]
-    db.insert "accounts", default_account_rows[2]
+    timestamp = db.insert "accounts", default_account_rows[2]
 
-    db.read("accounts", ["account_id"]).rows.count.must_equal 3
+    results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
+    results.rows.count.must_equal 3
+    results.timestamp.wont_be :nil?
 
     active_count_sql = "SELECT COUNT(*) AS count FROM accounts WHERE active = true"
 
-    db.execute(active_count_sql).rows.first[:count].must_equal 2
+    results = db.execute active_count_sql, single_use: { timestamp: timestamp }
+    results.rows.first[:count].must_equal 2
+    results.timestamp.wont_be :nil?
 
     activate_inactive_account = { account_id: 3, active: true }
 
-    db.upsert "accounts", activate_inactive_account
+    timestamp = db.upsert "accounts", activate_inactive_account
 
-    db.execute(active_count_sql).rows.first[:count].must_equal 3
+    results = db.execute active_count_sql, single_use: { timestamp: timestamp }
+    results.rows.first[:count].must_equal 3
+    results.timestamp.wont_be :nil?
 
-    db.delete "accounts", [1, 2, 3]
+    timestamp = db.delete "accounts", [1, 2, 3]
 
-    db.read("accounts", ["account_id"]).rows.count.must_equal 0
+    results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
+    results.rows.count.must_equal 0
+    results.timestamp.wont_be :nil?
   end
 
   it "inserts, updates, upserts, reads, and deletes records using commit" do
-    db.read("accounts", ["account_id"]).rows.count.must_equal 0
+    results = db.read "accounts", ["account_id"], single_use: { timestamp: @setup_timestamp }
+    results.rows.count.must_equal 0
+    results.timestamp.wont_be :nil?
 
-    db.commit do |c|
+    timestamp = db.commit do |c|
       c.insert "accounts", default_account_rows[0]
       c.upsert "accounts", default_account_rows[1]
       c.insert "accounts", default_account_rows[2]
     end
 
-    db.read("accounts", ["account_id"]).rows.count.must_equal 3
+    results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
+    results.rows.count.must_equal 3
+    results.timestamp.wont_be :nil?
 
     active_count_sql = "SELECT COUNT(*) AS count FROM accounts WHERE active = true"
 
-    db.execute(active_count_sql).rows.first[:count].must_equal 2
+    results = db.execute active_count_sql, single_use: { timestamp: timestamp }
+    results.rows.first[:count].must_equal 2
+    results.timestamp.wont_be :nil?
 
     activate_inactive_account = { account_id: 3, active: true }
 
-    db.commit do |c|
+    timestamp = db.commit do |c|
       c.upsert "accounts", activate_inactive_account
     end
 
-    db.execute(active_count_sql).rows.first[:count].must_equal 3
+    results = db.execute active_count_sql, single_use: { timestamp: timestamp }
+    results.rows.first[:count].must_equal 3
+    results.timestamp.wont_be :nil?
 
-    db.commit do |c|
+    timestamp = db.commit do |c|
       c.delete "accounts", [1, 2, 3]
     end
 
-    db.read("accounts", ["account_id"]).rows.count.must_equal 0
+    results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
+    results.rows.count.must_equal 0
+    results.timestamp.wont_be :nil?
   end
 
   it "inserts, updates, upserts, reads, and deletes records in a transaction" do
+    timestamp = @setup_timestamp
     active_count_sql = "SELECT COUNT(*) AS count FROM accounts WHERE active = true"
 
     db.transaction do |tx|
@@ -96,7 +107,7 @@ describe "Spanner Client", :crud, :spanner do
       tx.insert "accounts", default_account_rows[2]
     end
 
-    db.transaction do |tx|
+    timestamp = db.transaction do |tx|
       db.read("accounts", ["account_id"]).rows.count.must_equal 3
 
       tx.execute(active_count_sql).rows.first[:count].must_equal 2
@@ -106,12 +117,14 @@ describe "Spanner Client", :crud, :spanner do
       tx.upsert "accounts", activate_inactive_account
     end
 
-    db.transaction do |tx|
+    timestamp = db.transaction do |tx|
       tx.execute(active_count_sql).rows.first[:count].must_equal 3
 
       tx.delete "accounts", [1, 2, 3]
     end
 
-    db.read("accounts", ["account_id"]).rows.count.must_equal 0
+    results = db.read "accounts", ["account_id"], single_use: { timestamp: timestamp }
+    results.rows.count.must_equal 0
+    results.timestamp.wont_be :nil?
   end
 end

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-gax", "~> 0.8.1"
   gem.add_dependency "grpc", "~> 1.1"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.8"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -52,7 +52,7 @@ module Google
         ##
         # @private Creates a new Spanner Client instance.
         def initialize project, instance_id, database_id, min: 10, max: 100,
-                       keepalive: 1500, write_ratio: 0.3, fail: true
+                       keepalive: 1800, write_ratio: 0.3, fail: true
           @project = project
           @instance_id = instance_id
           @database_id = database_id

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -371,6 +371,12 @@ module Google
         # single-use transaction use {#commit}. To make changes in a transaction
         # that supports reads and automatic retry protection use {#transaction}.
         #
+        # **Note:** This method does not feature replay protection present in
+        # {Transaction#upsert} (See {#transaction}). This method makes a single
+        # RPC, whereas {Transaction#upsert} requires two RPCs (one of which may
+        # be performed in advance), and so this method may be appropriate for
+        # latency sensitive and/or high throughput blind upserts.
+        #
         # @param [String] table The name of the table in the database to be
         #   modified.
         # @param [Array<Hash>] rows One or more hash objects with the hash keys
@@ -421,6 +427,12 @@ module Google
         # single-use transaction use {#commit}. To make changes in a transaction
         # that supports reads and automatic retry protection use {#transaction}.
         #
+        # **Note:** This method does not feature replay protection present in
+        # {Transaction#insert} (See {#transaction}). This method makes a single
+        # RPC, whereas {Transaction#insert} requires two RPCs (one of which may
+        # be performed in advance), and so this method may be appropriate for
+        # latency sensitive and/or high throughput blind inserts.
+        #
         # @param [String] table The name of the table in the database to be
         #   modified.
         # @param [Array<Hash>] rows One or more hash objects with the hash keys
@@ -469,6 +481,12 @@ module Google
         # single-use transaction. To make multiple changes in the same
         # single-use transaction use {#commit}. To make changes in a transaction
         # that supports reads and automatic retry protection use {#transaction}.
+        #
+        # **Note:** This method does not feature replay protection present in
+        # {Transaction#update} (See {#transaction}). This method makes a single
+        # RPC, whereas {Transaction#update} requires two RPCs (one of which may
+        # be performed in advance), and so this method may be appropriate for
+        # latency sensitive and/or high throughput blind updates.
         #
         # @param [String] table The name of the table in the database to be
         #   modified.
@@ -521,6 +539,12 @@ module Google
         # single-use transaction use {#commit}. To make changes in a transaction
         # that supports reads and automatic retry protection use {#transaction}.
         #
+        # **Note:** This method does not feature replay protection present in
+        # {Transaction#replace} (See {#transaction}). This method makes a single
+        # RPC, whereas {Transaction#replace} requires two RPCs (one of which may
+        # be performed in advance), and so this method may be appropriate for
+        # latency sensitive and/or high throughput blind replaces.
+        #
         # @param [String] table The name of the table in the database to be
         #   modified.
         # @param [Array<Hash>] rows One or more hash objects with the hash keys
@@ -570,6 +594,12 @@ module Google
         # single-use transaction use {#commit}. To make changes in a transaction
         # that supports reads and automatic retry protection use {#transaction}.
         #
+        # **Note:** This method does not feature replay protection present in
+        # {Transaction#delete} (See {#transaction}). This method makes a single
+        # RPC, whereas {Transaction#delete} requires two RPCs (one of which may
+        # be performed in advance), and so this method may be appropriate for
+        # latency sensitive and/or high throughput blind deletions.
+        #
         # @param [String] table The name of the table in the database to be
         #   modified.
         # @param [Object, Array<Object>] keys A single, or list of keys or key
@@ -601,6 +631,12 @@ module Google
         # All changes are accumulated in memory until the block completes.
         # Unlike {#transaction}, which can also perform reads, this operation
         # accepts only mutations and makes a single API request.
+        #
+        # **Note:** This method does not feature replay protection present in
+        # {Transaction#commit} (See {#transaction}). This method makes a single
+        # RPC, whereas {Transaction#commit} requires two RPCs (one of which may
+        # be performed in advance), and so this method may be appropriate for
+        # latency sensitive and/or high throughput blind changes.
         #
         # @yield [commit] The block for mutating the data.
         # @yieldparam [Google::Cloud::Spanner::Commit] commit The Commit object.

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -51,8 +51,8 @@ module Google
       class Client
         ##
         # @private Creates a new Spanner Client instance.
-        def initialize project, instance_id, database_id, min: 2, max: 10,
-                       keepalive: 1500, write_ratio: 0.5, fail: true
+        def initialize project, instance_id, database_id, min: 10, max: 100,
+                       keepalive: 1500, write_ratio: 0.3, fail: true
           @project = project
           @instance_id = instance_id
           @database_id = database_id

--- a/google-cloud-spanner/lib/google/cloud/spanner/errors.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/errors.rb
@@ -61,6 +61,13 @@ module Google
       # More sessions have been allocated than configured for.
       class SessionLimitError < Google::Cloud::Error
       end
+
+      ##
+      # # ClientClosedError
+      #
+      # The client is closed and can no longer be used.
+      class ClientClosedError < Google::Cloud::Error
+      end
     end
   end
 end

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -31,8 +31,8 @@ module Google
       class Pool
         attr_accessor :all_sessions, :session_queue, :transaction_queue
 
-        def initialize client, min: 2, max: 10, keepalive: 1500,
-                       write_ratio: 0.5, fail: true
+        def initialize client, min: 10, max: 100, keepalive: 1500,
+                       write_ratio: 0.3, fail: true
           @client = client
           @min = min
           @max = max

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -90,6 +90,7 @@ module Google
             fail ArgumentError, "Cannot checkin session"
           end
 
+          session.reload!
           @mutex.synchronize do
             session_queue.push session
 
@@ -143,8 +144,9 @@ module Google
             fail ArgumentError, "Cannot checkin session"
           end
 
+          tx = tx.session.reload!.create_transaction
           @mutex.synchronize do
-            transaction_queue.push tx.session.create_transaction
+            transaction_queue.push tx
 
             @resource.signal
           end

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -83,7 +83,7 @@ module Google
           @mutex.synchronize do
             session_queue.push session
 
-            @resource.broadcast
+            @resource.signal
           end
 
           nil
@@ -123,7 +123,7 @@ module Google
           @mutex.synchronize do
             transaction_queue.push tx.session.create_transaction
 
-            @resource.broadcast
+            @resource.signal
           end
 
           nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -419,9 +419,10 @@ module Google
         #     maintain at any point in time. The default is 10.
         #   * `:max` (Integer) Maximum number of sessions that the client will
         #     have at any point in time. The default is 100.
-        #   * `:keepalive` (Integer) The delay in seconds between attemtps to
-        #     prevent the idle sessions from being closed by the Cloud Spanner
-        #     service. The default is 1500.
+        #   * `:keepalive` (Numeric) The amount of time a session can be idle
+        #     before an attempt is made to prevent the idle sessions from being
+        #     closed by the Cloud Spanner service. The default is 1800 (30
+        #     minutes).
         #   * `:write_ratio` (Float) The ratio of sessions with pre-allocated
         #     transactions to those without. Pre-allocating transactions
         #     improves the performance of writes made by the client. The higher

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -416,9 +416,9 @@ module Google
         #   managed by the client. The following settings can be provided:
         #
         #   * `:min` (Integer) Minimum number of sessions that the client will
-        #     maintain at any point in time. The default is 2.
+        #     maintain at any point in time. The default is 10.
         #   * `:max` (Integer) Maximum number of sessions that the client will
-        #     have at any point in time. The default is 10.
+        #     have at any point in time. The default is 100.
         #   * `:keepalive` (Integer) The delay in seconds between attemtps to
         #     prevent the idle sessions from being closed by the Cloud Spanner
         #     service. The default is 1500.
@@ -426,7 +426,7 @@ module Google
         #     transactions to those without. Pre-allocating transactions
         #     improves the performance of writes made by the client. The higher
         #     the value, the more transactions are pre-allocated. The value must
-        #     be >= 0 and <= 1. The default is 0.5.
+        #     be >= 0 and <= 1. The default is 0.3.
         #   * `:fail` (true/false) When `true` the client raises a
         #     {SessionLimitError} when the client has allocated the `max` number
         #     of sessions. When `false` the client blocks until a session

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -498,7 +498,14 @@ module Google
         def reload!
           ensure_service!
           @grpc = service.get_session path
-          self
+          @last_updated_at = Time.now
+          return self
+        rescue Google::Cloud::NotFoundError
+          @grpc = service.create_session \
+            Admin::Database::V1::DatabaseAdminClient.database_path(
+              project_id, instance_id, database_id)
+          @last_updated_at = Time.now
+          return self
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -470,14 +470,26 @@ module Google
 
         ##
         # @private
-        # Keeps the transaction alive by calling SELECT 1
+        # Keeps the transaction current by creating a new transaction.
         def keepalive!
-          ensure_service!
-          execute "SELECT 1"
-          return true
-        rescue Google::Cloud::NotFoundError
-          @grpc = session.create_transaction.grpc
-          return false
+          ensure_session!
+          @grpc = session.create_transaction.instance_variable_get :@grpc
+        end
+
+        ##
+        # @private
+        # Permanently deletes the transaction and session.
+        def release!
+          ensure_session!
+          session.release!
+        end
+
+        ##
+        # @private
+        # Determines if the transaction has been idle longer than the given
+        # duration.
+        def idle_since? duration
+          session.idle_since? duration
         end
 
         ##

--- a/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
@@ -31,12 +31,26 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
     p.session_queue = [session]
   end
 
-  it "deletes sessions" do
+  it "deletes sessions when closed" do
     mock = Minitest::Mock.new
     mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
     session.service.mocked_service = mock
 
     client.close
+
+    mock.verify
+  end
+
+  it "cannot be used after being closed" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
+    session.service.mocked_service = mock
+
+    client.close
+
+    assert_raises Google::Cloud::Spanner::ClientClosedError do
+      client.execute "SELECT 1"
+    end
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
 
   before do
+    session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.all_sessions = [session]
     p.session_queue = [session]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -72,6 +72,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.commit do |c|
@@ -99,6 +101,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.update "users", [{ id: 1, name: "Charlie", active: false }]
@@ -120,6 +124,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.insert "users", [{ id: 2, name: "Harvey",  active: true }]
@@ -141,6 +147,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.upsert "users", [{ id: 3, name: "Marley",  active: false }]
@@ -162,6 +170,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.save "users", [{ id: 3, name: "Marley",  active: false }]
@@ -183,6 +193,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.replace "users", [{ id: 4, name: "Henry",  active: true }]
@@ -207,6 +219,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", [1, 2, 3, 4, 5]
@@ -229,6 +243,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", 1..100
@@ -253,6 +269,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", 5
@@ -273,6 +291,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users"

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -32,6 +32,13 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "commits using a block" do
     mutations = [
       Google::Spanner::V1::Mutation.new(
@@ -72,8 +79,6 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.commit do |c|
@@ -84,6 +89,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       c.delete "users", [1, 2, 3, 4, 5]
     end
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -101,12 +108,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.update "users", [{ id: 1, name: "Charlie", active: false }]
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -124,12 +131,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.insert "users", [{ id: 2, name: "Harvey",  active: true }]
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -147,12 +154,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.upsert "users", [{ id: 3, name: "Marley",  active: false }]
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -170,12 +177,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.save "users", [{ id: 3, name: "Marley",  active: false }]
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -193,12 +200,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.replace "users", [{ id: 4, name: "Henry",  active: true }]
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -219,12 +226,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", [1, 2, 3, 4, 5]
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -243,12 +250,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", 1..100
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -269,12 +276,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", 5
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -291,12 +298,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users"
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
@@ -114,6 +114,8 @@ describe Google::Cloud::Spanner::Client, :execute, :resume, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, RaiseableEnumerator.new(results_enum1), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
     mock.expect :execute_streaming_sql, RaiseableEnumerator.new(results_enum2), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: "abc123", options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users"

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
@@ -109,18 +109,25 @@ describe Google::Cloud::Spanner::Client, :execute, :resume, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "resumes broken response streams" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, RaiseableEnumerator.new(results_enum1), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
     mock.expect :execute_streaming_sql, RaiseableEnumerator.new(results_enum2), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: "abc123", options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users"
 
     assert_results results
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
@@ -67,6 +67,13 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "executes with strong" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
@@ -79,11 +86,11 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { strong: true }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -102,11 +109,11 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { timestamp: time_obj }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -125,11 +132,11 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { read_timestamp: time_obj }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -148,11 +155,11 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { staleness: 120 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -171,11 +178,11 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { exact_staleness: 120 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -194,11 +201,11 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { bounded_timestamp: time_obj }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -217,11 +224,11 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { min_read_timestamp: time_obj }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -240,11 +247,11 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { bounded_staleness: 120 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -263,11 +270,11 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { max_staleness: 120 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
@@ -79,6 +79,8 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { strong: true }
@@ -100,6 +102,8 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { timestamp: time_obj }
@@ -121,6 +125,8 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { read_timestamp: time_obj }
@@ -142,6 +148,8 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { staleness: 120 }
@@ -163,6 +171,8 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { exact_staleness: 120 }
@@ -184,6 +194,8 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { bounded_timestamp: time_obj }
@@ -205,6 +217,8 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { min_read_timestamp: time_obj }
@@ -226,6 +240,8 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { bounded_staleness: 120 }
@@ -247,6 +263,8 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users", single_use: { max_staleness: 120 }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
@@ -68,6 +68,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users"
@@ -81,6 +83,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
@@ -94,6 +98,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
@@ -107,6 +113,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
@@ -122,6 +130,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
@@ -137,6 +147,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
@@ -150,6 +162,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
@@ -165,6 +179,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
@@ -178,6 +194,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
@@ -191,6 +209,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
@@ -206,6 +226,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -221,6 +243,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -236,6 +260,8 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
@@ -64,15 +64,22 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users"
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -83,11 +90,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -98,11 +105,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -113,11 +120,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -130,11 +137,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -147,11 +154,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -162,11 +169,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -179,11 +186,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -194,11 +201,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -209,11 +216,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -226,11 +233,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -243,11 +250,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -260,11 +267,11 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -55,6 +55,8 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     fields = client.fields_for "users"

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -51,15 +51,22 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "can get a table's fields" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: nil, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     fields = client.fields_for "users"
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
@@ -108,6 +108,8 @@ describe Google::Cloud::Spanner::Client, :read, :error, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(results_enum1), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     assert_raises Google::Cloud::InvalidArgumentError do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
@@ -113,6 +113,8 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, no_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns
@@ -148,6 +150,8 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, all_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns
@@ -184,6 +188,8 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(bounds_with_abort_enum), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -116,6 +116,8 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(results_enum1), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(results_enum2), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: "abc123", options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -109,6 +109,13 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "resumes broken response streams" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
@@ -116,13 +123,13 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(results_enum1), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(results_enum2), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: "abc123", options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns
 
     assert_results results
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -68,6 +68,13 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "reads with strong" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
@@ -80,11 +87,11 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { strong: true }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -103,11 +110,11 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { timestamp: time_obj }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -126,11 +133,11 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { read_timestamp: time_obj }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -149,11 +156,11 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { staleness: 120 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -172,11 +179,11 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { exact_staleness: 120 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -195,11 +202,11 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { bounded_timestamp: time_obj }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -218,11 +225,11 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { min_read_timestamp: time_obj }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -241,11 +248,11 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { bounded_staleness: 120 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -264,11 +271,11 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { max_staleness: 120 }
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -80,6 +80,8 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { strong: true }
@@ -101,6 +103,8 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { timestamp: time_obj }
@@ -122,6 +126,8 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { read_timestamp: time_obj }
@@ -143,6 +149,8 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { staleness: 120 }
@@ -164,6 +172,8 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { exact_staleness: 120 }
@@ -185,6 +195,8 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { bounded_timestamp: time_obj }
@@ -206,6 +218,8 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { min_read_timestamp: time_obj }
@@ -227,6 +241,8 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { bounded_staleness: 120 }
@@ -248,6 +264,8 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, single_use: { max_staleness: 120 }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -82,6 +82,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns
@@ -97,6 +99,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: [1, 2, 3]
@@ -112,6 +116,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
@@ -127,6 +133,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(ranges: [Google::Cloud::Spanner::Convert.to_key_range([1,1]..[3,3])]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     lookup_range = client.range [1,1], [3,3]
@@ -143,6 +151,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: 5, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, limit: 5
@@ -158,6 +168,8 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, options: default_options]
+    # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -76,17 +76,24 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "can read all rows" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -99,11 +106,11 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: [1, 2, 3]
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -116,11 +123,11 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -133,12 +140,12 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(ranges: [Google::Cloud::Spanner::Convert.to_key_range([1,1]..[3,3])]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     lookup_range = client.range [1,1], [3,3]
     results = client.read "my-table", columns, keys: lookup_range, index: "MyTableCompositeKey"
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -151,11 +158,11 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: 5, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, limit: 5
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -168,11 +175,11 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, options: default_options]
-    # created when checking in
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: 1, limit: 1
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -71,13 +71,18 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "can execute a simple query without any options" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-    # reload on session pool checkin
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = nil
@@ -85,6 +90,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
       results = snp.execute "SELECT * FROM users"
     end
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -101,6 +108,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       end
     end
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -112,8 +121,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-      # reload on session pool checkin
-      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -121,6 +128,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute "SELECT * FROM users"
       end
+
+      wait_until_thread_pool_is_done!
 
       mock.verify
 
@@ -139,8 +148,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-      # reload on session pool checkin
-      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -148,6 +155,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute "SELECT * FROM users"
       end
+
+      wait_until_thread_pool_is_done!
 
       mock.verify
 
@@ -159,8 +168,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-      # reload on session pool checkin
-      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -168,6 +175,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute "SELECT * FROM users"
       end
+
+      wait_until_thread_pool_is_done!
 
       mock.verify
 
@@ -179,8 +188,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-      # reload on session pool checkin
-      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -188,6 +195,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute "SELECT * FROM users"
       end
+
+      wait_until_thread_pool_is_done!
 
       mock.verify
 
@@ -199,8 +208,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-      # reload on session pool checkin
-      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -208,6 +215,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute "SELECT * FROM users"
       end
+
+      wait_until_thread_pool_is_done!
 
       mock.verify
 
@@ -225,8 +234,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-      # reload on session pool checkin
-      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -234,6 +241,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute "SELECT * FROM users"
       end
+
+      wait_until_thread_pool_is_done!
 
       mock.verify
 
@@ -245,8 +254,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
-      # reload on session pool checkin
-      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -254,6 +261,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         snp.must_be_kind_of Google::Cloud::Spanner::Snapshot
         results = snp.execute "SELECT * FROM users"
       end
+
+      wait_until_thread_pool_is_done!
 
       mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -76,6 +76,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+    # reload on session pool checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     results = nil
@@ -110,6 +112,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      # reload on session pool checkin
+      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -135,6 +139,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      # reload on session pool checkin
+      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -153,6 +159,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      # reload on session pool checkin
+      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -171,6 +179,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      # reload on session pool checkin
+      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -189,6 +199,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      # reload on session pool checkin
+      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -213,6 +225,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      # reload on session pool checkin
+      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil
@@ -231,6 +245,8 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
+      # reload on session pool checkin
+      mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
       spanner.service.mocked_service = mock
 
       results = nil

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -70,6 +70,13 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "retries aborted transactions without retry metadata" do
     mutations = [
       Google::Spanner::V1::Mutation.new(
@@ -89,7 +96,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args
@@ -120,6 +126,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     assert_results results
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -144,7 +152,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args
@@ -175,6 +182,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     assert_results results
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -199,7 +208,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args
@@ -230,6 +238,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     assert_results results
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -257,7 +267,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args
@@ -295,6 +304,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     assert_results results
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -328,7 +339,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args
@@ -365,6 +375,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
         tx.update "users", [{ id: 1, name: "Charlie", active: false }]
       end
     end
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -89,6 +89,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args
@@ -143,6 +144,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args
@@ -197,6 +199,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args
@@ -254,6 +257,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args
@@ -324,6 +328,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
 
     # transaction checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
 
     def mock.commit *args

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -77,6 +77,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
     mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
     # transaction checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -103,6 +104,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
     mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
     # transaction checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -79,6 +79,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, [], transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -72,6 +72,13 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     client.close
   end
 
+  def wait_until_thread_pool_is_done!
+    pool = client.instance_variable_get :@pool
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
@@ -79,7 +86,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, [], transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -89,6 +95,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       results = tx.execute "SELECT * FROM users"
     end
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
 
@@ -118,6 +126,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -143,6 +153,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       tx.insert "users", [{ id: 2, name: "Harvey",  active: true }]
     end
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -170,6 +182,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -196,6 +210,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -221,6 +237,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       tx.replace "users", [{ id: 4, name: "Henry",  active: true }]
     end
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -251,6 +269,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -277,6 +297,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       tx.delete "users", 1..100
     end
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -307,6 +329,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
+    wait_until_thread_pool_is_done!
+
     mock.verify
   end
 
@@ -331,6 +355,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       tx.delete "users"
     end
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end
@@ -388,6 +414,8 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       tx.delete "users", [1, 2, 3, 4, 5]
     end
     timestamp.must_equal commit_time
+
+    wait_until_thread_pool_is_done!
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
@@ -37,12 +37,26 @@ describe Google::Cloud::Spanner::Pool, :close, :mock_spanner do
     client.close
   end
 
-  it "deletes sessions" do
+  it "deletes sessions when closed" do
     mock = Minitest::Mock.new
     mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
     session.service.mocked_service = mock
 
     pool.close
+
+    mock.verify
+  end
+
+  it "cannot be used after being closed" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
+    session.service.mocked_service = mock
+
+    pool.close
+
+    assert_raises Google::Cloud::Spanner::ClientClosedError do
+      pool.checkout_session
+    end
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
@@ -24,6 +24,7 @@ describe Google::Cloud::Spanner::Pool, :close, :mock_spanner do
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0, max: 4 } }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:pool) do
+    session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.all_sessions = [session]
     p.session_queue = [session]

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -84,29 +84,4 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
     mock.verify
   end
-
-  it "creates eight sessions and three transactions" do
-    mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-006")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-007")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-007-01"), [session_path(instance_id, database_id, "session-007"), tx_opts, options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-008-01"), [session_path(instance_id, database_id, "session-008"), tx_opts, options: default_options]
-    spanner.service.mocked_service = mock
-
-    pool = Google::Cloud::Spanner::Pool.new client, min: 8, write_ratio: 0.3
-
-    wait_until_thread_pool_is_done! pool
-
-    pool.all_sessions.size.must_equal 8
-    pool.session_queue.size.must_equal 6
-    pool.transaction_queue.size.must_equal 2
-
-    mock.verify
-  end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -41,7 +41,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, "session-002"), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool = Google::Cloud::Spanner::Pool.new client, min: 2, write_ratio: 0.5, block_on_init: true
+    pool = Google::Cloud::Spanner::Pool.new client, min: 2, write_ratio: 0.5, block_on_init: true, skip_background_thread: true
 
     pool.all_sessions.size.must_equal 2
     pool.session_queue.size.must_equal 1
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-005-01"), [session_path(instance_id, database_id, "session-005"), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool = Google::Cloud::Spanner::Pool.new client, min: 5, write_ratio: 0.5, block_on_init: true
+    pool = Google::Cloud::Spanner::Pool.new client, min: 5, write_ratio: 0.5, block_on_init: true, skip_background_thread: true
 
     pool.all_sessions.size.must_equal 5
     pool.session_queue.size.must_equal 2
@@ -89,7 +89,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-008-01"), [session_path(instance_id, database_id, "session-008"), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool = Google::Cloud::Spanner::Pool.new client, min: 8, write_ratio: 0.3, block_on_init: true
+    pool = Google::Cloud::Spanner::Pool.new client, min: 8, write_ratio: 0.3, block_on_init: true, skip_background_thread: true
 
     pool.all_sessions.size.must_equal 8
     pool.session_queue.size.must_equal 6

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -38,18 +38,18 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-01"), [session_path(instance_id, database_id, "session-001"), tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, "session-002"), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool = Google::Cloud::Spanner::Pool.new client, min: 2, write_ratio: 0.5
+    pool = Google::Cloud::Spanner::Pool.new client, min: 2, write_ratio: 0.5, block_on_init: true
 
     pool.all_sessions.size.must_equal 2
     pool.session_queue.size.must_equal 1
     pool.transaction_queue.size.must_equal 1
 
-    pool.session_queue.first.session_id.must_equal "session-002"
-    pool.transaction_queue.first.transaction_id.must_equal "tx-001-01"
-    pool.transaction_queue.first.session.session_id.must_equal "session-001"
+    pool.session_queue.first.session_id.must_equal "session-001"
+    pool.transaction_queue.first.transaction_id.must_equal "tx-002-01"
+    pool.transaction_queue.first.session.session_id.must_equal "session-002"
 
     mock.verify
   end
@@ -61,12 +61,12 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-01"), [session_path(instance_id, database_id, "session-001"), tx_opts, options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, "session-002"), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-003-01"), [session_path(instance_id, database_id, "session-003"), tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-01"), [session_path(instance_id, database_id, "session-004"), tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-005-01"), [session_path(instance_id, database_id, "session-005"), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool = Google::Cloud::Spanner::Pool.new client, min: 5, write_ratio: 0.5
+    pool = Google::Cloud::Spanner::Pool.new client, min: 5, write_ratio: 0.5, block_on_init: true
 
     pool.all_sessions.size.must_equal 5
     pool.session_queue.size.must_equal 2
@@ -85,11 +85,11 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-006")), [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-007")), [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-01"), [session_path(instance_id, database_id, "session-001"), tx_opts, options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, "session-002"), tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-007-01"), [session_path(instance_id, database_id, "session-007"), tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-008-01"), [session_path(instance_id, database_id, "session-008"), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
-    pool = Google::Cloud::Spanner::Pool.new client, min: 8, write_ratio: 0.3
+    pool = Google::Cloud::Spanner::Pool.new client, min: 8, write_ratio: 0.3, block_on_init: true
 
     pool.all_sessions.size.must_equal 8
     pool.session_queue.size.must_equal 6

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -21,6 +21,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client_pool) do
+    session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.all_sessions = [session]
     p.session_queue = [session]

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -40,6 +40,11 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
   end
 
   it "can checkout and checkin a session" do
+    mock = Minitest::Mock.new
+    # reload on session pool checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    spanner.service.mocked_service = mock
+
     pool.all_sessions.size.must_equal 1
     pool.session_queue.size.must_equal 1
 
@@ -52,11 +57,16 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
     pool.all_sessions.size.must_equal 1
     pool.session_queue.size.must_equal 1
+
+    mock.verify
   end
 
   it "creates new sessions when needed" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    # reload on session pool checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     pool.all_sessions.size.must_equal 1
@@ -82,6 +92,11 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    # reload on session pool checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     pool.all_sessions.size.must_equal 1
@@ -126,6 +141,9 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock = Minitest::Mock.new
     # created when checking in
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
+    # reload on session pool checkin
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
     pool.all_sessions.size.must_equal 1
@@ -152,6 +170,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     # created when checking out
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -179,6 +198,8 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     spanner.service.mocked_service = mock
@@ -215,10 +236,16 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-003-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     # created when checking in
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-003-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-02"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
     spanner.service.mocked_service = mock
 
     pool.all_sessions.size.must_equal 1

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -25,6 +25,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
   let(:pool) do
+    session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.all_sessions = [session]
     p.session_queue = [session]

--- a/google-cloud-spanner/test/google/cloud/spanner/session/release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/release_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Session, :reload, :mock_spanner do
+describe Google::Cloud::Spanner::Session, :release, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -22,12 +22,12 @@ describe Google::Cloud::Spanner::Session, :reload, :mock_spanner do
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
 
-  it "can reload itself" do
+  it "can release itself" do
     mock = Minitest::Mock.new
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
+    mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
     session.service.mocked_service = mock
 
-    session.reload!
+    session.release!
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,24 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Session, :delete_session, :mock_spanner do
+describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:transaction_id) { "tx789" }
+  let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
+  let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
 
-  it "can delete itself" do
+  it "creates new transaction when calling keepalive" do
     mock = Minitest::Mock.new
-    mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
-    session.service.mocked_service = mock
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    spanner.service.mocked_service = mock
 
-    session.delete_session
+    transaction.keepalive!
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/release_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,23 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Session, :reload, :mock_spanner do
+describe Google::Cloud::Spanner::Session, :release, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+  let(:transaction_id) { "tx789" }
+  let(:transaction_grpc) { Google::Spanner::V1::Transaction.new id: transaction_id }
+  let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
 
-  it "can reload itself" do
+  it "can release itself" do
     mock = Minitest::Mock.new
-    mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
-    session.service.mocked_service = mock
+    mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
+    spanner.service.mocked_service = mock
 
-    session.reload!
+    transaction.release!
 
     mock.verify
   end


### PR DESCRIPTION
This PR addresses the following items from #1485:

- [x] Change max to 100
- [x] Create new sessions/transactions outside of mutex
- [x] Ensure Pool#close does not block waiting threads
- [x] Use signal instead of broadcast
- [x] Synchronize when calling keepalive
- [x] Track last used time on session, use for more intelligent keepalive
- [x] Handle errors when calling Session#delete_session
- [x] Add threading to Pool#init, so it won't block
- [x] Cull idle sessions
- [x] Change Transaction#keepalive to call BeginTransaction
