### PR TITLE
Add Pub/Sub AsyncPublisher

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/async_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/async_test.rb
@@ -1,0 +1,74 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "pubsub_helper"
+
+describe Google::Cloud::Pubsub, :async, :pubsub do
+  def retrieve_topic topic_name
+    pubsub.get_topic(topic_name) || pubsub.create_topic(topic_name)
+  end
+
+  def retrieve_subscription topic, subscription_name
+    topic.get_subscription(subscription_name) ||
+      topic.subscribe(subscription_name)
+  end
+
+  let(:topic) { retrieve_topic "#{$topic_prefix}-async" }
+  let(:sub) { retrieve_subscription topic, "#{$topic_prefix}-async-sub" }
+
+  it "publishes and pulls asyncronously" do
+    events = sub.pull
+    events.must_be :empty?
+    # Publish a new message
+    unpublished = true
+    publish_result = nil
+    topic.publish_async "hello" do |result|
+      publish_result = result
+      unpublished = false
+      assert_equal "hello", result.msg.data
+    end
+    unpublished_retries = 0
+    while unpublished
+      fail "publish has failed" if unpublished_retries >= 5
+      unpublished_retries += 1
+      puts "the async publish has not completed yet. sleeping for #{unpublished_retries*unpublished_retries} second(s) and retrying."
+      sleep unpublished_retries*unpublished_retries
+    end
+    publish_result.must_be :succeeded?
+    # Check it received the published message
+    events = pull_with_retry sub
+    events.wont_be :empty?
+    events.count.must_equal 1
+    event = events.first
+    event.wont_be :nil?
+    event.msg.data.must_equal publish_result.data
+    # Acknowledge the message
+    sub.ack event.ack_id
+    # Remove the subscription
+    sub.delete
+  end
+
+  def pull_with_retry sub
+    events = []
+    retries = 0
+    while retries <= 5 do
+      events = sub.pull
+      break if events.any?
+      retries += 1
+      puts "the subscription does not have the message yet. sleeping for #{retries*retries} second(s) and retrying."
+      sleep retries*retries
+    end
+    events
+  end
+end

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -79,10 +79,10 @@ $snapshot_names = 3.times.map { "#{$snapshot_prefix}-#{SecureRandom.hex(4)}".dow
 
 def clean_up_pubsub_topics
   puts "Cleaning up pubsub topics after tests."
-  $topic_names.each do |topic_name|
-    if t = $pubsub.get_topic(topic_name)
-      t.subscriptions.each { |s| s.delete }
-      t.delete
+  $pubsub.topics.all do |topic|
+    if topic.name.include? $topic_prefix
+      topic.subscriptions.each(&:delete)
+      topic.delete
     end
   end
 rescue => e

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "google-gax", "~> 0.8.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.8"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -197,9 +197,10 @@ module Google
         # @param [String] topic_name Name of a topic.
         # @param [String, File] data The message data.
         # @param [Hash] attributes Optional attributes for the message.
-        # @yield [publisher] a block for publishing multiple messages in one
+        # @yield [batch] a block for publishing multiple messages in one
         #   request
-        # @yieldparam [Topic::Publisher] publisher the topic publisher object
+        # @yieldparam [Topic::BatchPublisher] batch the topic batch publisher
+        #   object
         #
         # @return [Message, Array<Message>] Returns the published message when
         #   called without a block, or an array of messages when called with a
@@ -245,7 +246,7 @@ module Google
             data = nil
           end
           ensure_service!
-          publisher = Topic::Publisher.new data, attributes
+          publisher = Topic::BatchPublisher.new data, attributes
           yield publisher if block_given?
           return nil if publisher.messages.count.zero?
           publish_batch_messages topic_name, publisher

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -119,12 +119,12 @@ module Google
         #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.topic "another-topic", skip_lookup: true
         #
-        def topic topic_name, project: nil, skip_lookup: nil
+        def topic topic_name, project: nil, skip_lookup: nil, async: nil
           ensure_service!
           options = { project: project }
           return Topic.new_lazy(topic_name, service, options) if skip_lookup
           grpc = service.get_topic topic_name
-          Topic.from_grpc grpc, service
+          Topic.from_grpc grpc, service, async: async
         rescue Google::Cloud::NotFoundError
           nil
         end
@@ -218,7 +218,8 @@ module Google
         #
         #   pubsub = Google::Cloud::Pubsub.new
         #
-        #   msg = pubsub.publish "my-topic", File.open("message.txt")
+        #   file = File.open "message.txt", mode: "rb"
+        #   msg = pubsub.publish "my-topic", file
         #
         # @example Additionally, a message can be published with attributes:
         #   require "google/cloud/pubsub"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
@@ -1,0 +1,89 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Pubsub
+      ##
+      # # PublishResult
+      #
+      class PublishResult
+        ##
+        # @private Create an PublishResult object.
+        def initialize message, error = nil
+          @message = message
+          @error = error
+        end
+
+        ##
+        # The message.
+        def message
+          @message
+        end
+        alias_method :msg, :message
+
+        ##
+        # The message's data.
+        def data
+          message.data
+        end
+
+        ##
+        # The message's attributes.
+        def attributes
+          message.attributes
+        end
+
+        ##
+        # The ID of the message, assigned by the server at publication
+        # time. Guaranteed to be unique within the topic.
+        def message_id
+          message.message_id
+        end
+        alias_method :msg_id, :message_id
+
+        ##
+        # The error that was raised when published, if any.
+        def error
+          @error
+        end
+
+        ##
+        # Whether the publish request was successful.
+        def succeeded?
+          error.nil?
+        end
+
+        # Whether the publish request failed.
+        def failed?
+          !succeeded?
+        end
+
+        ##
+        # @private Create an PublishResult object from a message protobuf.
+        def self.from_grpc msg_grpc
+          new Message.from_grpc(msg_grpc)
+        end
+
+        ##
+        # @private Create an PublishResult object from a message protobuf and an
+        # error.
+        def self.from_error msg_grpc, error
+          new Message.from_grpc(msg_grpc), error
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -145,11 +145,6 @@ module Google
         # The messages parameter is an array of arrays.
         # The first element is the data, second is attributes hash.
         def publish topic, messages
-          messages = messages.map do |data, attributes|
-            Google::Pubsub::V1::PubsubMessage.new(
-              data: data, attributes: attributes)
-          end
-
           execute do
             publisher.publish topic_path(topic), messages,
                               options: default_options

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -14,7 +14,7 @@
 
 
 require "google/cloud/errors"
-require "google/cloud/pubsub/topic/publisher"
+require "google/cloud/pubsub/topic/batch_publisher"
 require "google/cloud/pubsub/topic/list"
 require "google/cloud/pubsub/subscription"
 require "google/cloud/pubsub/policy"
@@ -236,9 +236,10 @@ module Google
         #
         # @param [String, File] data The message data.
         # @param [Hash] attributes Optional attributes for the message.
-        # @yield [publisher] a block for publishing multiple messages in one
+        # @yield [batch] a block for publishing multiple messages in one
         #   request
-        # @yieldparam [Topic::Publisher] publisher the topic publisher object
+        # @yieldparam [Topic::BatchPublisher] batch the topic batch publisher
+        #   object
         #
         # @return [Message, Array<Message>] Returns the published message when
         #   called without a block, or an array of messages when called with a
@@ -284,10 +285,10 @@ module Google
         #
         def publish data = nil, attributes = {}
           ensure_service!
-          publisher = Publisher.new data, attributes
-          yield publisher if block_given?
-          return nil if publisher.messages.count.zero?
-          publish_batch_messages publisher
+          batch = BatchPublisher.new data, attributes
+          yield batch if block_given?
+          return nil if batch.messages.count.zero?
+          publish_batch_messages batch
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/async_publisher.rb
@@ -1,0 +1,230 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "monitor"
+require "concurrent"
+require "google/cloud/pubsub/publish_result"
+require "google/cloud/pubsub/service"
+
+module Google
+  module Cloud
+    module Pubsub
+      class Topic
+        ##
+        # # AsyncPublisher
+        #
+        class AsyncPublisher
+          include MonitorMixin
+
+          attr_reader :topic_name, :service, :batch
+          attr_reader :max_bytes, :max_messages, :interval
+          attr_reader :thread, :publisher_thread_pool, :callback_thread_pool
+
+          def initialize topic_name, service, max_bytes: 5242880,
+                         max_messages: 1000, interval: 0.25, threads: nil
+            @topic_name = service.topic_path topic_name
+            @service = service
+
+            @max_bytes = max_bytes
+            @max_messages = max_messages
+            @interval = interval
+            @threads = threads || [2, Concurrent.processor_count * 2].max
+
+            @cond = new_cond
+
+            # init MonitorMixin
+            super()
+          end
+
+          def publish data = nil, attributes = {}, &block
+            msg = create_pubsub_message data, attributes
+
+            synchronize do
+              fail "Can't publish when stopped." if @stopped
+
+              if @batch.nil?
+                @batch ||= Batch.new self
+                @batch.add msg, block
+              else
+                unless @batch.try_add msg, block
+                  publish_batch!
+                  @batch = Batch.new self
+                  @batch.add msg, block
+                end
+              end
+
+              @first_published_at ||= Time.now
+              @thread_pool ||= Concurrent::FixedThreadPool.new @threads
+              @thread ||= Thread.new { run_background }
+
+              @cond.signal
+            end
+            nil
+          end
+
+          def stop
+            synchronize do
+              break if @stopped
+
+              @stopped = true
+              publish_batch!
+              @cond.signal
+              @thread_pool.shutdown if @thread_pool
+            end
+
+            self
+          end
+
+          def wait! timeout = nil
+            synchronize do
+              @thread_pool.wait_for_termination timeout if @thread_pool
+            end
+
+            self
+          end
+
+          def flush
+            synchronize do
+              publish_batch!
+              @cond.signal
+            end
+
+            self
+          end
+
+          def started?
+            !stopped?
+          end
+
+          def stopped?
+            synchronize { @stopped }
+          end
+
+          protected
+
+          def run_background
+            synchronize do
+              until @stopped
+                if @batch.nil?
+                  @cond.wait
+                  next
+                end
+
+                time_since_first_publish = Time.now - @first_published_at
+                if time_since_first_publish > @interval
+                  # interval met, publish the batch...
+                  publish_batch!
+                  @cond.wait
+                else
+                  # still waiting for the interval to publish the batch...
+                  @cond.wait(@interval - time_since_first_publish)
+                end
+              end
+            end
+          end
+
+          def publish_batch!
+            return unless @batch
+
+            publish_batch_async @topic_name, @batch
+            @batch = nil
+            @first_published_at = nil
+          end
+
+          def publish_batch_async topic_name, batch
+            Concurrent::Future.new(executor: @thread_pool) do
+              begin
+                grpc = @service.publish topic_name, batch.messages
+                batch.items.zip(Array(grpc.message_ids)) do |item, id|
+                  next unless item.callback
+
+                  item.msg.message_id = id
+                  item.callback.call PublishResult.from_grpc(item.msg)
+                end
+              rescue => e
+                batch.items.each do |item|
+                  next unless item.callback
+
+                  item.callback.call PublishResult.from_error(item.msg, e)
+                end
+              end
+            end.execute
+          end
+
+          def create_pubsub_message data, attributes
+            attributes ||= {}
+            if data.is_a?(::Hash) && attributes.empty?
+              attributes = data
+              data = nil
+            end
+            # Convert IO-ish objects to strings
+            if data.respond_to?(:read) && data.respond_to?(:rewind)
+              data.rewind
+              data = data.read
+            end
+            # Convert data to encoded byte array to match the protobuf defn
+            data = String(data).force_encoding("ASCII-8BIT")
+
+            # Convert attributes to strings to match the protobuf definition
+            attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]
+
+            Google::Pubsub::V1::PubsubMessage.new data: data,
+                                                  attributes: attributes
+          end
+
+          class Batch
+            attr_reader :messages, :callbacks
+
+            def initialize publisher
+              @publisher = publisher
+              @messages = []
+              @callbacks = []
+            end
+
+            def add msg, callback
+              @messages << msg
+              @callbacks << callback
+            end
+
+            def try_add msg, callback
+              if total_message_count + 1 > @publisher.max_messages ||
+                 total_message_size + msg.to_proto.size >= @publisher.max_bytes
+                return false
+              end
+              add msg, callback
+              true
+            end
+
+            def total_message_count
+              @messages.count
+            end
+
+            def total_message_size
+              @messages.map(&:to_proto).map(&:size).inject(0, :+)
+            end
+
+            def items
+              @messages.zip(@callbacks).map do |msg, callback|
+                Item.new msg, callback
+              end
+            end
+
+            Item = Struct.new :msg, :callback
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/batch_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/batch_publisher.rb
@@ -52,25 +52,15 @@ module Google
           # All messages added will be published at once.
           # See {Google::Cloud::Pubsub::Topic#publish}
           def publish data, attributes = {}
