### PR TITLE
Fix Spanner Tests

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -86,11 +86,11 @@ module Google
         end
 
         def checkin_session session
-          unless all_sessions.include? session
-            fail ArgumentError, "Cannot checkin session"
-          end
-
           @mutex.synchronize do
+            unless all_sessions.include? session
+              fail ArgumentError, "Cannot checkin session"
+            end
+
             session_queue.push session
 
             @resource.signal
@@ -144,11 +144,11 @@ module Google
         end
 
         def checkin_transaction tx
-          unless all_sessions.include? tx.session
-            fail ArgumentError, "Cannot checkin session"
-          end
-
           @mutex.synchronize do
+            unless all_sessions.include? tx.session
+              fail ArgumentError, "Cannot checkin session"
+            end
+
             transaction_queue.push tx
 
             @resource.signal

--- a/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
@@ -24,9 +24,7 @@ describe Google::Cloud::Spanner::Client, :admin, :mock_spanner do
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
   after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
+    shutdown_client! client
   end
 
   it "knows its project_id" do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -26,19 +26,6 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "commits using a block" do
     mutations = [
       Google::Spanner::V1::Mutation.new(
@@ -90,7 +77,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -113,7 +100,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     timestamp = client.update "users", [{ id: 1, name: "Charlie", active: false }]
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -136,7 +123,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     timestamp = client.insert "users", [{ id: 2, name: "Harvey",  active: true }]
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -159,7 +146,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     timestamp = client.upsert "users", [{ id: 3, name: "Marley",  active: false }]
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -182,7 +169,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     timestamp = client.save "users", [{ id: 3, name: "Marley",  active: false }]
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -205,7 +192,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     timestamp = client.replace "users", [{ id: 4, name: "Henry",  active: true }]
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -231,7 +218,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     timestamp = client.delete "users", [1, 2, 3, 4, 5]
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -255,7 +242,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     timestamp = client.delete "users", 1..100
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -281,7 +268,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     timestamp = client.delete "users", 5
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -303,7 +290,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     timestamp = client.delete "users"
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
@@ -103,19 +103,6 @@ describe Google::Cloud::Spanner::Client, :execute, :resume, :mock_spanner do
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "resumes broken response streams" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
@@ -127,7 +114,7 @@ describe Google::Cloud::Spanner::Client, :execute, :resume, :mock_spanner do
 
     assert_results results
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
@@ -61,19 +61,6 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
   let(:timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp time_obj }
   let(:duration) { Google::Cloud::Spanner::Convert.number_to_duration 120 }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "executes with strong" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
@@ -90,7 +77,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
 
     results = client.execute "SELECT * FROM users", single_use: { strong: true }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -113,7 +100,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
 
     results = client.execute "SELECT * FROM users", single_use: { timestamp: time_obj }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -136,7 +123,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
 
     results = client.execute "SELECT * FROM users", single_use: { read_timestamp: time_obj }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -159,7 +146,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
 
     results = client.execute "SELECT * FROM users", single_use: { staleness: 120 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -182,7 +169,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
 
     results = client.execute "SELECT * FROM users", single_use: { exact_staleness: 120 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -205,7 +192,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
 
     results = client.execute "SELECT * FROM users", single_use: { bounded_timestamp: time_obj }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -228,7 +215,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
 
     results = client.execute "SELECT * FROM users", single_use: { min_read_timestamp: time_obj }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -251,7 +238,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
 
     results = client.execute "SELECT * FROM users", single_use: { bounded_staleness: 120 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -274,7 +261,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
 
     results = client.execute "SELECT * FROM users", single_use: { max_staleness: 120 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
@@ -58,19 +58,6 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
@@ -79,7 +66,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users"
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -94,7 +81,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE active = @active", params: { active: true }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -109,7 +96,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE age = @age", params: { age: 29 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -124,7 +111,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE score = @score", params: { score: 0.9 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -141,7 +128,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE updated_at = @updated_at", params: { updated_at: timestamp }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -158,7 +145,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE birthday = @birthday", params: { birthday: date }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -173,7 +160,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE name = @name", params: { name: "Charlie" }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -190,7 +177,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE avatar = @avatar", params: { avatar: file }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -205,7 +192,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [1,2,3] }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -220,7 +207,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE project_ids = @list", params: { list: [] }, types: { list: [:INT64] }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -237,7 +224,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -254,7 +241,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -271,7 +258,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -45,19 +45,6 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
   let(:results_enum) { Array(results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "can get a table's fields" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
@@ -66,7 +53,7 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
 
     fields = client.fields_for "users"
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
@@ -25,9 +25,7 @@ describe Google::Cloud::Spanner::Client, :range, :mock_spanner do
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
   after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
+    shutdown_client! client
   end
 
   it "creates an inclusive range" do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
@@ -96,19 +96,6 @@ describe Google::Cloud::Spanner::Client, :read, :error, :mock_spanner do
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "raises unhandled errors" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
@@ -121,7 +108,7 @@ describe Google::Cloud::Spanner::Client, :read, :error, :mock_spanner do
       client.read("my-table", columns).rows.to_a
     end
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -103,19 +103,6 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "resumes broken response streams" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
@@ -129,7 +116,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
 
     assert_results results
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -62,19 +62,6 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
   let(:timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp time_obj }
   let(:duration) { Google::Cloud::Spanner::Convert.number_to_duration 120 }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "reads with strong" do
     transaction = Google::Spanner::V1::TransactionSelector.new(
       single_use: Google::Spanner::V1::TransactionOptions.new(
@@ -91,7 +78,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
 
     results = client.read "my-table", columns, single_use: { strong: true }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -114,7 +101,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
 
     results = client.read "my-table", columns, single_use: { timestamp: time_obj }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -137,7 +124,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
 
     results = client.read "my-table", columns, single_use: { read_timestamp: time_obj }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -160,7 +147,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
 
     results = client.read "my-table", columns, single_use: { staleness: 120 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -183,7 +170,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
 
     results = client.read "my-table", columns, single_use: { exact_staleness: 120 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -206,7 +193,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
 
     results = client.read "my-table", columns, single_use: { bounded_timestamp: time_obj }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -229,7 +216,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
 
     results = client.read "my-table", columns, single_use: { min_read_timestamp: time_obj }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -252,7 +239,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
 
     results = client.read "my-table", columns, single_use: { bounded_staleness: 120 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -275,7 +262,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
 
     results = client.read "my-table", columns, single_use: { max_staleness: 120 }
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -70,19 +70,6 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "can read all rows" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
@@ -93,7 +80,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     results = client.read "my-table", columns
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -110,7 +97,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     results = client.read "my-table", columns, keys: [1, 2, 3]
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -127,7 +114,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     results = client.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -145,7 +132,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     lookup_range = client.range [1,1], [3,3]
     results = client.read "my-table", columns, keys: lookup_range, index: "MyTableCompositeKey"
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -162,7 +149,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     results = client.read "my-table", columns, limit: 5
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -179,7 +166,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     results = client.read "my-table", columns, keys: 1, limit: 1
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -65,19 +65,6 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
   let(:snp_opts) { Google::Spanner::V1::TransactionOptions::ReadOnly.new return_read_timestamp: true }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new read_only: snp_opts }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "can execute a simple query without any options" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
@@ -91,7 +78,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       results = snp.execute "SELECT * FROM users"
     end
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -108,7 +95,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
       end
     end
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -129,7 +116,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         results = snp.execute "SELECT * FROM users"
       end
 
-      wait_until_thread_pool_is_done!
+      shutdown_client! client
 
       mock.verify
 
@@ -156,7 +143,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         results = snp.execute "SELECT * FROM users"
       end
 
-      wait_until_thread_pool_is_done!
+      shutdown_client! client
 
       mock.verify
 
@@ -176,7 +163,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         results = snp.execute "SELECT * FROM users"
       end
 
-      wait_until_thread_pool_is_done!
+      shutdown_client! client
 
       mock.verify
 
@@ -196,7 +183,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         results = snp.execute "SELECT * FROM users"
       end
 
-      wait_until_thread_pool_is_done!
+      shutdown_client! client
 
       mock.verify
 
@@ -216,7 +203,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         results = snp.execute "SELECT * FROM users"
       end
 
-      wait_until_thread_pool_is_done!
+      shutdown_client! client
 
       mock.verify
 
@@ -242,7 +229,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         results = snp.execute "SELECT * FROM users"
       end
 
-      wait_until_thread_pool_is_done!
+      shutdown_client! client
 
       mock.verify
 
@@ -262,7 +249,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
         results = snp.execute "SELECT * FROM users"
       end
 
-      wait_until_thread_pool_is_done!
+      shutdown_client! client
 
       mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -64,19 +64,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:tx_opts) { Google::Spanner::V1::TransactionOptions.new(read_write: Google::Spanner::V1::TransactionOptions::ReadWrite.new) }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "retries aborted transactions without retry metadata" do
     mutations = [
       Google::Spanner::V1::Mutation.new(
@@ -126,7 +113,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     assert_results results
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -182,7 +169,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     assert_results results
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -238,7 +225,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     assert_results results
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -304,7 +291,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
 
     assert_results results
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -376,7 +363,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       end
     end
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -66,19 +66,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
   let(:commit_time) { Time.now }
   let(:commit_resp) { Google::Spanner::V1::CommitResponse.new commit_timestamp: Google::Cloud::Spanner::Convert.time_to_timestamp(commit_time) }
 
-  after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
-  end
-
   it "can execute a simple query" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
@@ -96,7 +83,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
 
@@ -126,7 +113,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -154,7 +141,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -182,7 +169,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -210,7 +197,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -238,7 +225,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -269,7 +256,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -298,7 +285,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -329,7 +316,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -356,7 +343,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end
@@ -415,7 +402,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     end
     timestamp.must_equal commit_time
 
-    wait_until_thread_pool_is_done!
+    shutdown_client! client
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
@@ -32,14 +32,7 @@ describe Google::Cloud::Spanner::Pool, :close, :mock_spanner do
   end
 
   after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool.instance_variable_get(:@thread_pool).shutdown
-    pool.instance_variable_get(:@thread_pool).wait_for_termination 60
+    shutdown_client! client
   end
 
   it "deletes sessions when closed" do
@@ -49,7 +42,7 @@ describe Google::Cloud::Spanner::Pool, :close, :mock_spanner do
 
     pool.close
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     mock.verify
   end
@@ -61,7 +54,7 @@ describe Google::Cloud::Spanner::Pool, :close, :mock_spanner do
 
     pool.close
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     assert_raises Google::Cloud::Spanner::ClientClosedError do
       pool.checkout_session

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -51,14 +51,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
   end
 
   after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool.instance_variable_get(:@thread_pool).shutdown
-    pool.instance_variable_get(:@thread_pool).wait_for_termination 60
+    shutdown_client! client
   end
 
   it "calls keepalive on the sessions that need it" do
@@ -74,7 +67,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
 
     pool.keepalive_or_release!
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     mock.verify
   end
@@ -92,7 +85,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
 
     pool.keepalive_or_release!
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     mock.verify
   end
@@ -109,6 +102,8 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
 
     pool.keepalive_or_release!
 
+    shutdown_pool! pool
+
     mock.verify
   end
 
@@ -123,6 +118,8 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     session.service.mocked_service = mock
 
     pool.keepalive_or_release!
+
+    shutdown_pool! pool
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -44,7 +44,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, "session-002"), tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
     pool = Google::Cloud::Spanner::Pool.new client, min: 2, write_ratio: 0.5
@@ -54,10 +54,6 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     pool.all_sessions.size.must_equal 2
     pool.session_queue.size.must_equal 1
     pool.transaction_queue.size.must_equal 1
-
-    pool.session_queue.first.session_id.must_equal "session-001"
-    pool.transaction_queue.first.transaction_id.must_equal "tx-002-01"
-    pool.transaction_queue.first.session.session_id.must_equal "session-002"
 
     mock.verify
   end
@@ -69,9 +65,9 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), options: default_options]
     mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-003-01"), [session_path(instance_id, database_id, "session-003"), tx_opts, options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-01"), [session_path(instance_id, database_id, "session-004"), tx_opts, options: default_options]
-    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-005-01"), [session_path(instance_id, database_id, "session-005"), tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-003-01"), [String, tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-01"), [String, tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-005-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
     pool = Google::Cloud::Spanner::Pool.new client, min: 5, write_ratio: 0.5
@@ -81,6 +77,31 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     pool.all_sessions.size.must_equal 5
     pool.session_queue.size.must_equal 2
     pool.transaction_queue.size.must_equal 3
+
+    mock.verify
+  end
+
+  it "creates eight sessions and three transactions" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-006")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-007")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-007-01"), [String, tx_opts, options: default_options]
+    mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-008-01"), [String, tx_opts, options: default_options]
+    spanner.service.mocked_service = mock
+
+    pool = Google::Cloud::Spanner::Pool.new client, min: 8, write_ratio: 0.3
+
+    wait_until_thread_pool_is_done! pool
+
+    pool.all_sessions.size.must_equal 8
+    pool.session_queue.size.must_equal 6
+    pool.transaction_queue.size.must_equal 2
 
     mock.verify
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -29,15 +29,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
   end
 
   after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done! pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
+    shutdown_client! client
   end
 
   it "creates two sessions and one transaction" do
@@ -49,7 +41,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
     pool = Google::Cloud::Spanner::Pool.new client, min: 2, write_ratio: 0.5
 
-    wait_until_thread_pool_is_done! pool
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 2
     pool.session_queue.size.must_equal 1
@@ -72,7 +64,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
     pool = Google::Cloud::Spanner::Pool.new client, min: 5, write_ratio: 0.5
 
-    wait_until_thread_pool_is_done! pool
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 5
     pool.session_queue.size.must_equal 2
@@ -97,7 +89,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
     pool = Google::Cloud::Spanner::Pool.new client, min: 8, write_ratio: 0.3
 
-    wait_until_thread_pool_is_done! pool
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 8
     pool.session_queue.size.must_equal 6

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -34,16 +34,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
   end
 
   after do
-    # Close the client and release the keepalive thread
-    client.instance_variable_get(:@pool).all_sessions = []
-    client.close
-  end
-
-  def wait_until_thread_pool_is_done!
-    pool = client.instance_variable_get :@pool
-    thread_pool = pool.instance_variable_get :@thread_pool
-    thread_pool.shutdown
-    thread_pool.wait_for_termination 60
+    shutdown_client! client
   end
 
   it "can checkout and checkin a session" do
@@ -57,7 +48,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
     pool.checkin_session s
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 1
     pool.session_queue.size.must_equal 1
@@ -80,7 +71,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     pool.checkin_session s1
     pool.checkin_session s2
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 2
     pool.session_queue.size.must_equal 2
@@ -115,7 +106,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     pool.checkin_session s3
     pool.checkin_session s4
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 4
     pool.session_queue.size.must_equal 4
@@ -158,7 +149,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
     pool.checkin_transaction tx
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 1
     pool.session_queue.size.must_equal 0
@@ -185,7 +176,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
     pool.checkin_transaction tx
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 1
     pool.session_queue.size.must_equal 0
@@ -214,7 +205,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     pool.checkin_transaction tx1
     pool.checkin_transaction tx2
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 2
     pool.session_queue.size.must_equal 0
@@ -246,7 +237,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
       end
     end
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     pool.all_sessions.size.must_equal 2
     pool.session_queue.size.must_equal 0
@@ -307,7 +298,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     pool.session_queue.size.must_equal 2
     pool.transaction_queue.size.must_equal 2
 
-    wait_until_thread_pool_is_done!
+    shutdown_pool! pool
 
     mock.verify
   end

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -55,6 +55,26 @@ class MockSpanner < Minitest::Spec
     addl.include? :mock_spanner
   end
 
+  def shutdown_client! client
+    # extract the pool
+    pool = client.instance_variable_get :@pool
+    # remove all sessions so we don't have to handle the calls to session_delete
+    pool.all_sessions = []
+
+    # close the client
+    client.close
+
+    # close the client
+    shutdown_pool! pool
+  end
+
+  def shutdown_pool! pool
+    # ensure the pool's thread pool is also shut down
+    thread_pool = pool.instance_variable_get :@thread_pool
+    thread_pool.shutdown
+    thread_pool.wait_for_termination 60
+  end
+
   def instance_configs_hash
     {
       instanceConfigs: [


### PR DESCRIPTION
This PR adds a fix for some unstable Spanner unit tests. The root cause for the instability is the assumption that work is performed in the order it was given. This has changed with the introduction of concurrent-ruby's FIxedThreadPool which may execute work in a different order than the work was given. The change in order was causing some mocks to fail.

This PR also includes some additional refactorings.