### PR TITLE
Add requester pays to Storage

### DIFF
--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -197,8 +197,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigquery::Dataset#load@Pass a google-cloud-storage `File` instance:" do
     mock_storage do |mock|
-      mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket"]
-      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
     end
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
@@ -451,8 +451,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigquery::Table#load@Pass a google-cloud-storage `File` instance:" do
     mock_storage do |mock|
-      mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket"]
-      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
     end
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -256,8 +256,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Logging::Project#create_sink" do
     mock_storage do |mock|
-      mock.expect :insert_bucket, bucket_gapi, ["my-todo-project", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>nil}]
-      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl]
+      mock.expect :insert_bucket, bucket_gapi, ["my-todo-project", Google::Apis::StorageV1::Bucket, Hash]
+      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl, Hash]
     end
     mock_logging do |mock, mock_metrics, mock_sinks|
       mock_sinks.expect :create_sink, nil, ["projects/my-project", Google::Logging::V2::LogSink, Hash]
@@ -272,8 +272,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Logging::Sink" do
     mock_storage do |mock|
-      mock.expect :insert_bucket, bucket_gapi, ["my-todo-project", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>nil}]
-      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl]
+      mock.expect :insert_bucket, bucket_gapi, ["my-todo-project", Google::Apis::StorageV1::Bucket, Hash]
+      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl, Hash]
     end
     mock_logging do |mock, mock_metrics, mock_sinks|
       mock_sinks.expect :create_sink, nil, ["projects/my-project", Google::Logging::V2::LogSink, Hash]

--- a/google-cloud-speech/support/doctest_helper.rb
+++ b/google-cloud-speech/support/doctest_helper.rb
@@ -133,8 +133,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Speech::Project#audio@With a Google Cloud Storage File object:" do
     mock_storage do |mock|
-      mock.expect :get_bucket,  OpenStruct.new(name: "bucket-name"), ["bucket-name"]
-      mock.expect :get_object,  OpenStruct.new(bucket: "bucket-name", name: "path/to/audio.raw"), ["bucket-name", "path/to/audio.raw", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket,  OpenStruct.new(name: "bucket-name"), ["bucket-name", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "bucket-name", name: "path/to/audio.raw"), ["bucket-name", "path/to/audio.raw", Hash]
     end
     mock_speech do |mock, mock_ops|
       mock.expect :long_running_recognize, op_done_false(mock_ops), recognize_args(recognition_config_alternatives, recognition_audio_uri)
@@ -154,8 +154,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Speech::Project#recognize@With a Google Cloud Storage File object:" do
     mock_storage do |mock|
-      mock.expect :get_bucket,  OpenStruct.new(name: "bucket-name"), ["bucket-name"]
-      mock.expect :get_object,  OpenStruct.new(bucket: "bucket-name", name: "path/to/audio.raw"), ["bucket-name", "path/to/audio.raw", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket,  OpenStruct.new(name: "bucket-name"), ["bucket-name", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "bucket-name", name: "path/to/audio.raw"), ["bucket-name", "path/to/audio.raw", Hash]
     end
     mock_speech do |mock|
       mock.expect :recognize, recognize_response, recognize_args(recognition_config_alternatives, recognition_audio_uri)
@@ -171,8 +171,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Speech::Project#process@With a Google Cloud Storage File object:" do
     mock_storage do |mock|
-      mock.expect :get_bucket,  OpenStruct.new(name: "bucket-name"), ["bucket-name"]
-      mock.expect :get_object,  OpenStruct.new(bucket: "bucket-name", name: "path/to/audio.raw"), ["bucket-name", "path/to/audio.raw", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket,  OpenStruct.new(name: "bucket-name"), ["bucket-name", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "bucket-name", name: "path/to/audio.raw"), ["bucket-name", "path/to/audio.raw", Hash]
     end
     mock_speech do |mock, mock_ops|
       mock.expect :long_running_recognize, op_done_false(mock_ops), recognize_args(recognition_config_alternatives, recognition_audio_uri)

--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -37,15 +37,18 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
     one_off_bucket.website_main.must_be :nil?
     one_off_bucket.website_404.must_be :nil?
+    one_off_bucket.requester_pays.must_be :nil?
     one_off_bucket.labels.must_equal({})
     one_off_bucket.update do |b|
       b.website_main = "index.html"
       b.website_404 = "not_found.html"
+      b.requester_pays = true
       # update labels with symbols
       b.labels[:foo] = :bar
     end
     one_off_bucket.website_main.must_equal "index.html"
     one_off_bucket.website_404.must_equal "not_found.html"
+    one_off_bucket.requester_pays.must_equal true
     # labels with symbols are not strings
     one_off_bucket.labels.must_equal({ "foo" => "bar" })
 
@@ -53,6 +56,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     one_off_bucket_copy.wont_be :nil?
     one_off_bucket_copy.website_main.must_equal "index.html"
     one_off_bucket_copy.website_404.must_equal "not_found.html"
+    one_off_bucket_copy.requester_pays.must_equal true
 
     one_off_bucket.files.all &:delete
     one_off_bucket.delete
@@ -72,6 +76,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     bucket.versioning?.must_be :nil?
     bucket.website_main.must_be :nil?
     bucket.website_404.must_be :nil?
+    bucket.requester_pays.must_be :nil?
     bucket.labels.must_be :empty?
 
     bucket.cors.each do |cors|

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -435,6 +435,59 @@ module Google
     # file.acl.public!
     # ```
     #
+    # ## Assigning payment to the requester
+    #
+    # The requester pays feature enables the owner of a bucket to indicate that
+    # a client accessing the bucket or a file it contains must assume the
+    # transit costs related to the access. This feature is currently available
+    # only to whitelisted projects.
+    #
+    # Assign transit costs for bucket and file operations to requesting clients
+    # with the `requester_pays` flag:
+    #
+    # ```ruby
+    # require "google/cloud/storage"
+    #
+    # storage = Google::Cloud::Storage.new
+    #
+    # bucket = storage.bucket "my-bucket"
+    #
+    # bucket.requester_pays = true # API call
+    # # Clients must now provide `user_project` option when calling
+    # # Project#bucket to access this bucket.
+    # ```
+    #
+    # Once the `requester_pays` flag is enabled for a bucket, a client
+    # attempting to access the bucket and its files must provide the
+    # `user_project` option to {Project#bucket}. If the argument given is
+    # `true`, transit costs for operations on the requested bucket or a file it
+    # contains will be billed to the current project for the client. (See
+    # {Project#project} for the ID of the current project.)
+    #
+    # ```ruby
+    # require "google/cloud/storage"
+    #
+    # storage = Google::Cloud::Storage.new
+    #
+    # bucket = storage.bucket "other-project-bucket", user_project: true
+    #
+    # files = bucket.files # Billed to current project
+    # ```
+    #
+    # If the argument is a project ID string, and the indicated project is
+    # authorized for the currently authenticated service account, transit costs
+    # will be billed to the indicated project.
+    #
+    # ```ruby
+    # require "google/cloud/storage"
+    #
+    # storage = Google::Cloud::Storage.new
+    #
+    # bucket = storage.bucket "other-project-bucket",
+    #                         user_project: "my-other-project"
+    # files = bucket.files # Billed to "my-other-project"
+    # ```
+    #
     # ## Configuring retries and timeout
     #
     # You can configure how many times API requests may be automatically

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -47,43 +47,33 @@ module Google
         attr_accessor :gapi
 
         ##
-        # A `true`/`false` value or a project ID string to be sent as the
-        # `userProject` query param for operations on requester pays buckets and
-        # their files. The default is `nil`. For convenience, this attribute
-        # should be set when first retrieving the bucket, by providing the
-        # `user_project` option to {Project#bucket}.
+        # A boolean value or a project ID string for a requester pays
+        # bucket and its files. If this attribute is set to `true`, transit
+        # costs for operations on the bucket will be billed to the current
+        # project for this client. (See {Project#project} for the ID of the
+        # current project.) If this attribute is set to a project ID, and that
+        # project is authorized for the currently authenticated service account,
+        # transit costs will be billed to the that project. The default is
+        # `nil`.
         #
-        # If the `requester_pays` flag is enabled for the bucket, and if this
-        # attribute is set to `true`, transit costs for operations on the bucket
-        # will be billed to the current project for this client. (See
-        # {Project#project} for the ID of the current project.) If this
-        # attribute is set to a project ID other than the current project, and
-        # that project is authorized for the currently authenticated service
-        # account, transit costs will be billed to the given project.
+        # In general, this attribute should be set when first retrieving the
+        # bucket by providing the `user_project` option to {Project#bucket}.
         #
         # The requester pays feature is currently available only to whitelisted
         # projects.
         #
-        # See also {#requester_pays=} and {#requester_pays}.
+        # See also {#requester_pays=} and {#requester_pays} to enable requester
+        # pays for a bucket.
         #
-        # @example With `user_project` set to pay for a requester pays bucket:
+        # @example Setting a non-default project:
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "other-project-bucket", user_project: true
         #   files = bucket.files # Billed to current project
-        #   bucket.user_project #=> true
-        #
-        # @example With `user_project` set to a project other than the default:
-        #   require "google/cloud/storage"
-        #
-        #   storage = Google::Cloud::Storage.new
-        #
-        #   bucket = storage.bucket "other-project-bucket",
-        #                           user_project: "my-other-project"
+        #   bucket.user_project = "my-other-project"
         #   files = bucket.files # Billed to "my-other-project"
-        #   bucket.user_project #=> "my-other-project"
         #
         attr_accessor :user_project
 
@@ -352,17 +342,18 @@ module Google
         alias_method :requester_pays?, :requester_pays
 
         ##
-        # Indicates that a client accessing the bucket or a file it contains
-        # must assume the transit costs related to the access. The requester
-        # must pass the `user_project` option to {Project#bucket} to indicate
-        # the project to which the access costs should be billed.
+        # Enables requester pays for the bucket. If enabled, a client accessing
+        # the bucket or a file it contains must assume the transit costs related
+        # to the access. The requester must pass the `user_project` option to
+        # {Project#bucket} to indicate the project to which the access costs
+        # should be billed.
         #
         # This feature is currently available only to whitelisted projects.
         #
-        # @param [Boolean] new_requester_pays When set to `true`, the bucket is
-        #   requester pays.
+        # @param [Boolean] new_requester_pays When set to `true`, requester pays
+        #   is enabled for the bucket.
         #
-        # @example
+        # @example Enable requester pays for a bucket:
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -447,14 +447,9 @@ module Google
         def files prefix: nil, delimiter: nil, token: nil, max: nil,
                   versions: nil
           ensure_service!
-          options = {
-            prefix:    prefix,
-            delimiter: delimiter,
-            token:     token,
-            max:       max,
-            versions:  versions
-          }
-          gapi = service.list_files name, options
+          gapi = service.list_files name, prefix: prefix, delimiter: delimiter,
+                                          token: token, max: max,
+                                          versions: versions
           File::List.from_gapi gapi, service, name, prefix, delimiter, max,
                                versions
         end
@@ -491,8 +486,8 @@ module Google
         #
         def file path, generation: nil, encryption_key: nil
           ensure_service!
-          options = { generation: generation, key: encryption_key }
-          gapi = service.get_file name, path, options
+          gapi = service.get_file name, path, generation: generation,
+                                              key: encryption_key
           File.from_gapi gapi, service
         rescue Google::Cloud::NotFoundError
           nil
@@ -844,12 +839,11 @@ module Google
                         client_email: nil, signing_key: nil,
                         private_key: nil
           ensure_service!
-          options = { issuer: issuer, client_email: client_email,
-                      signing_key: signing_key, private_key: private_key,
-                      policy: policy }
 
           signer = File::Signer.from_bucket self, path
-          signer.post_object options
+          signer.post_object issuer: issuer, client_email: client_email,
+                             signing_key: signing_key, private_key: private_key,
+                             policy: policy
         end
 
         ##

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -294,12 +294,45 @@ module Google
         end
 
         ##
+        # Indicates that a client accessing the bucket or a file it contains
+        # must assume the transit costs related to the access. The requester
+        # must indicate the project to which the access costs should be billed.
+        #
+        # This feature is currently available only to whitelisted projects.
+        #
+        # @return [Boolean, nil] Returns `true` if requester pays is enabled for
+        #   the bucket.
+        #
+        def requester_pays
+          @gapi.billing.requester_pays if @gapi.billing
+        end
+        alias_method :requester_pays?, :requester_pays
+
+        ##
+        # Indicates that a client accessing the bucket or a file it contains
+        # must assume the transit costs related to the access. The requester
+        # must indicate the project to which the access costs should be billed.
+        #
+        # This feature is currently available only to whitelisted projects.
+        #
+        # @param [Boolean] new_requester_pays When set to `true`, the bucket is
+        #   requester pays.
+        #
+        def requester_pays= new_requester_pays
+          @gapi.billing ||= Google::Apis::StorageV1::Bucket::Billing.new
+          @gapi.billing.requester_pays = new_requester_pays
+          patch_gapi! :billing
+        end
+
+        ##
         # Updates the bucket with changes made in the given block in a single
         # PATCH request. The following attributes may be set: {#cors},
         # {#logging_bucket=}, {#logging_prefix=}, {#versioning=},
-        # {#website_main=}, and {#website_404=}. In addition, the #cors
-        # configuration accessible in the block is completely mutable and will
-        # be included in the request. (See {Bucket::Cors})
+        # {#website_main=}, {#website_404=}, and {#requester_pays=}.
+        #
+        # In addition, the #cors configuration accessible in the block is
+        # completely mutable and will be included in the request. (See
+        # {Bucket::Cors})
         #
         # @yield [bucket] a block yielding a delegate object for updating the
         #   file

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
@@ -49,9 +49,25 @@ module Google
                     "public_write" => "publicReadWrite" }
 
           ##
-          # @private The user_pays flag for sending `userProject` query param
-          # for operations on requester_pays buckets and their files.
-          attr_accessor :user_pays
+          # A `true`/`false` value or a project ID string to be sent as the
+          # `userProject` query param for operations on requester pays buckets
+          # and their files. The default is `nil`. For convenience, this
+          # attribute should be set when first retrieving the bucket, by
+          # providing the `user_project` option to {Project#bucket}.
+          #
+          # If the `requester_pays` flag is enabled for the bucket, and if this
+          # attribute is set to `true`, transit costs for operations on the
+          # bucket will be billed to the current project for this client. (See
+          # {Project#project} for the ID of the current project.) If this
+          # attribute is set to a project ID other than the current project, and
+          # that project is authorized for the currently authenticated service
+          # account, transit costs will be billed to the given project.
+          #
+          # The requester pays feature is currently available only to
+          # whitelisted projects.
+          #
+          # See also {Bucket#requester_pays=} and {Bucket#requester_pays}.
+          attr_accessor :user_project
 
           ##
           # @private Initialized a new Acl object.
@@ -59,7 +75,7 @@ module Google
           def initialize bucket
             @bucket = bucket.name
             @service = bucket.service
-            @user_pays = bucket.user_pays
+            @user_project = bucket.user_project
             @owners  = nil
             @writers = nil
             @readers = nil
@@ -78,7 +94,7 @@ module Google
           #   bucket.acl.reload!
           #
           def reload!
-            gapi = @service.list_bucket_acls @bucket, user_pays: user_pays
+            gapi = @service.list_bucket_acls @bucket, user_project: user_project
             acls = Array(gapi.items)
             @owners  = entities_from_acls acls, "OWNER"
             @writers = entities_from_acls acls, "WRITER"
@@ -222,7 +238,7 @@ module Google
           #
           def add_writer entity
             gapi = @service.insert_bucket_acl @bucket, entity, "WRITER",
-                                              user_pays: user_pays
+                                              user_project: user_project
             entity = gapi.entity
             @writers.push entity unless @writers.nil?
             entity
@@ -297,7 +313,8 @@ module Google
           #   bucket.acl.delete "user-#{email}"
           #
           def delete entity
-            @service.delete_bucket_acl @bucket, entity, user_pays: user_pays
+            @service.delete_bucket_acl @bucket, entity,
+                                       user_project: user_project
             @owners.delete entity  unless @owners.nil?
             @writers.delete entity unless @writers.nil?
             @readers.delete entity unless @readers.nil?
@@ -414,7 +431,7 @@ module Google
 
           def update_predefined_acl! acl_role
             @service.patch_bucket @bucket, predefined_acl: acl_role,
-                                           user_pays: user_pays
+                                           user_project: user_project
             clear!
           end
 
@@ -458,9 +475,25 @@ module Google
                     "public_read" => "publicRead" }
 
           ##
-          # @private The user_pays flag for sending `userProject` query param
-          # for operations on requester_pays buckets and their files.
-          attr_accessor :user_pays
+          # A `true`/`false` value or a project ID string to be sent as the
+          # `userProject` query param for operations on requester pays buckets
+          # and their files. The default is `nil`. For convenience, this
+          # attribute should be set when first retrieving the bucket, by
+          # providing the `user_project` option to {Project#bucket}.
+          #
+          # If the `requester_pays` flag is enabled for the bucket, and if this
+          # attribute is set to `true`, transit costs for operations on the
+          # bucket will be billed to the current project for this client. (See
+          # {Project#project} for the ID of the current project.) If this
+          # attribute is set to a project ID other than the current project, and
+          # that project is authorized for the currently authenticated service
+          # account, transit costs will be billed to the given project.
+          #
+          # The requester pays feature is currently available only to
+          # whitelisted projects.
+          #
+          # See also {Bucket#requester_pays=} and {Bucket#requester_pays}.
+          attr_accessor :user_project
 
           ##
           # @private Initialized a new DefaultAcl object.
@@ -468,7 +501,7 @@ module Google
           def initialize bucket
             @bucket = bucket.name
             @service = bucket.service
-            @user_pays = bucket.user_pays
+            @user_project = bucket.user_project
             @owners  = nil
             @readers = nil
           end
@@ -486,7 +519,8 @@ module Google
           #   bucket.default_acl.reload!
           #
           def reload!
-            gapi = @service.list_default_acls @bucket, user_pays: user_pays
+            gapi = @service.list_default_acls @bucket,
+                                              user_project: user_project
             acls = Array(gapi.items).map do |acl|
               next acl if acl.is_a? Google::Apis::StorageV1::ObjectAccessControl
               fail "Unknown ACL format: #{acl.class}" unless acl.is_a? Hash
@@ -572,7 +606,7 @@ module Google
           #
           def add_owner entity
             gapi = @service.insert_default_acl @bucket, entity, "OWNER",
-                                               user_pays: user_pays
+                                               user_project: user_project
             entity = gapi.entity
             @owners.push entity unless @owners.nil?
             entity
@@ -615,7 +649,7 @@ module Google
           #
           def add_reader entity
             gapi = @service.insert_default_acl @bucket, entity, "READER",
-                                               user_pays: user_pays
+                                               user_project: user_project
             entity = gapi.entity
             @readers.push entity unless @readers.nil?
             entity
@@ -648,7 +682,8 @@ module Google
           #   bucket.default_acl.delete "user-#{email}"
           #
           def delete entity
-            @service.delete_default_acl @bucket, entity, user_pays: user_pays
+            @service.delete_default_acl @bucket, entity,
+                                        user_project: user_project
             @owners.delete entity  unless @owners.nil?
             @readers.delete entity unless @readers.nil?
             true
@@ -782,7 +817,7 @@ module Google
 
           def update_predefined_default_acl! acl_role
             @service.patch_bucket @bucket, predefined_default_acl: acl_role,
-                                           user_pays: user_pays
+                                           user_project: user_project
             clear!
           end
 

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
@@ -49,11 +49,17 @@ module Google
                     "public_write" => "publicReadWrite" }
 
           ##
