### PR TITLE
Add Pub/Sub Subcriber

### DIFF
--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "google-gax", "~> 0.8.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.8"
+  gem.add_dependency "grpc", "~> 1.1"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -247,6 +247,12 @@ module Google
           end
         end
 
+        def streaming_pull request_enum
+          execute do
+            subscriber.streaming_pull request_enum, options: default_options
+          end
+        end
+
         ##
         # Acknowledges receipt of a message.
         def acknowledge subscription, *ack_ids

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -14,9 +14,9 @@
 
 
 require "google/cloud/pubsub/service"
-require "google/cloud/errors"
+require "google/cloud/pubsub/subscriber/stream"
+require "google/cloud/pubsub/subscriber/enumerator_queue"
 require "monitor"
-require "forwardable"
 require "concurrent"
 
 module Google
@@ -29,356 +29,84 @@ module Google
         include MonitorMixin
 
         ##
-        # @private Implementation attributes.
-        attr_reader :request_queue, :output_enum, :thread_pool, :service
+        # Subscriber attributes.
+        attr_reader :subscription_name, :callback, :deadline, :streams,
+                    :inventory, :threads
 
         ##
-        # Subscriber attributes.
-        attr_reader :callback, :subscription_name, :deadline, :inventory,
-                    :threads
+        # @private Implementation attributes.
+        attr_reader :stream_pool, :thread_pool, :service
 
         ##
         # @private Create an empty {Subscriber} object.
-        def initialize callback, subscription_name, deadline, inventory,
-                       threads, service
-          @request_queue = nil
-          @output_enum = nil
+        def initialize subscription_name, callback, deadline: nil, streams: nil,
+                       inventory: nil, threads: nil, service: nil
           @callback = callback
           @subscription_name = subscription_name
           @deadline = deadline || 60
-          @inventory = Inventory.new self, (inventory || 100)
+          @streams = streams || 1
+          @inventory = inventory || 100
           @threads = threads || [2, Concurrent.processor_count * 2].max
+          @thread_pool = Concurrent::FixedThreadPool.new @threads
           @service = service
+
+          @stream_pool = @streams.times.map do
+            Thread.new do
+              Thread.current[:stream] = Stream.new self
+            end
+          end
+          @stream_pool.map!(&:join)
+          @stream_pool.map! { |t| t[:stream] }
 
           super() # to init MonitorMixin
         end
 
         def start
-          synchronize do
-            return if @request_queue
-
-            @request_queue = EnumeratorQueue.new self
-            @thread_pool = Concurrent::FixedThreadPool.new threads
-            start_streaming!
+          start_pool = synchronize do
+            @stream_pool.map do |stream|
+              Thread.new { stream.start }
+            end
           end
+          start_pool.join
 
-          true
+          self
         end
 
         def stop
-          synchronize do
-            return if @request_queue.nil?
-            @request_queue.push self
-            @inventory.stop
-            @stopped = true
+          stop_pool = synchronize do
+            @stream_pool.map do |stream|
+              Thread.new { stream.stop }
+            end
           end
+          stop_pool.join
 
-          true
-        end
-
-        def stopped?
-          synchronize { @stopped }
-        end
-
-        def paused?
-          synchronize { @paused }
+          self
         end
 
         def wait!
-          synchronize do
-            @background_thread.join if @background_thread
+          wait_pool = synchronize do
+            @stream_pool.map do |stream|
+              Thread.new { stream.wait! }
+            end
+          end
+          wait_pool.join
 
+          synchronize do
             @thread_pool.shutdown
             @thread_pool.wait_for_termination
           end
 
-          true
-        end
-
-        ##
-        # @private
-        def acknowledge *messages
-          ack_ids = coerce_ack_ids messages
-          return true if ack_ids.empty?
-
-          ack_request = Google::Pubsub::V1::StreamingPullRequest.new
-          ack_request.ack_ids += ack_ids
-
-          synchronize do
-            @request_queue.push ack_request
-            @inventory.remove ack_ids
-            unpause_streaming!
-          end
-
-          true
-        end
-
-        ##
-        # @private
-        def delay new_deadline, *messages
-          deadline_ack_ids = coerce_ack_ids messages
-          return true if deadline_ack_ids.empty?
-
-          deadline_seconds = deadline_ack_ids.count.times.map { new_deadline }
-          deadline_ack_request = Google::Pubsub::V1::StreamingPullRequest.new
-          deadline_ack_request.modify_deadline_ack_ids += deadline_ack_ids
-          deadline_ack_request.modify_deadline_seconds += deadline_seconds
-
-          synchronize do
-            @request_queue.push deadline_ack_request
-            @inventory.remove deadline_ack_ids
-            unpause_streaming!
-          end
-
-          true
-        end
-
-        def inventory
-          synchronize { @inventory.count }
-        end
-
-        ##
-        # @private
-        def delay_inventory!
-          synchronize do
-            return true if @inventory.empty?
-
-            inv_mod_ack_deadline = @inventory.ack_ids.map { deadline }
-            inv_mod_ack_request = Google::Pubsub::V1::StreamingPullRequest.new
-            inv_mod_ack_request.modify_deadline_ack_ids += @inventory.ack_ids
-            inv_mod_ack_request.modify_deadline_seconds += inv_mod_ack_deadline
-
-            @request_queue.push inv_mod_ack_request
-          end
-
-          true
-        end
-
-        ##
-        # @private
-        def clear_inventory!
-          synchronize do
-            @inventory.clear
-            unpause_streaming!
-          end
+          self
         end
 
         # @private
         def to_s
-          format "(subscription: %s, inventory: %i)", subscription_name,
-                 inventory
+          format "(subscription: %s, streams: %i)", subscription_name, streams
         end
 
         # @private
         def inspect
           "#<#{self.class.name} #{self}>"