-            # Convert IO-ish objects to strings
-            if data.respond_to?(:read) && data.respond_to?(:rewind)
-              data.rewind
-              data = data.read
-            end
-            # Convert data to encoded byte array to match the protobuf defn
-            data = String(data).force_encoding("ASCII-8BIT")
-            # Convert attributes to strings to match the protobuf definition
-            attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]
-            @messages << [data, attributes]
+            @messages << create_pubsub_message(data, attributes)
           end
 
           ##
           # @private Create Message objects with message ids.
           def to_gcloud_messages message_ids
-            msgs = @messages.zip(Array(message_ids)).map do |arr, id|
-              Message.from_grpc(
-                Google::Pubsub::V1::PubsubMessage.new(
-                  data: arr[0], attributes: arr[1], message_id: id))
+            msgs = @messages.zip(Array(message_ids)).map do |msg, id|
+              msg.message_id = id
+              Message.from_grpc msg
             end
             # Return just one Message if a single publish,
             # otherwise return the array of Messages.
@@ -79,6 +69,29 @@ module Google
             else
               msgs
             end
+          end
+
+          protected
+
+          def create_pubsub_message data, attributes
+            attributes ||= {}
+            if data.is_a?(::Hash) && attributes.empty?
+              attributes = data
+              data = nil
+            end
+            # Convert IO-ish objects to strings
+            if data.respond_to?(:read) && data.respond_to?(:rewind)
+              data.rewind
+              data = data.read
+            end
+            # Convert data to encoded byte array to match the protobuf defn
+            data = String(data).force_encoding("ASCII-8BIT")
+
+            # Convert attributes to strings to match the protobuf definition
+            attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]
+
+            Google::Pubsub::V1::PubsubMessage.new data: data,
+                                                  attributes: attributes
           end
         end
       end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/batch_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/batch_publisher.rb
