### PR TITLE
Ensure project is required

### DIFF
--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -246,6 +246,9 @@ module Google
       def self.new project: nil, keyfile: nil, scope: nil, timeout: nil,
                    client_config: nil
         project ||= Google::Cloud::Language::Project.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
         if keyfile.nil?
           credentials = Google::Cloud::Language::Credentials.default(
             scope: scope)
@@ -253,6 +256,7 @@ module Google
           credentials = Google::Cloud::Language::Credentials.new(
             keyfile, scope: scope)
         end
+
         Google::Cloud::Language::Project.new(
           Google::Cloud::Language::Service.new(
             project, credentials, timeout: timeout,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb
@@ -472,6 +472,8 @@ module Google
                    client_config: nil, emulator_host: nil
         project ||= Google::Cloud::Pubsub::Project.default_project
         project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
         emulator_host ||= ENV["PUBSUB_EMULATOR_HOST"]
         if emulator_host
           ps = Google::Cloud::Pubsub::Project.new(
@@ -480,7 +482,9 @@ module Google
           ps.service.host = emulator_host
           return ps
         end
+
         credentials = credentials_with_scope keyfile, scope
+
         Google::Cloud::Pubsub::Project.new(
           Google::Cloud::Pubsub::Service.new(
             project, credentials, timeout: timeout,

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -366,12 +366,16 @@ module Google
       def self.new project: nil, keyfile: nil, scope: nil, timeout: nil,
                    client_config: nil
         project ||= Google::Cloud::Spanner::Project.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
         if keyfile.nil?
           credentials = Google::Cloud::Spanner::Credentials.default scope: scope
         else
           credentials = Google::Cloud::Spanner::Credentials.new(
             keyfile, scope: scope)
         end
+
         Google::Cloud::Spanner::Project.new(
           Google::Cloud::Spanner::Service.new(
             project, credentials, timeout: timeout,

--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -222,12 +222,16 @@ module Google
       def self.new project: nil, keyfile: nil, scope: nil, timeout: nil,
                    client_config: nil
         project ||= Google::Cloud::Speech::Project.default_project
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+
         if keyfile.nil?
           credentials = Google::Cloud::Speech::Credentials.default scope: scope
         else
           credentials = Google::Cloud::Speech::Credentials.new(
             keyfile, scope: scope)
         end
+
         Google::Cloud::Speech::Project.new(
           Google::Cloud::Speech::Service.new(
             project, credentials, timeout: timeout,


### PR DESCRIPTION
Several services were inconsistent in not raising when project is missing.
Add the missing checks to Natural Language, Pub/Sub, Spanner, and Speech.