### PR TITLE
Add Storage Bucket#labels

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -37,12 +37,17 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
     one_off_bucket.website_main.must_be :nil?
     one_off_bucket.website_404.must_be :nil?
+    one_off_bucket.labels.must_equal({})
     one_off_bucket.update do |b|
       b.website_main = "index.html"
       b.website_404 = "not_found.html"
+      # update labels with symbols
+      b.labels[:foo] = :bar
     end
     one_off_bucket.website_main.must_equal "index.html"
     one_off_bucket.website_404.must_equal "not_found.html"
+    # labels with symbols are not strings
+    one_off_bucket.labels.must_equal({ "foo" => "bar" })
 
     one_off_bucket_copy = storage.bucket one_off_bucket_name
     one_off_bucket_copy.wont_be :nil?
@@ -67,6 +72,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     bucket.versioning?.must_be :nil?
     bucket.website_main.must_be :nil?
     bucket.website_404.must_be :nil?
+    bucket.labels.must_be :empty?
 
     bucket.cors.each do |cors|
       cors.must_be_kind_of Google::Cloud::Storage::Bucket::Cors::Rule

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -293,6 +293,7 @@ module Google
             b.versioning = versioning unless versioning.nil?
           end
           yield updater if block_given?
+          updater.check_for_changed_labels!
           updater.check_for_mutable_cors!
           gapi = service.insert_bucket \
             new_bucket, acl: acl_rule(acl), default_acl: acl_rule(default_acl)

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -36,10 +36,15 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   let(:bucket_versioning) { true }
   let(:bucket_website_main) { "index.html" }
   let(:bucket_website_404) { "404.html" }
-  let(:bucket_complete_hash) { random_bucket_hash bucket_name, bucket_url_root,
-                                                  bucket_location, bucket_storage_class, bucket_versioning,
-                                                  bucket_logging_bucket, bucket_logging_prefix, bucket_website_main,
-                                                  bucket_website_404, bucket_cors }
+  let(:bucket_labels) { { "env" => "production", "foo" => "bar" } }
+  let :bucket_complete_hash do
+    h = random_bucket_hash bucket_name, bucket_url_root,
+                           bucket_location, bucket_storage_class, bucket_versioning,
+                           bucket_logging_bucket, bucket_logging_prefix, bucket_website_main,
+                           bucket_website_404, bucket_cors
+    h[:labels] = bucket_labels
+    h
+  end
   let(:bucket_complete_json) { bucket_complete_hash.to_json }
   let(:bucket_complete_gapi) { Google::Apis::StorageV1::Bucket.from_json bucket_complete_json }
   let(:bucket_complete) { Google::Cloud::Storage::Bucket.from_gapi bucket_complete_gapi, storage.service }
@@ -65,6 +70,13 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     bucket_complete.versioning?.must_equal bucket_versioning
     bucket_complete.website_main.must_equal bucket_website_main
     bucket_complete.website_404.must_equal bucket_website_404
+  end
+
+  it "knows its labels" do
+    # mostly emtpy bucket has a labels hash
+    bucket.labels.must_equal Hash.new
+    # a complete bucket has a labels hash with the correct values
+    bucket_complete.labels.must_equal bucket_labels
   end
 
   it "return frozen cors" do

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -143,6 +143,27 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     bucket.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
   end
 
+  it "creates a bucket with block labels" do
+    mock = Minitest::Mock.new
+    created_bucket = create_bucket_gapi bucket_name
+    created_bucket.labels = { "env" => "production", "foo" => "bar" }
+    mock.expect :insert_bucket, created_bucket, [project, created_bucket, predefined_acl: nil, predefined_default_object_acl: nil]
+
+    storage.service.mocked_service = mock
+
+    bucket = storage.create_bucket bucket_name do |b|
+      b.labels.must_equal Hash.new
+      b.labels = { "env" => "production" }
+      b.labels["foo"] = "bar"
+    end
+
+    mock.verify
+
+    bucket.must_be_kind_of Google::Cloud::Storage::Bucket
+    bucket.name.must_equal bucket_name
+    bucket.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
+  end
+
   it "creates a bucket with predefined acl" do
     mock = Minitest::Mock.new
     created_bucket = create_bucket_gapi bucket_name


### PR DESCRIPTION
Adds `Bucket#labels` and `Bucket#labels=`, allows labels to be set on `Project#create_bucket` when using the yielded bucket object.