@@ -18,7 +18,8 @@ module Google
     module Pubsub
       class Topic
         ##
-        # Topic Publisher object used to publish multiple messages at once.
+        # Topic Batch Publisher object used to publish multiple messages at
+        # once.
         #
         # @example
         #   require "google/cloud/pubsub"
@@ -31,7 +32,7 @@ module Google
         #     t.publish "task 2 completed", foo: :baz
         #     t.publish "task 3 completed", foo: :bif
         #   end
-        class Publisher
+        class BatchPublisher
           ##
           # @private The messages to publish
           attr_reader :messages

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -15,7 +15,7 @@
 require "google/cloud/pubsub"
 
 class File
-  def self.open f
+  def self.open *args
     "task completed"
   end
 end
@@ -413,6 +413,20 @@ YARD::Doctest.configure do |doctest|
         pubsub_message("task 3 completed", { "foo" => "bif" })
       ]
       mock_publisher.expect :publish, OpenStruct.new(message_ids: ["1", "2", "3"]), ["projects/my-project/topics/my-topic", messages, Hash]
+    end
+  end
+
+  doctest.skip "Google::Cloud::Pubsub::Topic#publish_async" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
+      mock_publisher.expect :publish, nil, ["projects/my-project/topics/my-topic", "task completed", {}]
+    end
+  end
+
+  doctest.skip "Google::Cloud::Pubsub::Topic#publish_async@Additionally, a message can be published with attributes:" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
+      mock_publisher.expect :publish, nil, ["projects/my-project/topics/my-topic", "task completed", {:foo=>:bar, :this=>:that}]
     end
   end
 

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -456,9 +456,9 @@ YARD::Doctest.configure do |doctest|
   end
 
   ##
