### PR TITLE
Remove Pub/Sub autocreate

### DIFF
--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -145,12 +145,6 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Pubsub::Project#topic@With the `autocreate` option set to `true`." do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/non-existing-topic", Hash]
-    end
-  end
-                                                            
   doctest.before "Google::Cloud::Pubsub::Project#topic@Create topic in a different project with the `project` flag." do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/another-topic", Hash]
@@ -176,12 +170,6 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Pubsub::Project#publish@With `autocreate`:" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_publisher.expect :publish, OpenStruct.new(message_ids: ["1"]), ["projects/my-project/topics/new-topic", [pubsub_message("task completed")], Hash]
-    end
-  end
-
   doctest.before "Google::Cloud::Pubsub::Project#publish@Additionally, a message can be published with attributes:" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :publish, OpenStruct.new(message_ids: ["1"]), ["projects/my-project/topics/my-topic", [pubsub_message("task completed", {"foo"=>"bar", "this"=>"that"})], Hash]
@@ -202,12 +190,6 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Pubsub::Project#subscribe" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :create_subscription, OpenStruct.new(name: "my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", "projects/my-project/topics/my-topic", Hash]
-    end
-  end
-
-  doctest.before "Google::Cloud::Pubsub::Project#subscribe@With `autocreate`:" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :create_subscription, OpenStruct.new(name: "new-topic-sub"), ["projects/my-project/subscriptions/new-topic-sub", "projects/my-project/topics/new-topic", Hash]
     end
   end
 
@@ -652,9 +634,3 @@ def topic_permissions_resp
     permissions: ["pubsub.topics.get"]
   )
 end
-
-
-
-
-
-

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
@@ -28,121 +28,39 @@ describe Google::Cloud::Pubsub::Topic, :exists, :mock_pubsub do
   end
 
   describe "lazy topic object of a topic that exists" do
-    describe "lazy topic with default autocreate" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service }
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service }
 
-      it "checks if the topic exists by making an HTTP call" do
-        get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
-        mock = Minitest::Mock.new
-        mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
-        topic.service.mocked_publisher = mock
+    it "checks if the topic exists by making an HTTP call" do
+      get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
+      mock = Minitest::Mock.new
+      mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
+      topic.service.mocked_publisher = mock
 
-        topic.must_be :exists?
-        # Additional exists? calls do not make HTTP calls
-        topic.must_be :exists?
+      topic.must_be :exists?
+      # Additional exists? calls do not make HTTP calls
+      topic.must_be :exists?
 
-        mock.verify
-      end
-    end
-
-    describe "lazy topic with explicit autocreate" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service,
-                                                   autocreate: true }
-
-      it "checks if the topic exists by making an HTTP call" do
-        get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
-        mock = Minitest::Mock.new
-        mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
-        topic.service.mocked_publisher = mock
-
-        topic.must_be :exists?
-        # Additional exists? calls do not make HTTP calls
-        topic.must_be :exists?
-
-        mock.verify
-      end
-    end
-
-    describe "lazy topic without autocomplete" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service,
-                                                   autocreate: false }
-
-      it "checks if the topic exists by making an HTTP call" do
-        get_res = Google::Pubsub::V1::Topic.decode_json topic_json(topic_name)
-        mock = Minitest::Mock.new
-        mock.expect :get_topic, get_res, [topic_path(topic_name), options: default_options]
-        topic.service.mocked_publisher = mock
-
-        topic.must_be :exists?
-        # Additional exists? calls do not make HTTP calls
-        topic.must_be :exists?
-
-        mock.verify
-      end
+      mock.verify
     end
   end
 
   describe "lazy topic object of a topic that does not exist" do
-    describe "lazy topic with default autocreate" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service }
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service }
 
-      it "checks if the topic exists by making an HTTP call" do
-        stub = Object.new
-        def stub.get_topic *args
-          gax_error = Google::Gax::GaxError.new "not found"
-          gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
-          raise gax_error
-        end
-        topic.service.mocked_publisher = stub
-
-        topic.wont_be :exists?
-        # Additional exists? calls do not make HTTP calls
-        topic.wont_be :exists?
+    it "checks if the topic exists by making an HTTP call" do
+      stub = Object.new
+      def stub.get_topic *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
       end
-    end
+      topic.service.mocked_publisher = stub
 
-    describe "lazy topic with explicit autocreate" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service,
-                                                   autocreate: true }
-
-      it "checks if the topic exists by making an HTTP call" do
-        stub = Object.new
-        def stub.get_topic *args
-          gax_error = Google::Gax::GaxError.new "not found"
-          gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
-          raise gax_error
-        end
-        topic.service.mocked_publisher = stub
-
-        topic.wont_be :exists?
-        # Additional exists? calls do not make HTTP calls
-        topic.wont_be :exists?
-      end
-    end
-
-    describe "lazy topic without autocomplete" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service,
-                                                   autocreate: false }
-
-      it "checks if the topic exists by making an HTTP call" do
-        stub = Object.new
-        def stub.get_topic *args
-          gax_error = Google::Gax::GaxError.new "not found"
-          gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
-          raise gax_error
-        end
-        topic.service.mocked_publisher = stub
-
-        topic.wont_be :exists?
-        # Additional exists? calls do not make HTTP calls
-        topic.wont_be :exists?
-      end
+      topic.wont_be :exists?
+      # Additional exists? calls do not make HTTP calls
+      topic.wont_be :exists?
     end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
@@ -22,33 +22,4 @@ describe Google::Cloud::Pubsub::Topic, :lazy, :mock_pubsub do
   it "is not lazy when created with an HTTP method" do
     topic.wont_be :lazy?
   end