-        end
-
-        protected
-
-        # rubocop:disable all
-
-        def background_run
-          until synchronize { @stopped }
-            Thread.current.kill if synchronize { @paused }
-
-            begin
-              # Cannot syncronize the enumerator, causes deadlock
-              response = @output_enum.next
-              response.received_messages.each do |rec_msg_grpc|
-                rec_msg = ReceivedMessage.from_grpc(rec_msg_grpc, self)
-                synchronize do
-                  @inventory.add rec_msg.ack_id
-
-                  perform_callback_async rec_msg
-                end
-              end
-              synchronize { pause_streaming! }
-            rescue StopIteration
-              break
-            end
-          end
-        rescue GRPC::DeadlineExceeded
-          # The GRPC client will raise when stream is opened longer than the
-          # timeout value it is configured for. When this happends, restart the
-          # stream stealthly.
-        rescue => e
-          synchronize do
-            @request_queue.unshift Google::Cloud::Error.from_error(e)
-          end
-        ensure
-          Thread.pass
-        end
-
-        # rubocop:enable all
-
-        def perform_callback_async rec_msg
-          Concurrent::Future.new(executor: @thread_pool) do
-            @callback.call rec_msg
-          end.execute
-        end
-
-        def start_streaming!
-          @request_queue.unshift initial_input_request
-          @output_enum = service.streaming_pull @request_queue.each_item
-
-          @background_thread.kill if @background_thread
-          @background_thread = Thread.new { background_run }
-          @stopped = nil
-        end
-
-        def pause_streaming!
-          return if @paused
-
-          @paused = true if inventory_full?
-        end
-
-        def unpause_streaming!
-          return if @paused.nil? || inventory_full?
-
-          @paused = nil
-          # Need to recreate the enums otherwise we get the error:
-          # "fiber called across threads"
-          start_streaming!
-        end
-
-        def inventory_full?
-          @inventory.full?
-        end
-
-        def initial_input_request
-          Google::Pubsub::V1::StreamingPullRequest.new.tap do |req|
-            req.subscription = subscription_name
-            req.stream_ack_deadline_seconds = deadline
-          end
-        end
-
-        ##
-        # Makes sure the values are the `ack_id`. If given several
-        # {ReceivedMessage} objects extract the `ack_id` values.
-        def coerce_ack_ids messages
-          Array(messages).flatten.map do |msg|
-            msg.respond_to?(:ack_id) ? msg.ack_id : msg.to_s
-          end
-        end
-
-        # @private
-        class Inventory
-          include MonitorMixin
-
-          attr_reader :subscriber, :limit
-
-          def initialize subscriber, limit
-            @subscriber = subscriber
-            @limit = limit
-            @_ack_ids = []
-            @wait_cond = new_cond
-
-            super()
-          end
-
-          def ack_ids
-            @_ack_ids
-          end
-
-          def add *ack_ids
-            ack_ids = Array(ack_ids).flatten
-            synchronize do
-              @_ack_ids += ack_ids
-              @start_time ||= Time.now
-              @background_thread ||= Thread.new { background_run }
-            end
-          end
-
-          def remove *ack_ids
-            ack_ids = Array(ack_ids).flatten
-            synchronize do
-              @_ack_ids -= ack_ids
-              clear if @_ack_ids.empty?
-            end
-          end
-
-          def clear
-            synchronize do
-              @_ack_ids = []
-              if @background_thread
-                @background_thread.kill
-                @background_thread = nil
-              end
-              @start_time = nil
-            end
-          end
-
-          def count
-            synchronize do
-              @_ack_ids.count
-            end
-          end
-
-          def empty?
-            synchronize do
-              @_ack_ids.empty?
-            end
-          end
-
-          def stop
-            synchronize do
-              @stopped = true
-            end
-          end
-
-          def full?
-            count >= limit
-          end
-
-          protected
-
-          def background_run
-            synchronize do
-              until @stopped
-                @wait_cond.wait calc_delay
-
-                @subscriber.delay_inventory!
-              end
-            end
-          end
-
-          def calc_delay
-            (@subscriber.deadline - 3) * rand(0.8..0.9)
-          end
-        end
-
-        # @private
-        class EnumeratorQueue
-          extend Forwardable
-          def_delegators :@q, :push
-
-          # @private
-          def initialize sentinel
-            @q = Queue.new
-            @sentinel = sentinel
-          end
-
-          def unshift request
-            new_queue = Queue.new
-            new_queue.push request
-            while @q.size > 0
-              r = @q.pop
-              new_queue.push r unless r.equal? @sentinel
-            end
-            @q = new_queue
-          end
-
-          # @private
-          def each_item
-            return enum_for(:each_item) unless block_given?
-            loop do
-              r = @q.pop
-              break if r.equal? @sentinel
-              fail r if r.is_a? Exception
-              yield r
-            end
-          end
         end
       end
     end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -1,0 +1,214 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/pubsub/service"