-  # Topic::Publisher
+  # Topic::BatchPublisher
 
-  doctest.before "Google::Cloud::Pubsub::Topic::Publisher" do
+  doctest.before "Google::Cloud::Pubsub::Topic::BatchPublisher" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
       messages = [

--- a/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
@@ -1,0 +1,77 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::PublishResult, :mock_pubsub do
+  let(:data) { "msg-goes-here" }
+  let(:attributes) { { "foo" => "FOO", "bar" => "BAR" } }
+  let(:msg) { Google::Cloud::Pubsub::Message.new data, attributes }
+  let(:result) { Google::Cloud::Pubsub::PublishResult.new msg }
+
+  it "knows attributes" do
+    result.data.must_equal data
+    result.message.data.must_equal data
+    result.msg.data.must_equal data
+
+    result.attributes.keys.sort.must_equal   attributes.keys.sort
+    result.attributes.values.sort.must_equal attributes.values.sort
+    result.message.attributes.keys.sort.must_equal   attributes.keys.sort
+    result.message.attributes.values.sort.must_equal attributes.values.sort
+    result.msg.attributes.keys.sort.must_equal   attributes.keys.sort
+    result.msg.attributes.values.sort.must_equal attributes.values.sort
+
+    result.message_id.must_be :empty?
+    result.message.message_id.must_be :empty?
+    result.msg.message_id.must_be :empty?
+
+    result.message.must_equal msg
+    result.msg.must_equal msg
+
+    result.error.must_be :nil?
+
+    result.must_be :succeeded?
+    result.wont_be :failed?
+  end
+
+  describe "with error" do
+    let(:error) { StandardError.new "something happened" }
+    let(:result) { Google::Cloud::Pubsub::PublishResult.new msg, error }
+
+    it "knows attributes" do
+      result.data.must_equal data
+      result.message.data.must_equal data
+      result.msg.data.must_equal data
+
+      result.attributes.keys.sort.must_equal   attributes.keys.sort
+      result.attributes.values.sort.must_equal attributes.values.sort
+      result.message.attributes.keys.sort.must_equal   attributes.keys.sort
+      result.message.attributes.values.sort.must_equal attributes.values.sort
+      result.msg.attributes.keys.sort.must_equal   attributes.keys.sort
+      result.msg.attributes.values.sort.must_equal attributes.values.sort
+
+      result.message_id.must_be :empty?
+      result.message.message_id.must_be :empty?
+      result.msg.message_id.must_be :empty?
+
+      result.message.must_equal msg
+      result.msg.must_equal msg
+
+      result.error.must_equal error
+
+      result.wont_be :succeeded?
+      result.must_be :failed?
+    end
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/async_publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/async_publisher_test.rb
@@ -1,0 +1,315 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+Thread.abort_on_exception = true
+
+describe Google::Cloud::Pubsub::Topic::AsyncPublisher, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic_name2) { "differnt-topic-name" }
+  let(:message1) { "new-message-here" }
+  let(:message2) { "second-new-message" }
+  let(:message3) { "third-new-message" }
+  let(:msg_encoded1) { message1.encode("ASCII-8BIT") }
+  let(:msg_encoded2) { message2.encode("ASCII-8BIT") }
+  let(:msg_encoded3) { message3.encode("ASCII-8BIT") }
+
+  it "publishes a message" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Topic::AsyncPublisher.new topic_name, pubsub.service, interval: 10
+
+    publisher.publish message1
+
+    publisher.batch.messages.must_equal messages
+    publisher.batch.callbacks.must_equal [nil]
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop.wait!
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    publisher.batch.must_be :nil?
+
+    mock.verify
+  end
+
+  it "publishes a message with attributes" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1, attributes: {"format" => "text"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Topic::AsyncPublisher.new topic_name, pubsub.service, interval: 10
+
+    publisher.publish message1, format: :text
+
+    publisher.batch.messages.must_equal messages
+    publisher.batch.callbacks.must_equal [nil]
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop.wait!
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    publisher.batch.must_be :nil?
+
+    mock.verify
+  end
+
+  it "publishes a message with a callback" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Topic::AsyncPublisher.new topic_name, pubsub.service, interval: 10
+
+    callback_called = false
+
+    publisher.publish message1 do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      callback_called = true
+    end
+
+    publisher.batch.messages.must_equal messages
+    publisher.batch.callbacks.count.must_equal 1
+    publisher.batch.callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop.wait!
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    publisher.batch.must_be :nil?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes multiple messages" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1),
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded2),
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Topic::AsyncPublisher.new topic_name, pubsub.service, interval: 10
+
+    publisher.publish message1
+    publisher.publish message2
+    publisher.publish message3, format: :none
+
+    publisher.batch.messages.must_equal messages
+    publisher.batch.callbacks.must_equal [nil, nil, nil]
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop.wait!
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    publisher.batch.must_be :nil?
+
+    mock.verify
+  end
+
+  it "publishes multiple messages with callbacks" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1),
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded2),
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Topic::AsyncPublisher.new topic_name, pubsub.service, interval: 10
+
+    callback_count = 0
+
+    publisher.publish message1 do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      callback_count += 1
+    end
+    publisher.publish message2 do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      callback_count += 1
+    end
+    publisher.publish message3, format: :none do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      callback_count += 1
+    end
+
+    publisher.batch.messages.must_equal messages
+    publisher.batch.callbacks.count.must_equal 3
+    publisher.batch.callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.stop.wait!
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    publisher.batch.must_be :nil?
+    callback_count.must_equal 3
+
+    mock.verify
+  end
+
+  it "publishes multiple batches when message count limit is reached" do
+    messages = 10.times.map do
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
+    end
+    message_ids = 10.times.map do |i|
+      "msg#{i}"
+    end
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: message_ids }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    publisher = Google::Cloud::Pubsub::Topic::AsyncPublisher.new topic_name, pubsub.service, max_messages: 10, interval: 10
+
+    callbacks = 0
+
+    30.times do
+      publisher.publish message1 do |msg|
+        callbacks += 1
+      end
+    end
+
+    # messages in the batch are:
+    publisher.batch.messages.must_equal messages
+    publisher.batch.callbacks.count.must_equal 10
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.flush
+    wait_until { callbacks == 30 }
+
+    publisher.stop.wait!
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    publisher.batch.must_be :nil?
+
+    callbacks.must_equal 30
+
+    mock.verify
+  end
+
+  it "publishes multiple batches when message size limit is reached" do
+    messages = 10.times.map do
+      Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
+    end
+    message_ids = 10.times.map do |i|
+      "msg#{i}"
+    end
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: message_ids }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    # 190 is bigger than 10 messages, but less than 11.
+    publisher = Google::Cloud::Pubsub::Topic::AsyncPublisher.new topic_name, pubsub.service, max_bytes: 190, interval: 10
+
+    callbacks = 0
+
+    30.times do
+      publisher.publish message1 do |msg|
+        callbacks += 1
+      end
+    end
+
+    # messages in the batch are:
+    publisher.batch.messages.must_equal messages
+    publisher.batch.callbacks.count.must_equal 10
+
+    publisher.must_be :started?
+    publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    publisher.flush
+    wait_until { callbacks == 30 }
+
+    publisher.stop.wait!
+
+    publisher.wont_be :started?
+    publisher.must_be :stopped?
+
+    publisher.batch.must_be :nil?
+
+    callbacks.must_equal 30
+
+    mock.verify
+  end
+
+  def wait_until delay: 0.01, max: 10, output: nil, msg: "criteria not met", &block
+    attempts = 0
+    while !block.call
+      fail msg if attempts >= max
+      attempts += 1
+      puts "Retrying #{attempts} out of #{max}." if output
+      sleep delay
+    end
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
@@ -1,0 +1,379 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
+                                                       pubsub.service }
+
+  it "publishes a message" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    topic.async_publisher.must_be :nil?
+
+    topic.publish_async "async-message"
+
+    topic.async_publisher.wont_be :nil?
+
+    topic.async_publisher.batch.messages.must_equal messages
+    topic.async_publisher.batch.callbacks.count.must_equal 1
+    topic.async_publisher.batch.callbacks.must_equal [nil]
+
+    topic.async_publisher.must_be :started?
+    topic.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.async_publisher.stop.wait!
+
+    topic.async_publisher.wont_be :started?
+    topic.async_publisher.must_be :stopped?
+
+    topic.async_publisher.batch.must_be :nil?
+
+    mock.verify
+  end
+
+  it "publishes a message with a callback" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    topic.async_publisher.must_be :nil?
+
+    callback_called = false
+
+    topic.publish_async "async-message" do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      assert result.succeeded?
+      assert_equal "msg1", result.msg_id
+      callback_called = true
+    end
+
+    topic.async_publisher.wont_be :nil?
+
+    topic.async_publisher.batch.messages.must_equal messages
+    topic.async_publisher.batch.callbacks.count.must_equal 1
+    topic.async_publisher.batch.callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    topic.async_publisher.must_be :started?
+    topic.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.async_publisher.stop.wait!
+
+    topic.async_publisher.wont_be :started?
+    topic.async_publisher.must_be :stopped?
+
+    topic.async_publisher.batch.must_be :nil?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes a message with multibyte characters" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    topic.async_publisher.must_be :nil?
+
+    callback_called = false
+
+    topic.publish_async "あ" do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      assert result.succeeded?
+      assert_equal "msg1", result.msg_id
+      assert_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT"), result.data
+      callback_called = true
+    end
+
+    topic.async_publisher.wont_be :nil?
+
+    topic.async_publisher.batch.messages.must_equal messages
+    topic.async_publisher.batch.callbacks.count.must_equal 1
+    topic.async_publisher.batch.callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    topic.async_publisher.must_be :started?
+    topic.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.async_publisher.stop.wait!
+
+    topic.async_publisher.wont_be :started?
+    topic.async_publisher.must_be :stopped?
+
+    topic.async_publisher.batch.must_be :nil?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes a message using an IO-ish object" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    topic.async_publisher.must_be :nil?
+
+    callback_called = false
+
+    Tempfile.open ["message", "txt"] do |tmpfile|
+      tmpfile.binmode
+      tmpfile.write "あ"
+      tmpfile.rewind
+
+      topic.publish_async tmpfile do |result|
+        assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+        assert result.succeeded?
+        assert_equal "msg1", result.msg_id
+        assert_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT"), result.data
+        callback_called = true
+      end
+    end
+
+    topic.async_publisher.wont_be :nil?
+
+    topic.async_publisher.batch.messages.must_equal messages
+    topic.async_publisher.batch.callbacks.count.must_equal 1
+    topic.async_publisher.batch.callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    topic.async_publisher.must_be :started?
+    topic.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.async_publisher.stop.wait!
+
+    topic.async_publisher.wont_be :started?
+    topic.async_publisher.must_be :stopped?
+
+    topic.async_publisher.batch.must_be :nil?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  it "publishes a message with attributes" do
+    messages = [
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"), attributes: {"format" => "text"})
+    ]
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    topic.async_publisher.must_be :nil?
+
+    callback_called = false
+
+    topic.publish_async "async-message", format: :text do |result|
+      assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+      assert result.succeeded?
+      assert_equal "msg1", result.msg_id
+      assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+      assert_equal "text", result.attributes["format"]
+      callback_called = true
+    end
+
+    topic.async_publisher.wont_be :nil?
+
+    topic.async_publisher.batch.messages.must_equal messages
+    topic.async_publisher.batch.callbacks.count.must_equal 1
+    topic.async_publisher.batch.callbacks.each do |block|
+      block.must_be_kind_of Proc
+    end
+
+    topic.async_publisher.must_be :started?
+    topic.async_publisher.wont_be :stopped?
+
+    # force the queued messages to be published
+    topic.async_publisher.stop.wait!
+
+    topic.async_publisher.wont_be :started?
+    topic.async_publisher.must_be :stopped?
+
+    topic.async_publisher.batch.must_be :nil?
+    callback_called.must_equal true
+
+    mock.verify
+  end
+
+  describe "lazy topic that exists" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service,
+                                                 autocreate: false }
+
+    it "publishes a message" do
+      messages = [
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+      ]
+      publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      mock = Minitest::Mock.new
+      mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+      topic.service.mocked_publisher = mock
+
+      topic.async_publisher.must_be :nil?
+
+      topic.publish_async "async-message"
+
+      topic.async_publisher.wont_be :nil?
+
+      topic.async_publisher.batch.messages.must_equal messages
+      topic.async_publisher.batch.callbacks.count.must_equal 1
+      topic.async_publisher.batch.callbacks.must_equal [nil]
+
+      topic.async_publisher.must_be :started?
+      topic.async_publisher.wont_be :stopped?
+
+      # force the queued messages to be published
+      topic.async_publisher.stop.wait!
+
+      topic.async_publisher.wont_be :started?
+      topic.async_publisher.must_be :stopped?
+
+      topic.async_publisher.batch.must_be :nil?
+
+      mock.verify
+    end
+
+    it "publishes a message with attributes" do
+      messages = [
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"), attributes: { "format" => "text" })
+      ]
+      publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+      mock = Minitest::Mock.new
+      mock.expect :publish, publish_res, [topic_path(topic_name), messages, options: default_options]
+      topic.service.mocked_publisher = mock
+
+      topic.async_publisher.must_be :nil?
+
+      callback_called = false
+
+      topic.publish_async "async-message", format: :text do |result|
+        assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+        assert result.succeeded?
+        assert_equal "msg1", result.msg_id
+        assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+        assert_equal "text", result.attributes["format"]
+        callback_called = true
+      end
+
+      topic.async_publisher.wont_be :nil?
+
+      topic.async_publisher.batch.messages.must_equal messages
+      topic.async_publisher.batch.callbacks.count.must_equal 1
+      topic.async_publisher.batch.callbacks.each do |block|
+        block.must_be_kind_of Proc
+      end
+
+      topic.async_publisher.must_be :started?
+      topic.async_publisher.wont_be :stopped?
+
+      # force the queued messages to be published
+      topic.async_publisher.stop.wait!
+
+      topic.async_publisher.wont_be :started?
+      topic.async_publisher.must_be :stopped?
+
+      topic.async_publisher.batch.must_be :nil?
+      callback_called.must_equal true
+
+      mock.verify
+    end
+  end
+
+  describe "lazy topic that does not exist" do
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.service,
+                                                 autocreate: false }
+    let(:gax_error) do
+      Google::Gax::GaxError.new("not found").tap do |e|
+        e.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+      end
+    end
+
+    it "publishes a message" do
+      messages = [
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+      ]
+
+      stub = Object.new
+      def stub.publish *args
+        err = Google::Gax::GaxError.new("not found").tap do |e|
+          e.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        end
+        raise err
+      end
+      pubsub.service.mocked_publisher = stub
+
+      topic.async_publisher.must_be :nil?
+
+      callback_called = false
+
+      topic.publish_async "async-message" do |result|
+        assert_kind_of Google::Cloud::Pubsub::PublishResult, result
+        refute result.succeeded?
+        assert result.failed?
+        assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+        assert_kind_of Google::Cloud::NotFoundError, result.error
+        callback_called = true
+      end
+
+      topic.async_publisher.wont_be :nil?
+
+      topic.async_publisher.batch.messages.must_equal messages
+      topic.async_publisher.batch.callbacks.count.must_equal 1
+      topic.async_publisher.batch.callbacks.each do |block|
+        block.must_be_kind_of Proc
+      end
+
+      topic.async_publisher.must_be :started?
+      topic.async_publisher.wont_be :stopped?
+
+      # force the queued messages to be published
+      topic.async_publisher.stop.wait!
+
+      topic.async_publisher.wont_be :started?
+      topic.async_publisher.must_be :stopped?
+
+      topic.async_publisher.batch.must_be :nil?
+      callback_called.must_equal true
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a AsyncPublisher object to Topic that performs the following:

- [x] Asynchronously publish messages in batches
- [x] Will push batches in intervals _after_ first publish (every 0.25 seconds)
- [x] Will push batches when message count hits a limit (1000)
- [x] Will push batches when RPC payload reaches a size (5MB)

This functionality is expressed as `Topic#publish_async`. The publisher object can be accessed as `Topic#async_publisher`.

This change is to be merged into the pubsub branch, which will be used as the target for the upcoming Pub/Sub changes.

This PR is an alternative implementation to #1530, based on feedback provided.