### PR TITLE
Remove memoization of Policy

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -316,7 +316,7 @@ describe Google::Cloud::Pubsub, :pubsub do
         p.add role, member
       end
 
-      subscription.policy(force: true).role(role).must_include member
+      subscription.policy.role(role).must_include member
     end
 
     it "allows permissions to be tested on a topic" do

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/policy.rb
@@ -157,20 +157,6 @@ module Google
         end
 
         ##
-        # Returns a deep copy of the policy.
-        #
-        # @return [Policy]
-        #
-        def deep_dup
-          dup.tap do |p|
-            roles_dup = p.roles.each_with_object({}) do |(k, v), memo|
-              memo[k] = v.dup rescue value
-            end
-            p.instance_variable_set "@roles", roles_dup
-          end
-        end
-
-        ##
         # @private Convert the Policy to a Google::Iam::V1::Policy object.
         def to_grpc
           Google::Iam::V1::Policy.new(

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -513,11 +513,6 @@ module Google
         # @see https://cloud.google.com/pubsub/docs/reference/rpc/google.iam.v1#iampolicy
         #   google.iam.v1.IAMPolicy
         #
-        # @param [Boolean] force Force the latest policy to be retrieved from
-        #   the Pub/Sub service when `true`. Otherwise the policy will be
-        #   memoized to reduce the number of API calls made to the Pub/Sub
-        #   service. The default is `false`.
-        #
         # @yield [policy] A block for updating the policy. The latest policy
         #   will be read from the Pub/Sub service and passed to the block. After
         #   the block completes, the modified policy will be written to the
@@ -527,23 +522,13 @@ module Google
         #
         # @return [Policy] the current Cloud IAM Policy for this subscription
         #
-        # @example Policy values are memoized to reduce the number of API calls:
+        # @example
         #   require "google/cloud/pubsub"
         #
         #   pubsub = Google::Cloud::Pubsub.new
         #   sub = pubsub.subscription "my-subscription"
         #
-        #   policy = sub.policy # API call
-        #   policy_2 = sub.policy # No API call
-        #
-        # @example Use `force` to retrieve the latest policy from the service:
-        #   require "google/cloud/pubsub"
-        #
-        #   pubsub = Google::Cloud::Pubsub.new
-        #   sub = pubsub.subscription "my-subscription"
-        #
-        #   policy = sub.policy force: true # API call
-        #   policy_2 = sub.policy force: true # API call
+        #   policy = sub.policy
         #
         # @example Update the policy by passing a block:
         #   require "google/cloud/pubsub"
@@ -553,19 +538,15 @@ module Google
         #
         #   sub.policy do |p|
         #     p.add "roles/owner", "user:owner@example.com"
-        #   end # 2 API calls
+        #   end
         #
-        def policy force: nil
-          @policy = nil if force || block_given?
-          @policy ||= begin
-            ensure_service!
-            grpc = service.get_subscription_policy name
-            Policy.from_grpc grpc
-          end
-          return @policy unless block_given?
-          p = @policy.deep_dup
-          yield p
-          self.policy = p
+        def policy
+          ensure_service!
+          grpc = service.get_subscription_policy name
+          policy = Policy.from_grpc grpc
+          return policy unless block_given?
+          yield policy
+          self.policy = policy
         end
 
         ##
@@ -583,6 +564,8 @@ module Google
         # @param [Policy] new_policy a new or modified Cloud IAM Policy for this
         #   subscription
         #
+        # @return [Policy] the policy returned by the API update operation
+        #
         # @example
         #   require "google/cloud/pubsub"
         #
@@ -598,7 +581,7 @@ module Google
         def policy= new_policy
           ensure_service!
           grpc = service.set_subscription_policy name, new_policy.to_grpc
-          @policy = Policy.from_grpc grpc
+          Policy.from_grpc grpc
         end
 
         ##

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -317,14 +317,6 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Pubsub::Subscription#policy@Use `force` to retrieve the latest policy from the service:" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :get_subscription, subscription_resp("my-subscription"), ["projects/my-project/subscriptions/my-subscription", Hash]
-      mock_subscriber.expect :get_iam_policy, policy_resp, ["projects/my-project/subscriptions/my-subscription", Hash]
-      mock_subscriber.expect :get_iam_policy, policy_resp, ["projects/my-project/subscriptions/my-subscription", Hash]
-    end
-  end
-
   doctest.before "Google::Cloud::Pubsub::Subscription#pull@A maximum number of messages returned can also be specified:" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", Hash]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
@@ -51,84 +51,6 @@ describe Google::Cloud::Pubsub::Subscription, :policy, :mock_pubsub do
     policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
-  it "memoizes policy" do
-    existing_policy_json = {
-      "etag"=>"CAE=",
-      "bindings" => [{
-        "role" => "roles/viewer",
-        "members" => [
-          "user:viewer@example.com",
-          "serviceAccount:1234567890@developer.gserviceaccount.com"
-        ],
-      }]
-    }.to_json
-
-    existing_policy = Google::Cloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
-    subscription.instance_variable_set "@policy", existing_policy
-
-    # No mocks, no errors, no HTTP calls are made
-    policy = subscription.policy
-    policy.must_be_kind_of Google::Cloud::Pubsub::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
-  it "makes API calls when forced, even if already memoized" do
-    existing_policy_json = {
-      "etag"=>"CAE=",
-      "bindings" => [{
-        "role" => "roles/viewer",
-        "members" => [
-          "user:viewer@example.com",
-          "serviceAccount:1234567890@developer.gserviceaccount.com"
-        ],
-      }]
-    }.to_json
-
-    policy_json = {
-      "etag"=>"CAE=",
-      "bindings" => [{
-        "role" => "roles/owner",
-        "members" => [
-          "user:owner@example.com",
-          "serviceAccount:0987654321@developer.gserviceaccount.com"
-         ]
-      }]
-    }.to_json
-    get_res = Google::Iam::V1::Policy.decode_json policy_json
-    mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [subscription_path(sub_name), options: default_options]
-    subscription.service.mocked_subscriber = mock
-
-    existing_policy = Google::Cloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
-    subscription.instance_variable_set "@policy", existing_policy
-    returned_policy = subscription.policy
-    returned_policy.must_be_kind_of Google::Cloud::Pubsub::Policy
-    returned_policy.roles.must_be_kind_of Hash
-    returned_policy.roles.size.must_equal 1
-    returned_policy.roles["roles/viewer"].must_be_kind_of Array
-    returned_policy.roles["roles/viewer"].count.must_equal 2
-    returned_policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    returned_policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-
-    policy = subscription.policy force: true
-
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Pubsub::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "user:owner@example.com"
-    policy.roles["roles/owner"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-  end
-
   it "sets the IAM Policy" do
     policy_json = {
       "etag"=>"CAE=",
@@ -165,20 +87,18 @@ describe Google::Cloud::Pubsub::Subscription, :policy, :mock_pubsub do
     policy.add "roles/owner", "user:newowner@example.com"
     policy.remove "roles/owner", "user:owner@example.com"
 
-    subscription.policy = policy
+    policy_2 = subscription.policy = policy
 
     mock.verify
 
-    # Setting the policy also memoizes the policy
-    policy = subscription.policy
-    policy.must_be_kind_of Google::Cloud::Pubsub::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal "user:newowner@example.com"
+    policy_2.must_be_kind_of Google::Cloud::Pubsub::Policy
+    policy_2.roles.must_be_kind_of Hash
+    policy_2.roles.size.must_equal 1
+    policy_2.roles["roles/viewer"].must_be :nil?
+    policy_2.roles["roles/owner"].must_be_kind_of Array
+    policy_2.roles["roles/owner"].count.must_equal 2
+    policy_2.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    policy_2.roles["roles/owner"].last.must_equal "user:newowner@example.com"
   end
 
   it "sets the IAM Policy in a block" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
@@ -48,84 +48,6 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
-  it "memoizes policy" do
-    existing_policy_json = {
-      "etag"=>"CAE=",
-      "bindings" => [{
-        "role" => "roles/viewer",
-        "members" => [
-          "user:viewer@example.com",
-          "serviceAccount:1234567890@developer.gserviceaccount.com"
-        ],
-      }]
-    }.to_json
-
-    existing_policy = Google::Cloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
-    topic.instance_variable_set "@policy", existing_policy
-
-    # No mocks, no errors, no HTTP calls are made
-    policy = topic.policy
-    policy.must_be_kind_of Google::Cloud::Pubsub::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
-  it "makes API calls when forced, even if already memoized" do
-    existing_policy_json = {
-      "etag"=>"CAE=",
-      "bindings" => [{
-        "role" => "roles/viewer",
-        "members" => [
-          "user:viewer@example.com",
-          "serviceAccount:1234567890@developer.gserviceaccount.com"
-        ],
-      }]
-    }.to_json
-
-    policy_json = {
-      "etag"=>"CAE=",
-      "bindings"=>[{
-        "role"=>"roles/owner",
-        "members"=>[
-          "user:owner@example.com",
-          "serviceAccount:0987654321@developer.gserviceaccount.com"
-         ]
-      }]
-    }.to_json
-    get_res = Google::Iam::V1::Policy.decode_json policy_json
-    mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
-    topic.service.mocked_publisher = mock
-
-    existing_policy = Google::Cloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
-    topic.instance_variable_set "@policy", existing_policy
-    returned_policy = topic.policy
-    returned_policy.must_be_kind_of Google::Cloud::Pubsub::Policy
-    returned_policy.roles.must_be_kind_of Hash
-    returned_policy.roles.size.must_equal 1
-    returned_policy.roles["roles/viewer"].must_be_kind_of Array
-    returned_policy.roles["roles/viewer"].count.must_equal 2
-    returned_policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    returned_policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-
-    policy = topic.policy force: true
-
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Pubsub::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "user:owner@example.com"
-    policy.roles["roles/owner"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-  end
-
   it "sets the IAM Policy" do
     policy_json = {
       "etag"=>"CAE=",
@@ -162,20 +84,18 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     policy.add "roles/owner", "user:newowner@example.com"
     policy.remove "roles/owner", "user:owner@example.com"
 
-    topic.policy = policy
+    policy_2 = topic.policy = policy
 
     mock.verify
 
-    # Setting the policy also memoizes the policy
-    policy = topic.policy
-    policy.must_be_kind_of Google::Cloud::Pubsub::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal "user:newowner@example.com"
+    policy_2.must_be_kind_of Google::Cloud::Pubsub::Policy
+    policy_2.roles.must_be_kind_of Hash
+    policy_2.roles.size.must_equal 1
+    policy_2.roles["roles/viewer"].must_be :nil?
+    policy_2.roles["roles/owner"].must_be_kind_of Array
+    policy_2.roles["roles/owner"].count.must_equal 2
+    policy_2.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    policy_2.roles["roles/owner"].last.must_equal "user:newowner@example.com"
   end
 
   it "sets the IAM Policy in a block" do

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
@@ -160,20 +160,6 @@ module Google
         end
 
         ##
-        # Returns a deep copy of the policy.
-        #
-        # @return [Policy]
-        #
-        def deep_dup
-          dup.tap do |p|
-            roles_dup = p.roles.each_with_object({}) do |(k, v), memo|
-              memo[k] = v.dup rescue value
-            end
-            p.instance_variable_set "@roles", roles_dup
-          end
-        end
-
-        ##
         # @private Convert the Policy to a
         # Google::Apis::CloudresourcemanagerV1::Policy.
         def to_gapi

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/project_iam_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/project_iam_test.rb
@@ -65,87 +65,25 @@ describe Google::Cloud::ResourceManager::Project, :iam, :mock_res_man do
     policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
   end
 
-  it "memoizes policy" do
-    project.instance_variable_set "@policy", old_policy
-
-    # No mocks, no errors, no HTTP calls are made
-    policy = project.policy
-    policy.must_be_kind_of Google::Cloud::ResourceManager::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 1
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-  end
-
-  it "can force load the policy" do
-    mock = Minitest::Mock.new
-    mock.expect :get_project_iam_policy, new_policy_gapi, ["projects/example-project-123"]
-
-    resource_manager.service.mocked_service = mock
-    policy = project.policy force: true
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::ResourceManager::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
-  it "can force load the policy, even if already memoized" do
-    # memoize the policy object
-    project.instance_variable_set "@policy", old_policy
-
-    returned_policy = project.policy
-    returned_policy.must_be_kind_of Google::Cloud::ResourceManager::Policy
-    returned_policy.roles.must_be_kind_of Hash
-    returned_policy.roles.size.must_equal 1
-    returned_policy.roles["roles/viewer"].must_be_kind_of Array
-    returned_policy.roles["roles/viewer"].count.must_equal 1
-    returned_policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-
-    mock = Minitest::Mock.new
-    mock.expect :get_project_iam_policy, new_policy_gapi, ["projects/example-project-123"]
-
-    resource_manager.service.mocked_service = mock
-    policy = project.policy force: true
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::ResourceManager::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
   it "sets the policy" do
     mock = Minitest::Mock.new
     update_policy_request = Google::Apis::CloudresourcemanagerV1::SetIamPolicyRequest.new policy: new_policy_gapi
     mock.expect :set_project_iam_policy, new_policy_gapi, ["projects/example-project-123", update_policy_request]
 
     resource_manager.service.mocked_service = mock
-    project.policy = new_policy
+    policy = project.policy = new_policy
     mock.verify
 
-    # Setting the policy also memoizes the policy
-    project.policy.must_be_kind_of Google::Cloud::ResourceManager::Policy
-    project.policy.roles.must_be_kind_of Hash
-    project.policy.roles.size.must_equal 1
-    project.policy.roles["roles/viewer"].must_be_kind_of Array
-    project.policy.roles["roles/viewer"].count.must_equal 2
-    project.policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    project.policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    policy.must_be_kind_of Google::Cloud::ResourceManager::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be_kind_of Array
+    policy.roles["roles/viewer"].count.must_equal 2
+    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "sets the policy in a block" do
-    # memoize the policy object, to ensure that it is reloaded for update
-    project.instance_variable_set "@policy", old_policy
-
     mock = Minitest::Mock.new
     mock.expect :get_project_iam_policy, old_policy_gapi, ["projects/example-project-123"]
 
@@ -160,11 +98,11 @@ describe Google::Cloud::ResourceManager::Project, :iam, :mock_res_man do
 
     policy.must_be_kind_of Google::Cloud::ResourceManager::Policy
     policy.roles.must_be_kind_of Hash
-    project.policy.roles.size.must_equal 1
-    project.policy.roles["roles/viewer"].must_be_kind_of Array
-    project.policy.roles["roles/viewer"].count.must_equal 2
-    project.policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    project.policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be_kind_of Array
+    policy.roles["roles/viewer"].count.must_equal 2
+    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "tests the permissions available" do

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
@@ -333,11 +333,6 @@ module Google
         # @see https://cloud.google.com/spanner/reference/rpc/google.iam.v1#google.iam.v1.Policy
         #   google.iam.v1.IAMPolicy
         #
-        # @param [Boolean] force Force the latest policy to be retrieved from
-        #   the Spanner service when `true`. Otherwise the policy will be
-        #   memoized to reduce the number of API calls made to the Spanner
-        #   service. The default is `false`.
-        #
         # @yield [policy] A block for updating the policy. The latest policy
         #   will be read from the Spanner service and passed to the block. After
         #   the block completes, the modified policy will be written to the
@@ -347,23 +342,13 @@ module Google
         #
         # @return [Policy] The current Cloud IAM Policy for this instance.
         #
-        # @example Policy values are memoized to reduce the number of API calls:
+        # @example
         #   require "google/cloud/spanner"
         #
         #   spanner = Google::Cloud::Spanner.new
         #   instance = spanner.instance "my-instance"
         #
-        #   policy = instance.policy # API call
-        #   policy_2 = instance.policy # No API call
-        #
-        # @example Use `force` to retrieve the latest policy from the service:
-        #   require "google/cloud/spanner"
-        #
-        #   spanner = Google::Cloud::Spanner.new
-        #   instance = spanner.instance "my-instance"
-        #
-        #   policy = instance.policy force: true # API call
-        #   policy_2 = instance.policy force: true # API call
+        #   policy = instance.policy
         #
         # @example Update the policy by passing a block:
         #   require "google/cloud/spanner"
@@ -375,17 +360,13 @@ module Google
         #     p.add "roles/owner", "user:owner@example.com"
         #   end # 2 API calls
         #
-        def policy force: nil
-          @policy = nil if force || block_given?
-          @policy ||= begin
-            ensure_service!
-            grpc = service.get_instance_policy path
-            Policy.from_grpc grpc
-          end
-          return @policy unless block_given?
-          p = @policy.deep_dup
-          yield p
-          self.policy = p
+        def policy
+          ensure_service!
+          grpc = service.get_instance_policy path
+          policy = Policy.from_grpc grpc
+          return policy unless block_given?
+          yield policy
+          self.policy = policy
         end
 
         ##
@@ -403,6 +384,8 @@ module Google
         # @param [Policy] new_policy a new or modified Cloud IAM Policy for this
         #   instance
         #
+        # @return [Policy] The policy returned by the API update operation.
+        #
         # @example
         #   require "google/cloud/spanner"
         #
@@ -418,7 +401,7 @@ module Google
         def policy= new_policy
           ensure_service!
           grpc = service.set_instance_policy path, new_policy.to_grpc
-          @policy = Policy.from_grpc grpc
+          Policy.from_grpc grpc
         end
 
         ##

--- a/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
@@ -64,52 +64,6 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
     policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
-  it "memoizes policy" do
-    existing_policy = Google::Cloud::Spanner::Policy.from_grpc Google::Iam::V1::Policy.decode_json(viewer_policy_json)
-    database.instance_variable_set "@policy", existing_policy
-
-    # No mocks, no errors, no HTTP calls are made
-    policy = database.policy
-    policy.must_be_kind_of Google::Cloud::Spanner::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
-  it "makes API calls when forced, even if already memoized" do
-    get_res = Google::Iam::V1::Policy.decode_json owner_policy_json
-    mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [database.path]
-    database.service.mocked_databases = mock
-
-    existing_policy = Google::Cloud::Spanner::Policy.from_grpc Google::Iam::V1::Policy.decode_json(viewer_policy_json)
-    database.instance_variable_set "@policy", existing_policy
-    returned_policy = database.policy
-    returned_policy.must_be_kind_of Google::Cloud::Spanner::Policy
-    returned_policy.roles.must_be_kind_of Hash
-    returned_policy.roles.size.must_equal 1
-    returned_policy.roles["roles/viewer"].must_be_kind_of Array
-    returned_policy.roles["roles/viewer"].count.must_equal 2
-    returned_policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    returned_policy.roles["roles/viewer"].last.must_equal  "serviceAccount:1234567890@developer.gserviceaccount.com"
-
-    policy = database.policy force: true
-
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Spanner::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "user:owner@example.com"
-    policy.roles["roles/owner"].last.must_equal  "serviceAccount:0987654321@developer.gserviceaccount.com"
-  end
-
   it "sets the IAM Policy" do
     get_res = Google::Iam::V1::Policy.decode_json owner_policy_json
     mock = Minitest::Mock.new
@@ -129,12 +83,10 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
     policy.add "roles/owner", "user:newowner@example.com"
     policy.remove "roles/owner", "user:owner@example.com"
 
-    database.policy = policy
+    policy = database.policy = policy
 
     mock.verify
 
-    # Setting the policy also memoizes the policy
-    policy = database.policy
     policy.must_be_kind_of Google::Cloud::Spanner::Policy
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1

--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -130,7 +130,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
         p.add role, member
       end
 
-      bucket.policy(force: true).role(role).must_include member
+      bucket.policy.role(role).must_include member
     end
 
     it "allows permissions to be tested on a bucket" do

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -900,7 +900,7 @@ module Google
         #
         # @param [Boolean] force [Deprecated] Force the latest policy to be
         #   retrieved from the Storage service when `true`. Deprecated because
-        #   the latest policy is now always retrieved. The default is `false`.
+        #   the latest policy is now always retrieved. The default is `nil`.
         #
         # @yield [policy] A block for updating the policy. The latest policy
         #   will be read from the service and passed to the block. After the

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -898,9 +898,9 @@ module Google
         # @see https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy
         #   Buckets: setIamPolicy
         #
-        # @param [Boolean] force Force load the latest policy when `true`.
-        #   Otherwise the policy will be memoized to reduce the number of API
-        #   calls made. The default is `false`.
+        # @param [Boolean] force [Deprecated] Force the latest policy to be
+        #   retrieved from the Storage service when `true`. Deprecated because
+        #   the latest policy is now always retrieved. The default is `false`.
         #
         # @yield [policy] A block for updating the policy. The latest policy
         #   will be read from the service and passed to the block. After the
@@ -910,15 +910,14 @@ module Google
         #
         # @return [Policy] the current Cloud IAM Policy for this bucket
         #
-        # @example Policy values are memoized to reduce the number of API calls:
+        # @example
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "my-todo-app"
         #
-        #   policy = bucket.policy # API call
-        #   policy_2 = bucket.policy # No API call
+        #   policy = bucket.policy
         #
         # @example Retrieve the latest policy and update it in a block:
         #   require "google/cloud/storage"
@@ -929,19 +928,16 @@ module Google
         #
         #   bucket.policy do |p|
         #     p.add "roles/owner", "user:owner@example.com"
-        #   end # 2 API calls
+        #   end
         #
-        def policy force: false
-          @policy = nil if force || block_given?
-          @policy ||= begin
-            ensure_service!
-            gapi = service.get_bucket_policy name
-            Policy.from_gapi gapi
-          end
-          return @policy unless block_given?
-          p = @policy.deep_dup
-          yield p
-          self.policy = p
+        def policy force: nil
+          warn "DEPRECATED: 'force' in Bucket#policy" unless force.nil?
+          ensure_service!
+          gapi = service.get_bucket_policy name
+          policy = Policy.from_gapi gapi
+          return policy unless block_given?
+          yield policy
+          self.policy = policy
         end
 
         ##
@@ -961,6 +957,8 @@ module Google
         # @param [Policy] new_policy a new or modified Cloud IAM Policy for this
         #   bucket
         #
+        # @return [Policy] The policy returned by the API update operation.
+        #
         # @example
         #   require "google/cloud/storage"
         #
@@ -977,7 +975,7 @@ module Google
         def policy= new_policy
           ensure_service!
           gapi = service.set_bucket_policy name, new_policy.to_gapi
-          @policy = Policy.from_gapi gapi
+          Policy.from_gapi gapi
         end
 
         ##

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -164,9 +164,13 @@ module Google
         ##
         # Returns a deep copy of the policy.
         #
+        # @deprecated Because the latest policy is now always retrieved by
+        #   {Bucket#policy}.
+        #
         # @return [Policy]
         #
         def deep_dup
+          warn "DEPRECATED: Storage::Policy#deep_dup"
           dup.tap do |p|
             roles_dup = p.roles.each_with_object({}) do |(k, v), memo|
               memo[k] = v.dup rescue value

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -67,86 +67,24 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
   end
 
-  it "memoizes policy" do
-    bucket.instance_variable_set "@policy", old_policy
-
-    # No mocks, no errors, no HTTP calls are made
-    policy = bucket.policy
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 1
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-  end
-
-  it "can force load the policy" do
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, new_policy_gapi, [bucket_name]
-
-    storage.service.mocked_service = mock
-    policy = bucket.policy force: true
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
-  it "can force load the policy, even if already memoized" do
-    # memoize the policy object
-    bucket.instance_variable_set "@policy", old_policy
-
-    returned_policy = bucket.policy
-    returned_policy.must_be_kind_of Google::Cloud::Storage::Policy
-    returned_policy.roles.must_be_kind_of Hash
-    returned_policy.roles.size.must_equal 1
-    returned_policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    returned_policy.roles["roles/storage.objectViewer"].count.must_equal 1
-    returned_policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-
-    mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, new_policy_gapi, [bucket_name]
-
-    storage.service.mocked_service = mock
-    policy = bucket.policy force: true
-    mock.verify
-
-    policy.must_be_kind_of Google::Cloud::Storage::Policy
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
-  end
-
   it "sets the policy" do
     mock = Minitest::Mock.new
     mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi]
 
     storage.service.mocked_service = mock
-    bucket.policy = new_policy
+    policy = bucket.policy = new_policy
     mock.verify
 
-    # Setting the policy also memoizes the policy
-    bucket.policy.must_be_kind_of Google::Cloud::Storage::Policy
-    bucket.policy.roles.must_be_kind_of Hash
-    bucket.policy.roles.size.must_equal 1
-    bucket.policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    bucket.policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    bucket.policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    bucket.policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "sets the policy in a block" do
-    # memoize the policy object, to ensure that it is reloaded for update
-    bucket.instance_variable_set "@policy", old_policy
-
     mock = Minitest::Mock.new
     mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name]
 
@@ -160,11 +98,11 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
     policy.roles.must_be_kind_of Hash
-    bucket.policy.roles.size.must_equal 1
-    bucket.policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
-    bucket.policy.roles["roles/storage.objectViewer"].count.must_equal 2
-    bucket.policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
-    bucket.policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "tests the permissions available" do


### PR DESCRIPTION
This PR updates `#policy` and `#policy=` methods to remove the memoization of the IAM `Policy`, deprecates the `force` param in `#policy`, and prints a warning if `force` is passed to `#policy`.

Question: Should this PR also deprecate public method `Policy#deep_dup`, or does that method provide value for users?

[closes #1486]