+require "google/cloud/errors"
+require "monitor"
+require "forwardable"
+require "concurrent"
+
+module Google
+  module Cloud
+    module Pubsub
+      ##
+      # # Subscriber
+      #
+      class Subscriber
+        include MonitorMixin
+
+        ##
+        # @private Implementation attributes.
+        attr_reader :request_queue, :output_enum, :thread_pool, :service
+
+        ##
+        # Subscriber attributes.
+        attr_reader :callback, :subscription_name, :deadline, :threads
+
+        ##
+        # @private Create an empty {Subscriber} object.
+        def initialize callback, subscription_name, deadline, threads, service
+          @request_queue = nil
+          @output_enum = nil
+          @callback = callback
+          @subscription_name = subscription_name
+          @deadline = deadline
+          @threads = threads || [2, Concurrent.processor_count * 2].max
+          @service = service
+
+          super() # to init MonitorMixin
+        end
+
+        def start
+          synchronize do
+            return if @request_queue
+
+            @request_queue = EnumeratorQueue.new self
+            @thread_pool = Concurrent::FixedThreadPool.new threads
+            start_streaming!
+          end
+
+          true
+        end
+
+        def stop
+          synchronize do
+            return if @request_queue.nil?
+            @request_queue.push self
+          end
+
+          true
+        end
+
+        def wait!
+          synchronize do
+            return if @background_thread.nil?
+            @background_thread.join
+          end
+
+          return true if @thread_pool.shutdown?
+          @thread_pool.shutdown
+          @thread_pool.wait_for_termination
+
+          true
+        end
+
+        ##
+        # @private
+        def acknowledge *messages
+          ack_ids = coerce_ack_ids messages
+          return true if ack_ids.empty?
+
+          ack_request = Google::Pubsub::V1::StreamingPullRequest.new
+          ack_request.ack_ids += ack_ids
+
+          synchronize do
+            @request_queue.push ack_request
+          end
+
+          true
+        end
+
+        ##
+        # @private
+        def delay new_deadline, *messages
+          deadline_ack_ids = coerce_ack_ids messages
+          return true if deadline_ack_ids.empty?
+
+          deadline_seconds = deadline_ack_ids.count.times.map { new_deadline }
+          deadline_ack_request = Google::Pubsub::V1::StreamingPullRequest.new
+          deadline_ack_request.modify_deadline_ack_ids += deadline_ack_ids
+          deadline_ack_request.modify_deadline_seconds += deadline_seconds
+
+          synchronize do
+            @request_queue.push deadline_ack_request
+          end
+
+          true
+        end
+
+        # @private
+        def to_s
+          format "(subscription: %s)", subscription_name
+        end
+
+        # @private
+        def inspect
+          "#<#{self.class.name} #{self}>"
+        end
+
+        protected
+
+        def background_run
+          @output_enum.each do |response|
+            response.received_messages.each do |rec_msg_grpc|
+              perform_callback_async @callback, rec_msg_grpc
+            end
+          end
+        rescue GRPC::DeadlineExceeded
+          # The GRPC client will raise when stream is opened longer than the
+          # timeout value it is configured for. When this happends, restart the
+          # stream stealthly.
+          synchronize do
+            start_streaming!
+          end
+        rescue => e
+          @request_queue.unshift Google::Cloud::Error.from_error(e)
+          Thread.current.kill
+        ensure
+          Thread.pass
+        end
+
+        def perform_callback_async callback, rec_msg_grpc
+          Concurrent::Future.new(executor: @thread_pool) do
+            callback.call ReceivedMessage.from_grpc(rec_msg_grpc, self)
+          end.execute
+        end
+
+        def start_streaming!
+          @request_queue.unshift initial_input_request
+          @output_enum = service.streaming_pull @request_queue.each_item
+
+          @background_thread = Thread.new { background_run }
+        end
+
+        def initial_input_request
+          Google::Pubsub::V1::StreamingPullRequest.new.tap do |req|
+            req.subscription = subscription_name
+            req.stream_ack_deadline_seconds = deadline
+          end
+        end
+
+        ##
+        # Makes sure the values are the `ack_id`. If given several
+        # {ReceivedMessage} objects extract the `ack_id` values.
+        def coerce_ack_ids messages
+          Array(messages).flatten.map do |msg|
+            msg.respond_to?(:ack_id) ? msg.ack_id : msg.to_s
+          end
+        end
+
+        # @private
+        class EnumeratorQueue
+          extend Forwardable
+          def_delegators :@q, :push
+
+          # @private
+          def initialize sentinel
+            @q = Queue.new
+            @sentinel = sentinel
+          end
+
+          def unshift request
+            new_queue = Queue.new
+            new_queue.push request
+            new_queue.push @q.pop while @q.size > 0
+            @q = new_queue
+          end
+
+          # @private
+          def each_item
+            return enum_for(:each_item) unless block_given?
+            loop do
+              r = @q.pop
+              break if r.equal? @sentinel
+              fail r if r.is_a? Exception
+              yield r
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_acknowledger.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_acknowledger.rb
@@ -1,0 +1,177 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "monitor"
+require "concurrent"
+
+module Google
+  module Cloud
+    module Pubsub
+      class Subscriber
+        ##
+        # @private
+        # # AsyncAcknowledger
+        #
+        class AsyncAcknowledger
+          include MonitorMixin
+
+          attr_reader :batch
+          attr_reader :max_bytes, :interval
+
+          def initialize stream, max_bytes: 8388608, interval: 0.25
+            @stream = stream
+
+            @max_bytes = max_bytes
+            @interval = interval
+
+            @cond = new_cond
+
+            # init MonitorMixin
+            super()
+          end
+
+          def acknowledge ack_ids
+            return true if ack_ids.empty?
+
+            synchronize do
+              ack_ids.each do |ack_id|
+                if @batch.nil?
+                  @batch = Batch.new max_bytes: @max_bytes
+                  @batch.add ack_id
+                else
+                  unless @batch.try_add ack_id
+                    publish_batch!
+
+                    @batch = Batch.new max_bytes: @max_bytes
+                    @batch.add ack_id
+                  end
+                end
+
+                @batch_created_at ||= Time.now
+                @background_thread ||= Thread.new { run_background }
+              end
+
+              @cond.signal
+            end
+
+            nil
+          end
+
+          def stop
+            synchronize do
+              break if @stopped
+
+              @stopped = true
+              publish_batch!
+              @cond.signal
+            end
+
+            self
+          end
+
+          def wait!
+            synchronize do
+              @background_thread.join if @background_thread
+            end
+
+            self
+          end
+
+          def flush
+            synchronize do
+              publish_batch!
+              @cond.signal
+            end
+
+            self
+          end
+
+          def started?
+            !stopped?
+          end
+
+          def stopped?
+            synchronize { @stopped }
+          end
+
+          protected
+
+          def run_background
+            synchronize do
+              until @stopped
+                if @batch.nil?
+                  @cond.wait
+                  next
+                end
+
+                time_since_first_publish = Time.now - @batch_created_at
+                if time_since_first_publish > @interval
+                  # interval met, publish the batch...
+                  publish_batch!
+                  @cond.wait
+                else
+                  # still waiting for the interval to publish the batch...
+                  @cond.wait(@interval - time_since_first_publish)
+                end
+              end
+            end
+          end
+
+          def publish_batch!
+            return unless @batch
+
+            request = @batch.request
+            Concurrent::Future.new(executor: @stream.push_thread_pool) do
+              @stream.push request
+            end.execute
+
+            @batch = nil
+            @batch_created_at = nil
+          end
+
+          class Batch
+            attr_reader :ack_ids
+
+            def initialize max_bytes: 8388608
+              @max_bytes = max_bytes
+              @ack_ids = []
+            end
+
+            def add ack_id
+              @ack_ids << ack_id
+            end
+
+            def try_add ack_id
+              return false if total_message_size + ack_id.size >= @max_bytes
+
+              add ack_id
+              true
+            end
+
+            def total_message_size
+              request.to_proto.size
+            end
+
+            def request
+              Google::Pubsub::V1::StreamingPullRequest.new.tap do |r|
+                r.ack_ids += @ack_ids
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_delayer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_delayer.rb
@@ -1,0 +1,173 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "monitor"
+require "concurrent"
+
+module Google
+  module Cloud
+    module Pubsub
+      class Subscriber
+        ##
+        # @private
+        # # AsyncDelayer
+        #
+        class AsyncDelayer
+          include MonitorMixin
+
+          attr_reader :batch
+          attr_reader :max_bytes, :interval
+
+          def initialize stream, max_bytes: 8388608, interval: 0.25
+            @stream = stream
+
+            @max_bytes = max_bytes
+            @interval = interval
+
+            @cond = new_cond
+
+            # init MonitorMixin
+            super()
+          end
+
+          def delay deadline, ack_ids
+            return true if ack_ids.empty?
+
+            synchronize do
+              ack_ids.each do |ack_id|
+                if @batch.nil?
+                  @batch = Batch.new max_bytes: @max_bytes
+                  @batch.add deadline, ack_id
+                else
+                  unless @batch.try_add deadline, ack_id
+                    publish_batch!
+
+                    @batch = Batch.new max_bytes: @max_bytes
+                    @batch.add deadline, ack_id
+                  end
+                end
+
+                @batch_created_at ||= Time.now
+                @background_thread ||= Thread.new { run_background }
+              end
+
+              @cond.signal
+            end
+
+            nil
+          end
+
+          def stop
+            synchronize do
+              break if @stopped
+
+              @stopped = true
+              publish_batch!
+              @cond.signal
+            end
+
+            self
+          end
+
+          def wait!
+            synchronize do
+              @background_thread.join if @background_thread
+            end
+
+            self
+          end
+
+          def flush
+            synchronize do
+              publish_batch!
+              @cond.signal
+            end
+
+            self
+          end
+
+          def started?
+            !stopped?
+          end
+
+          def stopped?
+            synchronize { @stopped }
+          end
+
+          protected
+
+          def run_background
+            synchronize do
+              until @stopped
+                if @batch.nil?
+                  @cond.wait
+                  next
+                end
+
+                time_since_first_publish = Time.now - @batch_created_at
+                if time_since_first_publish > @interval
+                  # interval met, publish the batch...
+                  publish_batch!
+                  @cond.wait
+                else
+                  # still waiting for the interval to publish the batch...
+                  @cond.wait(@interval - time_since_first_publish)
+                end
+              end
+            end
+          end
+
+          def publish_batch!
+            return if @batch.nil?
+
+            request = @batch.request
+            Concurrent::Future.new(executor: @stream.push_thread_pool) do
+              @stream.push request
+            end.execute
+
+            @batch = nil
+            @batch_created_at = nil
+          end
+
+          class Batch
+            attr_reader :ack_ids, :request
+
+            def initialize max_bytes: 8388608
+              @max_bytes = max_bytes
+              @request = Google::Pubsub::V1::StreamingPullRequest.new
+            end
+
+            def add deadline, ack_id
+              @request.modify_deadline_seconds << deadline
+              @request.modify_deadline_ack_ids << ack_id
+            end
+
+            def try_add deadline, ack_id
+              addl_bytes = deadline.to_s.size + ack_id.size
+              return false if total_message_size + addl_bytes >= @max_bytes
+
+              add deadline, ack_id
+              true
+            end
+
+            def total_message_size
+              request.to_proto.size
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
@@ -1,0 +1,60 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "forwardable"
+
+module Google
+  module Cloud
+    module Pubsub
+      ##
+      # # Subscriber
+      #
+      class Subscriber
+        # @private
+        class EnumeratorQueue
+          extend Forwardable
+          def_delegators :@q, :push
+
+          # @private
+          def initialize sentinel
+            @q = Queue.new
+            @sentinel = sentinel
+          end
+
+          def unshift request
+            new_queue = Queue.new
+            new_queue.push request
+            while @q.size > 0
+              r = @q.pop
+              new_queue.push r unless r.equal? @sentinel
+            end
+            @q = new_queue
+          end
+
+          # @private
+          def each_item
+            return enum_for(:each_item) unless block_given?
+            loop do
+              r = @q.pop
+              break if r.equal? @sentinel
+              fail r if r.is_a? Exception
+              yield r
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -1,0 +1,348 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/pubsub/service"
+require "google/cloud/errors"
+require "monitor"
+require "concurrent"
+
+
+module Google
+  module Cloud
+    module Pubsub
+      class Subscriber
+        # @private
+        class Stream
+          include MonitorMixin
+
+          ##
+          # @private Implementation attributes.
+          attr_reader :request_queue, :output_enum
+
+          ##
+          # Subscriber attributes.
+          attr_reader :subscriber
+
+          ##
+          # @private Create an empty Subscriber::Stream object.
+          def initialize subscriber
+            @subscriber = subscriber
+
+            @request_queue = nil
+            @output_enum = nil
+            @stopped = nil
+
+            @inventory = Inventory.new self, subscriber.inventory
+
+            super() # to init MonitorMixin
+          end
+
+          def start
+            synchronize do
+              return if @request_queue
+
+              start_streaming!
+            end
+
+            true
+          end
+
+          def stop
+            synchronize do
+              return if @request_queue.nil?
+              @request_queue.push self
+              @inventory.stop
+              @stopped = true
+            end
+
+            true
+          end
+
+          def stopped?
+            synchronize { @stopped }
+          end
+
+          def paused?
+            synchronize { @paused }
+          end
+
+          def wait!
+            synchronize do
+              @background_thread.join if @background_thread
+            end
+
+            true
+          end
+
+          ##
+          # @private
+          def acknowledge *messages
+            ack_ids = coerce_ack_ids messages
+            return true if ack_ids.empty?
+
+            ack_request = Google::Pubsub::V1::StreamingPullRequest.new
+            ack_request.ack_ids += ack_ids
+
+            synchronize do
+              @request_queue.push ack_request
+              @inventory.remove ack_ids
+              unpause_streaming!
+            end
+
+            true
+          end
+
+          ##
+          # @private
+          def delay new_deadline, *messages
+            mod_ack_ids = coerce_ack_ids messages
+            return true if mod_ack_ids.empty?
+
+            mod_ack_deadline = mod_ack_ids.count.times.map { new_deadline }
+            mod_ack_request = Google::Pubsub::V1::StreamingPullRequest.new
+            mod_ack_request.modify_deadline_ack_ids += mod_ack_ids
+            mod_ack_request.modify_deadline_seconds += mod_ack_deadline
+
+            synchronize do
+              @request_queue.push mod_ack_request
+              @inventory.remove mod_ack_ids
+              unpause_streaming!
+            end
+
+            true
+          end
+
+          def inventory
+            synchronize { @inventory.count }
+          end
+
+          ##
+          # @private
+          def delay_inventory!
+            synchronize do
+              return true if @inventory.empty?
+
+              inv_deadline = @inventory.ack_ids.map { subscriber.deadline }
+              inv_request = Google::Pubsub::V1::StreamingPullRequest.new
+              inv_request.modify_deadline_ack_ids += @inventory.ack_ids
+              inv_request.modify_deadline_seconds += inv_deadline
+
+              @request_queue.push inv_request
+            end
+
+            true
+          end
+
+          # @private
+          def to_s
+            format "(inventory: %i)", inventory
+          end
+
+          # @private
+          def inspect
+            "#<#{self.class.name} #{self}>"
+          end
+
+          protected
+
+          # rubocop:disable all
+
+          def background_run
+            until synchronize { @stopped }
+              Thread.current.kill if synchronize { @paused }
+
+              begin
+                # Cannot syncronize the enumerator, causes deadlock
+                response = @output_enum.next
+                response.received_messages.each do |rec_msg_grpc|
+                  rec_msg = ReceivedMessage.from_grpc(rec_msg_grpc, self)
+                  synchronize do
+                    @inventory.add rec_msg.ack_id
+
+                    perform_callback_async rec_msg
+                  end
+                end
+                synchronize { pause_streaming! }
+              rescue StopIteration
+                break
+              end
+            end
+          rescue GRPC::DeadlineExceeded
+            # The GRPC client will raise when stream is opened longer than the
+            # timeout value it is configured for. When this happends, restart the
+            # stream stealthly.
+            synchronize { start_streaming! }
+          rescue => e
+            synchronize do
+              @request_queue.unshift Google::Cloud::Error.from_error(e)
+            end
+          end
+
+          # rubocop:enable all
+
+          def perform_callback_async rec_msg
+            Concurrent::Future.new(executor: subscriber.thread_pool) do
+              subscriber.callback.call rec_msg
+            end.execute
+          end
+
+          def start_streaming!
+            # signal to the previous queue to shut down
+            @background_thread.kill if @background_thread
+            @request_queue.push self if @request_queue
+
+            @request_queue = EnumeratorQueue.new self
+            @request_queue.push initial_input_request
+            @output_enum = subscriber.service.streaming_pull \
+              @request_queue.each_item
+
+            @background_thread = Thread.new { background_run }
+          end
+
+          def pause_streaming!
+            return unless pause_streaming?
+
+            @paused = true
+          end
+
+          def pause_streaming?
+            return if @paused
+
+            @inventory.full?
+          end
+
+          def unpause_streaming!
+            return unless unpause_streaming?
+
+            @paused = nil
+            # Need to recreate the enums otherwise we get the error:
+            # "fiber called across threads"
+            start_streaming!
+          end
+
+          def unpause_streaming?
+            return if @paused.nil?
+
+            @inventory.count < @inventory.limit*0.8
+          end
+
+          def initial_input_request
+            Google::Pubsub::V1::StreamingPullRequest.new.tap do |req|
+              req.subscription = subscriber.subscription_name
+              req.stream_ack_deadline_seconds = subscriber.deadline
+              req.modify_deadline_ack_ids += @inventory.ack_ids
+              req.modify_deadline_seconds += \
+                @inventory.ack_ids.map { subscriber.deadline }
+            end
+          end
+
+          ##
+          # Makes sure the values are the `ack_id`. If given several
+          # {ReceivedMessage} objects extract the `ack_id` values.
+          def coerce_ack_ids messages
+            Array(messages).flatten.map do |msg|
+              msg.respond_to?(:ack_id) ? msg.ack_id : msg.to_s
+            end
+          end
+
+          # @private
+          class Inventory
+            include MonitorMixin
+
+            attr_reader :stream, :limit
+
+            def initialize stream, limit
+              @stream = stream
+              @limit = limit
+              @_ack_ids = []
+              @wait_cond = new_cond
+
+              super()
+            end
+
+            def ack_ids
+              @_ack_ids
+            end
+
+            def add *ack_ids
+              ack_ids = Array(ack_ids).flatten
+              synchronize do
+                @_ack_ids += ack_ids
+                @start_time ||= Time.now
+                @background_thread ||= Thread.new { background_run }
+              end
+            end
+
+            def remove *ack_ids
+              ack_ids = Array(ack_ids).flatten
+              synchronize do
+                @_ack_ids -= ack_ids
+                clear if @_ack_ids.empty?
+              end
+            end
+
+            def clear
+              synchronize do
+                @_ack_ids = []
+                if @background_thread
+                  @background_thread.kill
+                  @background_thread = nil
+                end
+                @start_time = nil
+              end
+            end
+
+            def count
+              synchronize do
+                @_ack_ids.count
+              end
+            end
+
+            def empty?
+              synchronize do
+                @_ack_ids.empty?
+              end
+            end
+
+            def stop
+              synchronize do
+                @stopped = true
+              end
+            end
+
+            def full?
+              count >= limit
+            end
+
+            protected
+
+            def background_run
+              until synchronize { @stopped }
+                delay = calc_delay
+                synchronize { @wait_cond.wait delay }
+
+                stream.delay_inventory!
+              end
+            end
+
+            def calc_delay
+              (stream.subscriber.deadline - 3) * rand(0.8..0.9)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -309,11 +309,14 @@ module Google
         #   subscriber.start
         #   subscriber.wait!
         #
