### PR TITLE
Disable acceptance at_exit hook

### DIFF
--- a/google-cloud-spanner/acceptance/spanner_helper.rb
+++ b/google-cloud-spanner/acceptance/spanner_helper.rb
@@ -28,6 +28,9 @@ def SecureRandom.int64
   random_bytes(8).unpack("q")[0]
 end
 
+# Disable exit handlers because it messes with minitest/autorun
+Concurrent.disable_at_exit_handlers!
+
 # Create shared spanner object so we don't create new for each test
 $spanner = Google::Cloud::Spanner.new
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -216,8 +216,7 @@ module Google
         def init
           # init the thread pool
           @thread_pool = Concurrent::FixedThreadPool.new(
-            [2, Concurrent.processor_count].max * 2,
-            fallback_policy: :caller_runs
+            [2, Concurrent.processor_count*2].max
           )
           # init the queues
           @new_sessions_in_process = @min.to_i


### PR DESCRIPTION
Because we are creating a client in the acceptance test helper before the at_exit
hook is invoked by Minitest.autorun, the thread pool is being shutdown prematurely.
Tell Concurrent-Ruby to disable use of their at_exit hook for acceptance tests.
This will allow us to remove use of the caller_runs fallback.