+          # @private The user_pays flag for sending `userProject` query param
+          # for operations on requester_pays buckets and their files.
+          attr_accessor :user_pays
+
+          ##
           # @private Initialized a new Acl object.
           # Must provide a valid Bucket object.
           def initialize bucket
             @bucket = bucket.name
             @service = bucket.service
+            @user_pays = bucket.user_pays
             @owners  = nil
             @writers = nil
             @readers = nil
@@ -72,7 +78,7 @@ module Google
           #   bucket.acl.reload!
           #
           def reload!
-            gapi = @service.list_bucket_acls @bucket
+            gapi = @service.list_bucket_acls @bucket, user_pays: user_pays
             acls = Array(gapi.items)
             @owners  = entities_from_acls acls, "OWNER"
             @writers = entities_from_acls acls, "WRITER"
@@ -215,7 +221,8 @@ module Google
           #   bucket.acl.add_writer "group-#{email}"
           #
           def add_writer entity
-            gapi = @service.insert_bucket_acl @bucket, entity, "WRITER"
+            gapi = @service.insert_bucket_acl @bucket, entity, "WRITER",
+                                              user_pays: user_pays
             entity = gapi.entity
             @writers.push entity unless @writers.nil?
             entity
@@ -290,7 +297,7 @@ module Google
           #   bucket.acl.delete "user-#{email}"
           #
           def delete entity
-            @service.delete_bucket_acl @bucket, entity
+            @service.delete_bucket_acl @bucket, entity, user_pays: user_pays
             @owners.delete entity  unless @owners.nil?
             @writers.delete entity unless @writers.nil?
             @readers.delete entity unless @readers.nil?
@@ -406,7 +413,8 @@ module Google
           end
 
           def update_predefined_acl! acl_role
-            @service.patch_bucket @bucket, predefined_acl: acl_role
+            @service.patch_bucket @bucket, predefined_acl: acl_role,
+                                           user_pays: user_pays
             clear!
           end
 
@@ -450,11 +458,17 @@ module Google
                     "public_read" => "publicRead" }
 
           ##
+          # @private The user_pays flag for sending `userProject` query param
+          # for operations on requester_pays buckets and their files.
+          attr_accessor :user_pays
+
+          ##
           # @private Initialized a new DefaultAcl object.
           # Must provide a valid Bucket object.
           def initialize bucket
             @bucket = bucket.name
             @service = bucket.service
+            @user_pays = bucket.user_pays
             @owners  = nil
             @readers = nil
           end
@@ -472,7 +486,7 @@ module Google
           #   bucket.default_acl.reload!
           #
           def reload!
-            gapi = @service.list_default_acls @bucket
+            gapi = @service.list_default_acls @bucket, user_pays: user_pays
             acls = Array(gapi.items).map do |acl|
               next acl if acl.is_a? Google::Apis::StorageV1::ObjectAccessControl
               fail "Unknown ACL format: #{acl.class}" unless acl.is_a? Hash
@@ -557,7 +571,8 @@ module Google
           #   bucket.default_acl.add_owner "group-#{email}"
           #
           def add_owner entity
-            gapi = @service.insert_default_acl @bucket, entity, "OWNER"
+            gapi = @service.insert_default_acl @bucket, entity, "OWNER",
+                                               user_pays: user_pays
             entity = gapi.entity
             @owners.push entity unless @owners.nil?
             entity
@@ -599,7 +614,8 @@ module Google
           #   bucket.default_acl.add_reader "group-#{email}"
           #
           def add_reader entity
-            gapi = @service.insert_default_acl @bucket, entity, "READER"
+            gapi = @service.insert_default_acl @bucket, entity, "READER",
+                                               user_pays: user_pays
             entity = gapi.entity
             @readers.push entity unless @readers.nil?
             entity
@@ -632,7 +648,7 @@ module Google
           #   bucket.default_acl.delete "user-#{email}"
           #
           def delete entity
-            @service.delete_default_acl @bucket, entity
+            @service.delete_default_acl @bucket, entity, user_pays: user_pays
             @owners.delete entity  unless @owners.nil?
             @readers.delete entity unless @readers.nil?
             true
@@ -765,7 +781,8 @@ module Google
           end
 
           def update_predefined_default_acl! acl_role
-            @service.patch_bucket @bucket, predefined_default_acl: acl_role
+            @service.patch_bucket @bucket, predefined_default_acl: acl_role,
+                                           user_pays: user_pays
             clear!
           end
 

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
@@ -49,24 +49,25 @@ module Google
                     "public_write" => "publicReadWrite" }
 
           ##
-          # A `true`/`false` value or a project ID string to be sent as the
-          # `userProject` query param for operations on requester pays buckets
-          # and their files. The default is `nil`. For convenience, this
-          # attribute should be set when first retrieving the bucket, by
-          # providing the `user_project` option to {Project#bucket}.
+          # A boolean value or a project ID string for a requester pays
+          # bucket and its files. If this attribute is set to `true`, transit
+          # costs for operations on the bucket will be billed to the current
+          # project for this client. (See {Project#project} for the ID of the
+          # current project.) If this attribute is set to a project ID, and that
+          # project is authorized for the currently authenticated service
+          # account, transit costs will be billed to the that project. The
+          # default is `nil`.
           #
-          # If the `requester_pays` flag is enabled for the bucket, and if this
-          # attribute is set to `true`, transit costs for operations on the
-          # bucket will be billed to the current project for this client. (See
-          # {Project#project} for the ID of the current project.) If this
-          # attribute is set to a project ID other than the current project, and
-          # that project is authorized for the currently authenticated service
-          # account, transit costs will be billed to the given project.
+          # In general, this attribute should be set when first retrieving the
+          # owning bucket by providing the `user_project` option to
+          # {Project#bucket}.
           #
           # The requester pays feature is currently available only to
           # whitelisted projects.
           #
-          # See also {Bucket#requester_pays=} and {Bucket#requester_pays}.
+          # See also {Bucket#requester_pays=} and {Bucket#requester_pays} to
+          # enable requester pays for a bucket.
+          #
           attr_accessor :user_project
 
           ##
@@ -475,24 +476,25 @@ module Google
                     "public_read" => "publicRead" }
 
           ##
-          # A `true`/`false` value or a project ID string to be sent as the
-          # `userProject` query param for operations on requester pays buckets
-          # and their files. The default is `nil`. For convenience, this
-          # attribute should be set when first retrieving the bucket, by
-          # providing the `user_project` option to {Project#bucket}.
+          # A boolean value or a project ID string for a requester pays
+          # bucket and its files. If this attribute is set to `true`, transit
+          # costs for operations on the bucket will be billed to the current
+          # project for this client. (See {Project#project} for the ID of the
+          # current project.) If this attribute is set to a project ID, and that
+          # project is authorized for the currently authenticated service
+          # account, transit costs will be billed to the that project. The
+          # default is `nil`.
           #
-          # If the `requester_pays` flag is enabled for the bucket, and if this
-          # attribute is set to `true`, transit costs for operations on the
-          # bucket will be billed to the current project for this client. (See
-          # {Project#project} for the ID of the current project.) If this
-          # attribute is set to a project ID other than the current project, and
-          # that project is authorized for the currently authenticated service
-          # account, transit costs will be billed to the given project.
+          # In general, this attribute should be set when first retrieving the
+          # owning bucket by providing the `user_project` option to
+          # {Project#bucket}.
           #
           # The requester pays feature is currently available only to
           # whitelisted projects.
           #
-          # See also {Bucket#requester_pays=} and {Bucket#requester_pays}.
+          # See also {Bucket#requester_pays=} and {Bucket#requester_pays} to
+          # enable requester pays for a bucket.
+          #
           attr_accessor :user_project
 
           ##

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
@@ -71,8 +71,8 @@ module Google
           def next
             return nil unless next?
             ensure_service!
-            options = { prefix: @prefix, token: @token, max: @max }
-            gapi = @service.list_buckets options
+            gapi = @service.list_buckets prefix: @prefix, token: @token,
+                                         max: @max
             Bucket::List.from_gapi gapi, @service, @prefix, @max
           end
 

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -55,43 +55,34 @@ module Google
         attr_accessor :service
 
         ##
-        # A `true`/`false` value or a project ID string to be sent as the
-        # `userProject` query param for operations on requester pays buckets and
-        # their files. The default is `nil`. For convenience, this attribute
-        # should be set when first retrieving the bucket, by providing the
-        # `user_project` option to {Project#bucket}.
+        # A boolean value or a project ID string for a requester pays
+        # bucket and its files. If this attribute is set to `true`, transit
+        # costs for operations on the file will be billed to the current
+        # project for this client. (See {Project#project} for the ID of the
+        # current project.) If this attribute is set to a project ID, and that
+        # project is authorized for the currently authenticated service account,
+        # transit costs will be billed to the that project. The default is
+        # `nil`.
         #
-        # If the `requester_pays` flag is enabled for the bucket, and if this
-        # attribute is set to `true`, transit costs for operations on the bucket
-        # will be billed to the current project for this client. (See
-        # {Project#project} for the ID of the current project.) If this
-        # attribute is set to a project ID other than the current project, and
-        # that project is authorized for the currently authenticated service
-        # account, transit costs will be billed to the given project.
+        # In general, this attribute should be set when first retrieving the
+        # owning bucket by providing the `user_project` option to
+        # {Project#bucket}.
         #
         # The requester pays feature is currently available only to whitelisted
         # projects.
         #
-        # See also {Bucket#requester_pays=} and {Bucket#requester_pays}.
+        # See also {Bucket#requester_pays=} and {Bucket#requester_pays} to
+        # enable requester pays for a bucket.
         #
-        # @example With `user_project` set to pay for a requester pays bucket:
+        # @example Setting a non-default project:
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.new
         #
         #   bucket = storage.bucket "other-project-bucket", user_project: true
         #   file = bucket.file "path/to/file.ext" # Billed to current project
-        #   file.user_project #=> true
-        #
-        # @example With `user_project` set to a project other than the default:
-        #   require "google/cloud/storage"
-        #
-        #   storage = Google::Cloud::Storage.new
-        #
-        #   bucket = storage.bucket "other-project-bucket",
-        #                           user_project: "my-other-project"
-        #   file = bucket.file "path/to/file.ext" # Billed to current project
-        #   file.user_project #=> "my-other-project"
+        #   file.user_project = "my-other-project"
+        #   file.download "file.ext" # Billed to "my-other-project"
         #
         attr_accessor :user_project
 

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -746,12 +746,12 @@ module Google
                        content_md5: nil, headers: nil, issuer: nil,
                        client_email: nil, signing_key: nil, private_key: nil
           ensure_service!
-          options = { method: method, expires: expires, headers: headers,
-                      content_type: content_type, content_md5: content_md5,
-                      issuer: issuer, client_email: client_email,
-                      signing_key: signing_key, private_key: private_key }
           signer = File::Signer.from_file self
-          signer.signed_url options
+          signer.signed_url method: method, expires: expires, headers: headers,
+                            content_type: content_type,
+                            content_md5: content_md5,
+                            issuer: issuer, client_email: client_email,
+                            signing_key: signing_key, private_key: private_key
         end
 
         ##
@@ -860,9 +860,8 @@ module Google
           resp = service.rewrite_file bucket, name, bucket, name, update_gapi
           until resp.done
             sleep 1
-            rewrite_options = { token: resp.rewrite_token }
             resp = service.rewrite_file bucket, name, bucket, name,
-                                        update_gapi, rewrite_options
+                                        update_gapi, token: resp.rewrite_token
           end
           resp.resource
         end

--- a/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
@@ -51,24 +51,25 @@ module Google
                     "public_read" => "publicRead" }
 
           ##
-          # A `true`/`false` value or a project ID string to be sent as the
-          # `userProject` query param for operations on requester pays buckets
-          # and their files. The default is `nil`. For convenience, this
-          # attribute should be set when first retrieving the bucket, by
-          # providing the `user_project` option to {Project#bucket}.
+          # A boolean value or a project ID string for a requester pays
+          # bucket and its files. If this attribute is set to `true`, transit
+          # costs for operations on the file will be billed to the current
+          # project for this client. (See {Project#project} for the ID of the
+          # current project.) If this attribute is set to a project ID, and that
+          # project is authorized for the currently authenticated service
+          # account, transit costs will be billed to the that project. The
+          # default is `nil`.
           #
-          # If the `requester_pays` flag is enabled for the bucket, and if this
-          # attribute is set to `true`, transit costs for operations on the
-          # bucket will be billed to the current project for this client. (See
-          # {Project#project} for the ID of the current project.) If this
-          # attribute is set to a project ID other than the current project, and
-          # that project is authorized for the currently authenticated service
-          # account, transit costs will be billed to the given project.
+          # In general, this attribute should be set when first retrieving the
+          # owning bucket by providing the `user_project` option to
+          # {Project#bucket}.
           #
           # The requester pays feature is currently available only to
           # whitelisted projects.
           #
-          # See also {Bucket#requester_pays=} and {Bucket#requester_pays}.
+          # See also {Bucket#requester_pays=} and {Bucket#requester_pays} to
+          # enable requester pays for a bucket.
+          #
           attr_accessor :user_project
 
           ##

--- a/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
@@ -163,9 +163,8 @@ module Google
           #   file.acl.add_owner "group-#{email}"
           #
           def add_owner entity, generation: nil
-            options = { generation: generation }
             gapi = @service.insert_file_acl @bucket, @file, entity, "OWNER",
-                                            options
+                                            generation: generation
             entity = gapi.entity
             @owners.push entity unless @owners.nil?
             entity
@@ -212,9 +211,8 @@ module Google
           #   file.acl.add_reader "group-#{email}"
           #
           def add_reader entity, generation: nil
-            options = { generation: generation }
             gapi = @service.insert_file_acl @bucket, @file, entity, "READER",
-                                            options
+                                            generation: generation
             entity = gapi.entity
             @readers.push entity unless @readers.nil?
             entity
@@ -250,8 +248,8 @@ module Google
           #   file.acl.delete "user-#{email}"
           #
           def delete entity, generation: nil
-            options = { generation: generation }
-            @service.delete_file_acl @bucket, @file, entity, options
+            @service.delete_file_acl @bucket, @file, entity,
+                                     generation: generation
             @owners.delete entity  unless @owners.nil?
             @readers.delete entity unless @readers.nil?
             true

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -79,12 +79,12 @@ module Google
             ensure_service!
             options = {
               prefix: @prefix, delimiter: @delimiter, token: @token, max: @max,
-              versions: @versions, user_pays: @user_pays
+              versions: @versions, user_project: @user_project
             }
             gapi = @service.list_files @bucket, options
             File::List.from_gapi gapi, @service, @bucket, @prefix,
                                  @delimiter, @max, @versions,
-                                 user_pays: @user_pays
+                                 user_project: @user_project
           end
 
           ##
@@ -161,7 +161,7 @@ module Google
           # Google::Apis::StorageV1::Objects object.
           def self.from_gapi gapi_list, service, bucket = nil, prefix = nil,
                              delimiter = nil, max = nil, versions = nil,
-                             user_pays: nil
+                             user_project: nil
             files = new(Array(gapi_list.items).map do |gapi_object|
               File.from_gapi gapi_object, service
             end)
@@ -173,7 +173,7 @@ module Google
             files.instance_variable_set :@delimiter, delimiter
             files.instance_variable_set :@max, max
             files.instance_variable_set :@versions, versions
-            files.instance_variable_set :@user_pays, user_pays
+            files.instance_variable_set :@user_project, user_project
             files
           end
 

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -79,11 +79,12 @@ module Google
             ensure_service!
             options = {
               prefix: @prefix, delimiter: @delimiter, token: @token, max: @max,
-              versions: @versions
+              versions: @versions, user_pays: @user_pays
             }
             gapi = @service.list_files @bucket, options
             File::List.from_gapi gapi, @service, @bucket, @prefix,
-                                 @delimiter, @max, @versions
+                                 @delimiter, @max, @versions,
+                                 user_pays: @user_pays
           end
 
           ##
@@ -159,7 +160,8 @@ module Google
           # @private New File::List from a Google API Client
           # Google::Apis::StorageV1::Objects object.
           def self.from_gapi gapi_list, service, bucket = nil, prefix = nil,
-                             delimiter = nil, max = nil, versions = nil
+                             delimiter = nil, max = nil, versions = nil,
+                             user_pays: nil
             files = new(Array(gapi_list.items).map do |gapi_object|
               File.from_gapi gapi_object, service
             end)
@@ -171,6 +173,7 @@ module Google
             files.instance_variable_set :@delimiter, delimiter
             files.instance_variable_set :@max, max
             files.instance_variable_set :@versions, versions
