### PR TITLE
Implement Logpoint feature

### DIFF
--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -30,7 +30,7 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 10
 Metrics/AbcSize:
-  Max: 25
+  Max: 30
 Metrics/MethodLength:
   Max: 20
 Metrics/ParameterLists:

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
+gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.c
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.c
@@ -168,7 +168,7 @@ line_trace_callback(rb_event_flag_t event, VALUE data, VALUE obj, ID mid, VALUE 
     // Evaluate each of the matching breakpoint
     for (i = 0; i < matching_breakpoints_len; i++) {
         matching_breakpoint = c_matching_breakpoints[i];
-        rb_funcall(self, rb_intern("eval_breakpoint"), 2, matching_breakpoint, call_stack_bindings);
+        rb_funcall(self, rb_intern("breakpoint_hit"), 2, matching_breakpoint, call_stack_bindings);
     }
 
     return;

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "binding_of_caller", "~> 0.7"
   gem.add_dependency "google-cloud-core", "~> 1.0"
+  gem.add_dependency "google-cloud-logging", "~> 1.0"
   gem.add_dependency "google-gax", "~> 0.8.0"
   gem.add_dependency "stackdriver-core", "~> 1.0"
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -897,8 +897,8 @@ module Google
             def format_message message_format, expressions
               # Substitute placeholders with expressions
               message = message_format.gsub(/(?<!\$)\$\d+/) do |placeholder|
-                  index = placeholder.match(/\$(\d+)/)[1].to_i
-                  index < expressions.size ? expressions[index].inspect : ""
+                index = placeholder.match(/\$(\d+)/)[1].to_i
+                index < expressions.size ? expressions[index].inspect : ""
               end
 
               # Unescape "$" charactors

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -878,6 +878,33 @@ module Google
               result
             end
 
+            ##
+            # Format log message by interpolate expressions.
+            #
+            # @example
+            #   Evaluator.format_log_message("Hello $0",
+            #                                ["World"]) #=> "Hello World"
+            #
+            # @param [String] message_format The message with with
+            #   expression placeholders such as `$0`, `$1`, etc.
+            # @param [Array<Google::Cloud::Debugger::Breakpoint::Variable>]
+            #   expressions An array of evaluated expression variables to be
+            #   placed into message_format's placeholders. The variables need
+            #   to have type equal String.
+            #
+            # @return [String] The formatted message string
+            #
+            def format_message message_format, expressions
+              # Substitute placeholders with expressions
+              message = message_format.gsub(/(?<!\$)\$\d+/) do |placeholder|
+                  index = placeholder.match(/\$(\d+)/)[1].to_i
+                  index < expressions.size ? expressions[index].inspect : ""
+              end
+
+              # Unescape "$" charactors
+              message.gsub(/\$\$/, "$")
+            end
+
             private
 
             ##

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+require "google/cloud/logging/logger"
+
 module Google
   module Cloud
     module Debugger
@@ -47,6 +49,7 @@ module Google
                                    keyfile: configuration.keyfile,
                                    module_name: configuration.module_name,
                                    module_version: configuration.module_version)
+
           # Immediately start the debugger agent
           @debugger.start
         end
@@ -64,6 +67,11 @@ module Google
         def call env
           # Enable/resume breakpoints tracing
           @debugger.agent.tracer.start
+
+          # Use Stackdriver Logger for debugger if available
+          if env["rack.logger"].is_a? Google::Cloud::Logging::Logger
+            @debugger.agent.logger = env["rack.logger"]
+          end
 
           @app.call env
         ensure

--- a/google-cloud-debugger/lib/google/cloud/debugger/tracer.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/tracer.rb
@@ -103,31 +103,14 @@ module Google
         end
 
         ##
-        # Evaluates a hit breakpoint, and signal BreakpointManager and
-        # Transmitter if this breakpoint is evaluated successfully.
+        # Callback function when a breakpoint is hit. Handover the hit
+        # breakpoint to breakpoint_manager to be evaluated.
         #
-        # See {Breakpoint#eval_call_stack} for evaluation details.
-        #
-        # @param [Google::Cloud::Debugger::Breakpoint] breakpoint The breakpoint
-        #   to be evaluated
-        # @param [Array<Binding>] call_stack_bindings An array of Ruby Binding
-        #   objects, from the each frame of the call stack that leads to the
-        #   triggering of the breakpoints.
-        #
-        def eval_breakpoint breakpoint, call_stack_bindings
+        def breakpoint_hit breakpoint, call_stack_bindings
           return if breakpoint.nil? || breakpoint.complete?
 
