### PR TITLE
Pub/Sub Message data encoding

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
@@ -61,13 +61,14 @@ module Google
         end
 
         ##
-        # The received data.
+        # The message payload. This data is a list of bytes encoded as
+        # ASCII-8BIT.
         def data
           @grpc.data
         end
 
         ##
-        # The received attributes.
+        # Optional attributes for the message.
         def attributes
           return @grpc.attributes.to_h if @grpc.attributes.respond_to? :to_h
           # Enumerable doesn't have to_h on Ruby 2.0, so fallback to this

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -194,8 +194,12 @@ module Google
         ##
         # Publishes one or more messages to the given topic.
         #
+        # The message payload must not be empty; it must contain either a
+        # non-empty data field, or at least one attribute.
+        #
         # @param [String] topic_name Name of a topic.
-        # @param [String, File] data The message data.
+        # @param [String, File] data The message payload. This will be converted
+        #   to bytes encoded as ASCII-8BIT.
         # @param [Hash] attributes Optional attributes for the message.
         # @yield [batch] a block for publishing multiple messages in one
         #   request

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -66,13 +66,14 @@ module Google
         alias_method :msg, :message
 
         ##
-        # The received message's data.
+        # The received message payload. This data is a list of bytes encoded as
+        # ASCII-8BIT.
         def data
           message.data
         end
 
         ##
-        # The received message's attributes.
+        # Optional attributes for the received message.
         def attributes
           message.attributes
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -240,7 +240,11 @@ module Google
         ##
         # Publishes one or more messages to the topic.
         #
-        # @param [String, File] data The message data.
+        # The message payload must not be empty; it must contain either a
+        # non-empty data field, or at least one attribute.
+        #
+        # @param [String, File] data The message payload. This will be converted
+        #   to bytes encoded as ASCII-8BIT.
         # @param [Hash] attributes Optional attributes for the message.
         # @yield [batch] a block for publishing multiple messages in one
         #   request
@@ -301,7 +305,11 @@ module Google
         ##
         # Publishes a message asynchonously to the topic.
         #
-        # @param [String, File] data The message data.
+        # The message payload must not be empty; it must contain either a
+        # non-empty data field, or at least one attribute.
+        #
+        # @param [String, File] data The message payload. This will be converted
+        #   to bytes encoded as ASCII-8BIT.
         # @param [Hash] attributes Optional attributes for the message.
         # @yield [result] the callback for when the message has been published
         # @yieldparam [PublishResult] result the result of the asynchonous

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/async_publisher.rb
@@ -175,12 +175,12 @@ module Google
               data = data.read
             end
             # Convert data to encoded byte array to match the protobuf defn
-            data = String(data).force_encoding("ASCII-8BIT")
+            data_bytes = String(data).dup.force_encoding("ASCII-8BIT").freeze
 
             # Convert attributes to strings to match the protobuf definition
             attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]
 
-            Google::Pubsub::V1::PubsubMessage.new data: data,
+            Google::Pubsub::V1::PubsubMessage.new data: data_bytes,
                                                   attributes: attributes
           end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/batch_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/batch_publisher.rb
@@ -85,12 +85,12 @@ module Google
               data = data.read
             end
             # Convert data to encoded byte array to match the protobuf defn
-            data = String(data).force_encoding("ASCII-8BIT")
+            data_bytes = String(data).dup.force_encoding("ASCII-8BIT").freeze
 
             # Convert attributes to strings to match the protobuf definition
             attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]
 
-            Google::Pubsub::V1::PubsubMessage.new data: data,
+            Google::Pubsub::V1::PubsubMessage.new data: data_bytes,
                                                   attributes: attributes
           end
         end


### PR DESCRIPTION
Update documentation to detail how message data is processed when sending to Pub/Sub API, and how message data is encoded when received from Pub/Sub API.

The Google Cloud Pub/Sub Ruby library will follow how Google Protobuf [handles string data for bytes fields](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#fields), namely:

> The protobuf library will duplicate the string, convert it to ASCII-8BIT encoding, and freeze it.

The Google Cloud Pub/Sub Ruby library should not provide less convenience than Google Protobuf. In fact, it provides more convenience for `data` values, as it will also accept an IO-ish object, such as File, and convert it to a string/bytes.