+            files.instance_variable_set :@user_pays, user_pays
             files
           end
 

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -270,6 +270,7 @@ module Google
         #   bucket = storage.create_bucket "my-bucket" do |b|
         #     b.website_main = "index.html"
         #     b.website_404 = "not_found.html"
+        #     b.requester_pays = true
         #     b.cors.add_rule ["http://example.org", "https://example.org"],
         #                      "*",
         #                      headers: ["X-My-Custom-Header"],

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -137,14 +137,20 @@ module Google
         # Retrieves bucket by name.
         #
         # @param [String] bucket_name Name of a bucket.
-        # @param [Boolean] user_pays If the `requester_pays` flag is enabled
-        #   for the requested bucket and if this parameter is `true`, transit
-        #   costs for operations on the requested bucket or a file it contains
-        #   will be billed to the current project for this client. (See
-        #   {#project} for the ID of the current project.) The default is `nil`.
+        # @param [Boolean, String] user_project If the `requester_pays` flag is
+        #   enabled for the requested bucket, and if this parameter is set to
+        #   `true`, transit costs for operations on the requested bucket or a
+        #   file it contains will be billed to the current project for this
+        #   client. (See {#project} for the ID of the current project.) If this
+        #   parameter is set to a project ID other than the current project, and
+        #   that project is authorized for the currently authenticated service
+        #   account, transit costs will be billed to the given project. The
+        #   default is `nil`.
         #
         #   The requester pays feature is currently available only to
         #   whitelisted projects.
+        #
+        #   See also {Bucket#requester_pays=} and {Bucket#requester_pays}.
         #
         # @return [Google::Cloud::Storage::Bucket, nil] Returns nil if bucket
         #   does not exist
@@ -157,9 +163,26 @@ module Google
         #   bucket = storage.bucket "my-bucket"
         #   puts bucket.name
         #
-        def bucket bucket_name, user_pays: nil
-          gapi = service.get_bucket bucket_name, user_pays: user_pays
-          Bucket.from_gapi gapi, service, user_pays: user_pays
+        # @example With `user_project` set to pay for a requester pays bucket:
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "other-project-bucket", user_project: true
+        #   files = bucket.files # Billed to current project
+        #
+        # @example With `user_project` set to a project other than the default:
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "other-project-bucket",
+        #                           user_project: "my-other-project"
+        #   files = bucket.files # Billed to "my-other-project"
+        #
+        def bucket bucket_name, user_project: nil
+          gapi = service.get_bucket bucket_name, user_project: user_project
+          Bucket.from_gapi gapi, service, user_project: user_project
         rescue Google::Cloud::NotFoundError
           nil
         end

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -137,6 +137,14 @@ module Google
         # Retrieves bucket by name.
         #
         # @param [String] bucket_name Name of a bucket.
+        # @param [Boolean] user_pays If the `requester_pays` flag is enabled
+        #   for the requested bucket and if this parameter is `true`, transit
+        #   costs for operations on the requested bucket or a file it contains
+        #   will be billed to the current project for this client. (See
+        #   {#project} for the ID of the current project.) The default is `nil`.
+        #
+        #   The requester pays feature is currently available only to
+        #   whitelisted projects.
         #
         # @return [Google::Cloud::Storage::Bucket, nil] Returns nil if bucket
         #   does not exist
@@ -149,9 +157,9 @@ module Google
         #   bucket = storage.bucket "my-bucket"
         #   puts bucket.name
         #
-        def bucket bucket_name
-          gapi = service.get_bucket bucket_name
-          Bucket.from_gapi gapi, service
+        def bucket bucket_name, user_pays: nil
+          gapi = service.get_bucket bucket_name, user_pays: user_pays
+          Bucket.from_gapi gapi, service, user_pays: user_pays
         rescue Google::Cloud::NotFoundError
           nil
         end

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -128,8 +128,7 @@ module Google
         #   end
         #
         def buckets prefix: nil, token: nil, max: nil
-          options = { prefix: prefix, token: token, max: max }
-          gapi = service.list_buckets options
+          gapi = service.list_buckets prefix: prefix, token: token, max: max
           Bucket::List.from_gapi gapi, service, prefix, max
         end
         alias_method :find_buckets, :buckets
@@ -397,12 +396,12 @@ module Google
                        content_type: nil, content_md5: nil, headers: nil,
                        issuer: nil, client_email: nil, signing_key: nil,
                        private_key: nil
-          options = { method: method, expires: expires, headers: headers,
-                      content_type: content_type, content_md5: content_md5,
-                      issuer: issuer, client_email: client_email,
-                      signing_key: signing_key, private_key: private_key }
           signer = File::Signer.new bucket, path, service
-          signer.signed_url options
+          signer.signed_url method: method, expires: expires, headers: headers,
+                            content_type: content_type,
+                            content_md5: content_md5,
+                            issuer: issuer, client_email: client_email,
+                            signing_key: signing_key, private_key: private_key
         end
 
         protected

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -74,10 +74,10 @@ module Google
         ##
         # Retrieves bucket by name.
         # Returns Google::Apis::StorageV1::Bucket.
-        def get_bucket bucket_name, user_pays: nil
+        def get_bucket bucket_name, user_project: nil
           execute do
             service.get_bucket bucket_name,
-                               user_project: user_project(user_pays)
+                               user_project: user_project(user_project)
           end
         end
 
@@ -96,7 +96,7 @@ module Google
         ##
         # Updates a bucket, including its ACL metadata.
         def patch_bucket bucket_name, bucket_gapi = nil, predefined_acl: nil,
-                         predefined_default_acl: nil, user_pays: nil
+                         predefined_default_acl: nil, user_project: nil
           bucket_gapi ||= Google::Apis::StorageV1::Bucket.new
           bucket_gapi.acl = [] if predefined_acl
           bucket_gapi.default_object_acl = [] if predefined_default_acl
@@ -106,116 +106,116 @@ module Google
               bucket_name, bucket_gapi,
               predefined_acl: predefined_acl,
               predefined_default_object_acl: predefined_default_acl,
-              user_project: user_project(user_pays)
+              user_project: user_project(user_project)
           end
         end
 
         ##
         # Permanently deletes an empty bucket.
-        def delete_bucket bucket_name, user_pays: nil
+        def delete_bucket bucket_name, user_project: nil
           execute do
             service.delete_bucket bucket_name,
-                                  user_project: user_project(user_pays)
+                                  user_project: user_project(user_project)
           end
         end
 
         ##
         # Retrieves a list of ACLs for the given bucket.
-        def list_bucket_acls bucket_name, user_pays: nil
+        def list_bucket_acls bucket_name, user_project: nil
           execute do
             service.list_bucket_access_controls \
-              bucket_name, user_project: user_project(user_pays)
+              bucket_name, user_project: user_project(user_project)
           end
         end
 
         ##
         # Creates a new bucket ACL.
-        def insert_bucket_acl bucket_name, entity, role, user_pays: nil
+        def insert_bucket_acl bucket_name, entity, role, user_project: nil
           new_acl = Google::Apis::StorageV1::BucketAccessControl.new({
             entity: entity, role: role }.delete_if { |_k, v| v.nil? })
           execute do
             service.insert_bucket_access_control \
-              bucket_name, new_acl, user_project: user_project(user_pays)
+              bucket_name, new_acl, user_project: user_project(user_project)
           end
         end
 
         ##
         # Permanently deletes a bucket ACL.
-        def delete_bucket_acl bucket_name, entity, user_pays: nil
+        def delete_bucket_acl bucket_name, entity, user_project: nil
           execute do
             service.delete_bucket_access_control \
-              bucket_name, entity, user_project: user_project(user_pays)
+              bucket_name, entity, user_project: user_project(user_project)
           end
         end
 
         ##
         # Retrieves a list of default ACLs for the given bucket.
-        def list_default_acls bucket_name, user_pays: nil
+        def list_default_acls bucket_name, user_project: nil
           execute do
             service.list_default_object_access_controls \
-              bucket_name, user_project: user_project(user_pays)
+              bucket_name, user_project: user_project(user_project)
           end
         end
 
         ##
         # Creates a new default ACL.
-        def insert_default_acl bucket_name, entity, role, user_pays: nil
+        def insert_default_acl bucket_name, entity, role, user_project: nil
           new_acl = Google::Apis::StorageV1::ObjectAccessControl.new({
             entity: entity, role: role }.delete_if { |_k, v| v.nil? })
           execute do
             service.insert_default_object_access_control \
-              bucket_name, new_acl, user_project: user_project(user_pays)
+              bucket_name, new_acl, user_project: user_project(user_project)
           end
         end
 
         ##
         # Permanently deletes a default ACL.
-        def delete_default_acl bucket_name, entity, user_pays: nil
+        def delete_default_acl bucket_name, entity, user_project: nil
           execute do
             service.delete_default_object_access_control \
-              bucket_name, entity, user_project: user_project(user_pays)
+              bucket_name, entity, user_project: user_project(user_project)
           end
         end
 
         ##
         # Returns Google::Apis::StorageV1::Policy
-        def get_bucket_policy bucket_name, user_pays: nil
+        def get_bucket_policy bucket_name, user_project: nil
           # get_bucket_iam_policy(bucket, fields: nil, quota_user: nil,
           #                               user_ip: nil, options: nil)
           execute do
-            service.get_bucket_iam_policy bucket_name,
-                                          user_project: user_project(user_pays)
+            service.get_bucket_iam_policy \
+              bucket_name, user_project: user_project(user_project)
           end
         end
 
         ##
         # Returns Google::Apis::StorageV1::Policy
-        def set_bucket_policy bucket_name, new_policy, user_pays: nil
+        def set_bucket_policy bucket_name, new_policy, user_project: nil
           execute do
-            service.set_bucket_iam_policy bucket_name, new_policy,
-                                          user_project: user_project(user_pays)
+            service.set_bucket_iam_policy \
+              bucket_name, new_policy, user_project: user_project(user_project)
           end
         end
 
         ##
         # Returns Google::Apis::StorageV1::TestIamPermissionsResponse
-        def test_bucket_permissions bucket_name, permissions, user_pays: nil
+        def test_bucket_permissions bucket_name, permissions, user_project: nil
           execute do
             service.test_bucket_iam_permissions \
-              bucket_name, permissions, user_project: user_project(user_pays)
+              bucket_name, permissions, user_project: user_project(user_project)
           end
         end
 
         ##
         # Retrieves a list of files matching the criteria.
         def list_files bucket_name, delimiter: nil, max: nil, token: nil,
-                       prefix: nil, versions: nil, user_pays: nil
+                       prefix: nil, versions: nil, user_project: nil
           execute do
             service.list_objects \
               bucket_name, delimiter: delimiter, max_results: max,
                            page_token: token, prefix: prefix,
                            versions: versions,
-                           user_project: user_project(user_pays)
+                           user_project: user_project(user_project)
           end
         end
 
@@ -225,7 +225,7 @@ module Google
                         cache_control: nil, content_disposition: nil,
                         content_encoding: nil, content_language: nil,
                         content_type: nil, crc32c: nil, md5: nil, metadata: nil,