-        def listen deadline: nil, inventory: nil, threads: nil, &block
+        def listen deadline: nil, streams: nil, inventory: nil, threads: nil,
+                   &block
           ensure_service!
           deadline ||= self.deadline
 
-          Subscriber.new block, name, deadline, inventory, threads, service
+          Subscriber.new name, block, deadline: deadline, streams: streams,
+                                      inventory: inventory, threads: threads,
+                                      service: service
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -307,7 +307,6 @@ module Google
         #   end
         #
         #   subscriber.start
-        #   subscriber.wait!
         #
         def listen deadline: nil, streams: nil, inventory: nil, threads: nil,
                    &block

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -309,11 +309,11 @@ module Google
         #   subscriber.start
         #   subscriber.wait!
         #
-        def listen deadline: nil, threads: nil, &block
+        def listen deadline: nil, inventory: nil, threads: nil, &block
           ensure_service!
           deadline ||= self.deadline
 
-          Subscriber.new block, name, deadline, threads, service
+          Subscriber.new block, name, deadline, inventory, threads, service
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client_config.json
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client_config.json
@@ -31,9 +31,9 @@
           "initial_retry_delay_millis": 100,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 12000,
+          "initial_rpc_timeout_millis": 120000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 12000,
+          "max_rpc_timeout_millis": 120000,
           "total_timeout_millis": 600000
         }
       },

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -612,10 +612,10 @@ def rec_message_json message, id = rand(1000000)
   }.to_json
 end
 