-          breakpoint.eval_call_stack call_stack_bindings
-
-          # Take this completed breakpoint off manager's active breakpoints
-          # list, submit the breakpoint snapshot, and update Tracer's
-          # breakpoints_cache.
-          return unless breakpoint.complete?
-
-          # Signal breakpoint_manager that this breakpoint is evaluated
-          agent.breakpoint_manager.mark_off breakpoint
-          # Signal transmitter to submit this breakpoint
-          agent.transmitter.submit breakpoint
+          agent.breakpoint_manager.breakpoint_hit breakpoint,
+                                                  call_stack_bindings
 
           update_breakpoints_cache
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
@@ -53,7 +53,7 @@ module Google
 
         ##
         # @private Construct a new instance of Tramsnitter
-        def initialize service, agent, max_queue_size = DEFAULT_MAX_QUEUE_SIZE
+        def initialize agent, service, max_queue_size = DEFAULT_MAX_QUEUE_SIZE
           super()
           @service = service
           @agent = agent

--- a/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
@@ -22,6 +22,20 @@ describe Google::Cloud::Debugger::Agent, :mock_debugger do
       agent.breakpoint_manager.must_be_kind_of Google::Cloud::Debugger::BreakpointManager
       agent.breakpoint_manager.on_breakpoints_change.must_be_kind_of Method
       agent.transmitter.must_be_kind_of Google::Cloud::Debugger::Transmitter
+      agent.logger.must_be_kind_of Google::Cloud::Logging::Logger
+    end
+
+    it "the default logger shares same project_id and credentials" do
+      agent.logger.project.must_equal service.project
+
+      agent.logger.writer.logging.service.credentials.must_equal service.credentials
+    end
+
+    it "uses the logger passed in" do
+      new_agent = Google::Cloud::Debugger::Agent.new nil, logger: "test-logger",
+                                                          module_name: nil,
+                                                          module_version: nil
+      new_agent.logger.must_equal "test-logger"
     end
   end
 

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -222,4 +222,26 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
       result.must_match "no method name given"
     end
   end
+
+  describe ".format_message" do
+    it "formats basic message" do
+      evaluator.format_message("Hello World", []).must_equal "Hello World"
+    end
+
+    it "formats message with expressions" do
+      evaluator.format_message("Hello $0$1", ["World", :!]).must_equal "Hello \"World\":!"
+    end
+
+    it "formats message with extra expressions" do
+      evaluator.format_message("Hello $0$1", ["World", :!, :zomg]).must_equal "Hello \"World\":!"
+    end
+
+    it "formats message with extra placeholder" do
+      evaluator.format_message("Hello $0$1$2", ["World", :!]).must_equal "Hello \"World\":!"
+    end
+
+    it "doesn't substitute escaped placeholder and unescape them" do
+      evaluator.format_message("Hello 0 $0 $$0 $$$$0", ["World"]).must_equal "Hello 0 \"World\" $0 $$0"
+    end
+  end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
@@ -40,37 +40,37 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     Google::Cloud::Debugger::Breakpoint.new "7", breakpoint_path, 72 }
 
   it "catches breakpoint from function call" do
-    breakpoint_hit = false
-    stubbed_eval_breakpoint = ->(breakpoint, call_stack_bindings) do
+    hit = false
+    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
       breakpoint.must_equal breakpoint1
-      breakpoint_hit = true
+      hit = true
     end
 
     breakpoint_manager.update_breakpoints [breakpoint1]
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :eval_breakpoint, stubbed_eval_breakpoint do
+    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
       tracer.start
       tracer_test_func
       tracer.stop
     end
 
-    breakpoint_hit.must_equal true
+    hit.must_equal true
   end
 
   it "catches breakpoint called from a child thread" do
-    breakpoint_hit = false
-    stubbed_eval_breakpoint = ->(breakpoint, call_stack_bindings) do
+    hit = false
+    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
       assert_equal breakpoint, breakpoint1
-      breakpoint_hit = true
+      hit = true
     end
 
     breakpoint_manager.update_breakpoints [breakpoint1]
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :eval_breakpoint, stubbed_eval_breakpoint do
+    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
       tracer.start
       thr = Thread.new do
         tracer_test_func
@@ -79,121 +79,121 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    breakpoint_hit.must_equal true
+    hit.must_equal true
   end
 
   it "catches breakpoint from block yield" do
-    breakpoint_hit = false
-    stubbed_eval_breakpoint = ->(breakpoint, call_stack_bindings) do
+    hit = false
+    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
       breakpoint.must_equal breakpoint2