-                        storage_class: nil, key: nil, user_pays: nil
+                        storage_class: nil, key: nil, user_project: nil
           file_obj = Google::Apis::StorageV1::Object.new({
             cache_control: cache_control, content_type: content_type,
             content_disposition: content_disposition, md5_hash: md5,
@@ -239,19 +239,20 @@ module Google
               bucket_name, file_obj,
               name: path, predefined_acl: acl, upload_source: source,
               content_encoding: content_encoding, content_type: content_type,
-              user_project: user_project(user_pays), options: key_options(key)
+              user_project: user_project(user_project),
+              options: key_options(key)
           end
         end
 
         ##
         # Retrieves an object or its metadata.
         def get_file bucket_name, file_path, generation: nil, key: nil,
-                     user_pays: nil
+                     user_project: nil
           execute do
             service.get_object \
               bucket_name, file_path,
               generation: generation,
-              user_project: user_project(user_pays),
+              user_project: user_project(user_project),
               options: key_options(key)
           end
         end
@@ -261,7 +262,7 @@ module Google
         def copy_file source_bucket_name, source_file_path,
                       destination_bucket_name, destination_file_path,
                       file_gapi = nil, key: nil, acl: nil, generation: nil,
-                      token: nil, user_pays: nil
+                      token: nil, user_project: nil
           key_options = rewrite_key_options key, key
           execute do
             service.rewrite_object \
@@ -271,7 +272,7 @@ module Google
               destination_predefined_acl: acl,
               source_generation: generation,
               rewrite_token: token,
-              user_project: user_project(user_pays),
+              user_project: user_project(user_project),
               options: key_options
           end
         end
@@ -281,7 +282,8 @@ module Google
         def rewrite_file source_bucket_name, source_file_path,
                          destination_bucket_name, destination_file_path,
                          file_gapi = nil, source_key: nil, destination_key: nil,
-                         acl: nil, generation: nil, token: nil, user_pays: nil
+                         acl: nil, generation: nil, token: nil,
+                         user_project: nil
           key_options = rewrite_key_options source_key, destination_key
           execute do
             service.rewrite_object \
@@ -291,7 +293,7 @@ module Google
               destination_predefined_acl: acl,
               source_generation: generation,
               rewrite_token: token,
-              user_project: user_project(user_pays),
+              user_project: user_project(user_project),
               options: key_options
           end
         end
@@ -299,67 +301,68 @@ module Google
         ##
         # Download contents of a file.
         def download_file bucket_name, file_path, target_path, generation: nil,
-                          key: nil, user_pays: nil
+                          key: nil, user_project: nil
           execute do
             service.get_object \
               bucket_name, file_path,
               download_dest: target_path, generation: generation,
-              user_project: user_project(user_pays), options: key_options(key)
+              user_project: user_project(user_project),
+              options: key_options(key)
           end
         end
 
         ##
         # Updates a file's metadata.
         def patch_file bucket_name, file_path, file_gapi = nil,
-                       predefined_acl: nil, user_pays: nil
+                       predefined_acl: nil, user_project: nil
           file_gapi ||= Google::Apis::StorageV1::Object.new
           execute do
             service.patch_object \
               bucket_name, file_path, file_gapi,
               predefined_acl: predefined_acl,
-              user_project: user_project(user_pays)
+              user_project: user_project(user_project)
           end
         end
 
         ##
         # Permanently deletes a file.
-        def delete_file bucket_name, file_path, user_pays: nil
+        def delete_file bucket_name, file_path, user_project: nil
           execute do
             service.delete_object bucket_name, file_path,
-                                  user_project: user_project(user_pays)
+                                  user_project: user_project(user_project)
           end
         end
 
         ##
         # Retrieves a list of ACLs for the given file.
-        def list_file_acls bucket_name, file_name, user_pays: nil
+        def list_file_acls bucket_name, file_name, user_project: nil
           execute do
             service.list_object_access_controls \
-              bucket_name, file_name, user_project: user_project(user_pays)
+              bucket_name, file_name, user_project: user_project(user_project)
           end
         end
 
         ##
         # Creates a new file ACL.
         def insert_file_acl bucket_name, file_name, entity, role,
-                            generation: nil, user_pays: nil
+                            generation: nil, user_project: nil
           new_acl = Google::Apis::StorageV1::ObjectAccessControl.new({
             entity: entity, role: role }.delete_if { |_k, v| v.nil? })
           execute do
             service.insert_object_access_control \
               bucket_name, file_name, new_acl,
-              generation: generation, user_project: user_project(user_pays)
+              generation: generation, user_project: user_project(user_project)
           end
         end
 
         ##
         # Permanently deletes a file ACL.
         def delete_file_acl bucket_name, file_name, entity, generation: nil,
-                            user_pays: nil
+                            user_project: nil
           execute do
             service.delete_object_access_control \
               bucket_name, file_name, entity,
-              generation: generation, user_project: user_project(user_pays)
+              generation: generation, user_project: user_project(user_project)
           end
         end
 
@@ -377,8 +380,12 @@ module Google
 
         protected
 
-        def user_project user_pays
-          @project if user_pays
+        def user_project user_project
+          if user_project.respond_to?(:to_str)
+            user_project.to_str
+          elsif user_project
+            @project
+          end
         end
 
         def key_options key

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -74,8 +74,11 @@ module Google
         ##
         # Retrieves bucket by name.
         # Returns Google::Apis::StorageV1::Bucket.
-        def get_bucket bucket_name
-          execute { service.get_bucket bucket_name }
+        def get_bucket bucket_name, user_pays: nil
+          execute do
+            service.get_bucket bucket_name,
+                               user_project: user_project(user_pays)
+          end
         end
 
         ##
@@ -93,7 +96,7 @@ module Google
         ##
         # Updates a bucket, including its ACL metadata.
         def patch_bucket bucket_name, bucket_gapi = nil, predefined_acl: nil,
-                         predefined_default_acl: nil
+                         predefined_default_acl: nil, user_pays: nil
           bucket_gapi ||= Google::Apis::StorageV1::Bucket.new
           bucket_gapi.acl = [] if predefined_acl
           bucket_gapi.default_object_acl = [] if predefined_default_acl
@@ -102,93 +105,117 @@ module Google
             service.patch_bucket \
               bucket_name, bucket_gapi,
               predefined_acl: predefined_acl,
-              predefined_default_object_acl: predefined_default_acl
+              predefined_default_object_acl: predefined_default_acl,
+              user_project: user_project(user_pays)
           end
         end
 
         ##
         # Permanently deletes an empty bucket.
-        def delete_bucket bucket_name
-          execute { service.delete_bucket bucket_name }
+        def delete_bucket bucket_name, user_pays: nil
+          execute do
+            service.delete_bucket bucket_name,
+                                  user_project: user_project(user_pays)
+          end
         end
 
         ##
         # Retrieves a list of ACLs for the given bucket.
-        def list_bucket_acls bucket_name
-          execute { service.list_bucket_access_controls bucket_name }
+        def list_bucket_acls bucket_name, user_pays: nil
+          execute do
+            service.list_bucket_access_controls \
+              bucket_name, user_project: user_project(user_pays)
+          end
         end
 
         ##
         # Creates a new bucket ACL.
-        def insert_bucket_acl bucket_name, entity, role
+        def insert_bucket_acl bucket_name, entity, role, user_pays: nil
           new_acl = Google::Apis::StorageV1::BucketAccessControl.new({
             entity: entity, role: role }.delete_if { |_k, v| v.nil? })
-          execute { service.insert_bucket_access_control bucket_name, new_acl }
+          execute do
+            service.insert_bucket_access_control \
+              bucket_name, new_acl, user_project: user_project(user_pays)
+          end
         end
 
         ##
         # Permanently deletes a bucket ACL.
-        def delete_bucket_acl bucket_name, entity
-          execute { service.delete_bucket_access_control bucket_name, entity }
+        def delete_bucket_acl bucket_name, entity, user_pays: nil
+          execute do
+            service.delete_bucket_access_control \
+              bucket_name, entity, user_project: user_project(user_pays)
+          end
         end
 
         ##
         # Retrieves a list of default ACLs for the given bucket.
-        def list_default_acls bucket_name
-          execute { service.list_default_object_access_controls bucket_name }
+        def list_default_acls bucket_name, user_pays: nil
+          execute do
+            service.list_default_object_access_controls \
+              bucket_name, user_project: user_project(user_pays)
+          end
         end
 
         ##
         # Creates a new default ACL.
-        def insert_default_acl bucket_name, entity, role
+        def insert_default_acl bucket_name, entity, role, user_pays: nil
           new_acl = Google::Apis::StorageV1::ObjectAccessControl.new({
             entity: entity, role: role }.delete_if { |_k, v| v.nil? })
           execute do
-            service.insert_default_object_access_control bucket_name, new_acl
+            service.insert_default_object_access_control \
+              bucket_name, new_acl, user_project: user_project(user_pays)
           end
         end
 
         ##
         # Permanently deletes a default ACL.
-        def delete_default_acl bucket_name, entity
+        def delete_default_acl bucket_name, entity, user_pays: nil
           execute do
-            service.delete_default_object_access_control bucket_name, entity
+            service.delete_default_object_access_control \
+              bucket_name, entity, user_project: user_project(user_pays)
           end
         end
 
         ##
         # Returns Google::Apis::StorageV1::Policy
-        def get_bucket_policy bucket_name
+        def get_bucket_policy bucket_name, user_pays: nil
           # get_bucket_iam_policy(bucket, fields: nil, quota_user: nil,
           #                               user_ip: nil, options: nil)
-          execute { service.get_bucket_iam_policy bucket_name }
+          execute do
+            service.get_bucket_iam_policy bucket_name,
+                                          user_project: user_project(user_pays)
+          end
         end
 
         ##
         # Returns Google::Apis::StorageV1::Policy
-        def set_bucket_policy bucket_name, new_policy
+        def set_bucket_policy bucket_name, new_policy, user_pays: nil
           execute do
-            service.set_bucket_iam_policy bucket_name, new_policy
+            service.set_bucket_iam_policy bucket_name, new_policy,
+                                          user_project: user_project(user_pays)
           end
         end
 
         ##
         # Returns Google::Apis::StorageV1::TestIamPermissionsResponse
-        def test_bucket_permissions bucket_name, permissions
+        def test_bucket_permissions bucket_name, permissions, user_pays: nil
           execute do
-            service.test_bucket_iam_permissions bucket_name, permissions
+            service.test_bucket_iam_permissions \
+              bucket_name, permissions, user_project: user_project(user_pays)
           end
         end
 
         ##
         # Retrieves a list of files matching the criteria.
         def list_files bucket_name, delimiter: nil, max: nil, token: nil,
-                       prefix: nil, versions: nil
+                       prefix: nil, versions: nil, user_pays: nil
           execute do
             service.list_objects \
               bucket_name, delimiter: delimiter, max_results: max,
                            page_token: token, prefix: prefix,
-                           versions: versions
+                           versions: versions,
+                           user_project: user_project(user_pays)
           end
         end
 
@@ -198,7 +225,7 @@ module Google
                         cache_control: nil, content_disposition: nil,
                         content_encoding: nil, content_language: nil,
                         content_type: nil, crc32c: nil, md5: nil, metadata: nil,
-                        storage_class: nil, key: nil
+                        storage_class: nil, key: nil, user_pays: nil
           file_obj = Google::Apis::StorageV1::Object.new({
             cache_control: cache_control, content_type: content_type,
             content_disposition: content_disposition, md5_hash: md5,
@@ -212,17 +239,19 @@ module Google
               bucket_name, file_obj,
               name: path, predefined_acl: acl, upload_source: source,
               content_encoding: content_encoding, content_type: content_type,
-              options: key_options(key)
+              user_project: user_project(user_pays), options: key_options(key)
           end
         end
 
         ##
         # Retrieves an object or its metadata.
-        def get_file bucket_name, file_path, generation: nil, key: nil
+        def get_file bucket_name, file_path, generation: nil, key: nil,
+                     user_pays: nil
           execute do
             service.get_object \
               bucket_name, file_path,
               generation: generation,
+              user_project: user_project(user_pays),
               options: key_options(key)
           end
         end
@@ -232,7 +261,7 @@ module Google
         def copy_file source_bucket_name, source_file_path,
                       destination_bucket_name, destination_file_path,
                       file_gapi = nil, key: nil, acl: nil, generation: nil,
-                      token: nil
+                      token: nil, user_pays: nil
           key_options = rewrite_key_options key, key
           execute do
             service.rewrite_object \
@@ -242,6 +271,7 @@ module Google
               destination_predefined_acl: acl,
               source_generation: generation,
               rewrite_token: token,
+              user_project: user_project(user_pays),
               options: key_options
           end
         end
@@ -251,7 +281,7 @@ module Google
         def rewrite_file source_bucket_name, source_file_path,
                          destination_bucket_name, destination_file_path,
                          file_gapi = nil, source_key: nil, destination_key: nil,
-                         acl: nil, generation: nil, token: nil
+                         acl: nil, generation: nil, token: nil, user_pays: nil
           key_options = rewrite_key_options source_key, destination_key
           execute do
             service.rewrite_object \
@@ -261,6 +291,7 @@ module Google
               destination_predefined_acl: acl,
               source_generation: generation,
               rewrite_token: token,
+              user_project: user_project(user_pays),
               options: key_options
           end
         end
@@ -268,57 +299,67 @@ module Google
         ##
         # Download contents of a file.
         def download_file bucket_name, file_path, target_path, generation: nil,
-                          key: nil
+                          key: nil, user_pays: nil
           execute do
             service.get_object \
               bucket_name, file_path,
               download_dest: target_path, generation: generation,
-              options: key_options(key)
+              user_project: user_project(user_pays), options: key_options(key)
           end
         end
 
         ##
         # Updates a file's metadata.
         def patch_file bucket_name, file_path, file_gapi = nil,
-                       predefined_acl: nil
+                       predefined_acl: nil, user_pays: nil
           file_gapi ||= Google::Apis::StorageV1::Object.new
           execute do
             service.patch_object \
               bucket_name, file_path, file_gapi,
-              predefined_acl: predefined_acl
+              predefined_acl: predefined_acl,
+              user_project: user_project(user_pays)
           end
         end
 
         ##
         # Permanently deletes a file.
-        def delete_file bucket_name, file_path
-          execute { service.delete_object bucket_name, file_path }
+        def delete_file bucket_name, file_path, user_pays: nil
+          execute do
+            service.delete_object bucket_name, file_path,
+                                  user_project: user_project(user_pays)
+          end
         end
 
         ##
         # Retrieves a list of ACLs for the given file.
-        def list_file_acls bucket_name, file_name
-          execute { service.list_object_access_controls bucket_name, file_name }
+        def list_file_acls bucket_name, file_name, user_pays: nil
+          execute do
+            service.list_object_access_controls \
+              bucket_name, file_name, user_project: user_project(user_pays)
+          end
         end
 
         ##
         # Creates a new file ACL.
         def insert_file_acl bucket_name, file_name, entity, role,
-                            generation: nil
+                            generation: nil, user_pays: nil
           new_acl = Google::Apis::StorageV1::ObjectAccessControl.new({
             entity: entity, role: role }.delete_if { |_k, v| v.nil? })
           execute do
             service.insert_object_access_control \
-              bucket_name, file_name, new_acl, generation: generation
+              bucket_name, file_name, new_acl,
+              generation: generation, user_project: user_project(user_pays)
           end
         end
 
         ##
         # Permanently deletes a file ACL.
-        def delete_file_acl bucket_name, file_name, entity, generation: nil
+        def delete_file_acl bucket_name, file_name, entity, generation: nil,
+                            user_pays: nil
           execute do
             service.delete_object_access_control \
-              bucket_name, file_name, entity, generation: generation
+              bucket_name, file_name, entity,
+              generation: generation, user_project: user_project(user_pays)
           end
         end
 
@@ -335,6 +376,10 @@ module Google
         end
 
         protected
+
+        def user_project user_pays
+          @project if user_pays
+        end
 
         def key_options key
           options = {}

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -381,11 +381,9 @@ module Google
         protected
 
         def user_project user_project
-          if user_project.respond_to?(:to_str)
-            user_project.to_str
-          elsif user_project
-            @project
-          end
+          return nil unless user_project # nil or false get nil
+          return @project if user_project == true # handle the true  condition
+          String(user_project) # convert the value to a string
         end
 
         def key_options key

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -81,12 +81,12 @@ module Google
         ##
         # Creates a new bucket.
         # Returns Google::Apis::StorageV1::Bucket.
-        def insert_bucket bucket_gapi, options = {}
+        def insert_bucket bucket_gapi, acl: nil, default_acl: nil
           execute do
             service.insert_bucket \
               @project, bucket_gapi,
-              predefined_acl: options[:acl],
-              predefined_default_object_acl: options[:default_acl]
+              predefined_acl: acl,
+              predefined_default_object_acl: default_acl
           end
         end
 
@@ -182,14 +182,13 @@ module Google
 
         ##
         # Retrieves a list of files matching the criteria.
-        def list_files bucket_name, options = {}
+        def list_files bucket_name, delimiter: nil, max: nil, token: nil,
+                       prefix: nil, versions: nil
           execute do
             service.list_objects \
-              bucket_name, delimiter: options[:delimiter],
-                           max_results: options[:max],
-                           page_token: options[:token],
-                           prefix: options[:prefix],
-                           versions: options[:versions]
+              bucket_name, delimiter: delimiter, max_results: max,
+                           page_token: token, prefix: prefix,
+                           versions: versions
           end
         end
 
@@ -232,17 +231,17 @@ module Google
         # destination bucket/object.
         def copy_file source_bucket_name, source_file_path,
                       destination_bucket_name, destination_file_path,
-                      file_gapi = nil, options = {}
-          key_options = rewrite_key_options options[:key],
-                                            options[:key]
+                      file_gapi = nil, key: nil, acl: nil, generation: nil,
+                      token: nil
+          key_options = rewrite_key_options key, key
           execute do
             service.rewrite_object \
               source_bucket_name, source_file_path,
               destination_bucket_name, destination_file_path,
               file_gapi,
-              destination_predefined_acl: options[:acl],
-              source_generation: options[:generation],
-              rewrite_token: options[:token],
+              destination_predefined_acl: acl,
+              source_generation: generation,
+              rewrite_token: token,
               options: key_options
           end
         end
@@ -251,17 +250,17 @@ module Google
         # destination bucket/object.
         def rewrite_file source_bucket_name, source_file_path,
                          destination_bucket_name, destination_file_path,
-                         file_gapi = nil, options = {}
-          key_options = rewrite_key_options options[:source_key],
-                                            options[:destination_key]
+                         file_gapi = nil, source_key: nil, destination_key: nil,
+                         acl: nil, generation: nil, token: nil
+          key_options = rewrite_key_options source_key, destination_key
           execute do
             service.rewrite_object \
               source_bucket_name, source_file_path,
               destination_bucket_name, destination_file_path,
               file_gapi,
-              destination_predefined_acl: options[:acl],
-              source_generation: options[:generation],
-              rewrite_token: options[:token],
+              destination_predefined_acl: acl,
+              source_generation: generation,
+              rewrite_token: token,
               options: key_options
           end
         end
@@ -304,21 +303,22 @@ module Google
 
         ##
         # Creates a new file ACL.
-        def insert_file_acl bucket_name, file_name, entity, role, options = {}
+        def insert_file_acl bucket_name, file_name, entity, role,
+                            generation: nil
           new_acl = Google::Apis::StorageV1::ObjectAccessControl.new({
             entity: entity, role: role }.delete_if { |_k, v| v.nil? })
           execute do
             service.insert_object_access_control \
-              bucket_name, file_name, new_acl, generation: options[:generation]
+              bucket_name, file_name, new_acl, generation: generation
           end
         end
 
         ##
         # Permanently deletes a file ACL.
-        def delete_file_acl bucket_name, file_name, entity, options = {}
+        def delete_file_acl bucket_name, file_name, entity, generation: nil
           execute do
             service.delete_object_access_control \
-              bucket_name, file_name, entity, generation: options[:generation]
+              bucket_name, file_name, entity, generation: generation
           end
         end
 

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -263,11 +263,32 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::Bucket#requester_pays" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, bucket_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Bucket#user_project" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["other-project-bucket", Hash]
+      mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Storage::Bucket#test_permissions" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
       mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
       mock.expect :test_bucket_iam_permissions, permissions_gapi, ["my-todo-app", ["storage.buckets.get", "storage.buckets.delete"], Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Bucket#user_project" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["other-project-bucket", Hash]
+      mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
     end
   end
 
@@ -574,6 +595,13 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::File#user_project" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["other-project-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/file.ext", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Storage::File#acl" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
@@ -714,6 +742,20 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::Project#bucket@With `user_project` set to pay for a requester pays bucket:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["other-project-bucket", Hash]
+      mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Project#bucket@With `user_project` set to a project other than the default:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["other-project-bucket", Hash]
+      mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Storage::Project#buckets" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
@@ -730,6 +772,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.skip "Google::Cloud::Storage::Project#find_bucket" # alias for #bucket
   doctest.skip "Google::Cloud::Storage::Project#find_buckets" # alias for #buckets
 
   doctest.before "Google::Cloud::Storage::Project#create_bucket" do

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -289,6 +289,7 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["other-project-bucket", Hash]
       mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
+      mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
     end
   end
 
@@ -598,6 +599,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Storage::File#user_project" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["other-project-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/file.ext", Hash]
       mock.expect :get_object, file_gapi, ["my-bucket", "path/to/file.ext", Hash]
     end
   end

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -110,28 +110,28 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud.storage" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
     end
   end
 
   doctest.before "Google::Cloud#storage" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage.new" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
     end
   end
 
@@ -139,49 +139,49 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#cors" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :patch_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :patch_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#update" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :patch_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :patch_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#delete" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :delete_bucket, nil, ["my-bucket"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :delete_bucket, nil, ["my-bucket", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#files" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :list_objects, list_files_gapi, ["my-bucket", {:delimiter=>nil, :max_results=>nil, :page_token=>nil, :prefix=>nil, :versions=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#find_files" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :list_objects, list_files_gapi, ["my-bucket", {:delimiter=>nil, :max_results=>nil, :page_token=>nil, :prefix=>nil, :versions=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#create_file" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
       mock.expect :insert_object, file_gapi, ["my-bucket", Google::Apis::StorageV1::Object, Hash]
       # Following expectation is only used in last example
       mock.expect :get_object, file_gapi, ["my-bucket", "destination/path/file.ext", Hash]
@@ -190,7 +190,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket#new_file" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
       mock.expect :insert_object, file_gapi, ["my-bucket", Google::Apis::StorageV1::Object, Hash]
       # Following expectation is only used in last example
       mock.expect :get_object, file_gapi, ["my-bucket", "destination/path/file.ext", Hash]
@@ -199,7 +199,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket#upload_file" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
       mock.expect :insert_object, file_gapi, ["my-bucket", Google::Apis::StorageV1::Object, Hash]
       # Following expectation is only used in last example
       mock.expect :get_object, file_gapi, ["my-bucket", "destination/path/file.ext", Hash]
@@ -208,66 +208,66 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket#signed_url" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#acl" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-todo-app", Google::Apis::StorageV1::BucketAccessControl]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-todo-app", Google::Apis::StorageV1::BucketAccessControl, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#acl@Or, grant access via a predefined permissions list:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-todo-app", Google::Apis::StorageV1::Bucket, {:predefined_acl=>"publicRead", :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-todo-app", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#default_acl" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :insert_default_object_access_control, object_access_control_gapi, ["my-todo-app", Google::Apis::StorageV1::ObjectAccessControl]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :insert_default_object_access_control, object_access_control_gapi, ["my-todo-app", Google::Apis::StorageV1::ObjectAccessControl, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#default_acl@Or, grant access via a predefined permissions list:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-todo-app", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>"publicRead"}]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-todo-app", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#policy" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#policy@Retrieve the latest policy and update it in a block:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#policy=" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#test_permissions" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :test_bucket_iam_permissions, permissions_gapi, ["my-todo-app", ["storage.buckets.get", "storage.buckets.delete"]]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :test_bucket_iam_permissions, permissions_gapi, ["my-todo-app", ["storage.buckets.get", "storage.buckets.delete"], Hash]
     end
   end
 
@@ -275,94 +275,94 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#reload!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
       access_controls = Google::Apis::StorageV1::BucketAccessControls.from_json(random_bucket_acl_hash("my-bucket").to_json)
-      mock.expect :list_bucket_access_controls, access_controls, ["my-bucket"]
+      mock.expect :list_bucket_access_controls, access_controls, ["my-bucket", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
       access_controls = Google::Apis::StorageV1::BucketAccessControls.from_json(random_bucket_acl_hash("my-bucket").to_json)
-      mock.expect :list_bucket_access_controls, access_controls, ["my-bucket"]
+      mock.expect :list_bucket_access_controls, access_controls, ["my-bucket", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#add_owner" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#add_writer" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#add_reader" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :insert_bucket_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::BucketAccessControl, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#delete" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :delete_bucket_access_control, true, ["my-bucket", "user-heidi@example.net"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :delete_bucket_access_control, true, ["my-bucket", "user-heidi@example.net", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#auth" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>"authenticatedRead", :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#private" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>"private", :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#project_private!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>"projectPrivate", :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#projectPrivate!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>"projectPrivate", :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#public" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>"publicRead", :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#public_write!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>"publicReadWrite", :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Acl#publicReadWrite!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>"publicReadWrite", :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
@@ -370,79 +370,79 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
       access_controls = Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash("my-bucket").to_json)
-      mock.expect :list_default_object_access_controls, access_controls, ["my-bucket"]
+      mock.expect :list_default_object_access_controls, access_controls, ["my-bucket", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#add_" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :insert_default_object_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::ObjectAccessControl]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :insert_default_object_access_control, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::ObjectAccessControl, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#delete" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :delete_default_object_access_control, true, ["my-bucket", "user-heidi@example.net"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :delete_default_object_access_control, true, ["my-bucket", "user-heidi@example.net", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#auth" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>"authenticatedRead"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#owner_full!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>"bucketOwnerFullControl"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#bucketOwnerFullControl!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>"bucketOwnerFullControl"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#owner_read!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>"bucketOwnerRead"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#bucketOwnerRead!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>"bucketOwnerRead"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#private" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>"private"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#project" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>"projectPrivate"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::DefaultAcl#public" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>"publicRead"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, object_access_control_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
@@ -450,14 +450,14 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket::Cors" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :patch_bucket, bucket_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :patch_bucket, bucket_gapi, ["my-bucket", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Bucket::Cors#add_rule" do
     mock_storage do |mock|
-      mock.expect :insert_bucket, bucket_gapi, ["my-todo-project", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>nil}]
+      mock.expect :insert_bucket, bucket_gapi, ["my-todo-project", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
@@ -465,7 +465,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket::List" do
     mock_storage do |mock|
-      mock.expect :list_buckets, list_buckets_gapi, ["my-todo-project", {:prefix=>nil, :page_token=>nil, :max_results=>nil}]
+      mock.expect :list_buckets, list_buckets_gapi, ["my-todo-project", Hash]
     end
   end
 
@@ -473,17 +473,17 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Policy" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Policy#role" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app"]
-      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
+      mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
 
@@ -491,55 +491,55 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::File" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:download_dest=>"path/to/downloaded/file.ext", :generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#update" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#copy" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", nil, {:destination_predefined_acl=>nil, :source_generation=>nil, :rewrite_token => nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", nil, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#copy@The file can be copied to a new path in the current bucket:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "path/to/destination/file.ext", nil, {:destination_predefined_acl=>nil, :source_generation=>nil, :rewrite_token => nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "path/to/destination/file.ext", nil, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#copy@The file can also be copied by specifying a generation:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "copy/of/previous/generation/file.ext", nil, {:destination_predefined_acl=>nil, :source_generation=>123456, :rewrite_token => nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "copy/of/previous/generation/file.ext", nil, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#copy@The file can be modified during copying:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", Google::Apis::StorageV1::Object, {:destination_predefined_acl=>nil, :source_generation=>nil, :rewrite_token => nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#rotate" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
       mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
       mock.expect :rewrite_object, OpenStruct.new(done: true, resource: file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "path/to/my-file.ext", nil, Hash]
     end
@@ -547,53 +547,53 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::File#delete" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :delete_object, file_gapi, ["my-bucket", "path/to/my-file.ext"]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :delete_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#download@Download to an in-memory StringIO object." do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#public_url" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#url" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#acl" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", {:generation=>nil, :options=>{}}]
-      mock.expect :insert_object_access_control, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::ObjectAccessControl, {:generation=>nil}]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", Hash]
+      mock.expect :insert_object_access_control, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::ObjectAccessControl, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#acl@Or, grant access via a predefined permissions list:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>"publicRead"}]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File#signed_url" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
-      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
+      mock.expect :get_object, file_gapi, ["my-todo-app", "avatars/heidi/400x400.png", Hash]
     end
   end
 
@@ -601,98 +601,98 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::File::Acl" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
       access_controls = Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash("my-bucket", "path/to/my-file.ext").to_json)
-      mock.expect :list_object_access_controls, access_controls, ["my-bucket", "path/to/my-file.ext"]
+      mock.expect :list_object_access_controls, access_controls, ["my-bucket", "path/to/my-file.ext", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#add_owner" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :insert_object_access_control, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::ObjectAccessControl, {:generation=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :insert_object_access_control, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::ObjectAccessControl, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#add_reader" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :insert_object_access_control, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::ObjectAccessControl, {:generation=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :insert_object_access_control, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::ObjectAccessControl, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#delete" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :delete_object_access_control, true, ["my-bucket", "path/to/my-file.ext", "user-heidi@example.net", {:generation=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :delete_object_access_control, true, ["my-bucket", "path/to/my-file.ext", "user-heidi@example.net", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#auth" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>"authenticatedRead"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#owner_full!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>"bucketOwnerFullControl"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#bucketOwnerFullControl!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>"bucketOwnerFullControl"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#owner_read!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>"bucketOwnerRead"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#bucketOwnerRead!" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>"bucketOwnerRead"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#private" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>"private"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#project" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>"projectPrivate"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::File::Acl#public" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, {:predefined_acl=>"publicRead"}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :patch_object, object_access_control_gapi, ["my-bucket", "path/to/my-file.ext", Google::Apis::StorageV1::Object, Hash]
     end
   end
 
@@ -700,8 +700,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::File::List" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :list_objects, list_files_gapi, ["my-bucket", {:delimiter=>nil, :max_results=>nil, :page_token=>nil, :prefix=>nil, :versions=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
     end
   end
 
@@ -709,24 +709,24 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Project" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Project#buckets" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :list_buckets, list_buckets_gapi, ["my-todo-project", {:prefix=>nil, :page_token=>nil, :max_results=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :list_buckets, list_buckets_gapi, ["my-todo-project", Hash]
     end
   end
 
   doctest.before "Google::Cloud::Storage::Project#buckets@Retrieve buckets with names that begin with a given prefix:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :list_buckets, list_buckets_gapi, ["my-todo-project", {:prefix=>"user-", :page_token=>nil, :max_results=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :list_buckets, list_buckets_gapi, ["my-todo-project", Hash]
     end
   end
 
@@ -734,9 +734,9 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Project#create_bucket" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket"]
-      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", {:generation=>nil, :options=>{}}]
-      mock.expect :insert_bucket, bucket_gapi, ["my-todo-project", Google::Apis::StorageV1::Bucket, {:predefined_acl=>nil, :predefined_default_object_acl=>nil}]
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :insert_bucket, bucket_gapi, ["my-todo-project", Google::Apis::StorageV1::Bucket, Hash]
     end
   end
 
@@ -744,25 +744,25 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Storage::Bucket#post_object" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
     end
   end
   doctest.before "Google::Cloud::Storage::Bucket#post_object@Using a policy to define the upload authorization:" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
     end
   end
   doctest.before "Google::Cloud::Storage::Bucket#post_object@Using the issuer and signing_key options:" do
     mock_storage do |mock|
       OpenSSL::PKey::RSA.stub :new, "key" do
-        mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+        mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
       end
     end
   end
 
   doctest.before "Google::Cloud::Storage::PostObject" do
     mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app"]
+      mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
     end
   end
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
@@ -41,7 +41,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     mock.verify
   end
 
-  it "retrieves the ACL with user_pays set to true" do
+  it "retrieves the ACL with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :get_bucket, bucket_gapi, [bucket_name, {user_project: "test"}]
     mock.expect :list_bucket_access_controls,
@@ -50,7 +50,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    bucket = storage.bucket bucket_name, user_pays: true
+    bucket = storage.bucket bucket_name, user_project: true
     bucket.name.must_equal bucket_name
     bucket.acl.owners.wont_be  :empty?
     bucket.acl.writers.must_be :empty?
@@ -98,7 +98,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     mock.verify
   end
 
-  it "adds to the ACL with user_pays set to true" do
+  it "adds to the ACL with user_project set to true" do
     writer_entity = "user-user@example.net"
     writer_acl = {
        "kind" => "storage#bucketAccessControl",
@@ -122,7 +122,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    bucket = storage.bucket bucket_name, user_pays: true
+    bucket = storage.bucket bucket_name, user_project: true
     bucket.name.must_equal bucket_name
     bucket.acl.owners.wont_be  :empty?
     bucket.acl.writers.must_be :empty?
@@ -165,7 +165,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     mock.verify
   end
 
-  it "removes from the ACL with user_pays set to true" do
+  it "removes from the ACL with user_project set to true" do
     existing_reader_entity = "project-viewers-1234567890"
 
     mock = Minitest::Mock.new
@@ -178,7 +178,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    bucket = storage.bucket bucket_name, user_pays: true
+    bucket = storage.bucket bucket_name, user_project: true
     bucket.name.must_equal bucket_name
     bucket.acl.owners.wont_be  :empty?
     bucket.acl.writers.must_be :empty?

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
   let(:bucket_json) { bucket_hash.to_json }
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json bucket_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
-  let(:bucket_user_pays) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_pays: true }
+  let(:bucket_user_project) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_project: true }
 
   let(:old_policy_gapi) {
     Google::Apis::StorageV1::Policy.new(
@@ -68,12 +68,12 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
   end
 
-  it "gets the policy with user_pays set to true" do
+  it "gets the policy with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
 
     storage.service.mocked_service = mock
-    policy = bucket_user_pays.policy
+    policy = bucket_user_project.policy
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
@@ -101,12 +101,12 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
-  it "sets the policy with user_pays set to true" do
+  it "sets the policy with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: "test"]
 
     storage.service.mocked_service = mock
-    policy = bucket_user_pays.policy = new_policy
+    policy = bucket_user_project.policy = new_policy
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
@@ -139,14 +139,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
-  it "sets the policy in a block with user_pays set to true" do
+  it "sets the policy in a block with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
 
     mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: "test"]
 
     storage.service.mocked_service = mock
-    policy = bucket_user_pays.policy do |p|
+    policy = bucket_user_project.policy do |p|
       p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
     mock.verify
@@ -173,13 +173,13 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     permissions.must_equal ["storage.buckets.get"]
   end
 
-  it "tests the permissions available with user_pays set to true" do
+  it "tests the permissions available with user_project set to true" do
     mock = Minitest::Mock.new
     update_policy_response = Google::Apis::StorageV1::TestIamPermissionsResponse.new permissions: ["storage.buckets.get"]
     mock.expect :test_bucket_iam_permissions, update_policy_response, [bucket_name, ["storage.buckets.get", "storage.buckets.delete"], user_project: "test"]
 
     storage.service.mocked_service = mock
-    permissions = bucket_user_pays.test_permissions "storage.buckets.get",
+    permissions = bucket_user_project.test_permissions "storage.buckets.get",
                                            "storage.buckets.delete"
     mock.verify
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -20,7 +20,8 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
   let(:bucket_json) { bucket_hash.to_json }
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json bucket_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
-  
+  let(:bucket_user_pays) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_pays: true }
+
   let(:old_policy_gapi) {
     Google::Apis::StorageV1::Policy.new(
       etag: "CAE=",
@@ -53,7 +54,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
   it "gets the policy" do
     mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name]
+    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: nil]
 
     storage.service.mocked_service = mock
     policy = bucket.policy
@@ -67,9 +68,25 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
   end
 
+  it "gets the policy with user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
+
+    storage.service.mocked_service = mock
+    policy = bucket_user_pays.policy
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 1
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+  end
+
   it "sets the policy" do
     mock = Minitest::Mock.new
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: nil]
 
     storage.service.mocked_service = mock
     policy = bucket.policy = new_policy
@@ -84,11 +101,28 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
+  it "sets the policy with user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: "test"]
+
+    storage.service.mocked_service = mock
+    policy = bucket_user_pays.policy = new_policy
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
   it "sets the policy in a block" do
     mock = Minitest::Mock.new
-    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name]
+    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: nil]
 
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: nil]
 
     storage.service.mocked_service = mock
     policy = bucket.policy do |p|
@@ -105,13 +139,47 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
+  it "sets the policy in a block with user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
+
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: "test"]
+
+    storage.service.mocked_service = mock
+    policy = bucket_user_pays.policy do |p|
+      p.add "roles/storage.objectViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+    mock.verify
+
+    policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
+    policy.roles["roles/storage.objectViewer"].count.must_equal 2
+    policy.roles["roles/storage.objectViewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/storage.objectViewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
   it "tests the permissions available" do
     mock = Minitest::Mock.new
     update_policy_response = Google::Apis::StorageV1::TestIamPermissionsResponse.new permissions: ["storage.buckets.get"]
-    mock.expect :test_bucket_iam_permissions, update_policy_response, [bucket_name, ["storage.buckets.get", "storage.buckets.delete"]]
+    mock.expect :test_bucket_iam_permissions, update_policy_response, [bucket_name, ["storage.buckets.get", "storage.buckets.delete"], user_project: nil]
 
     storage.service.mocked_service = mock
     permissions = bucket.test_permissions "storage.buckets.get",
+                                           "storage.buckets.delete"
+    mock.verify
+
+    permissions.must_equal ["storage.buckets.get"]
+  end
+
+  it "tests the permissions available with user_pays set to true" do
+    mock = Minitest::Mock.new
+    update_policy_response = Google::Apis::StorageV1::TestIamPermissionsResponse.new permissions: ["storage.buckets.get"]
+    mock.expect :test_bucket_iam_permissions, update_policy_response, [bucket_name, ["storage.buckets.get", "storage.buckets.delete"], user_project: "test"]
+
+    storage.service.mocked_service = mock
+    permissions = bucket_user_pays.test_permissions "storage.buckets.get",
                                            "storage.buckets.delete"
     mock.verify
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -36,12 +36,13 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   let(:bucket_versioning) { true }
   let(:bucket_website_main) { "index.html" }
   let(:bucket_website_404) { "404.html" }
+  let(:bucket_requester_pays) { true }
   let(:bucket_labels) { { "env" => "production", "foo" => "bar" } }
   let :bucket_complete_hash do
     h = random_bucket_hash bucket_name, bucket_url_root,
                            bucket_location, bucket_storage_class, bucket_versioning,
                            bucket_logging_bucket, bucket_logging_prefix, bucket_website_main,
-                           bucket_website_404, bucket_cors
+                           bucket_website_404, bucket_cors, bucket_requester_pays
     h[:labels] = bucket_labels
     h
   end
@@ -70,6 +71,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     bucket_complete.versioning?.must_equal bucket_versioning
     bucket_complete.website_main.must_equal bucket_website_main
     bucket_complete.website_404.must_equal bucket_website_404
+    bucket_complete.requester_pays.must_equal bucket_requester_pays
   end
 
   it "knows its labels" do

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   let(:bucket_json) { bucket_hash.to_json }
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json bucket_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
-  let(:bucket_user_pays) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_pays: true }
+  let(:bucket_user_project) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_project: true }
 
   let(:bucket_name) { "new-bucket-#{Time.now.to_i}" }
   let(:bucket_url_root) { "https://www.googleapis.com/storage/v1" }
@@ -101,13 +101,13 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     mock.verify
   end
 
-  it "can delete itself with user_pays set to true" do
+  it "can delete itself with user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :delete_bucket, nil, [bucket_user_pays.name, user_project: "test"]
+    mock.expect :delete_bucket, nil, [bucket_user_project.name, user_project: "test"]
 
-    bucket_user_pays.service.mocked_service = mock
+    bucket_user_project.service.mocked_service = mock
 
-    bucket_user_pays.delete
+    bucket_user_project.delete
 
     mock.verify
   end
@@ -338,7 +338,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     end
   end
 
-  it "creates a file with user_pays set to true" do
+  it "creates a file with user_project set to true" do
     new_file_name = random_file_path
 
     Tempfile.open ["google-cloud", ".txt"] do |tmpfile|
@@ -346,12 +346,12 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
       tmpfile.rewind
 
       mock = Minitest::Mock.new
-      mock.expect :insert_object, create_file_gapi(bucket_user_pays.name, new_file_name),
-        [bucket_user_pays.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: "test", options: {}]
+      mock.expect :insert_object, create_file_gapi(bucket_user_project.name, new_file_name),
+        [bucket_user_project.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: "test", options: {}]
 
-      bucket_user_pays.service.mocked_service = mock
+      bucket_user_project.service.mocked_service = mock
 
-      bucket_user_pays.create_file tmpfile, new_file_name
+      bucket_user_project.create_file tmpfile, new_file_name
 
       mock.verify
     end
@@ -703,16 +703,16 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     files.count.must_equal 6
   end
 
-  it "paginates files with all and user_pays set to true" do
+  it "paginates files with all and user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket_user_pays.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test"]
+      [bucket_user_project.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test"]
     mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
-      [bucket_user_pays.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test"]
+      [bucket_user_project.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test"]
 
-    bucket_user_pays.service.mocked_service = mock
+    bucket_user_project.service.mocked_service = mock
 
-    files = bucket_user_pays.files.all(request_limit: 1).to_a
+    files = bucket_user_project.files.all(request_limit: 1).to_a
 
     mock.verify
 
@@ -784,16 +784,16 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     file.name.must_equal file_name
   end
 
-  it "finds a file with user_pays set to true" do
+  it "finds a file with user_project set to true" do
     file_name = "file.ext"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, find_file_gapi(bucket_user_pays.name, file_name),
-      [bucket_user_pays.name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :get_object, find_file_gapi(bucket_user_project.name, file_name),
+      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
 
-    bucket_user_pays.service.mocked_service = mock
+    bucket_user_project.service.mocked_service = mock
 
-    file = bucket_user_pays.file file_name
+    file = bucket_user_project.file file_name
 
     mock.verify
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -21,6 +21,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   let(:bucket_json) { bucket_hash.to_json }
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json bucket_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
+  let(:bucket_user_pays) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_pays: true }
 
   let(:bucket_name) { "new-bucket-#{Time.now.to_i}" }
   let(:bucket_url_root) { "https://www.googleapis.com/storage/v1" }
@@ -91,11 +92,22 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_bucket, nil, [bucket.name]
+    mock.expect :delete_bucket, nil, [bucket.name, user_project: nil]
 
     bucket.service.mocked_service = mock
 
     bucket.delete
+
+    mock.verify
+  end
+
+  it "can delete itself with user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_bucket, nil, [bucket_user_pays.name, user_project: "test"]
+
+    bucket_user_pays.service.mocked_service = mock
+
+    bucket_user_pays.delete
 
     mock.verify
   end
@@ -109,7 +121,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: {}]
+        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -128,7 +140,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: {}]
+        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -147,7 +159,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: {}]
+        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -163,7 +175,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-      [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: new_file_contents, content_encoding: nil, content_type: "text/plain", options: {}]
+      [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: new_file_contents, content_encoding: nil, content_type: "text/plain", user_project: nil, options: {}]
 
     bucket.service.mocked_service = mock
 