-def rec_messages_json message
+def rec_messages_json message, id = nil
   {
     "received_messages" => [
-      JSON.parse(rec_message_json(message))
+      JSON.parse(rec_message_json(message, id))
     ]
   }.to_json
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
@@ -57,12 +57,6 @@ describe Google::Cloud::Pubsub::Subscriber, :acknowledge, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
-
-    called.must_equal true
-    requests_made = stub.request_enum.to_a
-    requests_made.count.must_equal 2
-    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(ack_ids: ["ack-id-#{rec_message_ack_id}"])
   end
 
   it "can acknowledge multiple messages" do
@@ -89,13 +83,5 @@ describe Google::Cloud::Pubsub::Subscriber, :acknowledge, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
-
-    called.must_equal 3
-    requests_made = stub.request_enum.to_a
-    requests_made.count.must_equal 4
-    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(ack_ids: ["ack-id-1111"])
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(ack_ids: ["ack-id-1112"])
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(ack_ids: ["ack-id-1113"])
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
@@ -1,0 +1,101 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::Subscriber, :acknowledge, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let(:sub_grpc) { Google::Pubsub::V1::Subscription.decode_json(sub_json) }
+  let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc sub_grpc, pubsub.service }
+  let(:rec_msg1_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
+                          rec_message_json("rec_message1-msg-goes-here", 1111) }
+  let(:rec_msg2_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
+                          rec_message_json("rec_message2-msg-goes-here", 1112) }
+  let(:rec_msg3_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
+                          rec_message_json("rec_message3-msg-goes-here", 1113) }
+
+  it "can acknowledge a single message" do
+    rec_message_msg = "pulled-message"
+    rec_message_ack_id = 123456789
+    pull_res = Google::Pubsub::V1::StreamingPullResponse.decode_json rec_messages_json(rec_message_msg, rec_message_ack_id)
+    responses = [pull_res]
+
+    stub = StreamingPullStub.new responses.each
+    called = false
+
+    subscription.service.mocked_subscriber = stub
+    subscriber = subscription.listen do |msg|
+      assert_kind_of Google::Cloud::Pubsub::ReceivedMessage, msg
+      assert_equal rec_message_msg, msg.data
+      assert_equal "ack-id-#{rec_message_ack_id}", msg.ack_id
+
+      msg.ack!
+      called = true
+    end
+    subscriber.start
+
+    subscriber_retries = 0
+    while !called
+      fail "total number of calls were never made" if subscriber_retries > 100
+      subscriber_retries += 1
+      sleep 0.01
+    end
+
+    subscriber.stop
+    subscriber.wait!
+
+    called.must_equal true
+    requests_made = stub.request_enum.to_a
+    requests_made.count.must_equal 2
+    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
+    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(ack_ids: ["ack-id-#{rec_message_ack_id}"])
+  end
+
+  it "can acknowledge multiple messages" do
+    pull_res = Google::Pubsub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc, rec_msg2_grpc, rec_msg3_grpc]
+    responses = [pull_res]
+
+    stub = StreamingPullStub.new responses.each
+    called = 0
+
+    subscription.service.mocked_subscriber = stub
+    subscriber = subscription.listen do |msg|
+      assert_kind_of Google::Cloud::Pubsub::ReceivedMessage, msg
+      msg.ack!
+      called +=1
+    end
+    subscriber.start
+
+    subscriber_retries = 0
+    while called < 3
+      fail "total number of calls were never made" if subscriber_retries > 100
+      subscriber_retries += 1
+      sleep 0.01
+    end
+
+    subscriber.stop
+    subscriber.wait!
+
+    called.must_equal 3
+    requests_made = stub.request_enum.to_a
+    requests_made.count.must_equal 4
+    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
+    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(ack_ids: ["ack-id-1111"])
+    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(ack_ids: ["ack-id-1112"])
+    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(ack_ids: ["ack-id-1113"])
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
@@ -1,0 +1,101 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let(:sub_grpc) { Google::Pubsub::V1::Subscription.decode_json(sub_json) }
+  let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc sub_grpc, pubsub.service }
+  let(:rec_msg1_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
+                          rec_message_json("rec_message1-msg-goes-here", 1111) }
+  let(:rec_msg2_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
+                          rec_message_json("rec_message2-msg-goes-here", 1112) }
+  let(:rec_msg3_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
+                          rec_message_json("rec_message3-msg-goes-here", 1113) }
+
+  it "can delay a single message" do
+    rec_message_msg = "pulled-message"
+    rec_message_ack_id = 123456789
+    pull_res = Google::Pubsub::V1::StreamingPullResponse.decode_json rec_messages_json(rec_message_msg, rec_message_ack_id)
+    responses = [pull_res]
+
+    stub = StreamingPullStub.new responses.each
+    called = false
+
+    subscription.service.mocked_subscriber = stub
+    subscriber = subscription.listen do |msg|
+      assert_kind_of Google::Cloud::Pubsub::ReceivedMessage, msg
+      assert_equal rec_message_msg, msg.data
+      assert_equal "ack-id-#{rec_message_ack_id}", msg.ack_id
+
+      msg.delay! 42
+      called = true
+    end
+    subscriber.start
+
+    subscriber_retries = 0
+    while !called
+      fail "total number of calls were never made" if subscriber_retries > 100
+      subscriber_retries += 1
+      sleep 0.01
+    end
+
+    subscriber.stop
+    subscriber.wait!
+
+    called.must_equal true
+    requests_made = stub.request_enum.to_a
+    requests_made.count.must_equal 2
+    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
+    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-#{rec_message_ack_id}"], modify_deadline_seconds: [42])
+  end
+
+  it "can delay multiple messages" do
+    pull_res = Google::Pubsub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc, rec_msg2_grpc, rec_msg3_grpc]
+    responses = [pull_res]
+
+    stub = StreamingPullStub.new responses.each
+    called = 0
+
+    subscription.service.mocked_subscriber = stub
+    subscriber = subscription.listen do |msg|
+      assert_kind_of Google::Cloud::Pubsub::ReceivedMessage, msg
+      msg.delay! 42
+      called +=1
+    end
+    subscriber.start
+
+    subscriber_retries = 0
+    while called < 3
+      fail "total number of calls were never made" if subscriber_retries > 100
+      subscriber_retries += 1
+      sleep 0.01
+    end
+
+    subscriber.stop
+    subscriber.wait!
+
+    called.must_equal 3
+    requests_made = stub.request_enum.to_a
+    requests_made.count.must_equal 4
+    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
+    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-1111"], modify_deadline_seconds: [42])
+    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-1112"], modify_deadline_seconds: [42])
+    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-1113"], modify_deadline_seconds: [42])
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
@@ -38,7 +38,7 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
     called = false
 
     subscription.service.mocked_subscriber = stub
