### PR TITLE
Make Debugger gem play nicely with byebug

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -324,6 +324,10 @@ module Google
       # Google::Cloud if haven't already
       unless Google::Cloud.configure.option? :debugger
         Google::Cloud.configure.add_options :debugger
+
+        Google::Cloud.configure.define_singleton_method :debugger do
+          Google::Cloud.configure[:debugger]
+        end
       end
 
       ##
@@ -394,9 +398,9 @@ module Google
       #   the Google::Cloud::ErrorReporting module uses.
       #
       def self.configure
-        yield Google::Cloud.configure.debugger if block_given?
+        yield Google::Cloud.configure[:debugger] if block_given?
 
-        Google::Cloud.configure.debugger
+        Google::Cloud.configure[:debugger]
       end
     end
   end


### PR DESCRIPTION
If the `byebug` gem is used, the `.debugger` keyword is reserved. We need to make sure the google-cloud-debugger gem doesn't start a byebug session.