@@ -188,7 +200,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "private", upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: {}]
+        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "private", upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -207,7 +219,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "publicRead", upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: {}]
+        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "publicRead", upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -226,7 +238,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(md5: "HXB937GQDFxDFqUGi//weQ=="), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: {}]
+        [bucket.name, empty_file_gapi(md5: "HXB937GQDFxDFqUGi//weQ=="), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -245,7 +257,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(crc32c: "Lm1F3g=="), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: {}]
+        [bucket.name, empty_file_gapi(crc32c: "Lm1F3g=="), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -273,7 +285,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(options), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type], options: {}]
+        [bucket.name, empty_file_gapi(options), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type], user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -297,7 +309,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(metadata: metadata), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: {}]
+        [bucket.name, empty_file_gapi(metadata: metadata), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -316,11 +328,30 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", options: key_options]
+        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: nil, options: key_options]
 
       bucket.service.mocked_service = mock
 
       bucket.create_file tmpfile, new_file_name, encryption_key: encryption_key
+
+      mock.verify
+    end
+  end
+
+  it "creates a file with user_pays set to true" do
+    new_file_name = random_file_path
+
+    Tempfile.open ["google-cloud", ".txt"] do |tmpfile|
+      tmpfile.write "Hello world"
+      tmpfile.rewind
+
+      mock = Minitest::Mock.new
+      mock.expect :insert_object, create_file_gapi(bucket_user_pays.name, new_file_name),
+        [bucket_user_pays.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", user_project: "test", options: {}]
+
+      bucket_user_pays.service.mocked_service = mock
+
+      bucket_user_pays.create_file tmpfile, new_file_name
 
       mock.verify
     end
@@ -342,7 +373,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(num_files),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -358,7 +389,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(num_files),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -372,7 +403,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "lists files with prefix set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, nil, ["/prefix/path1/", "/prefix/path2/"]),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -389,7 +420,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "lists files with delimiter set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, nil, ["/prefix/path1/", "/prefix/path2/"]),
-      [bucket.name, delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -406,7 +437,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "lists files with max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -422,7 +453,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "lists files with versions set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -436,9 +467,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -458,9 +489,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -479,9 +510,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next and prefix set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -500,9 +531,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next and delimiter set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: "/", max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil]
+      [bucket.name, delimiter: "/", max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -521,9 +552,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next and max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -542,9 +573,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next and versions set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -563,9 +594,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -579,9 +610,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and prefix set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -595,9 +626,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and delimiter set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: "/", max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil]
+      [bucket.name, delimiter: "/", max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -611,9 +642,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -627,9 +658,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and versions set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil]
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -643,9 +674,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all using Enumerator" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -659,13 +690,29 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and request_limit set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil]
     mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
