### PR TITLE
Spanner thread pool config

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -51,13 +51,11 @@ module Google
       class Client
         ##
         # @private Creates a new Spanner Client instance.
-        def initialize project, instance_id, database_id, min: 10, max: 100,
-                       keepalive: 1800, write_ratio: 0.3, fail: true
+        def initialize project, instance_id, database_id, opts = {}
           @project = project
           @instance_id = instance_id
           @database_id = database_id
-          @pool = Pool.new self, min: min, max: max, keepalive: keepalive,
-                                 write_ratio: write_ratio, fail: fail
+          @pool = Pool.new self, opts
         end
 
         # The unique identifier for the project.

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -432,6 +432,8 @@ module Google
         #     {SessionLimitError} when the client has allocated the `max` number
         #     of sessions. When `false` the client blocks until a session
         #     becomes available. The default is `true`.
+        #   * `:threads` (Integer) The number of threads in the thread pool. The
+        #     default is twice the number of available CPUs.
         #
         # @return [Client] The newly created client.
         #
@@ -471,7 +473,8 @@ module Google
 
         def valid_session_pool_options opts = {}
           { min: opts[:min], max: opts[:max], keepalive: opts[:keepalive],
-            write_ratio: opts[:write_ratio], fail: opts[:fail]
+            write_ratio: opts[:write_ratio], fail: opts[:fail],
+            threads: opts[:threads]
           }.delete_if { |_k, v| v.nil? }
         end
       end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/threads_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/threads_test.rb
@@ -1,0 +1,43 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Client, :threads, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
+
+  it "creates a thread pool with the number of threads specified" do
+    mock = Minitest::Mock.new
+    # mock.expect :delete_session, nil, [session_grpc.name, options: default_options]
+    session.service.mocked_service = mock
+
+    client = spanner.client instance_id, database_id, pool: { min: 0, max: 4, threads: 13 }
+    pool = client.instance_variable_get :@pool
+    threads = pool.instance_variable_get :@threads
+    thread_pool = pool.instance_variable_get :@thread_pool
+
+    threads.must_equal 13
+    thread_pool.max_length.must_equal 13
+
+    client.close
+
+    shutdown_client! client
+
+    mock.verify
+  end
+end


### PR DESCRIPTION
This PR adds the ability to specify the size of the Session Pool's fixed thread pool.

```ruby
require "google/cloud/spanner"

spanner = Google::Cloud::Spanner.new
client = spanner.client "production",
                        "main",
                        pool: { min: 0, max: 16, threads: 4 }
```