### PR TITLE
Fix Resource Manager #create_project method

### DIFF
--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
@@ -75,7 +75,7 @@ module Google
         ##
         # Returns API::Project
         def create_project project_id, name, labels
-          project_attrs = { projectId: project_id, name: name,
+          project_attrs = { project_id: project_id, name: name,
                             labels: labels }.delete_if { |_, v| v.nil? }
           execute { service.create_project API::Project.new(project_attrs) }
         end

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/manager_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/manager_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
   it "creates a project" do
     mock = Minitest::Mock.new
     created_project = create_project_gapi("new-project-456")
-    mock.expect :create_project, created_project, [Google::Apis::CloudresourcemanagerV1::Project.new(projectId: "new-project-456")]
+    mock.expect :create_project, created_project, [Google::Apis::CloudresourcemanagerV1::Project.new(project_id: "new-project-456")]
 
     resource_manager.service.mocked_service = mock
     project = resource_manager.create_project "new-project-456"
@@ -46,7 +46,7 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
   it "creates a project with a name and labels" do
     mock = Minitest::Mock.new
     created_project = create_project_gapi("new-project-789", "My New Project", {"env" => "development"})
-    mock.expect :create_project, created_project, [Google::Apis::CloudresourcemanagerV1::Project.new(projectId: "new-project-789", name: "My New Project", labels: {:env => :development})]
+    mock.expect :create_project, created_project, [Google::Apis::CloudresourcemanagerV1::Project.new(project_id: "new-project-789", name: "My New Project", labels: {:env => :development})]
 
     resource_manager.service.mocked_service = mock
     project = resource_manager.create_project "new-project-789",


### PR DESCRIPTION
The `Google::Apis::CloudresourcemanagerV1::Project.new` method takes `project_id` as a parameter. The current `projectId` argument is ignored.

[close #1511]