-      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil]
+      [bucket.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
     files = bucket.files.all(request_limit: 1).to_a
+
+    mock.verify
+
+    files.count.must_equal 6
+  end
+
+  it "paginates files with all and user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
+      [bucket_user_pays.name, delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test"]
+    mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
+      [bucket_user_pays.name, delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test"]
+
+    bucket_user_pays.service.mocked_service = mock
+
+    files = bucket_user_pays.files.all(request_limit: 1).to_a
 
     mock.verify
 
@@ -677,7 +724,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: nil, options: {}]
+      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
 
     bucket.service.mocked_service = mock
 
@@ -693,7 +740,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: nil, options: {}]
+      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
 
     bucket.service.mocked_service = mock
 
@@ -710,7 +757,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: generation, options: {}]
+      [bucket.name, file_name, generation: generation, user_project: nil, options: {}]
 
     bucket.service.mocked_service = mock
 
@@ -726,11 +773,27 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: nil, options: key_options]
+      [bucket.name, file_name, generation: nil, user_project: nil, options: key_options]
 
     bucket.service.mocked_service = mock
 
     file = bucket.file file_name, encryption_key: encryption_key
+
+    mock.verify
+
+    file.name.must_equal file_name
+  end
+
+  it "finds a file with user_pays set to true" do
+    file_name = "file.ext"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_object, find_file_gapi(bucket_user_pays.name, file_name),
+      [bucket_user_pays.name, file_name, generation: nil, user_project: "test", options: {}]
+
+    bucket_user_pays.service.mocked_service = mock
+
+    file = bucket_user_pays.file file_name
 
     mock.verify
 
@@ -743,9 +806,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_bucket, Google::Apis::StorageV1::Bucket.from_json(random_bucket_hash(bucket_name).to_json),
-      [bucket_name]
+      [bucket_name, {user_project: nil}]
     mock.expect :get_bucket, Google::Apis::StorageV1::Bucket.from_json(random_bucket_hash(bucket_name, new_url_root).to_json),
-      [bucket_name]
+      [bucket_name, {user_project: nil}]
 
     bucket.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -61,7 +61,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     mock.verify
   end
 
-  it "updates its versioning with user_pays set to true" do
+  it "updates its versioning with user_project set to true" do
     mock = Minitest::Mock.new
     patch_versioning_gapi = Google::Apis::StorageV1::Bucket::Versioning.new enabled: true
     patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new versioning: patch_versioning_gapi
@@ -71,7 +71,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: "test"]
 
     bucket.service.mocked_service = mock
-    bucket.user_pays = true
+    bucket.user_project = true
 
     bucket.versioning?.must_equal nil
     bucket.versioning = true

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -26,6 +26,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
   let(:bucket_logging_prefix) { "AccessLog" }
   let(:bucket_website_main) { "index.html" }
   let(:bucket_website_404) { "404.html" }
+  let(:bucket_requester_pays) { true }
   let(:bucket_cors_gapi) { Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
     max_age_seconds: 300,
     origin: ["http://example.org", "https://example.org"],
@@ -182,6 +183,24 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     mock.verify
   end
 
+  it "updates its requester pays" do
+    mock = Minitest::Mock.new
+    patch_billing_gapi = Google::Apis::StorageV1::Bucket::Billing.new requester_pays: bucket_requester_pays
+    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new billing: patch_billing_gapi
+    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [], bucket_requester_pays).to_json
+    mock.expect :patch_bucket, returned_bucket_gapi,
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+
+    bucket.service.mocked_service = mock
+
+    bucket.requester_pays.must_equal nil
+    bucket.requester_pays = bucket_requester_pays
+    bucket.requester_pays.must_equal bucket_requester_pays
+
+    mock.verify
+  end
+
   it "cannot modify its labels" do
     bucket.labels.must_equal Hash.new
     assert_raises do
@@ -213,8 +232,9 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     patch_versioning_gapi = Google::Apis::StorageV1::Bucket::Versioning.new enabled: true
     patch_logging_gapi = Google::Apis::StorageV1::Bucket::Logging.new log_bucket: bucket_logging_bucket, log_object_prefix: bucket_logging_prefix
     patch_website_gapi = Google::Apis::StorageV1::Bucket::Website.new main_page_suffix: bucket_website_main, not_found_page: bucket_website_404
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(versioning: patch_versioning_gapi, logging: patch_logging_gapi, website: patch_website_gapi, labels: { "env" => "production" })
-    returned_bucket_hash = random_bucket_hash bucket_name, bucket_url, bucket_location, bucket_storage_class, true, bucket_logging_bucket, bucket_logging_prefix, bucket_website_main, bucket_website_404
+    patch_billing_gapi = Google::Apis::StorageV1::Bucket::Billing.new requester_pays: bucket_requester_pays
+    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(versioning: patch_versioning_gapi, logging: patch_logging_gapi, website: patch_website_gapi, billing: patch_billing_gapi, labels: { "env" => "production" })
+    returned_bucket_hash = random_bucket_hash bucket_name, bucket_url, bucket_location, bucket_storage_class, true, bucket_logging_bucket, bucket_logging_prefix, bucket_website_main, bucket_website_404, [], bucket_requester_pays
     returned_bucket_hash[:labels] = { "env" => "production" }
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json returned_bucket_hash.to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
@@ -227,6 +247,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     bucket.logging_prefix.must_equal nil
     bucket.website_main.must_equal nil
     bucket.website_404.must_equal nil
+    bucket.requester_pays.must_equal nil
     bucket.labels.must_equal Hash.new
 
     bucket.update do |b|
@@ -235,6 +256,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       b.logging_bucket = bucket_logging_bucket
       b.website_main = bucket_website_main
       b.website_404 = bucket_website_404
+      b.requester_pays = bucket_requester_pays
       b.labels["env"] = "production"
     end
 
@@ -243,6 +265,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     bucket.logging_prefix.must_equal bucket_logging_prefix
     bucket.website_main.must_equal bucket_website_main
     bucket.website_404.must_equal bucket_website_404
+    bucket.requester_pays.must_equal bucket_requester_pays
     bucket.labels.must_equal({ "env" => "production" })
 
     mock.verify

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -50,9 +50,28 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, true).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
+
+    bucket.versioning?.must_equal nil
+    bucket.versioning = true
+    bucket.versioning?.must_equal true
+
+    mock.verify
+  end
+
+  it "updates its versioning with user_pays set to true" do
+    mock = Minitest::Mock.new
+    patch_versioning_gapi = Google::Apis::StorageV1::Bucket::Versioning.new enabled: true
+    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new versioning: patch_versioning_gapi
+    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, true).to_json
+    mock.expect :patch_bucket, returned_bucket_gapi,
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: "test"]
+
+    bucket.service.mocked_service = mock
+    bucket.user_pays = true
 
     bucket.versioning?.must_equal nil
     bucket.versioning = true
@@ -68,7 +87,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, bucket_logging_bucket).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -86,7 +105,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, bucket_logging_prefix).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -104,7 +123,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, bucket_logging_bucket, bucket_logging_prefix).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi.class, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi.class, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -129,7 +148,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, bucket_website_main).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -147,7 +166,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, bucket_website_404).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -165,7 +184,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, bucket_website_main, bucket_website_404).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -190,7 +209,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [], bucket_requester_pays).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -216,7 +235,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_hash[:labels] = new_labels
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json returned_bucket_hash.to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -238,7 +257,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_hash[:labels] = { "env" => "production" }
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json returned_bucket_hash.to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
 
     bucket.service.mocked_service = mock
 
@@ -277,7 +296,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     bucket.service.mocked_service = mock
 
     bucket.cors.must_equal []
@@ -311,7 +330,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     bucket_with_cors.service.mocked_service = mock
 
     bucket_with_cors.cors.must_be :frozen?
@@ -347,7 +366,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     bucket_with_cors.service.mocked_service = mock
 
     bucket_with_cors.update do |b|
@@ -383,7 +402,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     bucket.service.mocked_service = mock
 
     returned_cors = bucket.cors do |c|
@@ -412,7 +431,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
     mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil]
+      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
     bucket.service.mocked_service = mock
 
     bucket_with_cors.cors.size.must_equal 1

--- a/google-cloud-storage/test/google/cloud/storage/default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/default_acl_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     mock.verify
   end
 
-  it "retrieves the default ACL with user_pays set to true" do
+  it "retrieves the default ACL with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :get_bucket, bucket_gapi, [bucket_name, {user_project: "test"}]
     mock.expect :list_default_object_access_controls,
@@ -49,7 +49,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    bucket = storage.bucket bucket_name, user_pays: true
+    bucket = storage.bucket bucket_name, user_project: true
     bucket.name.must_equal bucket_name
     bucket.default_acl.owners.wont_be  :empty?
     bucket.default_acl.readers.wont_be :empty?
@@ -94,7 +94,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     mock.verify
   end
 
-  it "adds to the default ACL with user_pays set to true" do
+  it "adds to the default ACL with user_project set to true" do
     reader_entity = "user-user@example.net"
     reader_acl = {
        "kind" => "storage#bucketAccessControl",
@@ -118,7 +118,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    bucket = storage.bucket bucket_name, user_pays: true
+    bucket = storage.bucket bucket_name, user_project: true
     bucket.name.must_equal bucket_name
     bucket.default_acl.owners.wont_be  :empty?
     bucket.default_acl.readers.wont_be :empty?
@@ -157,7 +157,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     mock.verify
   end
 
-  it "removes from the default ACL with user_pays set to true" do
+  it "removes from the default ACL with user_project set to true" do
     existing_reader_entity = "project-viewers-1234567890"
 
     mock = Minitest::Mock.new
@@ -170,7 +170,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    bucket = storage.bucket bucket_name, user_pays: true
+    bucket = storage.bucket bucket_name, user_project: true
     bucket.name.must_equal bucket_name
     bucket.default_acl.owners.wont_be  :empty?
     bucket.default_acl.readers.wont_be :empty?

--- a/google-cloud-storage/test/google/cloud/storage/default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/default_acl_test.rb
@@ -25,14 +25,31 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
 
   it "retrieves the default ACL" do
     mock = Minitest::Mock.new
-    mock.expect :get_bucket, bucket_gapi, [bucket_name]
+    mock.expect :get_bucket, bucket_gapi, [bucket_name, {user_project: nil}]
     mock.expect :list_default_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
-      [bucket_name]
+      [bucket_name, user_project: nil]
 
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
+    bucket.name.must_equal bucket_name
+    bucket.default_acl.owners.wont_be  :empty?
+    bucket.default_acl.readers.wont_be :empty?
+
+    mock.verify
+  end
+
+  it "retrieves the default ACL with user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket, bucket_gapi, [bucket_name, {user_project: "test"}]
+    mock.expect :list_default_object_access_controls,
+      Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
+      [bucket_name, user_project: "test"]
+
+    storage.service.mocked_service = mock
+
+    bucket = storage.bucket bucket_name, user_pays: true
     bucket.name.must_equal bucket_name
     bucket.default_acl.owners.wont_be  :empty?
     bucket.default_acl.readers.wont_be :empty?
@@ -54,13 +71,13 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
       }
 
     mock = Minitest::Mock.new
-    mock.expect :get_bucket, bucket_gapi, [bucket_name]
+    mock.expect :get_bucket, bucket_gapi, [bucket_name, {user_project: nil}]
     mock.expect :list_default_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
-      [bucket_name]
+      [bucket_name, user_project: nil]
     mock.expect :insert_default_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")]
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER"), user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -77,20 +94,83 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     mock.verify
   end
 
+  it "adds to the default ACL with user_pays set to true" do
+    reader_entity = "user-user@example.net"
+    reader_acl = {
+       "kind" => "storage#bucketAccessControl",
+       "id" => "#{bucket_name}-UUID/#{reader_entity}",
+       "selfLink" => "https://www.googleapis.com/storage/v1/b/#{bucket_name}-UUID/acl/#{reader_entity}",
+       "bucket" => "#{bucket_name}-UUID",
+       "entity" => reader_entity,
+       "email" => "user@example.net",
+       "role" => "READER",
+       "etag" => "CAE="
+      }
+
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket, bucket_gapi, [bucket_name, {user_project: "test"}]
+    mock.expect :list_default_object_access_controls,
+      Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
+      [bucket_name, user_project: "test"]
+    mock.expect :insert_default_object_access_control,
+      Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER"), user_project: "test"]
+
+    storage.service.mocked_service = mock
+
+    bucket = storage.bucket bucket_name, user_pays: true
+    bucket.name.must_equal bucket_name
+    bucket.default_acl.owners.wont_be  :empty?
+    bucket.default_acl.readers.wont_be :empty?
+
+    bucket.default_acl.add_reader reader_entity
+    bucket.default_acl.owners.wont_be  :empty?
+    bucket.default_acl.readers.wont_be :empty?
+    bucket.default_acl.readers.must_include reader_entity
+
+    mock.verify
+  end
+
   it "removes from the default ACL" do
     existing_reader_entity = "project-viewers-1234567890"
 
     mock = Minitest::Mock.new
-    mock.expect :get_bucket, bucket_gapi, [bucket_name]
+    mock.expect :get_bucket, bucket_gapi, [bucket_name, {user_project: nil}]
     mock.expect :list_default_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
-      [bucket_name]
+      [bucket_name, user_project: nil]
     mock.expect :delete_default_object_access_control, nil,
-      [bucket_name, existing_reader_entity]
+      [bucket_name, existing_reader_entity, user_project: nil]
 
     storage.service.mocked_service = mock
 
     bucket = storage.bucket bucket_name
+    bucket.name.must_equal bucket_name
+    bucket.default_acl.owners.wont_be  :empty?
+    bucket.default_acl.readers.wont_be :empty?
+
+    reader_entity = bucket.default_acl.readers.first
+    bucket.default_acl.delete reader_entity
+    bucket.default_acl.owners.wont_be  :empty?
+    bucket.default_acl.readers.must_be :empty?
+
+    mock.verify
+  end
+
+  it "removes from the default ACL with user_pays set to true" do
+    existing_reader_entity = "project-viewers-1234567890"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket, bucket_gapi, [bucket_name, {user_project: "test"}]
+    mock.expect :list_default_object_access_controls,
+      Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
+      [bucket_name, user_project: "test"]
+    mock.expect :delete_default_object_access_control, nil,
+      [bucket_name, existing_reader_entity, user_project: "test"]
+
+    storage.service.mocked_service = mock
+
+    bucket = storage.bucket bucket_name, user_pays: true
     bucket.name.must_equal bucket_name
     bucket.default_acl.owners.wont_be  :empty?
     bucket.default_acl.readers.wont_be :empty?
@@ -287,7 +367,8 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
     mock = Minitest::Mock.new
     mock.expect :patch_bucket,
       Google::Apis::StorageV1::Bucket.from_json(random_bucket_hash(bucket.name).to_json),