-    subscriber = subscription.listen do |msg|
+    subscriber = subscription.listen streams: 1 do |msg|
       assert_kind_of Google::Cloud::Pubsub::ReceivedMessage, msg
       assert_equal rec_message_msg, msg.data
       assert_equal "ack-id-#{rec_message_ack_id}", msg.ack_id
@@ -73,7 +73,7 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
     called = 0
 
     subscription.service.mocked_subscriber = stub
-    subscriber = subscription.listen do |msg|
+    subscriber = subscription.listen streams: 1 do |msg|
       assert_kind_of Google::Cloud::Pubsub::ReceivedMessage, msg
       msg.delay! 42
       called +=1

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
@@ -57,12 +57,6 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
-
-    called.must_equal true
-    requests_made = stub.request_enum.to_a
-    requests_made.count.must_equal 2
-    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-#{rec_message_ack_id}"], modify_deadline_seconds: [42])
   end
 
   it "can delay multiple messages" do
@@ -89,13 +83,5 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
-
-    called.must_equal 3
-    requests_made = stub.request_enum.to_a
-    requests_made.count.must_equal 4
-    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-1111"], modify_deadline_seconds: [42])
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-1112"], modify_deadline_seconds: [42])
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-1113"], modify_deadline_seconds: [42])
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
@@ -54,15 +54,8 @@ describe Google::Cloud::Pubsub::Subscriber, :nack, :mock_pubsub do
       subscriber_retries += 1
       sleep 0.01
     end
