### PR TITLE
Fix deadlock in AsyncActor

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -358,9 +358,7 @@ module Google
               @queue_resource.wait
             end
             queue_item = nil
-            if @queue.empty?
-              async_stop
-            else
+            unless @queue.empty?
               queue_item = @queue.shift
               @queue_size -= queue_item.entries.size
             end

--- a/stackdriver-core/lib/stackdriver/core/async_actor.rb
+++ b/stackdriver-core/lib/stackdriver/core/async_actor.rb
@@ -305,12 +305,14 @@ module Stackdriver
           if (@thread.nil? || !@thread.alive?) && @async_state != :stopped
             @lock_cond = new_cond
             AsyncActor.register_for_cleanup self
+
+            @async_state = :running
+            async_state_change
+
             @thread = Thread.new do
               async_run_job
               AsyncActor.unregister_for_cleanup self
             end
-            @async_state = :running
-            async_state_change
           end
         end
       end


### PR DESCRIPTION
Ensure the state variable is set to `:running` before starting child thread that checks this state.