### PR TITLE
Trace outgoing gRPC requests

### DIFF
--- a/google-cloud-trace/lib/google/cloud/trace/label_key.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/label_key.rb
@@ -70,8 +70,10 @@ module Google
         GAE_MEMCACHE_SIZE = "g.co/gae/memcache/size"
         GAE_REQUEST_LOG_ID = "g.co/gae/request_log_id"
 
+        RPC_HOST = "/rpc/host"
         RPC_REQUEST_SIZE = "/rpc/request/size"
         RPC_RESPONSE_SIZE = "/rpc/response/size"
+        RPC_STATUS_CODE = "/rpc/status_code"
 
         ##
         # Set the stack trace label in the given labels hash. The current call

--- a/google-cloud-trace/lib/google/cloud/trace/label_key.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/label_key.rb
@@ -71,6 +71,7 @@ module Google
         GAE_REQUEST_LOG_ID = "g.co/gae/request_log_id"
 
         RPC_HOST = "/rpc/host"
+        RPC_REQUEST_TYPE = "/rpc/request/type"
         RPC_REQUEST_SIZE = "/rpc/request/size"
         RPC_RESPONSE_SIZE = "/rpc/response/size"
         RPC_STATUS_CODE = "/rpc/status_code"

--- a/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
@@ -1,0 +1,43 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/trace"
+
+module GRPC
+  ##
+  # Stackdriver Trace instrumentation of GRPC by patching GRPC::ActiveCall
+  # class. Intercept each GRPC request and create a Trace span with basic
+  # request information.
+  module ActiveCallWithTrace
+    ##
+    # Override GRPC::ActiveCall#request_response method. Wrap the original
+    # method with a trace span that will get submitted with the overall request
+    # trace span tree.
+    def request_response *args
+      Google::Cloud::Trace.in_span "gRPC request" do |span|
+        if span && !args.empty?
+          grpc_request = args[0]
+          label_key = Google::Cloud::Trace::LabelKey::RPC_REQUEST_TYPE
+          span.labels[label_key] = grpc_request.class.name.gsub(/^.*::/, "")
+        end
+
+        super
+      end
+    end
+  end
+
+  # Patch GRPC::ActiveCall#request_response method
+  ::GRPC::ActiveCall.send(:prepend, ActiveCallWithTrace)
+end

--- a/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
@@ -21,12 +21,14 @@ module GRPC
   # class. Intercept each GRPC request and create a Trace span with basic
   # request information.
   module ActiveCallWithTrace
+    SPAN_NAME = "gRPC request"
+
     ##
     # Override GRPC::ActiveCall#request_response method. Wrap the original
     # method with a trace span that will get submitted with the overall request
     # trace span tree.
     def request_response *args
-      Google::Cloud::Trace.in_span "gRPC request" do |span|
+      Google::Cloud::Trace.in_span SPAN_NAME do |span|
         if span && !args.empty?
           grpc_request = args[0]
           label_key = Google::Cloud::Trace::LabelKey::RPC_REQUEST_TYPE

--- a/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
@@ -68,7 +68,7 @@ module GRPC
       def run_batch *args
         span = Google::Cloud::Trace.get
         # Make sure we're in a "gRPC request" span
-        span = nil if span && span.name != "gRPC request"
+        span = nil if span && span.name != GRPC::ActiveCallWithTrace::SPAN_NAME
 
         if span && !args.empty?
           message = args[0]