-
     subscriber.stop
     subscriber.wait!
-
-    called.must_equal true
-    requests_made = stub.request_enum.to_a
-    requests_made.count.must_equal 2
-    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-#{rec_message_ack_id}"], modify_deadline_seconds: [0])
   end
 
   it "can nack multiple messages" do
@@ -89,13 +82,5 @@ describe Google::Cloud::Pubsub::Subscriber, :nack, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
-
-    called.must_equal 3
-    requests_made = stub.request_enum.to_a
-    requests_made.count.must_equal 4
-    requests_made.first.must_equal Google::Pubsub::V1::StreamingPullRequest.new(subscription: subscription_path(sub_name), stream_ack_deadline_seconds: 60)
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-1111"], modify_deadline_seconds: [0])
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-1112"], modify_deadline_seconds: [0])
-    requests_made.must_include Google::Pubsub::V1::StreamingPullRequest.new(modify_deadline_ack_ids: ["ack-id-1113"], modify_deadline_seconds: [0])
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -18,14 +18,16 @@ describe Google::Cloud::Pubsub::Subscriber, :mock_pubsub do
   let(:callback) { Proc.new { |msg| puts msg.inspect } }
   let(:subscription_name) { "subscription-name-goes-here" }
   let(:deadline) { 120 }
+  let(:inventory) { 250 }
   let(:threads) { 4 }
