### PR TITLE
Add Pub/Sub Publisher

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/async_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/async_test.rb
@@ -1,0 +1,106 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "pubsub_helper"
+
+describe Google::Cloud::Pubsub, :async, :pubsub do
+  def retrieve_topic topic_name
+    pubsub.get_topic(topic_name) || pubsub.create_topic(topic_name)
+  end
+
+  def retrieve_subscription topic, subscription_name
+    topic.get_subscription(subscription_name) ||
+      topic.subscribe(subscription_name)
+  end
+
+  let(:topic) { retrieve_topic "#{$topic_prefix}-async" }
+  let(:sub) { retrieve_subscription topic, "#{$topic_prefix}-async-sub" }
+
+  it "publishes and pulls asyncronously (topic)" do
+    events = sub.pull
+    events.must_be :empty?
+    # Publish a new message
+    unpublished = true
+    publish_result = nil
+    topic.publish_async "hello" do |result|
+      publish_result = result
+      unpublished = false
+      assert_equal "hello", result.msg.data
+    end
+    unpublished_retries = 0
+    while unpublished
+      fail "publish has failed" if unpublished_retries >= 5
+      unpublished_retries += 1
+      puts "the async publish has not completed yet. sleeping for #{unpublished_retries*unpublished_retries} second(s) and retrying."
+      sleep unpublished_retries*unpublished_retries
+    end
+    publish_result.must_be :succeeded?
+    # Check it received the published message
+    events = pull_with_retry sub
+    events.wont_be :empty?
+    events.count.must_equal 1
+    event = events.first
+    event.wont_be :nil?
+    event.msg.data.must_equal publish_result.data
+    # Acknowledge the message
+    sub.ack event.ack_id
+    # Remove the subscription
+    sub.delete
+  end
+
+  it "publishes and pulls asyncronously (project)" do
+    events = sub.pull
+    events.must_be :empty?
+    # Publish a new message
+    unpublished = true
+    publish_result = nil
+    pubsub.publish_async topic.name, "hello" do |result|
+      publish_result = result
+      unpublished = false
+      assert_equal "hello", result.msg.data
+    end
+    unpublished_retries = 0
+    while unpublished
+      fail "publish has failed" if unpublished_retries >= 5
+      unpublished_retries += 1
+      puts "the async publish has not completed yet. sleeping for #{unpublished_retries*unpublished_retries} second(s) and retrying."
+      sleep unpublished_retries*unpublished_retries
+    end
+    publish_result.must_be :succeeded?
+    # Check it received the published message
+    events = pull_with_retry sub
+    events.wont_be :empty?
+    events.count.must_equal 1
+    event = events.first
+    event.wont_be :nil?
+    event.msg.data.must_equal publish_result.data
+    # Acknowledge the message
+    sub.ack event.ack_id
+    # Remove the subscription
+    sub.delete
+  end
+
+  def pull_with_retry sub
+    events = []
+    retries = 0
+    while retries <= 5 do
+      events = sub.pull
+      break if events.any?
+      retries += 1
+      puts "the subscription does not have the message yet. sleeping for #{retries*retries} second(s) and retrying."
+      sleep retries*retries
+    end
+    events
+  end
+end

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -79,10 +79,10 @@ $snapshot_names = 3.times.map { "#{$snapshot_prefix}-#{SecureRandom.hex(4)}".dow
 
 def clean_up_pubsub_topics
   puts "Cleaning up pubsub topics after tests."
-  $topic_names.each do |topic_name|
-    if t = $pubsub.get_topic(topic_name)
-      t.subscriptions.each { |s| s.delete }
-      t.delete
+  $pubsub.topics.all do |topic|
+    if topic.name.include? $topic_prefix
+      topic.subscriptions.each(&:delete)
+      topic.delete
     end
   end
 rescue => e

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "google-gax", "~> 0.8.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.8"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -19,6 +19,7 @@ require "google/cloud/pubsub/service"
 require "google/cloud/pubsub/credentials"
 require "google/cloud/pubsub/topic"
 require "google/cloud/pubsub/snapshot"
+require "google/cloud/pubsub/publisher"
 
 module Google
   module Cloud
@@ -217,7 +218,8 @@ module Google
         #
         #   pubsub = Google::Cloud::Pubsub.new
         #
-        #   msg = pubsub.publish "my-topic", File.open("message.txt")
+        #   file = File.open "message.txt", mode: "rb"
+        #   msg = pubsub.publish "my-topic", file
         #
         # @example Additionally, a message can be published with attributes:
         #   require "google/cloud/pubsub"
@@ -249,6 +251,47 @@ module Google
           yield publisher if block_given?
           return nil if publisher.messages.count.zero?
           publish_batch_messages topic_name, publisher
+        end
+
+        ##
+        # Publishes a message to the given topic asynchonously.
+        #
+        # @param [String] topic_name Name of a topic.
+        # @param [String, File] data The message data.
+        # @param [Hash] attributes Optional attributes for the message.
+        # @yield [result] the callback for when the message has been published
+        # @yieldparam [PublishResult] result the result of the asynchonous
+        #   publish
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   pubsub.publish_async "my-topic", "task completed" do |result|
+        #     puts result.msg_id if result.succeeded?
+        #   end
+        #
+        # @example A message can be published using a File object:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   file = File.open "message.txt", mode: "rb"
+        #   pubsub.publish_async "my-topic", file
+        #
+        # @example Additionally, a message can be published with attributes:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   pubsub.publish_async "my-topic",
+        #                        "task completed",
+        #                        foo: :bar, this: :that
+        #
+        def publish_async topic_name, data = nil, attributes = {}, &block
+          ensure_service!
+          service.publish_async topic_name, data, attributes, &block
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
@@ -1,0 +1,89 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Pubsub
+      ##
+      # # PublishResult
+      #
+      class PublishResult
+        ##
+        # @private Create an PublishResult object.
+        def initialize message, error = nil
+          @message = message
+          @error = error
+        end
+
+        ##
+        # The message.
+        def message
+          @message
+        end
+        alias_method :msg, :message
+
+        ##
+        # The message's data.
+        def data
+          message.data
+        end
+
+        ##
+        # The message's attributes.
+        def attributes
+          message.attributes
+        end
+
+        ##
+        # The ID of the message, assigned by the server at publication
+        # time. Guaranteed to be unique within the topic.
+        def message_id
+          message.message_id
+        end
+        alias_method :msg_id, :message_id
+
+        ##
+        # The error that was raised when published, if any.
+        def error
+          @error
+        end
+
+        ##
+        # Whether the publish request was successful.
+        def succeeded?
+          error.nil?
+        end
+
+        # Whether the publish request failed.
+        def failed?
+          !succeeded?
+        end
+
+        ##
+        # @private Create an PublishResult object from a message protobuf.
+        def self.from_grpc msg_grpc
+          new Message.from_grpc(msg_grpc)
+        end
+
+        ##
+        # @private Create an PublishResult object from a message protobuf and an
+        # error.
+        def self.from_error msg_grpc, error
+          new Message.from_grpc(msg_grpc), error
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/publisher.rb
@@ -1,0 +1,202 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "monitor"
+require "concurrent"
+require "google/cloud/pubsub/publish_result"
+require "google/cloud/pubsub/service"
+
+module Google
+  module Cloud
+    module Pubsub
+      ##
+      # @private
+      # # Publisher
+      #
+      class Publisher
+        include MonitorMixin
+
+        MAX_BYTES = 5*1024*1024
+        MAX_MESSAGES = 1000
+        TIMER_DELAY = 0.25
+
+        attr_reader :service, :queue
+        attr_reader :max_bytes, :max_messages, :timer_delay
+        attr_reader :thread_pool, :timer_task
+
+        def initialize service, max_bytes: MAX_BYTES,
+                       max_messages: MAX_MESSAGES, timer_delay: TIMER_DELAY
+          @service = service
+          @max_bytes = max_bytes
+          @max_messages = max_messages
+          @timer_delay = timer_delay
+
+          @queue = {}
+          @thread_pool = Concurrent::ThreadPoolExecutor.new
+          @timer_task = Concurrent::TimerTask.new(
+            execution_interval: @timer_delay) { flush }
+
+          # init MonitorMixin
+          super()
+        end
+
+        def publish topic_name, data = nil, attributes = {}, &block
+          topic_name = service.topic_path topic_name
+          msg = create_pubsub_message data, attributes
+
+          synchronize do
+            batch = @queue[topic_name]
+            if batch.nil?
+              # Create a new batch.
+              batch = QueuedBatch.new msg, block
+            elsif !batch.try_add(msg, block, max_messages: max_messages,
+                                             max_bytes: max_bytes)
+              # We hit a threshold, publish existing batch.
+              publish_batch_async topic_name, batch
+              # Create a new batch.
+              batch = QueuedBatch.new msg, block
+            end
+            @queue[topic_name] = batch
+          end
+          nil
+        end
+
+        def start
+          @timer_task.execute
+        end
+
+        def stop
+          flush
+          @timer_task.shutdown
+        end
+
+        def started?
+          @timer_task.running?
+        end
+
+        def stopping?
+          @timer_task.shuttingdown?
+        end
+
+        def stopped?
+          @timer_task.shutdown?
+        end
+
+        def wait timeout = nil
+          @timer_task.wait_for_termination timeout
+        end
+
+        def flush
+          synchronize do
+            @queue.each do |topic_name, batch|
+              publish_batch_async topic_name, batch
+            end
+            @queue = {}
+          end
+        end
+
+        protected
+
+        def create_pubsub_message data, attributes
+          attributes ||= {}
+          if data.is_a?(::Hash) && attributes.empty?
+            attributes = data
+            data = nil
+          end
+
+          # Convert IO-ish objects to strings
+          if data.respond_to?(:read) && data.respond_to?(:rewind)
+            data.rewind
+            data = data.read
+          end
+          # Convert data to encoded byte array to match the protobuf defn
+          data = String(data).force_encoding("ASCII-8BIT")
+
+          # Convert attributes to strings to match the protobuf definition
+          attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]
+
+          Google::Pubsub::V1::PubsubMessage.new data: data,
+                                                attributes: attributes
+        end
+
+        def publish_batch topic_name, batch
+          grpc = service.publish_messages topic_name, batch.messages
+          batch.items.zip(Array(grpc.message_ids)) do |item, id|
+            item.msg.message_id = id
+            if item.callback
+              item.callback.call PublishResult.from_grpc(item.msg)
+            end
+          end
+        rescue => e
+          batch.items.each do |item|
+            if item.callback
+              item.callback.call PublishResult.from_error(item.msg, e)
+            end
+          end
+        end
+
+        def publish_batch_async topic_name, batch
+          Concurrent::Future.new(executor: @thread_pool) do
+            publish_batch topic_name, batch
+          end.execute
+        end
+
+        class QueuedBatch
+          attr_reader :messages, :callbacks
+
+          def initialize msg, callback
+            @messages = [msg]
+            @callbacks = [callback]
+          end
+
+          def add msg, callback
+            @messages << msg
+            @callbacks << callback
+          end
+
+          def try_add msg, callback,
+                      max_messages: MAX_MESSAGES, max_bytes: MAX_BYTES
+            return false if total_message_count + 1 > max_messages
+            return false if total_message_size + msg.to_proto.size >= max_bytes
+            add msg, callback
+            true
+          end
+
+          def total_message_count
+            @messages.count
+          end
+
+          def total_message_size
+            @messages.map(&:to_proto).map(&:size).inject(0, :+)
+          end
+
+          def items
+            @messages.zip(@callbacks).map do |msg, callback|
+              Item.new msg, callback
+            end
+          end
+
+          class Item
+            attr_accessor :msg, :callback
+            def initialize msg, callback
+              @msg = msg
+              @callback = callback
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -258,7 +258,8 @@ module Google
         #   pubsub = Google::Cloud::Pubsub.new
         #
         #   topic = pubsub.topic "my-topic"