--- a/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
@@ -1,0 +1,87 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/trace"
+
+module GRPC
+  module Core
+    ##
+    # Instrumentation Stackdriver Trace in GRPC by patching GRPC::Core::Call
+    # class. Intercept each GRPC request and create a Trace span with basic
+    # request information.
+    module CallWithTrace
+      ##
+      # @private Add request labels from the Call object and message.
+      def self.add_request_labels call, message, labels
+        label_keys = Google::Cloud::Trace::LabelKey
+
+        message_size = message.to_s.bytesize.to_s
+
+        set_label labels, label_keys::RPC_REQUEST_SIZE, message_size
+        set_label labels, label_keys::RPC_HOST, call.peer.to_s
+      end
+
+      ##
+      # @private Add response labels from gRPC response
+      def self.add_response_labels response, labels
+        label_keys = Google::Cloud::Trace::LabelKey
+
+        response_size = response.message.to_s.bytesize.to_s
+        status = status_code_to_label response.status.code
+
+        set_label labels, label_keys::RPC_RESPONSE_SIZE, response_size
+        set_label labels, label_keys::RPC_STATUS_CODE, status
+      end
+
+      ##
+      # @private Helper method to set label
+      def self.set_label labels, key, value
+        labels[key] = value if value.is_a? ::String
+      end
+
+      ##
+      # @private Reverse lookup from numeric status code to readable string.
+      def self.status_code_to_label code
+        @lookup ||= GRPC::Core::StatusCodes.constants.map do |c|
+          [GRPC::Core::StatusCodes.const_get(c), c.to_s]
+        end.to_h
+
+        @lookup[code]
+      end
+
+      ##
+      # Override GRPC::Core::Call#run_batch method. Wrap the original method
+      # with a trace span that will get submitted with the overall request trace
+      # span tree.
+      def run_batch *args
+        Google::Cloud::Trace.in_span "gRPC request" do |span|
+          if span && args.size > 0
+            message = args[0]
+            CallWithTrace.add_request_labels self, message, span.labels
+          end
+
+          response = super
+
+          CallWithTrace.add_response_labels response, span.labels if span
+
+          response
+        end
+      end
+    end
+
+    # Patch GRPC::Core::Call#run_batch method
+    ::GRPC::Core::Call.send(:prepend, CallWithTrace)
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
@@ -54,9 +54,9 @@ module GRPC
       ##
       # @private Reverse lookup from numeric status code to readable string.
       def self.status_code_to_label code
-        @lookup ||= GRPC::Core::StatusCodes.constants.map do |c|
+        @lookup ||= Hash[GRPC::Core::StatusCodes.constants.map do |c|
           [GRPC::Core::StatusCodes.const_get(c), c.to_s]
-        end.to_h
+        end]
 
         @lookup[code]
       end

--- a/google-cloud-trace/lib/google/cloud/trace/service.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/service.rb
@@ -59,13 +59,13 @@ module Google
         end
 
         def channel
-          require "grpc"
+          load_grpc
           GRPC::Core::Channel.new host, nil, chan_creds
         end
 
         def chan_creds
           return credentials if insecure?
-          require "grpc"
+          load_grpc
           GRPC::Core::ChannelCredentials.new.compose \
             GRPC::Core::CallCredentials.new credentials.client.updater_proc
         end
@@ -159,6 +159,12 @@ module Google
         rescue Google::Gax::GaxError => e
           # GaxError wraps BadStatus, but exposes it as #cause
           raise Google::Cloud::Error.from_error(e.cause)
+        end
+
+        def load_grpc
+          require "grpc"
+          # require "google/cloud/trace/patches/active_call_with_trace"
+          require "google/cloud/trace/patches/call_with_trace"
         end
       end
     end

--- a/google-cloud-trace/lib/google/cloud/trace/service.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/service.rb
@@ -163,7 +163,7 @@ module Google
 
         def load_grpc
           require "grpc"
-          # require "google/cloud/trace/patches/active_call_with_trace"
+          require "google/cloud/trace/patches/active_call_with_trace"
           require "google/cloud/trace/patches/call_with_trace"
         end
       end

--- a/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
@@ -1,0 +1,59 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "grpc"
+require "google/cloud/trace/patches/active_call_with_trace"
+require "ostruct"
+
+class MockActiveCall
+  prepend GRPC::ActiveCallWithTrace
+
+  attr_accessor :run_batch_count
+
+  def initialize
+    @request_response_count = 0
+  end
+
+  def request_response *args
+    @request_response_count += 1
+    "test-response"
+  end
+end
+
+describe GRPC::ActiveCallWithTrace do
+  let (:active_call_with_trace) { MockActiveCall.new }
+
+  describe "#request_response" do
+    it "calls super even if a span is not set" do
+      Google::Cloud::Trace.stub :get, nil do
+        active_call_with_trace.request_response("test").must_equal "test-response"
+      end
+    end
+
+    it "sets labels" do
+      stubbed_span = OpenStruct.new labels: {}
+      stubbed_span.define_singleton_method :in_span do |_, _, &b|
+        b.call self
+      end
+
+      Google::Cloud::Trace.stub :get, stubbed_span do
+        active_call_with_trace.request_response("test").must_equal "test-response"
+      end
+
+      stubbed_span.labels[Google::Cloud::Trace::LabelKey::RPC_REQUEST_TYPE].must_equal "String"
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
@@ -57,7 +57,7 @@ describe GRPC::Core::CallWithTrace do
         message.must_equal "grpc-test-message"
         add_labels_called = true
       end