-
-  describe "lazy topic with default autocreate" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
-
-    it "will autocreate when created lazily" do
-      topic.must_be :lazy?
-    end
-  end
-
-  describe "lazy topic with explicit autocreate" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service,
-                                                 autocreate: true }
-
-    it "will autocreate when created lazily" do
-      topic.must_be :lazy?
-    end
-  end
-
-  describe "lazy topic without autocomplete" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service,
-                                                 autocreate: false }
-
-    it "knows if it will create a topic on the Pub/Sub service" do
-      topic.must_be :lazy?
-    end
-  end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
@@ -22,33 +22,4 @@ describe Google::Cloud::Pubsub::Topic, :name, :mock_pubsub do
   it "gives the name returned from the HTTP method" do
     topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
   end
-
-  describe "lazy topic with default autocreate" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service }
-
-    it "matches the name returned from the HTTP method" do
-      topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
-    end
-  end
-
-  describe "lazy topic with explicit autocreate" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service,
-                                                 autocreate: true }
-
-    it "matches the name returned from the HTTP method" do
-      topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
-    end
-  end
-
-  describe "lazy topic without autocomplete" do
-    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service,
-                                                 autocreate: false }
-
-    it "matches the name returned from the HTTP method" do
-      topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
-    end
-  end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
@@ -130,8 +130,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
 
   describe "lazy topic that exists" do
     let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service,
-                                                 autocreate: false }
+                                                 pubsub.service }
 
     it "publishes a message" do
      messages = [
@@ -197,8 +196,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
 
   describe "lazy topic that does not exist" do
     let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service,
-                                                 autocreate: false }
+                                                 pubsub.service }
 
     it "publishes a message" do
       stub = Object.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -36,8 +36,7 @@ describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
 
   describe "lazy topic that exists" do
     let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service,
-                                                 autocreate: false }
+                                                 pubsub.service }
 
     it "creates a subscription when calling subscribe" do
       create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
@@ -56,8 +55,7 @@ describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
 
   describe "lazy topic that does not exist" do
     let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                 pubsub.service,
-                                                 autocreate: false }
+                                                 pubsub.service }
 
     it "raises NotFoundError when calling subscribe" do
       stub = Object.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
@@ -40,90 +40,42 @@ describe Google::Cloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
   end
 
   describe "lazy topic that exists" do
-    describe "created with autocreate" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service,
-                                                   autocreate: true }
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service }
 
-      it "lists subscriptions" do
-        mock = Minitest::Mock.new
-        mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
-        topic.service.mocked_publisher = mock
+    it "lists subscriptions" do
+      mock = Minitest::Mock.new
+      mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
+      topic.service.mocked_publisher = mock
 
-        subs = topic.subscriptions
+      subs = topic.subscriptions
 
-        mock.verify
+      mock.verify
 
-        subs.count.must_equal 3
-        subs.each do |sub|
-          sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-          sub.must_be :lazy?
-        end
-      end
-    end
-
-    describe "created without autocomplete" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service,
-                                                   autocreate: false }
-
-      it "lists subscriptions" do
-        mock = Minitest::Mock.new
-        mock.expect :list_topic_subscriptions, subscriptions_with_token, [topic_path(topic_name), page_size: nil, options: default_options]
-        topic.service.mocked_publisher = mock
-
-        subs = topic.subscriptions
-
-        mock.verify
-
-        subs.count.must_equal 3
-        subs.each do |sub|
-          sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
-          sub.must_be :lazy?
-        end
+      subs.count.must_equal 3
+      subs.each do |sub|
+        sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
+        sub.must_be :lazy?
       end
     end
   end
 
   describe "lazy topic that does not exist" do
-    describe "created with autocreate" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service,
-                                                   autocreate: true }
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service }
 
-      it "lists subscriptions" do
-        stub = Object.new
-        def stub.list_topic_subscriptions *args
-          gax_error = Google::Gax::GaxError.new "not found"
-          gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
-          raise gax_error
-        end
-        topic.service.mocked_publisher = stub
-
-        expect do
-          topic.subscriptions
-        end.must_raise Google::Cloud::NotFoundError
+    it "lists subscriptions" do
+      stub = Object.new
+      def stub.list_topic_subscriptions *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
       end
-    end
+      topic.service.mocked_publisher = stub
 
-    describe "created without autocomplete" do
-      let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
-                                                   pubsub.service,
-                                                   autocreate: false }
-
-      it "lists subscriptions" do
-        stub = Object.new
-        def stub.list_topic_subscriptions *args
-          gax_error = Google::Gax::GaxError.new "not found"
-          gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
-          raise gax_error
-        end
-        topic.service.mocked_publisher = stub
-
-        expect do
-          topic.subscriptions
-        end.must_raise Google::Cloud::NotFoundError
-      end
+      expect do
+        topic.subscriptions
+      end.must_raise Google::Cloud::NotFoundError
     end
   end
 end


### PR DESCRIPTION
This PR removes the `autocreate` feature in Pub/Sub. This feature was implemented early on in the initial design of the Pub/Sub library, along with `autoack`. Since `autoack` is being removed, I think it makes sense to reconsider `autocreate` as well.

The `autocreate` option simply allows for the creation of a topic when pulling it. So, instead of this:

```ruby
require "google/cloud/pubsub"

pubsub = Google::Cloud::Pubsub.new

topic = pubsub.topic("existing-topic") ||
        pubsub.create_topic("my-topic")
```

Users could instead do this:

```ruby
require "google/cloud/pubsub"

pubsub = Google::Cloud::Pubsub.new

topic = pubsub.topic "existing-topic", autocreate: true
```

But this feature has been problematic at times, especially when attempted to be combined with the `skip_lookup` option. Since we are about to break backwards compatibility by removing `autoack` and adding new features, I think it might be wise to remove `autocreate` as well. Thoughts?