### PR TITLE
Make Trace instrumentation asynchronous

### DIFF
--- a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
@@ -1,0 +1,124 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "stackdriver/core/async_actor"
+
+module Google
+  module Cloud
+    module Trace
+      ##
+      # # AsyncReporter
+      #
+      # @private Used by the {Google::Cloud::Trace::Middleware} to
+      # asynchronously update traces to Stackdriver Trace service when used in
+      # a Rack-based application.
+      class AsyncReporter
+        include Stackdriver::Core::AsyncActor
+
+        ##
+        # @private Default Maximum blacklog size for the job queue
+        DEFAULT_MAX_QUEUE_SIZE = 1000
+
+        ##
+        # The {Google::Cloud::Trace::Service} object to patch traces
+        attr_accessor :service
+
+        ##
+        # The max number of items the queue holds
+        attr_accessor :max_queue_size
+
+        ##
+        # @private Construct a new instance of AsyncReporter
+        def initialize service, max_queue_size = DEFAULT_MAX_QUEUE_SIZE
+          super()
+
+          @service = service
+          @max_queue_size = max_queue_size
+          @queue = []
+          @queue_resource = new_cond
+        end
+
+        ##
+        # Add the traces to the queue to be reported to Stackdriver Trace
+        # asynchronously. Signal the child thread to start processing the queue.
+        def patch_traces traces
+          ensure_thread
+
+          synchronize do
+            @queue.push traces
+            @queue_resource.broadcast
+
+            while @max_queue_size && @queue.size > max_queue_size
+              @queue_resource.wait 1
+
+              @queue.pop while @queue.size > max_queue_size
+            end
+          end
+        end
+
+        ##
+        # @private Callback function for AsyncActor module to process the queue
+        # in a loop
+        def run_backgrounder
+          traces = wait_next_item
+          return if traces.nil?
+
+          begin
+            service.patch_traces traces
+          rescue => e
+            @last_exception = e
+          end
+        end
+
+        ##
+        # @private Callback function when the async actor thread state changes
+        def on_async_state_change
+          synchronize do
+            @queue_resource.broadcast
+          end
+        end
+
+        ##
+        # Get the project id from underlying service object.
+        def project
+          service.project
+        end
+
+        private
+
+        ##
+        # @private Wait for the next item from the reporter queue. If there are
+        # no more items, it blocks the child thread until an item is enqueued.
+        def wait_next_item
+          synchronize do
+            @queue_resource.wait_while do
+              async_suspended? || (async_running? && @queue.empty?)
+            end
+            @queue.pop
+          end
+        end
+
+        ##
+        # @private Override the #backgrounder_stoppable? method from AsyncActor
+        # module. The actor can be gracefully stopped when queue is empty.
+        def backgrounder_stoppable?
+          synchronize do
+            @queue.empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -14,6 +14,7 @@
 
 
 require "google/cloud/env"
+require "google/cloud/trace/async_reporter"
 require "stackdriver/core/trace_context"
 
 module Google
@@ -112,8 +113,8 @@ module Google
         # Create a new Middleware for traces
         #
         # @param [Rack Application] app Rack application
-        # @param [Google::Cloud::Trace::Service] service The service object.
-        #     Optional if running on GCE.
+        # @param [Google::Cloud::Trace::Service, AsyncReporter] service
+        #   The service object to update traces. Optional if running on GCE.
         # @param [Hash] *kwargs Hash of configuration settings. Used for
         #   backward API compatibility. See the [Configuration
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
@@ -128,8 +129,12 @@ module Google
             @service = service
           else
             project_id = configuration.project_id
+
             if project_id
-              @service = Google::Cloud::Trace.new(project: project_id).service
+              keyfile = configuration.keyfile
+              tracer = Google::Cloud::Trace.new project: project_id,
+                                                keyfile: keyfile
+              @service = Google::Cloud::Trace::AsyncReporter.new tracer.service
             end
           end
         end

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -98,16 +98,9 @@ module Google
         #
         def self.init_middleware app
           trace_config = Trace.configure
