### PR TITLE
Create Google::Cloud::Trace::FaradayMiddleware

### DIFF
--- a/google-cloud-trace/docs/instrumentation.md
+++ b/google-cloud-trace/docs/instrumentation.md
@@ -16,7 +16,7 @@ for full configuration parameters.
 
 ## Rails Integration
 
-To use the Stackdriver Logging Railtie for Ruby on Rails applications, simply add this line to config/application.rb:
+To use the Stackdriver Logging Railtie for Ruby on Rails applications, simply add this line to `config/application.rb`:
 ```ruby
 require "google/cloud/trace/rails"
 ```
@@ -30,3 +30,20 @@ Other Rack base frameworks can also directly leverage the built-in Middleware.
 require "google/cloud/trace"
 use Google::Cloud::Trace::Middleware
 ```
+
+## Faraday Middleware
+
+On top of the Rack Middleware, you can also trace outbound Faraday requests by 
+using the Faraday Middleware provided with this gem:
+
+```ruby
+require "google/cloud/trace/faraday_middleware"
+
+conn = Faraday.new "https://www.google.com"
+conn.use Google::Cloud::Trace::FaradayMiddleware
+
+result = conn.get
+```
+
+A child span will be create for each outbound Faraday request, and will be 
+submitted together with the overall application request trace by the Rack Middleware.

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
+  gem.add_development_dependency "faraday", "~> 0.8"
   gem.add_development_dependency "railties", "~> 4.0"
   gem.add_development_dependency "rubocop", "<= 0.35.1"
   gem.add_development_dependency "simplecov", "~> 0.9"

--- a/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
@@ -42,16 +42,10 @@ module Google
           labels = span.labels
           label_keys = Google::Cloud::Trace::LabelKey
 
-          set_label labels, label_keys::AGENT,
-                    Google::Cloud::Trace::Middleware::AGENT_NAME
-          set_label labels, label_keys::HTTP_HOST, env.url.host
           set_label labels, label_keys::HTTP_METHOD, env.method
-          set_label labels, label_keys::HTTP_CLIENT_PROTOCOL, env.url.scheme
           set_label labels, label_keys::HTTP_USER_AGENT,
                     env.request_headers[:user_agent]
           set_label labels, label_keys::HTTP_URL, env.url.to_s
-          set_label labels, label_keys::PID, ::Process.pid.to_s
-          set_label labels, label_keys::TID, ::Thread.current.object_id.to_s
         end
 
         ##

--- a/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
@@ -1,0 +1,79 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "faraday"
+require "google/cloud/trace"
+
+module Google
+  module Cloud
+    module Trace
+      class FaradayMiddleware < Faraday::Middleware
+        ##
+        # Create a Trace span with the HTTP request/response information.
+        def call env
+          Google::Cloud::Trace.in_span "faraday_request" do |span|
+            add_request_labels span, env if span
+
+            response = @app.call env
+
+            add_response_labels span, response if span
+
+            response
+          end
+        end
+
+        protected
+
+        ##
+        # @private Set Trace span labels from request object
+        def add_request_labels span, env
+          labels = span.labels
+          label_keys = Google::Cloud::Trace::LabelKey
+
+          set_label labels, label_keys::AGENT,
+                    Google::Cloud::Trace::Middleware::AGENT_NAME
+          set_label labels, label_keys::HTTP_HOST, env.url.host
+          set_label labels, label_keys::HTTP_METHOD, env.method
+          set_label labels, label_keys::HTTP_CLIENT_PROTOCOL, env.url.scheme
+          set_label labels, label_keys::HTTP_USER_AGENT,
+                    env.request_headers[:user_agent]
+          set_label labels, label_keys::HTTP_URL, env.url.to_s
+          set_label labels, label_keys::PID, ::Process.pid.to_s
+          set_label labels, label_keys::TID, ::Thread.current.object_id.to_s
+        end
+
+        ##
+        # @private Set Trace span labels from response
+        def add_response_labels span, response
+          set_label span.labels,
+                    Google::Cloud::Trace::LabelKey::HTTP_STATUS_CODE,
+                    response.status.to_s
+        end
+
+        ##
+        # Sets the given label if the given value is a proper string.
+        #
+        # @private
+        # @param [Hash] labels The labels hash.
+        # @param [String] key The key of the label to set.
+        # @param [Object] value The value to set.
+        #
+        def set_label labels, key, value
+          labels[key] = value if value.is_a? ::String
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
@@ -1,0 +1,78 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "google/cloud/trace/faraday_middleware"
+require "ostruct"
+
+describe Google::Cloud::Trace::FaradayMiddleware do
+  let(:app) {
+    app = Object.new
+    app.define_singleton_method :call do |_| end
+    app
+  }
+  let(:middleware) do
+    Google::Cloud::Trace::FaradayMiddleware.new app
+  end
+
+  describe "#call" do
+    it "doesn't interfere @app.call even if there are no parent span" do
+      mocked_app = Minitest::Mock.new
+      mocked_app.expect :call, nil, [NilClass]
+
+      middleware.instance_variable_set :@app, mocked_app
+
+      Google::Cloud::Trace.stub :get, nil do
+        middleware.call nil
+      end
+
+      mocked_app.verify
+    end
+  end
+
+  describe "#add_request_labels" do
+    it "sets all the labels" do
+      env = OpenStruct.new request_headers: {user_agent: "test-agent"},
+                           url: OpenStruct.new(host: "test-host",
+                                               scheme: "tcp")
+      env.define_singleton_method(:method) { "test-method" }
+      env.url.define_singleton_method(:to_s) { "full-url" }
+
+      span = OpenStruct.new labels: {}
+
+      middleware.send :add_request_labels, span, env
+
+      span.labels[Google::Cloud::Trace::LabelKey::AGENT].must_equal Google::Cloud::Trace::Middleware::AGENT_NAME
+      span.labels[Google::Cloud::Trace::LabelKey::HTTP_HOST].must_equal "test-host"
+      span.labels[Google::Cloud::Trace::LabelKey::HTTP_METHOD].must_equal "test-method"
+      span.labels[Google::Cloud::Trace::LabelKey::HTTP_CLIENT_PROTOCOL].must_equal "tcp"
+      span.labels[Google::Cloud::Trace::LabelKey::HTTP_USER_AGENT].must_equal "test-agent"
+      span.labels[Google::Cloud::Trace::LabelKey::HTTP_URL].must_equal "full-url"
+      span.labels[Google::Cloud::Trace::LabelKey::PID].must_be_kind_of String
+      span.labels[Google::Cloud::Trace::LabelKey::TID].must_be_kind_of String
+    end
+  end
+
+  describe "#add_response_labels" do
+    it "sets all the labels" do
+      response = OpenStruct.new status: 42
+      span = OpenStruct.new labels: {}
+
+      middleware.send :add_response_labels, span, response
+
+      span.labels[Google::Cloud::Trace::LabelKey::HTTP_STATUS_CODE].must_equal "42"
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
@@ -45,8 +45,7 @@ describe Google::Cloud::Trace::FaradayMiddleware do
   describe "#add_request_labels" do
     it "sets all the labels" do
       env = OpenStruct.new request_headers: {user_agent: "test-agent"},
-                           url: OpenStruct.new(host: "test-host",
-                                               scheme: "tcp")
+                           url: Object.new
       env.define_singleton_method(:method) { "test-method" }
       env.url.define_singleton_method(:to_s) { "full-url" }
 
@@ -54,14 +53,9 @@ describe Google::Cloud::Trace::FaradayMiddleware do
 
       middleware.send :add_request_labels, span, env
 
-      span.labels[Google::Cloud::Trace::LabelKey::AGENT].must_equal Google::Cloud::Trace::Middleware::AGENT_NAME
-      span.labels[Google::Cloud::Trace::LabelKey::HTTP_HOST].must_equal "test-host"
       span.labels[Google::Cloud::Trace::LabelKey::HTTP_METHOD].must_equal "test-method"
-      span.labels[Google::Cloud::Trace::LabelKey::HTTP_CLIENT_PROTOCOL].must_equal "tcp"
       span.labels[Google::Cloud::Trace::LabelKey::HTTP_USER_AGENT].must_equal "test-agent"
       span.labels[Google::Cloud::Trace::LabelKey::HTTP_URL].must_equal "full-url"
-      span.labels[Google::Cloud::Trace::LabelKey::PID].must_be_kind_of String
-      span.labels[Google::Cloud::Trace::LabelKey::TID].must_be_kind_of String
     end
   end
 


### PR DESCRIPTION
Provide a Faraday Middleware for users to trace outbound requests.