-      breakpoint_hit = true
+      hit = true
     end
 
     breakpoint_manager.update_breakpoints [breakpoint2]
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :eval_breakpoint, stubbed_eval_breakpoint do
+    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
       tracer.start
       tracer_test_func3
       tracer.stop
     end
 
-    breakpoint_hit.must_equal true
+    hit.must_equal true
   end
 
   it "catches breakpoint when function interleave files" do
-    breakpoint_hit = false
-    stubbed_eval_breakpoint = ->(breakpoint, call_stack_bindings) do
+    hit = false
+    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
       breakpoint.must_equal breakpoint3
-      breakpoint_hit = true
+      hit = true
     end
 
     breakpoint_manager.update_breakpoints [breakpoint3]
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :eval_breakpoint, stubbed_eval_breakpoint do
+    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
       tracer.start
       tracer_test_func4
       tracer.stop
     end
 
-    breakpoint_hit.must_equal true
+    hit.must_equal true
   end
 
   it "catches breakpoint from lambda function" do
-    breakpoint_hit = false
-    stubbed_eval_breakpoint = ->(breakpoint, call_stack_bindings) do
+    hit = false
+    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
       breakpoint.must_equal breakpoint4
-      breakpoint_hit = true
+      hit = true
     end
 
     breakpoint_manager.update_breakpoints [breakpoint4]
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :eval_breakpoint, stubbed_eval_breakpoint do
+    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
       tracer.start
       tracer_test_lambda.call
       tracer.stop
     end
 
-    breakpoint_hit.must_equal true
+    hit.must_equal true
   end
 
   it "catches breakpoint from proc" do
-    breakpoint_hit = false
-    stubbed_eval_breakpoint = ->(breakpoint, call_stack_bindings) do
+    hit = false
+    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
       breakpoint.must_equal breakpoint5
-      breakpoint_hit = true
+      hit = true
     end
 
     breakpoint_manager.update_breakpoints [breakpoint5]
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :eval_breakpoint, stubbed_eval_breakpoint do
+    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
       tracer.start
       tracer_test_proc.call
       tracer.stop
     end
 
-    breakpoint_hit.must_equal true
+    hit.must_equal true
   end
 
   it "catches breakpoint from fiber" do
-    breakpoint_hit = false
-    stubbed_eval_breakpoint = ->(breakpoint, call_stack_bindings) do
+    hit = false
+    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
       assert_equal breakpoint, breakpoint6
-      breakpoint_hit = true
+      hit = true
     end
 
     breakpoint_manager.update_breakpoints [breakpoint6]
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :eval_breakpoint, stubbed_eval_breakpoint do
+    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
       tracer.start
       tracer_test_fiber.resume
       tracer.stop
     end
 
-    breakpoint_hit.must_equal true
+    hit.must_equal true
   end
 
   it "catches breakpoint from fiber after fiber yields" do
-    breakpoint_hit = false
-    stubbed_eval_breakpoint = ->(breakpoint, call_stack_bindings) do
+    hit = false
+    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
       assert_equal breakpoint, breakpoint7
-      breakpoint_hit = true
+      hit = true
     end
 
     breakpoint_manager.update_breakpoints [breakpoint7]
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :eval_breakpoint, stubbed_eval_breakpoint do
+    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
       tracer.start
       test_filber = tracer_test_fiber
       test_filber.resume
@@ -201,6 +201,6 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    breakpoint_hit.must_equal true
+    hit.must_equal true
   end
 end

--- a/google-cloud-debugger/test/helper.rb
+++ b/google-cloud-debugger/test/helper.rb
@@ -104,6 +104,7 @@ class MockDebugger < Minitest::Spec
     timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
     {
       "id" => "abc123",
+      "action" => :CAPTURE,
       "location" => random_source_location_hash,
       "create_time" => {
         "seconds" => timestamp.to_i,

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
     Google::Cloud::Logging.configure.delete :log_name_map
     Google::Cloud::Logging.configure.monitored_resource.delete :type
     Google::Cloud::Logging.configure.monitored_resource.delete :labels
-    Google::Cloud.configure.instance_variable_get(:@configs).delete :use_logging
+    Google::Cloud.configure.delete :use_logging
   }
 
   describe "#initialize" do


### PR DESCRIPTION
Implement Logpoint feature for Stackdriver Debugger Ruby agent. Now when user create logpoints through Stackdriver Debugger UI, the debugger agent is able to send evaluated log statements to Stackdriver Logging service in the requested format. 

See the [official doc](https://cloud.google.com/debugger/docs/logpoints) for more details on the feature.