-      stubbed_span = OpenStruct.new(labels: {}, name: "gRPC request")
+      stubbed_span = OpenStruct.new(labels: {}, name: GRPC::ActiveCallWithTrace::SPAN_NAME)
       stubbed_span.define_singleton_method :in_span do |_, _, &b|
         b.call self
       end

--- a/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
@@ -1,0 +1,100 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "grpc"
+require "google/cloud/trace/patches/call_with_trace"
+require "ostruct"
+
+class MockGRPCCall
+  prepend GRPC::Core::CallWithTrace
+
+  attr_accessor :run_batch_count
+
+  def initialize
+    @run_batch_count = 0
+  end
+
+  def run_batch *args
+    @run_batch_count += 1
+    OpenStruct.new message: "test-grpc-response-message",
+                   status: OpenStruct.new(code: 0)
+  end
+
+  def peer
+    "test-host.googleapi.com"
+  end
+end
+
+describe GRPC::Core::CallWithTrace do
+  let (:call_with_trace) { MockGRPCCall.new }
+
+  describe "#run_batch" do
+    it "doesn't interfere orignal #run_patch if there are no parent span" do
+      Google::Cloud::Trace.stub :get, nil do
+        call_with_trace.run_batch
+      end
+
+      call_with_trace.run_batch_count.must_equal 1
+    end
+
+    it "calls add_request_labels with first message" do
+      add_labels_called = false
+
+      stubbed_add_labels = ->(_, message, _) do
+        message.must_equal "grpc-test-message"
+        add_labels_called = true
+      end
+      stubbed_span = OpenStruct.new(labels: {})
+      stubbed_span.define_singleton_method :in_span do |_, _, &b|
+        b.call self
+      end
+
+      Google::Cloud::Trace.stub :get, stubbed_span do
+        GRPC::Core::CallWithTrace.stub :add_request_labels, stubbed_add_labels do
+          GRPC::Core::CallWithTrace.stub :add_response_labels, nil do
+            call_with_trace.run_batch "grpc-test-message"
+          end
+        end
+      end
+
+      add_labels_called.must_equal true
+    end
+
+    it "addes all the labels" do
+      stubbed_span = OpenStruct.new(labels: {})
+      stubbed_span.define_singleton_method :in_span do |_, _, &b|
+        b.call self
+      end
+
+      Google::Cloud::Trace.stub :get, stubbed_span do
+        call_with_trace.run_batch "grpc-test-message"
+      end
+
+      label_keys = Google::Cloud::Trace::LabelKey
+      stubbed_span.labels[label_keys::RPC_REQUEST_SIZE].must_equal "grpc-test-message".bytesize.to_s
+      stubbed_span.labels[label_keys::RPC_HOST].must_equal "test-host.googleapi.com"
+      stubbed_span.labels[label_keys::RPC_RESPONSE_SIZE].must_equal "test-grpc-response-message".bytesize.to_s
+      stubbed_span.labels[label_keys::RPC_STATUS_CODE].must_equal "OK"
+    end
+  end
+
+  describe ".status_code_to_label" do
+    it "returns correct label" do
+      GRPC::Core::CallWithTrace.status_code_to_label(0).must_equal "OK"
+      GRPC::Core::CallWithTrace.status_code_to_label(7).must_equal "PERMISSION_DENIED"
+    end
+  end
+end

--- a/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
@@ -57,7 +57,7 @@ describe GRPC::Core::CallWithTrace do
         message.must_equal "grpc-test-message"
         add_labels_called = true
       end
-      stubbed_span = OpenStruct.new(labels: {})
+      stubbed_span = OpenStruct.new(labels: {}, name: "gRPC request")
       stubbed_span.define_singleton_method :in_span do |_, _, &b|
         b.call self
       end
@@ -74,7 +74,7 @@ describe GRPC::Core::CallWithTrace do
     end
 
     it "addes all the labels" do
-      stubbed_span = OpenStruct.new(labels: {})
+      stubbed_span = OpenStruct.new(labels: {}, name: "gRPC request")
       stubbed_span.define_singleton_method :in_span do |_, _, &b|
         b.call self
       end


### PR DESCRIPTION
Instrumentation Stackdriver Trace in GRPC by patching `GRPC::Core::Call` class. Intercept each GRPC request and create a Trace span with some basic request information.