### PR TITLE
Update BigQuery examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ load_job = table.load file
 count_sql = "SELECT owner, COUNT(*) AS complete_count FROM todos GROUP BY owner"
 data = bigquery.query count_sql
 data.each do |row|
-  puts row["name"]
+  puts row[:name]
 end
 ```
 

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -42,7 +42,7 @@ load_job = table.load file
 count_sql = "SELECT owner, COUNT(*) AS complete_count FROM todos GROUP BY owner"
 data = bigquery.query count_sql
 data.each do |row|
-  puts row["name"]
+  puts row[:name]
 end
 ```
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -153,7 +153,7 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.data.all do |row|
-        #     puts row["word"]
+        #     puts row[:word]
         #   end
         #
         # @example Using the enumerator by not passing a block:
@@ -164,7 +164,7 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   words = table.data.all.map do |row|
-        #     row["word"]
+        #     row[:word]
         #   end
         #
         # @example Limit the number of API calls made:
@@ -175,7 +175,7 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.data.all(request_limit: 10) do |row|
-        #     puts row["word"]
+        #     puts row[:word]
         #   end
         #
         def all request_limit: nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -619,7 +619,7 @@ module Google
         #   job.wait_until_done!
         #   if !job.failed?
         #     job.query_results.each do |row|
-        #       puts row["name"]
+        #       puts row[:name]
         #     end
         #   end
         #
@@ -635,7 +635,7 @@ module Google
         #   job.wait_until_done!
         #   if !job.failed?
         #     job.query_results.each do |row|
-        #       puts row["name"]
+        #       puts row[:name]
         #     end
         #   end
         #
@@ -651,7 +651,7 @@ module Google
         #   job.wait_until_done!
         #   if !job.failed?
         #     job.query_results.each do |row|
-        #       puts row["name"]
+        #       puts row[:name]
         #     end
         #   end
         #
@@ -667,7 +667,7 @@ module Google
         #   job.wait_until_done!
         #   if !job.failed?
         #     job.query_results.each do |row|
-        #       puts row["name"]
+        #       puts row[:name]
         #     end
         #   end
         #
@@ -780,7 +780,7 @@ module Google
         #   data = dataset.query "SELECT name FROM my_table"
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         # @example Query using legacy SQL:
@@ -793,7 +793,7 @@ module Google
         #                        legacy_sql: true
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         # @example Query using positional query parameters:
@@ -806,7 +806,7 @@ module Google
         #                        params: [1]
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         # @example Query using named query parameters:
@@ -819,7 +819,7 @@ module Google
         #                        params: { id: 1 }
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         # @!group Data

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -205,7 +205,7 @@ module Google
         #   job.wait_until_done!
         #   if !job.failed?
         #     job.query_results.each do |row|
-        #       puts row["name"]
+        #       puts row[:name]
         #     end
         #   end
         #
@@ -221,7 +221,7 @@ module Google
         #   job.wait_until_done!
         #   if !job.failed?
         #     job.query_results.each do |row|
-        #       puts row["name"]
+        #       puts row[:name]
         #     end
         #   end
         #
@@ -238,7 +238,7 @@ module Google
         #   job.wait_until_done!
         #   if !job.failed?
         #     job.query_results.each do |row|
-        #       puts row["name"]
+        #       puts row[:name]
         #     end
         #   end
         #
@@ -255,7 +255,7 @@ module Google
         #   job.wait_until_done!
         #   if !job.failed?
         #     job.query_results.each do |row|
-        #       puts row["name"]
+        #       puts row[:name]
         #     end
         #   end
         #
@@ -371,7 +371,7 @@ module Google
         #   data = bigquery.query sql
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         # @example Query using legacy SQL:
@@ -383,7 +383,7 @@ module Google
         #   data = bigquery.query sql, legacy_sql: true
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         # @example Retrieve all rows: (See {QueryData#all})
@@ -394,7 +394,7 @@ module Google
         #   data = bigquery.query "SELECT name FROM `my_dataset.my_table`"
         #
         #   data.all do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         # @example Query using positional query parameters:
@@ -408,7 +408,7 @@ module Google
         #                         params: [1]
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         # @example Query using named query parameters:
@@ -422,7 +422,7 @@ module Google
         #                         params: { id: 1 }
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         def query query, params: nil, max: nil, timeout: 10000, dryrun: nil,
@@ -729,7 +729,7 @@ module Google
         #                         params: { time: fourpm }
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         # @example Create Time with fractional seconds:
@@ -744,7 +744,7 @@ module Google
         #                         params: { time: precise_time }
         #
         #   data.each do |row|
-        #     puts row["name"]
+        #     puts row[:name]
         #   end
         #
         def time hour, minute, second

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_data.rb
@@ -144,7 +144,7 @@ module Google
         #
         #   data = job.query_results
         #   data.all do |row|
-        #     puts row["word"]
+        #     puts row[:word]
         #   end
         #
         # @example Using the enumerator by not passing a block:
@@ -155,7 +155,7 @@ module Google
         #
         #   data = job.query_results
         #   words = data.all.map do |row|
-        #     row["word"]
+        #     row[:word]
         #   end
         #
         # @example Limit the number of API calls made:
@@ -166,7 +166,7 @@ module Google
         #
         #   data = job.query_results
         #   data.all(request_limit: 10) do |row|
-        #     puts row["word"]
+        #     puts row[:word]
         #   end
         #
         def all request_limit: nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -152,7 +152,7 @@ module Google
         #   job.wait_until_done!
         #   data = job.query_results
         #   data.each do |row|
-        #     puts row["word"]
+        #     puts row[:word]
         #   end
         #   data = data.next if data.next?
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -413,7 +413,7 @@ module Google
         #
         #   data = table.data
         #   data.each do |row|
-        #     puts row["first_name"]
+        #     puts row[:first_name]
         #   end
         #   if data.next?
         #     more_data = data.next if data.next?
@@ -428,7 +428,7 @@ module Google
         #
         #   data = table.data
         #   data.all do |row|
-        #     puts row["first_name"]
+        #     puts row[:first_name]
         #   end
         #
         # @!group Data

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
@@ -35,7 +35,7 @@ module Google
       #                         params: { time: fourpm }
       #
       #   data.each do |row|
-      #     puts row["name"]
+      #     puts row[:name]
       #   end
       #
       # @example Create Time with fractional seconds:
@@ -50,7 +50,7 @@ module Google
       #                         params: { time: precise_time }
       #
       #   data.each do |row|
-      #     puts row["name"]
+      #     puts row[:name]
       #   end
       #
       Time = Struct.new :value

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -384,7 +384,7 @@ module Google
         #
         #   data = view.data
         #   data.each do |row|
-        #     puts row["first_name"]
+        #     puts row[:first_name]
         #   end
         #   more_data = data.next if data.next?
         #


### PR DESCRIPTION
Update row field access in docs code examples to use symbols instead of strings.

[closes #1496]