-      [bucket_name, Google::Apis::StorageV1::Bucket.new(default_object_acl: []), predefined_acl: nil, predefined_default_object_acl: acl_role]
+      [bucket_name, Google::Apis::StorageV1::Bucket.new(default_object_acl: []),
+       predefined_acl: nil, predefined_default_object_acl: acl_role, user_project: nil]
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
   let(:bucket_name) { "bucket" }
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash(bucket_name).to_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
-  let(:bucket_user_pays) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_pays: true }
+  let(:bucket_user_project) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_project: true }
 
   let(:file_name) { "file.ext" }
   let(:file_hash) { random_file_hash bucket.name, file_name }
@@ -44,7 +44,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     mock.verify
   end
 
-  it "retrieves the ACL with user_pays set to true" do
+  it "retrieves the ACL with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: "test", options: {}]
     mock.expect :list_object_access_controls,
@@ -53,7 +53,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    file = bucket_user_pays.file file_name
+    file = bucket_user_project.file file_name
     file.name.must_equal file_name
     file.acl.owners.wont_be  :empty?
     file.acl.readers.wont_be :empty?
@@ -136,7 +136,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     mock.verify
   end
 
-  it "adds to the ACL with user_pays set to true" do
+  it "adds to the ACL with user_project set to true" do
     reader_entity = "user-user@example.net"
     reader_acl = {
        "kind" => "storage#bucketAccessControl",
@@ -160,7 +160,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    file = bucket_user_pays.file file_name
+    file = bucket_user_project.file file_name
     file.name.must_equal file_name
     file.acl.owners.wont_be  :empty?
     file.acl.readers.wont_be :empty?
@@ -226,7 +226,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     mock.verify
   end
 
-  it "removes from the ACL with user_pays set to true" do
+  it "removes from the ACL with user_project set to true" do
     existing_reader_entity = "project-viewers-1234567890"
 
     mock = Minitest::Mock.new
@@ -239,7 +239,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    file = bucket_user_pays.file file_name
+    file = bucket_user_project.file file_name
     file.name.must_equal file_name
     file.acl.owners.wont_be  :empty?
     file.acl.readers.wont_be :empty?

--- a/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
@@ -20,6 +20,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
   let(:bucket_name) { "bucket" }
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash(bucket_name).to_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
+  let(:bucket_user_pays) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_pays: true }
 
   let(:file_name) { "file.ext" }
   let(:file_hash) { random_file_hash bucket.name, file_name }
@@ -28,14 +29,31 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
 
   it "retrieves the ACL" do
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, options: {}]
+    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name]
+      [bucket_name, file_name, user_project: nil]
 
     storage.service.mocked_service = mock
 
     file = bucket.file file_name
+    file.name.must_equal file_name
+    file.acl.owners.wont_be  :empty?
+    file.acl.readers.wont_be :empty?
+
+    mock.verify
+  end
+
+  it "retrieves the ACL with user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :list_object_access_controls,
+      Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
+      [bucket_name, file_name, user_project: "test"]
+
+    storage.service.mocked_service = mock
+
+    file = bucket_user_pays.file file_name
     file.name.must_equal file_name
     file.acl.owners.wont_be  :empty?
     file.acl.readers.wont_be :empty?
@@ -57,13 +75,13 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       }
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, options: {}]
+    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name]
+      [bucket_name, file_name, user_project: nil]
     mock.expect :insert_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER"), generation: nil]
+      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER"), generation: nil, user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -95,13 +113,13 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       }
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, options: {}]
+    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name]
+      [bucket_name, file_name, user_project: nil]
     mock.expect :insert_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER"), generation: generation]
+      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER"), generation: generation, user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -118,16 +136,53 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     mock.verify
   end
 
+  it "adds to the ACL with user_pays set to true" do
+    reader_entity = "user-user@example.net"
+    reader_acl = {
+       "kind" => "storage#bucketAccessControl",
+       "id" => "#{bucket_name}-UUID/#{reader_entity}",
+       "selfLink" => "https://www.googleapis.com/storage/v1/b/#{bucket_name}-UUID/acl/#{reader_entity}",
+       "bucket" => "#{bucket_name}-UUID",
+       "entity" => reader_entity,
+       "email" => "user@example.net",
+       "role" => "READER",
+       "etag" => "CAE="
+      }
+
+    mock = Minitest::Mock.new
+    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :list_object_access_controls,
+      Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
+      [bucket_name, file_name, user_project: "test"]
+    mock.expect :insert_object_access_control,
+      Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
+      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER"), generation: nil, user_project: "test"]
+
+    storage.service.mocked_service = mock
+
+    file = bucket_user_pays.file file_name
+    file.name.must_equal file_name
+    file.acl.owners.wont_be  :empty?
+    file.acl.readers.wont_be :empty?
+
+    file.acl.add_reader reader_entity
+    file.acl.owners.wont_be  :empty?
+    file.acl.readers.wont_be :empty?
+    file.acl.readers.must_include reader_entity
+
+    mock.verify
+  end
+
   it "removes from the ACL without generation" do
     existing_reader_entity = "project-viewers-1234567890"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, options: {}]
+    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name]
+      [bucket_name, file_name, user_project: nil]
     mock.expect :delete_object_access_control, nil,
-      [bucket_name, file_name, existing_reader_entity, generation: nil]
+      [bucket_name, file_name, existing_reader_entity, generation: nil, user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -149,12 +204,12 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     existing_reader_entity = "project-viewers-1234567890"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, options: {}]
+    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name]
+      [bucket_name, file_name, user_project: nil]
     mock.expect :delete_object_access_control, nil,
-      [bucket_name, file_name, existing_reader_entity, generation: generation]
+      [bucket_name, file_name, existing_reader_entity, generation: generation, user_project: nil]
 
     storage.service.mocked_service = mock
 
@@ -165,6 +220,32 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
 
     reader_entity = file.acl.readers.first
     file.acl.delete reader_entity, generation: generation
+    file.acl.owners.wont_be  :empty?
+    file.acl.readers.must_be :empty?
+
+    mock.verify
+  end
+
+  it "removes from the ACL with user_pays set to true" do
+    existing_reader_entity = "project-viewers-1234567890"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :list_object_access_controls,
+      Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
+      [bucket_name, file_name, user_project: "test"]
+    mock.expect :delete_object_access_control, nil,
+      [bucket_name, file_name, existing_reader_entity, generation: nil, user_project: "test"]
+
+    storage.service.mocked_service = mock
+
+    file = bucket_user_pays.file file_name
+    file.name.must_equal file_name
+    file.acl.owners.wont_be  :empty?
+    file.acl.readers.wont_be :empty?
+
+    reader_entity = file.acl.readers.first
+    file.acl.delete reader_entity
     file.acl.owners.wont_be  :empty?
     file.acl.readers.must_be :empty?
 
@@ -355,7 +436,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     mock = Minitest::Mock.new
     mock.expect :patch_object,
       Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::Bucket.new(acl: []), predefined_acl: acl_role]
+      [bucket_name, file_name, Google::Apis::StorageV1::Bucket.new(acl: []), predefined_acl: acl_role, user_project: nil]
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -19,10 +19,12 @@ require "uri"
 describe Google::Cloud::Storage::File, :mock_storage do
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash("bucket").to_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
+  let(:bucket_user_pays) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_pays: true }
 
   let(:file_hash) { random_file_hash bucket.name, "file.ext" }
   let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
+  let(:file_user_pays) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_pays: true }
 
   let(:encryption_key) { "y\x03\"\x0E\xB6\xD3\x9B\x0E\xAB*\x19\xFAv\xDEY\xBEI\xF8ftA|[z\x1A\xFBE\xDE\x97&\xBC\xC7" }
   let(:encryption_key_sha256) { "5\x04_\xDF\x1D\x8A_d\xFEK\e6p[XZz\x13s]E\xF6\xBB\x10aQH\xF6o\x14f\xF9" }
@@ -83,11 +85,22 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket.name, file.name]
+    mock.expect :delete_object, nil, [bucket.name, file.name, { user_project: nil }]
 
     file.service.mocked_service = mock
 
     file.delete
+
+    mock.verify
+  end
+
+  it "can delete itself with user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_object, nil, [bucket.name, file_user_pays.name, { user_project: "test" }]
+
+    file_user_pays.service.mocked_service = mock
+
+    file_user_pays.delete
 
     mock.verify
   end
@@ -104,7 +117,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :get_object, tmpfile,
-        [bucket.name, file.name, download_dest: tmpfile, generation: nil, options: {}]
+        [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
@@ -127,11 +140,34 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :get_object, tmpfile,
-        [bucket.name, file.name, download_dest: tmpfile.path, generation: nil, options: {}]
+        [bucket.name, file.name, download_dest: tmpfile.path, generation: nil, user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile.path
+      downloaded.must_be_kind_of File
+
+      mock.verify
+    end
+  end
+
+  it "can download itself to a file with user_pays set to true" do
+    # Stub the md5 to match.
+    def file_user_pays.md5
+      "1B2M2Y8AsgTpgAmY7PhCfg=="
+    end
+
+    Tempfile.open "google-cloud" do |tmpfile|
+      # write to the file since the mocked call won't
+      tmpfile.write "yay!"
+
+      mock = Minitest::Mock.new
+      mock.expect :get_object, tmpfile,
+        [bucket.name, file_user_pays.name, download_dest: tmpfile, generation: nil, user_project: "test", options: {}]
+
+      bucket.service.mocked_service = mock
+
+      downloaded = file_user_pays.download tmpfile
       downloaded.must_be_kind_of File
 
       mock.verify
@@ -188,7 +224,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :get_object, nil, # using encryption keys seems to return nil
-        [bucket.name, file.name, download_dest: tmpfile, generation: nil, options: key_options]
+        [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: key_options]
 
       bucket.service.mocked_service = mock
 
@@ -208,7 +244,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
         mock.expect :get_object, tmpfile,
-          [bucket.name, file.name, download_dest: tmpfile, generation: nil, options: {}]
+          [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
 
@@ -235,7 +271,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
         mock.expect :get_object, tmpfile,
-          [bucket.name, file.name, download_dest: tmpfile, generation: nil, options: {}]
+          [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
 
@@ -262,7 +298,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
         mock.expect :get_object, tmpfile,
-          [bucket.name, file.name, download_dest: tmpfile, generation: nil, options: {}]
+          [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
 
@@ -289,7 +325,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
         mock.expect :get_object, tmpfile,
-          [bucket.name, file.name, download_dest: tmpfile, generation: nil, options: {}]
+          [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
 
@@ -320,7 +356,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
         mock.expect :get_object, tmpfile,
-          [bucket.name, file.name, download_dest: tmpfile, generation: nil, options: {}]
+          [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
 
@@ -345,7 +381,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
         mock.expect :get_object, tmpfile,
-          [bucket.name, file.name, download_dest: tmpfile.path, generation: nil, options: {}]
+          [bucket.name, file.name, download_dest: tmpfile.path, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
 
@@ -370,7 +406,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself in the same bucket" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -382,7 +418,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself in the same bucket with generation" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -394,7 +430,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself in the same bucket with predefined ACL" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -406,7 +442,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself in the same bucket with ACL alias" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -418,7 +454,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself with customer-supplied encryption key" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: copy_key_options]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: copy_key_options]
 
     file.service.mocked_service = mock
 
@@ -427,10 +463,22 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
+  it "can copy itself with user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :rewrite_object, done_rewrite(file_gapi),
+      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+
+    file_user_pays.service.mocked_service = mock
+
+    file_user_pays.copy "new-file.ext"
+
+    mock.verify
+  end
+
   it "can copy itself to a different bucket" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -442,7 +490,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself to a different bucket with generation" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -454,7 +502,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself to a different bucket with predefined ACL" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -466,7 +514,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself to a different bucket with ACL alias" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -478,7 +526,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself to a different bucket with customer-supplied encryption key" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: copy_key_options]
+      [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: copy_key_options]
 
     file.service.mocked_service = mock
 
@@ -490,13 +538,13 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can copy itself calling rewrite multiple times" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: nil, options: {}]
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: nil, options: {}]
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -505,6 +553,28 @@ describe Google::Cloud::Storage::File, :mock_storage do
     end
 
     file.copy "new-file.ext"
+
+    mock.verify
+  end
+
+  it "can copy itself calling rewrite multiple times with user_pays set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
+      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+    mock.expect :rewrite_object, undone_rewrite("keeptrying"),
+      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
+    mock.expect :rewrite_object, undone_rewrite("almostthere"),
+      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
+    mock.expect :rewrite_object, done_rewrite(file_gapi),
+      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
+
+    file_user_pays.service.mocked_service = mock
+
+    # mock out sleep to make the test run faster
+    def file_user_pays.sleep *args
+    end
+
+    file_user_pays.copy "new-file.ext"
 
     mock.verify
   end
@@ -521,11 +591,41 @@ describe Google::Cloud::Storage::File, :mock_storage do
       storage_class: "NEARLINE"
     )
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
     file.copy "new-file.ext" do |f|
+      f.cache_control = "private, max-age=0, no-cache"
+      f.content_disposition = "inline; filename=filename.ext"
+      f.content_encoding = "deflate"
+      f.content_language = "de"
+      f.content_type = "application/json"
+      f.metadata["player"] = "Bob"
+      f.metadata["score"] = "10"
+      f.storage_class = :nearline
+    end
+
+    mock.verify
+  end
+
+  it "can copy itself while updating its attributes with user_pays set to true" do
+    mock = Minitest::Mock.new
+    update_file_gapi = Google::Apis::StorageV1::Object.new(
+      cache_control: "private, max-age=0, no-cache",
+      content_disposition: "inline; filename=filename.ext",
+      content_encoding: "deflate",
+      content_language: "de",
+      content_type: "application/json",
+      metadata: { "player" => "Bob", "score" => "10" },
+      storage_class: "NEARLINE"
+    )
+    mock.expect :rewrite_object, done_rewrite(file_gapi),
+      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", update_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+
+    file_user_pays.service.mocked_service = mock
+
+    file_user_pays.copy "new-file.ext" do |f|
       f.cache_control = "private, max-age=0, no-cache"
       f.content_disposition = "inline; filename=filename.ext"
       f.content_encoding = "deflate"
@@ -545,12 +645,28 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.expect :rewrite_object, done_rewrite(file_gapi),
                 [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, options: options ]
+                 rewrite_token: nil, user_project: nil, options: options ]
 
     file.service.mocked_service = mock
 
     updated = file.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
     updated.name.must_equal file.name
+
+    mock.verify
+  end
+
+  it "can rotate its customer-supplied encryption keys with user_pays set to true" do
+    mock = Minitest::Mock.new
+    options = { header: source_key_headers.merge(key_headers) }
+    mock.expect :rewrite_object, done_rewrite(file_gapi),
+                [bucket.name, file_user_pays.name, bucket.name, file_user_pays.name, nil,
+                 destination_predefined_acl: nil, source_generation: nil,
+                 rewrite_token: nil, user_project: "test", options: options ]
+
+    file_user_pays.service.mocked_service = mock
+
+    updated = file_user_pays.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
+    updated.name.must_equal file_user_pays.name
 
     mock.verify
   end
@@ -561,7 +677,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.expect :rewrite_object, done_rewrite(file_gapi),
                 [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, options: options ]
+                 rewrite_token: nil, user_project: nil, options: options ]
 
     file.service.mocked_service = mock
 
@@ -577,7 +693,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.expect :rewrite_object, done_rewrite(file_gapi),
                 [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, options: options ]
+                 rewrite_token: nil, user_project: nil, options: options ]
 
     file.service.mocked_service = mock
 
@@ -593,11 +709,11 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
                 [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, options: options ]
+                 rewrite_token: nil, user_project: nil, options: options ]
     mock.expect :rewrite_object, done_rewrite(file_gapi),
                 [bucket.name, file.name, bucket.name, file.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: "notyetcomplete", options: options ]
+                 rewrite_token: "notyetcomplete", user_project: nil, options: options ]
 
     file.service.mocked_service = mock
 
@@ -611,19 +727,63 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
+  it "can rotate its customer-supplied encryption keys with multiple requests for large objects with user_pays set to true" do
+    mock = Minitest::Mock.new
+    options = { header: source_key_headers.merge(key_headers) }
+    mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
+                [bucket.name, file_user_pays.name, bucket.name, file_user_pays.name, nil,
+                 destination_predefined_acl: nil, source_generation: nil,
+                 rewrite_token: nil, user_project: "test", options: options ]
+    mock.expect :rewrite_object, done_rewrite(file_gapi),
+                [bucket.name, file_user_pays.name, bucket.name, file_user_pays.name, nil,
+                 destination_predefined_acl: nil, source_generation: nil,
+                 rewrite_token: "notyetcomplete", user_project: "test", options: options ]
+
+    file_user_pays.service.mocked_service = mock
+
+    # mock out sleep to make the test run faster
+    def file_user_pays.sleep *args
+    end
+
+    updated = file_user_pays.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
+    updated.name.must_equal file_user_pays.name
+
+    mock.verify
+  end
+
   it "can reload itself" do
     file_name = "file.ext"
 
     mock = Minitest::Mock.new
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567891).to_json),
-      [bucket.name, file_name, generation: nil, options: {}]
+      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567892).to_json),
-      [bucket.name, file_name, generation: nil, options: {}]
+      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
 
     bucket.service.mocked_service = mock
     file.service.mocked_service = mock
 
     file = bucket.file file_name
+    file.generation.must_equal 1234567891
+    file.reload!
+    file.generation.must_equal 1234567892
+
+    mock.verify
+  end
+
+  it "can reload itself with user_pays set to true" do
+    file_name = "file.ext"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_pays.name, file_name, 1234567891).to_json),
+      [bucket_user_pays.name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_pays.name, file_name, 1234567892).to_json),
+      [bucket_user_pays.name, file_name, generation: nil, user_project: "test", options: {}]
+
+    bucket_user_pays.service.mocked_service = mock
+    file.service.mocked_service = mock
+
+    file = bucket_user_pays.file file_name
     file.generation.must_equal 1234567891
     file.reload!
     file.generation.must_equal 1234567892

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -19,12 +19,12 @@ require "uri"
 describe Google::Cloud::Storage::File, :mock_storage do
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash("bucket").to_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
-  let(:bucket_user_pays) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_pays: true }
+  let(:bucket_user_project) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_project: true }
 
   let(:file_hash) { random_file_hash bucket.name, "file.ext" }
   let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