-          project_id = trace_config.project_id
-          keyfile = trace_config.keyfile
 
-          tracer = Google::Cloud::Trace.new project: project_id,
-                                            keyfile: keyfile
-
-          app.middleware.insert_before \
-            Rack::Runtime,
-            Google::Cloud::Trace::Middleware,
-            service: tracer.service
+          app.middleware.insert_before Rack::Runtime,
+                                       Google::Cloud::Trace::Middleware
 
           trace_config.notifications.each do |type|
             Google::Cloud::Trace::Notifications.instrument \

--- a/google-cloud-trace/test/google/cloud/trace/async_reporter_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/async_reporter_test.rb
@@ -1,0 +1,85 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Trace::AsyncReporter, :mock_trace do
+  let(:reporter) {
+    Google::Cloud::Trace::AsyncReporter.new tracer.service
+  }
+
+  describe "#patch_traces" do
+    let(:queue) { reporter.instance_variable_get :@queue }
+    let(:queue_resource) { reporter.instance_variable_get :@queue_resource }
+
+    it "puts the trace on queue" do
+      trace = Object.new
+
+      reporter.async_suspend
+
+      reporter.patch_traces trace
+      queue.pop.must_equal trace
+    end
+
+    it "takes array of traces" do
+      trace1 = Object.new
+      trace2 = Object.new
+      traces = [trace1, trace2]
+
+      reporter.async_suspend
+
+      reporter.patch_traces traces
+      queue.pop.must_equal [trace1, trace2]
+    end
+
+    it "doesn't exceed max_queue_size" do
+      max_queue_size = 3
+      reporter.max_queue_size = max_queue_size
+      reporter.async_suspend
+
+      max_queue_size.times do |i|
+        reporter.patch_traces i
+      end
+
+      reporter.patch_traces nil
+
+      queue.size.must_equal max_queue_size
+    end
+
+    it "wakes up the child thread to dequeue the events" do
+      trace = Object.new
+      mocked_service = Minitest::Mock.new
+      mocked_service.expect :patch_traces, nil, [trace]
+
+      reporter = Google::Cloud::Trace::AsyncReporter.new mocked_service
+
+      reporter.patch_traces trace
+
+      wait_until_true do
+        reporter.instance_variable_get(:@queue).size == 0
+      end
+
+      mocked_service.verify
+    end
+  end
+
+  describe "#project" do
+    it "returns that of #service" do
+      reporter.service.stub :project, "service-project" do
+        reporter.project.must_equal "service-project"
+      end
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
@@ -106,6 +106,20 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
     }
   end
 
+  describe ".initialize" do
+    it "uses the service object passed in" do
+      middleware = Google::Cloud::Trace::Middleware.new base_app, service: "test-service"
+      middleware.instance_variable_get(:@service).must_equal "test-service"
+    end
+
+    it "creates a default AsyncReporter if service isn't passed in" do
+      Google::Cloud::Trace.configure.project_id = "test"
+      Google::Cloud::Trace.stub :new, OpenStruct.new(service: nil) do
+        base_middleware.instance_variable_get(:@service).must_be_kind_of Google::Cloud::Trace::AsyncReporter
+      end
+    end
+  end
+
   describe ".get_trace_context" do
     it "passes through the existing sampling decision" do
       env = rack_env sample: true

--- a/google-cloud-trace/test/helper.rb
+++ b/google-cloud-trace/test/helper.rb
@@ -66,3 +66,16 @@ class MockTrace < Minitest::Spec
     "projects/#{project}"
   end
 end
+
+##
+# Helper method to loop until block yields true or timeout.
+def wait_until_true timeout = 5
+  begin_t = Time.now
+
+  until yield
+    return :timeout if Time.now - begin_t > timeout
+    sleep 0.1
+  end
+
+  :completed
+end


### PR DESCRIPTION
Make Trace instrumentation submitting traces asynchronously by using AsyncActor.