### PR TITLE
Add Pub/Sub GRPC channel args

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -41,7 +41,12 @@ module Google
 
         def channel
           require "grpc"
-          GRPC::Core::Channel.new host, nil, chan_creds
+          GRPC::Core::Channel.new host, chan_args, chan_creds
+        end
+
+        def chan_args
+          { "grpc.max_send_message_length"    => -1,
+            "grpc.max_receive_message_length" => -1 }
         end
 
         def chan_creds


### PR DESCRIPTION
Add configuration needed to pull messages larger than 4MB. Resolves #1467.