-  let(:file_user_pays) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_pays: true }
+  let(:file_user_project) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_project: true }
 
   let(:encryption_key) { "y\x03\"\x0E\xB6\xD3\x9B\x0E\xAB*\x19\xFAv\xDEY\xBEI\xF8ftA|[z\x1A\xFBE\xDE\x97&\xBC\xC7" }
   let(:encryption_key_sha256) { "5\x04_\xDF\x1D\x8A_d\xFEK\e6p[XZz\x13s]E\xF6\xBB\x10aQH\xF6o\x14f\xF9" }
@@ -94,13 +94,13 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
-  it "can delete itself with user_pays set to true" do
+  it "can delete itself with user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket.name, file_user_pays.name, { user_project: "test" }]
+    mock.expect :delete_object, nil, [bucket.name, file_user_project.name, { user_project: "test" }]
 
-    file_user_pays.service.mocked_service = mock
+    file_user_project.service.mocked_service = mock
 
-    file_user_pays.delete
+    file_user_project.delete
 
     mock.verify
   end
@@ -151,9 +151,9 @@ describe Google::Cloud::Storage::File, :mock_storage do
     end
   end
 
-  it "can download itself to a file with user_pays set to true" do
+  it "can download itself to a file with user_project set to true" do
     # Stub the md5 to match.
-    def file_user_pays.md5
+    def file_user_project.md5
       "1B2M2Y8AsgTpgAmY7PhCfg=="
     end
 
@@ -163,11 +163,11 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :get_object, tmpfile,
-        [bucket.name, file_user_pays.name, download_dest: tmpfile, generation: nil, user_project: "test", options: {}]
+        [bucket.name, file_user_project.name, download_dest: tmpfile, generation: nil, user_project: "test", options: {}]
 
       bucket.service.mocked_service = mock
 
-      downloaded = file_user_pays.download tmpfile
+      downloaded = file_user_project.download tmpfile
       downloaded.must_be_kind_of File
 
       mock.verify
@@ -463,14 +463,14 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
-  it "can copy itself with user_pays set to true" do
+  it "can copy itself with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
 
-    file_user_pays.service.mocked_service = mock
+    file_user_project.service.mocked_service = mock
 
-    file_user_pays.copy "new-file.ext"
+    file_user_project.copy "new-file.ext"
 
     mock.verify
   end
@@ -557,24 +557,24 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
-  it "can copy itself calling rewrite multiple times with user_pays set to true" do
+  it "can copy itself calling rewrite multiple times with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
+      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
+      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
+      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
 
-    file_user_pays.service.mocked_service = mock
+    file_user_project.service.mocked_service = mock
 
     # mock out sleep to make the test run faster
-    def file_user_pays.sleep *args
+    def file_user_project.sleep *args
     end
 
-    file_user_pays.copy "new-file.ext"
+    file_user_project.copy "new-file.ext"
 
     mock.verify
   end
@@ -609,7 +609,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
-  it "can copy itself while updating its attributes with user_pays set to true" do
+  it "can copy itself while updating its attributes with user_project set to true" do
     mock = Minitest::Mock.new
     update_file_gapi = Google::Apis::StorageV1::Object.new(
       cache_control: "private, max-age=0, no-cache",
@@ -621,11 +621,11 @@ describe Google::Cloud::Storage::File, :mock_storage do
       storage_class: "NEARLINE"
     )
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-      [bucket.name, file_user_pays.name, bucket.name, "new-file.ext", update_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
 
-    file_user_pays.service.mocked_service = mock
+    file_user_project.service.mocked_service = mock
 
-    file_user_pays.copy "new-file.ext" do |f|
+    file_user_project.copy "new-file.ext" do |f|
       f.cache_control = "private, max-age=0, no-cache"
       f.content_disposition = "inline; filename=filename.ext"
       f.content_encoding = "deflate"
@@ -655,18 +655,18 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
-  it "can rotate its customer-supplied encryption keys with user_pays set to true" do
+  it "can rotate its customer-supplied encryption keys with user_project set to true" do
     mock = Minitest::Mock.new
     options = { header: source_key_headers.merge(key_headers) }
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-                [bucket.name, file_user_pays.name, bucket.name, file_user_pays.name, nil,
+                [bucket.name, file_user_project.name, bucket.name, file_user_project.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
                  rewrite_token: nil, user_project: "test", options: options ]
 
-    file_user_pays.service.mocked_service = mock
+    file_user_project.service.mocked_service = mock
 
-    updated = file_user_pays.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-    updated.name.must_equal file_user_pays.name
+    updated = file_user_project.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
+    updated.name.must_equal file_user_project.name
 
     mock.verify
   end
@@ -727,26 +727,26 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
-  it "can rotate its customer-supplied encryption keys with multiple requests for large objects with user_pays set to true" do
+  it "can rotate its customer-supplied encryption keys with multiple requests for large objects with user_project set to true" do
     mock = Minitest::Mock.new
     options = { header: source_key_headers.merge(key_headers) }
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-                [bucket.name, file_user_pays.name, bucket.name, file_user_pays.name, nil,
+                [bucket.name, file_user_project.name, bucket.name, file_user_project.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
                  rewrite_token: nil, user_project: "test", options: options ]
     mock.expect :rewrite_object, done_rewrite(file_gapi),
-                [bucket.name, file_user_pays.name, bucket.name, file_user_pays.name, nil,
+                [bucket.name, file_user_project.name, bucket.name, file_user_project.name, nil,
                  destination_predefined_acl: nil, source_generation: nil,
                  rewrite_token: "notyetcomplete", user_project: "test", options: options ]
 
-    file_user_pays.service.mocked_service = mock
+    file_user_project.service.mocked_service = mock
 
     # mock out sleep to make the test run faster
-    def file_user_pays.sleep *args
+    def file_user_project.sleep *args
     end
 
-    updated = file_user_pays.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
-    updated.name.must_equal file_user_pays.name
+    updated = file_user_project.rotate encryption_key: source_encryption_key, new_encryption_key: encryption_key
+    updated.name.must_equal file_user_project.name
 
     mock.verify
   end
@@ -771,19 +771,19 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
-  it "can reload itself with user_pays set to true" do
+  it "can reload itself with user_project set to true" do
     file_name = "file.ext"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_pays.name, file_name, 1234567891).to_json),
-      [bucket_user_pays.name, file_name, generation: nil, user_project: "test", options: {}]
-    mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_pays.name, file_name, 1234567892).to_json),
-      [bucket_user_pays.name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_project.name, file_name, 1234567891).to_json),
+      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_project.name, file_name, 1234567892).to_json),
+      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
 
-    bucket_user_pays.service.mocked_service = mock
+    bucket_user_project.service.mocked_service = mock
     file.service.mocked_service = mock
 
-    file = bucket_user_pays.file file_name
+    file = bucket_user_project.file file_name
     file.generation.must_equal 1234567891
     file.reload!
     file.generation.must_equal 1234567892

--- a/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
@@ -21,12 +21,13 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   let(:file_hash) { random_file_hash bucket_name, "file.ext" }
   let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
+  let(:file_user_pays) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_pays: true }
 
   it "updates its cache control" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new cache_control: "private, max-age=0, no-cache"
     mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil]
+      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
 
     file.service.mocked_service = mock
 
@@ -40,7 +41,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_disposition: "inline; filename=filename.ext"
     mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil]
+      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
 
     file.service.mocked_service = mock
 
@@ -54,7 +55,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_encoding: "deflate"
     mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil]
+      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
 
     file.service.mocked_service = mock
 
@@ -68,7 +69,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_language: "de"
     mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil]
+      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
 
     file.service.mocked_service = mock
 
@@ -82,7 +83,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_type: "application/json"
     mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil]
+      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
 
     file.service.mocked_service = mock
 
@@ -96,7 +97,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new metadata: { "player" => "Bob", score: 10 }
     mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil]
+      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
 
     file.service.mocked_service = mock
 
@@ -112,7 +113,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -123,19 +124,36 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock.verify
   end
 
+  it "updates its storage_class with user_pays set to true" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new storage_class: "DURABLE_REDUCED_AVAILABILITY"
+    patched_file_gapi = file_gapi.dup
+    patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
+    mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
+      [bucket_name, file.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+
+    file_user_pays.service.mocked_service = mock
+
+    file_user_pays.storage_class.must_equal "STANDARD"
+    file_user_pays.storage_class = :dra
+    file_user_pays.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+
+    mock.verify
+  end
+
   it "updates its storage_class, calling rewrite_object as many times as is needed" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new storage_class: "DURABLE_REDUCED_AVAILABILITY"
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", options: {}]
+      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: nil, options: {}]
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", options: {}]
+      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: nil, options: {}]
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", options: {}]
+      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 
@@ -146,6 +164,33 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     file.storage_class.must_equal "STANDARD"
     file.storage_class = :dra
     file.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+
+    mock.verify
+  end
+
+  it "updates its storage_class, calling rewrite_object as many times as is needed with user_pays set to true" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new storage_class: "DURABLE_REDUCED_AVAILABILITY"
+    patched_file_gapi = file_gapi.dup
+    patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
+    mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
+      [bucket_name, file_user_pays.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+    mock.expect :rewrite_object, undone_rewrite("keeptrying"),
+      [bucket_name, file_user_pays.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
+    mock.expect :rewrite_object, undone_rewrite("almostthere"),
+      [bucket_name, file_user_pays.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
+    mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
+      [bucket_name, file_user_pays.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
+
+    file_user_pays.service.mocked_service = mock
+
+    # mock out sleep to make the test run faster
+    def file_user_pays.sleep *args
+    end
+
+    file_user_pays.storage_class.must_equal "STANDARD"
+    file_user_pays.storage_class = :dra
+    file_user_pays.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
 
     mock.verify
   end
@@ -161,11 +206,39 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
       metadata: { "player" => "Bob", "score" => "10" }
     )
     mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil]
+      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
 
     file.service.mocked_service = mock
 
     file.update do |f|
+      f.cache_control = "private, max-age=0, no-cache"
+      f.content_disposition = "inline; filename=filename.ext"
+      f.content_encoding = "deflate"
+      f.content_language = "de"
+      f.content_type = "application/json"
+      f.metadata["player"] = "Bob"
+      f.metadata["score"] = "10"
+    end
+
+    mock.verify
+  end
+
+  it "updates multiple attributes in a block with user_pays set to true" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new(
+      cache_control: "private, max-age=0, no-cache",
+      content_disposition: "inline; filename=filename.ext",
+      content_encoding: "deflate",
+      content_language: "de",
+      content_type: "application/json",
+      metadata: { "player" => "Bob", "score" => "10" }
+    )
+    mock.expect :patch_object, file_gapi,
+      [bucket_name, file_user_pays.name, patch_file_gapi, predefined_acl: nil, user_project: "test"]
+
+    file_user_pays.service.mocked_service = mock
+
+    file_user_pays.update do |f|
       f.cache_control = "private, max-age=0, no-cache"
       f.content_disposition = "inline; filename=filename.ext"
       f.content_encoding = "deflate"
@@ -184,7 +257,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
       content_language: "de"
     )
     mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil]
+      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
 
     file.service.mocked_service = mock
 
@@ -201,7 +274,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "NEARLINE"
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, options: {}]
+      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
 
     file.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   let(:file_hash) { random_file_hash bucket_name, "file.ext" }
   let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
-  let(:file_user_pays) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_pays: true }
+  let(:file_user_project) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_project: true }
 
   it "updates its cache control" do
     mock = Minitest::Mock.new
@@ -124,19 +124,19 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock.verify
   end
 
-  it "updates its storage_class with user_pays set to true" do
+  it "updates its storage_class with user_project set to true" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new storage_class: "DURABLE_REDUCED_AVAILABILITY"
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      [bucket_name, file.name, bucket_name, file_user_project.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
 
-    file_user_pays.service.mocked_service = mock
+    file_user_project.service.mocked_service = mock
 
-    file_user_pays.storage_class.must_equal "STANDARD"
-    file_user_pays.storage_class = :dra
-    file_user_pays.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+    file_user_project.storage_class.must_equal "STANDARD"
+    file_user_project.storage_class = :dra
+    file_user_project.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
 
     mock.verify
   end
@@ -168,29 +168,29 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock.verify
   end
 
-  it "updates its storage_class, calling rewrite_object as many times as is needed with user_pays set to true" do
+  it "updates its storage_class, calling rewrite_object as many times as is needed with user_project set to true" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new storage_class: "DURABLE_REDUCED_AVAILABILITY"
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket_name, file_user_pays.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket_name, file_user_pays.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
+      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket_name, file_user_pays.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
+      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file_user_pays.name, bucket_name, file_user_pays.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
+      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
 
-    file_user_pays.service.mocked_service = mock
+    file_user_project.service.mocked_service = mock
 
     # mock out sleep to make the test run faster
-    def file_user_pays.sleep *args
+    def file_user_project.sleep *args
     end
 
-    file_user_pays.storage_class.must_equal "STANDARD"
-    file_user_pays.storage_class = :dra
-    file_user_pays.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
+    file_user_project.storage_class.must_equal "STANDARD"
+    file_user_project.storage_class = :dra
+    file_user_project.storage_class.must_equal "DURABLE_REDUCED_AVAILABILITY"
 
     mock.verify
   end
@@ -223,7 +223,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock.verify
   end
 
-  it "updates multiple attributes in a block with user_pays set to true" do
+  it "updates multiple attributes in a block with user_project set to true" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new(
       cache_control: "private, max-age=0, no-cache",
@@ -234,11 +234,11 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
       metadata: { "player" => "Bob", "score" => "10" }
     )
     mock.expect :patch_object, file_gapi,
-      [bucket_name, file_user_pays.name, patch_file_gapi, predefined_acl: nil, user_project: "test"]
+      [bucket_name, file_user_project.name, patch_file_gapi, predefined_acl: nil, user_project: "test"]
 
-    file_user_pays.service.mocked_service = mock
+    file_user_project.service.mocked_service = mock
 
-    file_user_pays.update do |f|
+    file_user_project.update do |f|
       f.cache_control = "private, max-age=0, no-cache"
       f.content_disposition = "inline; filename=filename.ext"
       f.content_encoding = "deflate"

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -465,7 +465,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     bucket.name.must_equal bucket_name
   end
 
-  it "finds a bucket with user_pays" do
+  it "finds a bucket with user_project set to true" do
     bucket_name = "found-bucket"
 
     mock = Minitest::Mock.new
@@ -473,7 +473,22 @@ describe Google::Cloud::Storage::Project, :mock_storage do
 
     storage.service.mocked_service = mock
 
-    bucket = storage.bucket bucket_name, user_pays: true
+    bucket = storage.bucket bucket_name, user_project: true
+
+    mock.verify
+
+    bucket.name.must_equal bucket_name
+  end
+
+  it "finds a bucket with user_project set to another project ID" do
+    bucket_name = "found-bucket"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name, { user_project: "my-other-project" }]
+
+    storage.service.mocked_service = mock
+
+    bucket = storage.bucket bucket_name, user_project: "my-other-project"
 
     mock.verify
 

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -439,7 +439,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     bucket_name = "found-bucket"
 
     mock = Minitest::Mock.new
-    mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name]
+    mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name, {user_project: nil}]
 
     storage.service.mocked_service = mock
 
@@ -454,11 +454,26 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     bucket_name = "found-bucket"
 
     mock = Minitest::Mock.new
-    mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name]
+    mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name, {user_project: nil}]
 
     storage.service.mocked_service = mock
 
     bucket = storage.find_bucket bucket_name
+
+    mock.verify
+
+    bucket.name.must_equal bucket_name
+  end
+
+  it "finds a bucket with user_pays" do
+    bucket_name = "found-bucket"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name, { user_project: "test" }]
+
+    storage.service.mocked_service = mock
+
+    bucket = storage.bucket bucket_name, user_pays: true
 
     mock.verify
 

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -48,7 +48,7 @@ class MockStorage < Minitest::Spec
   def random_bucket_hash(name=random_bucket_name,
     url_root="https://www.googleapis.com/storage/v1", location="US",
     storage_class="STANDARD", versioning=nil, logging_bucket=nil,
-    logging_prefix=nil, website_main=nil, website_404=nil, cors=[])
+    logging_prefix=nil, website_main=nil, website_404=nil, cors=[], requester_pays=nil)
     versioning_config = { "enabled" => versioning } if versioning
     { "kind" => "storage#bucket",
       "id" => name,
@@ -64,6 +64,7 @@ class MockStorage < Minitest::Spec
       "storageClass" => storage_class,
       "versioning" => versioning_config,
       "website" => website_hash(website_main, website_404),
+      "billing" => billing_hash(requester_pays),
       "etag" => "CAE=" }.delete_if { |_, v| v.nil? }
   end
 
@@ -77,6 +78,10 @@ class MockStorage < Minitest::Spec
     { "mainPageSuffix" => website_main,
       "notFoundPage"   => website_404,
     }.delete_if { |_, v| v.nil? } if website_main || website_404
+  end
+
+  def billing_hash(requester_pays)
+    { "requesterPays" => requester_pays} unless requester_pays.nil?
   end
 
   def random_file_hash bucket=random_bucket_name, name=random_file_path, generation="1234567890"


### PR DESCRIPTION
This PR has two parts:

- [x] Add `requester_pays` to `Bucket` (#1540)
- [x] Add `userProject` request param to support requester pays in all relevant `Bucket` and `File` operations (#1541)

[closes #1540, closes #1541]

```ruby
require "google/cloud/storage"

storage = Google::Cloud::Storage.new
                    
# Set `user_pays` property once when retrieving bucket.
# All relevant RPCs made for this bucket and its objects
# will include `userProject` set to the currently authenticated
# project.

bucket = storage.bucket "my-todo-app", user_pays: true # Send `userProject`

file = bucket.file "avatars/heidi/400x400.png" # Send `userProject`

file.acl.add_reader "group-authors@example.net" # Send `userProject`
```