-  let(:subscriber) { Google::Cloud::Pubsub::Subscriber.new callback, subscription_name, deadline, threads, pubsub.service }
+  let(:subscriber) { Google::Cloud::Pubsub::Subscriber.new callback, subscription_name, deadline, inventory, threads, pubsub.service }
 
   it "knows itself" do
     subscriber.must_be_kind_of Google::Cloud::Pubsub::Subscriber
     subscriber.callback.must_equal callback
     subscriber.subscription_name.must_equal subscription_name
     subscriber.deadline.must_equal deadline
+    subscriber.instance_variable_get(:@inventory).limit.must_equal inventory
     subscriber.threads.must_equal threads
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -1,0 +1,31 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::Subscriber, :mock_pubsub do
+  let(:callback) { Proc.new { |msg| puts msg.inspect } }
+  let(:subscription_name) { "subscription-name-goes-here" }
+  let(:deadline) { 120 }
+  let(:threads) { 4 }
+  let(:subscriber) { Google::Cloud::Pubsub::Subscriber.new callback, subscription_name, deadline, threads, pubsub.service }
+
+  it "knows itself" do
+    subscriber.must_be_kind_of Google::Cloud::Pubsub::Subscriber
+    subscriber.callback.must_equal callback
+    subscriber.subscription_name.must_equal subscription_name
+    subscriber.deadline.must_equal deadline
+    subscriber.threads.must_equal threads
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -18,16 +18,18 @@ describe Google::Cloud::Pubsub::Subscriber, :mock_pubsub do
   let(:callback) { Proc.new { |msg| puts msg.inspect } }
   let(:subscription_name) { "subscription-name-goes-here" }
   let(:deadline) { 120 }
+  let(:streams) { 4 }
   let(:inventory) { 250 }
-  let(:threads) { 4 }
-  let(:subscriber) { Google::Cloud::Pubsub::Subscriber.new callback, subscription_name, deadline, inventory, threads, pubsub.service }
+  let(:threads) { 8 }
+  let(:subscriber) { Google::Cloud::Pubsub::Subscriber.new subscription_name, callback, deadline: deadline, streams: streams, inventory: inventory, threads: threads, service: pubsub.service }
 
   it "knows itself" do
     subscriber.must_be_kind_of Google::Cloud::Pubsub::Subscriber
     subscriber.callback.must_equal callback
     subscriber.subscription_name.must_equal subscription_name
     subscriber.deadline.must_equal deadline
-    subscriber.instance_variable_get(:@inventory).limit.must_equal inventory
+    subscriber.streams.must_equal streams
+    subscriber.inventory.must_equal inventory
     subscriber.threads.must_equal threads
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -29,6 +29,7 @@ describe Google::Cloud::Pubsub::Subscription, :listen, :mock_pubsub do
     subscriber.must_be_kind_of Google::Cloud::Pubsub::Subscriber
     subscriber.subscription_name.must_equal subscription.name
     subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 1
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -38,5 +39,16 @@ describe Google::Cloud::Pubsub::Subscription, :listen, :mock_pubsub do
     subscriber.must_be_kind_of Google::Cloud::Pubsub::Subscriber
     subscriber.subscription_name.must_equal subscription.name
     subscriber.deadline.must_equal 120
+    subscriber.streams.must_equal 1
+  end
+
+  it "will set deadline while creating a Subscriber" do
+    subscriber = subscription.listen streams: 2 do |msg|
+      puts msg.msg_id
+    end
+    subscriber.must_be_kind_of Google::Cloud::Pubsub::Subscriber
+    subscriber.subscription_name.must_equal subscription.name
+    subscriber.deadline.must_equal 60
+    subscriber.streams.must_equal 2
   end
 end

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -45,6 +45,20 @@ class Google::Gax::CallOptions
   end
 end
 
+class StreamingPullStub
+  attr_reader :request_enum, :responses
+
+  def initialize responses
+    @responses = responses
+  end
+
+  def streaming_pull request_enum, options: nil
+    @request_enum = request_enum
+    # return response enumerator
+    @responses.each
+  end
+end
+
 class MockPubsub < Minitest::Spec
   let(:project) { "test" }
   let(:default_options) { Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" }) }
@@ -131,10 +145,10 @@ class MockPubsub < Minitest::Spec
     }.to_json
   end
 
-  def rec_messages_json message
+  def rec_messages_json message, id = nil
     {
       "received_messages" => [
-        JSON.parse(rec_message_json(message))
+        JSON.parse(rec_message_json(message, id))
       ]
     }.to_json
   end


### PR DESCRIPTION
This PR adds a Subscriber object that has the following:

- [x] Uses StreamingPull to pull, acknowledge, and delay received messages
- [x] Calls a user-defined callback that can be used to acknowledge or delay received messages
- [x] Uses a ThreadPool to call callbacks, so streaming requests and responses are handled in a non-blocking manner
- [x] Maintain lease on received messages until they are asked or nacked by users.

This functionality is expressed as `Subscription#listen`.

This change is to be merged into the pubsub branch, which will be used as the target for the upcoming Pub/Sub changes.