-        #   msg = topic.publish File.open("message.txt")
+        #   file = File.open "message.txt", mode: "rb"
+        #   msg = topic.publish file
         #
         # @example Additionally, a message can be published with attributes:
         #   require "google/cloud/pubsub"
@@ -288,6 +289,48 @@ module Google
           yield publisher if block_given?
           return nil if publisher.messages.count.zero?
           publish_batch_messages publisher
+        end
+
+        ##
+        # Publishes a message asynchonously to the topic.
+        #
+        # @param [String, File] data The message data.
+        # @param [Hash] attributes Optional attributes for the message.
+        # @yield [result] the callback for when the message has been published
+        # @yieldparam [PublishResult] result the result of the asynchonous
+        #   publish
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #   topic.publish_async "task completed" do |result|
+        #     puts result.msg_id if result.succeeded?
+        #   end
+        #
+        # @example A message can be published using a File object:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #   file = File.open "message.txt", mode: "rb"
+        #   topic.publish_async file
+        #
+        # @example Additionally, a message can be published with attributes:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #   topic.publish_async "task completed",
+        #                       foo: :bar, this: :that
+        #
+        def publish_async data = nil, attributes = {}, &block
+          ensure_service!
+          service.publish_async name, data, attributes, &block
         end
 
         ##

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project/publish_async_test.rb
@@ -1,0 +1,403 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::Project, :publish_async, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
+                                                       pubsub.service }
+
+  it "publishes a message" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    pubsub.publish_async topic_name, "async-message"
+
+    pubsub.service.async_publisher.queue.wont_be :empty?
+    pubsub.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil]
+
+    pubsub.service.async_publisher.must_be :started?
+    pubsub.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    pubsub.service.async_publisher.stop
+    pubsub.service.async_publisher.wait
+
+    pubsub.service.async_publisher.wont_be :started?
+    pubsub.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    pubsub.service.async_publisher.thread_pool.shutdown
+    pubsub.service.async_publisher.thread_pool.wait_for_termination
+
+    pubsub.service.async_publisher.queue.must_be :empty?
+
+    mock.verify
+  end
+
+  it "publishes a message with a callback" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    callback_called = false
+
+    pubsub.publish_async topic_name, "async-message" do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      assert result.succeeded?
+      assert_equal "msg1", result.msg_id
+      callback_called = true
+    end
+
+    pubsub.service.async_publisher.queue.wont_be :empty?
+    pubsub.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    pubsub.service.async_publisher.must_be :started?
+    pubsub.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    pubsub.service.async_publisher.stop
+    pubsub.service.async_publisher.wait
+
+    pubsub.service.async_publisher.wont_be :started?
+    pubsub.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    pubsub.service.async_publisher.thread_pool.shutdown
+    pubsub.service.async_publisher.thread_pool.wait_for_termination
+
+    pubsub.service.async_publisher.queue.must_be :empty?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes a message with multibyte characters" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    callback_called = false
+
+    pubsub.publish_async topic_name, "あ" do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      assert result.succeeded?
+      assert_equal "msg1", result.msg_id
+      assert_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT"), result.data
+      callback_called = true
+    end
+
+    pubsub.service.async_publisher.queue.wont_be :empty?
+    pubsub.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    pubsub.service.async_publisher.must_be :started?
+    pubsub.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    pubsub.service.async_publisher.stop
+    pubsub.service.async_publisher.wait
+
+    pubsub.service.async_publisher.wont_be :started?
+    pubsub.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    pubsub.service.async_publisher.thread_pool.shutdown
+    pubsub.service.async_publisher.thread_pool.wait_for_termination
+
+    pubsub.service.async_publisher.queue.must_be :empty?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes a message using an IO-ish object" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    callback_called = false
+
+    Tempfile.open ["message", "txt"] do |tmpfile|
+      tmpfile.binmode
+      tmpfile.write "あ"
+      tmpfile.rewind
+
+      pubsub.publish_async topic_name, tmpfile do |result|
+        assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+        assert result.succeeded?
+        assert_equal "msg1", result.msg_id
+        assert_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT"), result.data
+        callback_called = true
+      end
+    end
+
+    pubsub.service.async_publisher.queue.wont_be :empty?
+    pubsub.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    pubsub.service.async_publisher.must_be :started?
+    pubsub.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    pubsub.service.async_publisher.stop
+    pubsub.service.async_publisher.wait
+
+    pubsub.service.async_publisher.wont_be :started?
+    pubsub.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    pubsub.service.async_publisher.thread_pool.shutdown
+    pubsub.service.async_publisher.thread_pool.wait_for_termination
+
+    pubsub.service.async_publisher.queue.must_be :empty?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes a message with attributes" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"), attributes: {"format" => "text"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    callback_called = false
+
+    pubsub.publish_async topic_name, "async-message", format: :text do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      assert result.succeeded?
+      assert_equal "msg1", result.msg_id
+      assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+      assert_equal "text", result.attributes["format"]
+      callback_called = true
+    end
+
+    pubsub.service.async_publisher.queue.wont_be :empty?
+    pubsub.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    pubsub.service.async_publisher.must_be :started?
+    pubsub.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    pubsub.service.async_publisher.stop
+    pubsub.service.async_publisher.wait
+
+    pubsub.service.async_publisher.wont_be :started?
+    pubsub.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    pubsub.service.async_publisher.thread_pool.shutdown
+    pubsub.service.async_publisher.thread_pool.wait_for_termination
+
+    pubsub.service.async_publisher.queue.must_be :empty?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  describe "lazy topic that exists" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service,
+                                                 autocreate: false }
+
+    it "publishes a message" do
+      messages = [
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+      ]
+      publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      mock = Minitest::Mock.new
+      mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+      pubsub.service.mocked_publisher = mock
+
+      pubsub.publish_async topic_name, "async-message"
+
+      pubsub.service.async_publisher.queue.wont_be :empty?
+      pubsub.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+      pubsub.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+      pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+      pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil]
+
+      pubsub.service.async_publisher.must_be :started?
+      pubsub.service.async_publisher.wont_be :stopped?
+
+      # force the queued messages to be published
+      pubsub.service.async_publisher.stop
+      pubsub.service.async_publisher.wait
+
+      pubsub.service.async_publisher.wont_be :started?
+      pubsub.service.async_publisher.must_be :stopped?
+
+      # shut down the thread pool to ensure all the tasks are completed
+      pubsub.service.async_publisher.thread_pool.shutdown
+      pubsub.service.async_publisher.thread_pool.wait_for_termination
+
+      pubsub.service.async_publisher.queue.must_be :empty?
+
+      mock.verify
+    end
+
+    it "publishes a message with attributes" do
+      messages = [
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"), attributes: { "format" => "text" })
+      ]
+      publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      mock = Minitest::Mock.new
+      mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+      pubsub.service.mocked_publisher = mock
+
+      callback_called = false
+
+      pubsub.publish_async topic_name, "async-message", format: :text do |result|
+        assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+        assert result.succeeded?
+        assert_equal "msg1", result.msg_id
+        assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+        assert_equal "text", result.attributes["format"]
+        callback_called = true
+      end
+
+      pubsub.service.async_publisher.queue.wont_be :empty?
+      pubsub.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+      pubsub.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+      pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+      pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+        block.must_be_kind_of Proc
+      end
+
+      pubsub.service.async_publisher.must_be :started?
+      pubsub.service.async_publisher.wont_be :stopped?
+
+      # force the queued messages to be published
+      pubsub.service.async_publisher.stop
+      pubsub.service.async_publisher.wait
+
+      pubsub.service.async_publisher.wont_be :started?
+      pubsub.service.async_publisher.must_be :stopped?
+
+      # shut down the thread pool to ensure all the tasks are completed
+      pubsub.service.async_publisher.thread_pool.shutdown
+      pubsub.service.async_publisher.thread_pool.wait_for_termination
+
+      pubsub.service.async_publisher.queue.must_be :empty?
+      callback_called.must_equal true
+
+      mock.verify
+    end
+  end
+
+  describe "lazy topic that does not exist" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service,
+                                                 autocreate: false }
+    let(:gax_error) do
+      Google::Gax::GaxError.new("not found").tap do |e|
+        e.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+      end
+    end
+
+    it "publishes a message" do
+      messages = [
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+      ]
+
+      stub = Object.new
+      def stub.publish *args
+        err = Google::Gax::GaxError.new("not found").tap do |e|
+          e.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        end
+        raise err
+      end
+      pubsub.service.mocked_publisher = stub
+
+      callback_called = false
+
+      pubsub.publish_async topic_name, "async-message" do |result|
+        assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+        refute result.succeeded?
+        assert result.failed?
+        assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+        assert_kind_of Google::Cloud::NotFoundError, result.error
+        callback_called = true
+      end
+
+      pubsub.service.async_publisher.queue.wont_be :empty?
+      pubsub.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+      pubsub.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+      pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+      pubsub.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+        block.must_be_kind_of Proc
+      end
+
+      pubsub.service.async_publisher.must_be :started?
+      pubsub.service.async_publisher.wont_be :stopped?
+
+      # force the queued messages to be published
+      pubsub.service.async_publisher.stop
+      pubsub.service.async_publisher.wait
+
+      pubsub.service.async_publisher.wont_be :started?
+      pubsub.service.async_publisher.must_be :stopped?
+
+      # shut down the thread pool to ensure all the tasks are completed
+      pubsub.service.async_publisher.thread_pool.shutdown
+      pubsub.service.async_publisher.thread_pool.wait_for_termination
+
+      pubsub.service.async_publisher.queue.must_be :empty?
+      callback_called.must_equal true
+    end
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
@@ -1,0 +1,77 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::PublishResult, :mock_pubsub do
+  let(:data) { "msg-goes-here" }
+  let(:attributes) { { "foo" => "FOO", "bar" => "BAR" } }
+  let(:msg) { Google::Cloud::Pubsub::Message.new data, attributes }
+  let(:result) { Google::Cloud::Pubsub::PublishResult.new msg }
+
+  it "knows attributes" do
+    result.data.must_equal data
+    result.message.data.must_equal data
+    result.msg.data.must_equal data
+
+    result.attributes.keys.sort.must_equal   attributes.keys.sort
+    result.attributes.values.sort.must_equal attributes.values.sort
+    result.message.attributes.keys.sort.must_equal   attributes.keys.sort
+    result.message.attributes.values.sort.must_equal attributes.values.sort
+    result.msg.attributes.keys.sort.must_equal   attributes.keys.sort
+    result.msg.attributes.values.sort.must_equal attributes.values.sort
+
+    result.message_id.must_be :empty?
+    result.message.message_id.must_be :empty?
+    result.msg.message_id.must_be :empty?
+
+    result.message.must_equal msg
+    result.msg.must_equal msg
+
+    result.error.must_be :nil?
+
+    result.must_be :succeeded?
+    result.wont_be :failed?
+  end
+
+  describe "with error" do
+    let(:error) { StandardError.new "something happened" }
+    let(:result) { Google::Cloud::Pubsub::PublishResult.new msg, error }
+
+    it "knows attributes" do
+      result.data.must_equal data
+      result.message.data.must_equal data
+      result.msg.data.must_equal data
+
+      result.attributes.keys.sort.must_equal   attributes.keys.sort
+      result.attributes.values.sort.must_equal attributes.values.sort
+      result.message.attributes.keys.sort.must_equal   attributes.keys.sort
+      result.message.attributes.values.sort.must_equal attributes.values.sort
+      result.msg.attributes.keys.sort.must_equal   attributes.keys.sort
+      result.msg.attributes.values.sort.must_equal attributes.values.sort
+
+      result.message_id.must_be :empty?
+      result.message.message_id.must_be :empty?
+      result.msg.message_id.must_be :empty?
+
+      result.message.must_equal msg
+      result.msg.must_equal msg
+
+      result.error.must_equal error
+
+      result.wont_be :succeeded?
+      result.must_be :failed?
+    end
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/publisher_test.rb
@@ -1,0 +1,372 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::Publisher, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic_name2) { "differnt-topic-name" }
+  let(:message1) { "new-message-here" }
+  let(:message2) { "second-new-message" }
+  let(:message3) { "third-new-message" }
+  let(:msg_encoded1) { message1.encode("ASCII-8BIT") }
+  let(:msg_encoded2) { message2.encode("ASCII-8BIT") }
+  let(:msg_encoded3) { message3.encode("ASCII-8BIT") }
+
+  it "publishes a message" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Publisher.new pubsub.service
+    publisher.start
+
+    publisher.publish topic_name, message1
+
+    publisher.queue.wont_be :empty?
+    publisher.queue.keys.must_equal [topic_path(topic_name)]
+    publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil]
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop
+    publisher.wait
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    publisher.thread_pool.shutdown
+    publisher.thread_pool.wait_for_termination
+
+    publisher.queue.must_be :empty?
+
+    mock.verify
+  end
+
+  it "publishes a message with attributes" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1, attributes: {"format" => "text"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Publisher.new pubsub.service
+    publisher.start
+
+    publisher.publish topic_name, message1, format: :text
+
+    publisher.queue.wont_be :empty?
+    publisher.queue.keys.must_equal [topic_path(topic_name)]
+    publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil]
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop
+    publisher.wait
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    publisher.thread_pool.shutdown
+    publisher.thread_pool.wait_for_termination
+
+    publisher.queue.must_be :empty?
+
+    mock.verify
+  end
+
+  it "publishes a message with a callback" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Publisher.new pubsub.service
+    publisher.start
+
+    callback_called = false
+
+    publisher.publish topic_name, message1 do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      callback_called = true
+    end
+
+    publisher.queue.wont_be :empty?
+    publisher.queue.keys.must_equal [topic_path(topic_name)]
+    publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop
+    publisher.wait
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    publisher.thread_pool.shutdown
+    publisher.thread_pool.wait_for_termination
+
+    publisher.queue.must_be :empty?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes multiple messages" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1),
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded2),
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Publisher.new pubsub.service
+    publisher.start
+
+    publisher.publish topic_name, message1
+    publisher.publish topic_name, message2
+    publisher.publish topic_name, message3, format: :none
+
+    publisher.queue.wont_be :empty?
+    publisher.queue.keys.must_equal [topic_path(topic_name)]
+    publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil, nil, nil]
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop
+    publisher.wait
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    publisher.thread_pool.shutdown
+    publisher.thread_pool.wait_for_termination
+
+    publisher.queue.must_be :empty?
+
+    mock.verify
+  end
+
+  it "publishes multiple messages with callbacks" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1),
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded2),
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Publisher.new pubsub.service
+    publisher.start
+
+    callback_count = 0
+
+    publisher.publish topic_name, message1 do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      callback_count += 1
+    end
+    publisher.publish topic_name, message2 do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      callback_count += 1
+    end
+    publisher.publish topic_name, message3, format: :none do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      callback_count += 1
+    end
+
+    publisher.queue.wont_be :empty?
+    publisher.queue.keys.must_equal [topic_path(topic_name)]
+    publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 3
+    publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop
+    publisher.wait
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    publisher.thread_pool.shutdown
+    publisher.thread_pool.wait_for_termination
+
+    publisher.queue.must_be :empty?
+    callback_count.must_equal 3
+
+    mock.verify
+  end
+
+  it "publishes multiple messages to different topics" do
+    messages1 = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1),
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded2)
+    ]
+    messages2 = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages1, options: default_options]
+    mock.expect :publish, publish_res, [topic_path(topic_name2), messages2, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Publisher.new pubsub.service
+    publisher.start
+
+    publisher.publish topic_name, message1
+    publisher.publish topic_name, message2
+    publisher.publish topic_name2, message3, format: :none
+
+    publisher.queue.wont_be :empty?
+    publisher.queue.keys.must_equal [topic_path(topic_name), topic_path(topic_name2)]
+    publisher.queue[topic_path(topic_name)].messages.must_equal messages1
+    publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil, nil]
+    publisher.queue[topic_path(topic_name2)].messages.must_equal messages2
+    publisher.queue[topic_path(topic_name2)].callbacks.must_equal [nil]
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop
+    publisher.wait
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    publisher.thread_pool.shutdown
+    publisher.thread_pool.wait_for_termination
+
+    publisher.queue.must_be :empty?
+
+    mock.verify
+  end
+
+  it "publishes multiple batches when message count limit is reached" do
+    messages = 10.times.map do
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
+    end
+    message_ids = 10.times.map do |i|
+      "msg#{i}"
+    end
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: message_ids }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Publisher.new pubsub.service, max_messages: 10
+    # Don't start the timer so we don't interfere with the limit calculations
+
+    30.times do
+      publisher.publish topic_name, message1
+    end
+
+    publisher.queue.wont_be :empty?
+    publisher.queue.keys.must_equal [topic_path(topic_name)]
+    publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]
+
+    # flush the 3rd batch
+    publisher.flush
+
+    # shut down the thread pool to ensure all the tasks are completed
+    publisher.thread_pool.shutdown
+    publisher.thread_pool.wait_for_termination
+
+    publisher.queue.must_be :empty?
+
+    mock.verify
+  end
+
+  it "publishes multiple batches when message size limit is reached" do
+    messages = 10.times.map do
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
+    end
+    message_ids = 10.times.map do |i|
+      "msg#{i}"
+    end
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: message_ids }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    # 190 is bigger than 10 messages, but less than 11.
+    publisher = Google::Cloud::Pubsub::Publisher.new pubsub.service, max_bytes: 190
+    # Don't start the timer so we don't interfere with the limit calculations
+
+    30.times do
+      publisher.publish topic_name, message1
+    end
+
+    publisher.queue.wont_be :empty?
+    publisher.queue.keys.must_equal [topic_path(topic_name)]
+    publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]
+
+    # flush the 3rd batch
+    publisher.flush
+
+    # shut down the thread pool to ensure all the tasks are completed
+    publisher.thread_pool.shutdown
+    publisher.thread_pool.wait_for_termination
+
+    publisher.queue.must_be :empty?
+
+    mock.verify
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
@@ -1,0 +1,403 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
+                                                       pubsub.service }
+
+  it "publishes a message" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    topic.publish_async "async-message"
+
+    topic.service.async_publisher.queue.wont_be :empty?
+    topic.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    topic.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil]
+
+    topic.service.async_publisher.must_be :started?
+    topic.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.service.async_publisher.stop
+    topic.service.async_publisher.wait
+
+    topic.service.async_publisher.wont_be :started?
+    topic.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    topic.service.async_publisher.thread_pool.shutdown
+    topic.service.async_publisher.thread_pool.wait_for_termination
+
+    topic.service.async_publisher.queue.must_be :empty?
+
+    mock.verify
+  end
+
+  it "publishes a message with a callback" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    callback_called = false
+
+    topic.publish_async "async-message" do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      assert result.succeeded?
+      assert_equal "msg1", result.msg_id
+      callback_called = true
+    end
+
+    topic.service.async_publisher.queue.wont_be :empty?
+    topic.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    topic.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    topic.service.async_publisher.must_be :started?
+    topic.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.service.async_publisher.stop
+    topic.service.async_publisher.wait
+
+    topic.service.async_publisher.wont_be :started?
+    topic.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    topic.service.async_publisher.thread_pool.shutdown
+    topic.service.async_publisher.thread_pool.wait_for_termination
+
+    topic.service.async_publisher.queue.must_be :empty?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes a message with multibyte characters" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    callback_called = false
+
+    topic.publish_async "あ" do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      assert result.succeeded?
+      assert_equal "msg1", result.msg_id
+      assert_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT"), result.data
+      callback_called = true
+    end
+
+    topic.service.async_publisher.queue.wont_be :empty?
+    topic.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    topic.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    topic.service.async_publisher.must_be :started?
+    topic.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.service.async_publisher.stop
+    topic.service.async_publisher.wait
+
+    topic.service.async_publisher.wont_be :started?
+    topic.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    topic.service.async_publisher.thread_pool.shutdown
+    topic.service.async_publisher.thread_pool.wait_for_termination
+
+    topic.service.async_publisher.queue.must_be :empty?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes a message using an IO-ish object" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    callback_called = false
+
+    Tempfile.open ["message", "txt"] do |tmpfile|
+      tmpfile.binmode
+      tmpfile.write "あ"
+      tmpfile.rewind
+
+      topic.publish_async tmpfile do |result|
+        assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+        assert result.succeeded?
+        assert_equal "msg1", result.msg_id
+        assert_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT"), result.data
+        callback_called = true
+      end
+    end
+
+    topic.service.async_publisher.queue.wont_be :empty?
+    topic.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    topic.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    topic.service.async_publisher.must_be :started?
+    topic.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.service.async_publisher.stop
+    topic.service.async_publisher.wait
+
+    topic.service.async_publisher.wont_be :started?
+    topic.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    topic.service.async_publisher.thread_pool.shutdown
+    topic.service.async_publisher.thread_pool.wait_for_termination
+
+    topic.service.async_publisher.queue.must_be :empty?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes a message with attributes" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"), attributes: {"format" => "text"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    callback_called = false
+
+    topic.publish_async "async-message", format: :text do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      assert result.succeeded?
+      assert_equal "msg1", result.msg_id
+      assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+      assert_equal "text", result.attributes["format"]
+      callback_called = true
+    end
+
+    topic.service.async_publisher.queue.wont_be :empty?
+    topic.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+    topic.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+    topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    topic.service.async_publisher.must_be :started?
+    topic.service.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.service.async_publisher.stop
+    topic.service.async_publisher.wait
+
+    topic.service.async_publisher.wont_be :started?
+    topic.service.async_publisher.must_be :stopped?
+
+    # shut down the thread pool to ensure all the tasks are completed
+    topic.service.async_publisher.thread_pool.shutdown
+    topic.service.async_publisher.thread_pool.wait_for_termination
+
+    topic.service.async_publisher.queue.must_be :empty?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  describe "lazy topic that exists" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service,
+                                                 autocreate: false }
+
+    it "publishes a message" do
+      messages = [
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+      ]
+      publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      mock = Minitest::Mock.new
+      mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+      topic.service.mocked_publisher = mock
+
+      topic.publish_async "async-message"
+
+      topic.service.async_publisher.queue.wont_be :empty?
+      topic.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+      topic.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+      topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+      topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.must_equal [nil]
+
+      topic.service.async_publisher.must_be :started?
+      topic.service.async_publisher.wont_be :stopped?
+
+      # force the queued messages to be published
+      topic.service.async_publisher.stop
+      topic.service.async_publisher.wait
+
+      topic.service.async_publisher.wont_be :started?
+      topic.service.async_publisher.must_be :stopped?
+
+      # shut down the thread pool to ensure all the tasks are completed
+      topic.service.async_publisher.thread_pool.shutdown
+      topic.service.async_publisher.thread_pool.wait_for_termination
+
+      topic.service.async_publisher.queue.must_be :empty?
+
+      mock.verify
+    end
+
+    it "publishes a message with attributes" do
+      messages = [
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"), attributes: { "format" => "text" })
+      ]
+      publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      mock = Minitest::Mock.new
+      mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+      topic.service.mocked_publisher = mock
+
+      callback_called = false
+
+      topic.publish_async "async-message", format: :text do |result|
+        assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+        assert result.succeeded?
+        assert_equal "msg1", result.msg_id
+        assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+        assert_equal "text", result.attributes["format"]
+        callback_called = true
+      end
+
+      topic.service.async_publisher.queue.wont_be :empty?
+      topic.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+      topic.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+      topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+      topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+        block.must_be_kind_of Proc
+      end
+
+      topic.service.async_publisher.must_be :started?
+      topic.service.async_publisher.wont_be :stopped?
+
+      # force the queued messages to be published
+      topic.service.async_publisher.stop
+      topic.service.async_publisher.wait
+
+      topic.service.async_publisher.wont_be :started?
+      topic.service.async_publisher.must_be :stopped?
+
+      # shut down the thread pool to ensure all the tasks are completed
+      topic.service.async_publisher.thread_pool.shutdown
+      topic.service.async_publisher.thread_pool.wait_for_termination
+
+      topic.service.async_publisher.queue.must_be :empty?
+      callback_called.must_equal true
+
+      mock.verify
+    end
+  end
+
+  describe "lazy topic that does not exist" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service,
+                                                 autocreate: false }
+    let(:gax_error) do
+      Google::Gax::GaxError.new("not found").tap do |e|
+        e.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+      end
+    end
+
+    it "publishes a message" do
+      messages = [
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+      ]
+
+      stub = Object.new
+      def stub.publish *args
+        err = Google::Gax::GaxError.new("not found").tap do |e|
+          e.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        end
+        raise err
+      end
+      pubsub.service.mocked_publisher = stub
+
+      callback_called = false
+
+      topic.publish_async "async-message" do |result|
+        assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+        refute result.succeeded?
+        assert result.failed?
+        assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+        assert_kind_of Google::Cloud::NotFoundError, result.error
+        callback_called = true
+      end
+
+      topic.service.async_publisher.queue.wont_be :empty?
+      topic.service.async_publisher.queue.keys.must_equal [topic_path(topic_name)]
+      topic.service.async_publisher.queue[topic_path(topic_name)].messages.must_equal messages
+      topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.count.must_equal 1
+      topic.service.async_publisher.queue[topic_path(topic_name)].callbacks.each do |block|
+        block.must_be_kind_of Proc
+      end
+
+      topic.service.async_publisher.must_be :started?
+      topic.service.async_publisher.wont_be :stopped?
+
+      # force the queued messages to be published
+      topic.service.async_publisher.stop
+      topic.service.async_publisher.wait
+
+      topic.service.async_publisher.wont_be :started?
+      topic.service.async_publisher.must_be :stopped?
+
+      # shut down the thread pool to ensure all the tasks are completed
+      topic.service.async_publisher.thread_pool.shutdown
+      topic.service.async_publisher.thread_pool.wait_for_termination
+
+      topic.service.async_publisher.queue.must_be :empty?
+      callback_called.must_equal true
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a Publisher object that has the following:

- [x] Asynchronously publish messages in batches
- [x] Will push batches in intervals (every 0.25 seconds)
- [x] Will push batches when message count hits a limit (2000)
- [x] Will push batches when RPC payload reaches a size (10MB)

This functionality is expressed as `Topic#publish_async` and `Project#publish_async`.

This change is to be merged into the `pubsub` branch, which will be used as the target for the upcoming Pub/Sub changes.