### PR TITLE
Add schema option to Bigquery::Dataset#load

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -127,11 +127,12 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   end
 
   it "imports data from a local file and creates a new table with specified schema as an option" do
-    schema = bigquery.schema
-    schema.integer  "id",     description: "id description",    mode: :required
-    schema.string    "breed", description: "breed description", mode: :required
-    schema.string    "name",  description: "name description",  mode: :required
-    schema.timestamp "dob",   description: "dob description",   mode: :required
+    schema = bigquery.schema do |s|
+      s.integer  "id",     description: "id description",    mode: :required
+      s.string    "breed", description: "breed description", mode: :required
+      s.string    "name",  description: "name description",  mode: :required
+      s.timestamp "dob",   description: "dob description",   mode: :required
+    end
 
     job = dataset.load "local_file_table_2", local_file, schema: schema
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1002,8 +1002,7 @@ module Google
 
           schema = nil
           if block_given?
-            schema_gapi = Google::Apis::BigqueryV2::TableSchema.new(fields: [])
-            schema = Schema.from_gapi schema_gapi
+            schema = Schema.from_gapi
             yield schema
             schema = schema.to_gapi
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -753,10 +753,17 @@ module Google
         end
 
         ##
-        # Creates a new, empty schema instance. This instance can be populated
-        # and passed to {Dataset#load} using the `schema` option. However, for
-        # most use cases, the block yielded by {Dataset#load} is a more
-        # convenient way to configure the schema for the destination table.
+        # Creates a new schema instance. An optional block may be given to
+        # configure the schema, otherwise the schema is returned empty and may
+        # be configured directly.
+        #
+        # The returned schema can be passed to {Dataset#load} using the `schema`
+        # option. However, for most use cases, the block yielded by
+        # {Dataset#load} is a more convenient way to configure the schema for
+        # the destination table.
+        #
+        # @yield [schema] a block for setting the schema
+        # @yieldparam [Schema] schema the object accepting the schema
         #
         # @return [Google::Cloud::Bigquery::Schema]
         #
@@ -765,11 +772,12 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   schema = bigquery.schema
-        #   schema.string "first_name", mode: :required
-        #   schema.record "cities_lived", mode: :repeated do |nested_schema|
-        #     nested_schema.string "place", mode: :required
-        #     nested_schema.integer "number_of_years", mode: :required
+        #   schema = bigquery.schema do |s|
+        #     s.string "first_name", mode: :required
+        #     s.record "cities_lived", mode: :repeated do |nested_schema|
+        #       nested_schema.string "place", mode: :required
+        #       nested_schema.integer "number_of_years", mode: :required
+        #     end
         #   end
         #
         #   dataset = bigquery.dataset "my_dataset"
@@ -778,7 +786,9 @@ module Google
         #   load_job = dataset.load "my_new_table", gs_url, schema: schema
         #
         def schema
-          Schema.from_gapi
+          s = Schema.from_gapi
+          yield s if block_given?
+          s
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -22,6 +22,7 @@ require "google/cloud/bigquery/job"
 require "google/cloud/bigquery/query_data"
 require "google/cloud/bigquery/project/list"
 require "google/cloud/bigquery/time"
+require "google/cloud/bigquery/schema"
 
 module Google
   module Cloud
@@ -749,6 +750,35 @@ module Google
         #
         def time hour, minute, second
           Bigquery::Time.new "#{hour}:#{minute}:#{second}"
+        end
+
+        ##
+        # Creates a new, empty schema instance. This instance can be populated
+        # and passed to {Dataset#load} using the `schema` option. However, for
+        # most use cases, the block yielded by {Dataset#load} is a more
+        # convenient way to configure the schema for the destination table.
+        #
+        # @return [Google::Cloud::Bigquery::Schema]
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   schema = bigquery.schema
+        #   schema.string "first_name", mode: :required
+        #   schema.record "cities_lived", mode: :repeated do |nested_schema|
+        #     nested_schema.string "place", mode: :required
+        #     nested_schema.integer "number_of_years", mode: :required
+        #   end
+        #
+        #   dataset = bigquery.dataset "my_dataset"
+        #
+        #   gs_url = "gs://my-bucket/file-name.csv"
+        #   load_job = dataset.load "my_new_table", gs_url, schema: schema
+        #
+        def schema
+          Schema.from_gapi
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -260,7 +260,10 @@ module Google
         end
 
         # @private
-        def self.from_gapi gapi
+        # @param [Google::Apis::BigqueryV2::TableSchema, nil] gapi Returns an
+        #   empty schema if nil or no arg is provided. The default is nil.
+        #
+        def self.from_gapi gapi = nil
           gapi ||= Google::Apis::BigqueryV2::TableSchema.new fields: []
           gapi.fields ||= []
           new.tap do |s|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -361,11 +361,7 @@ module Google
           ensure_full_data!
           schema_builder = Schema.from_gapi @gapi.schema
           if block_given?
-            if replace
-              empty_schema = Google::Apis::BigqueryV2::TableSchema.new(
-                fields: [])
-              schema_builder = Schema.from_gapi empty_schema
-            end
+            schema_builder = Schema.from_gapi if replace
             yield schema_builder
             if schema_builder.changed?
               @gapi.schema = schema_builder.to_gapi
@@ -909,10 +905,7 @@ module Google
             # TODO: make sure to call ensure_full_data! on Dataset#update
             @schema ||= Schema.from_gapi @gapi.schema
             if block_given?
-              if replace
-                @schema = Schema.from_gapi \
-                  Google::Apis::BigqueryV2::TableSchema.new(fields: [])
-              end
+              @schema = Schema.from_gapi if replace
               yield @schema
               check_for_mutated_schema!
             end

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -323,6 +323,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Project#schema" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
+      mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
+    end
+  end
+
   # Google::Cloud::Bigquery::Project::List#all@Iterating each result by passing a block:
   # Google::Cloud::Bigquery::Project::List#all@Limit the number of API calls made:
   # Google::Cloud::Bigquery::Project::List#all@Using the enumerator by not passing a block:

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
@@ -748,6 +748,25 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
   end
 
+  it "creates a schema" do
+    schema = bigquery.schema
+    schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    schema.wont_be :frozen?
+    schema.fields.must_be :empty?
+  end
+
+  it "creates a schema with configuration in a block" do
+    schema = bigquery.schema do |s|
+      s.string "first_name", mode: :required
+    end
+    schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    schema.wont_be :frozen?
+    schema.fields.wont_be :empty?
+    schema.fields.size.must_equal 1
+    schema.fields[0].name.must_equal "first_name"
+    schema.fields[0].mode.must_equal "REQUIRED"
+  end
+
   def create_dataset_gapi id, name = nil, description = nil, default_expiration = nil, location = "US"
     Google::Apis::BigqueryV2::Dataset.from_json \
       random_dataset_hash(id, name, description, default_expiration, location).to_json


### PR DESCRIPTION
This PR adds a `schema` option and supporting `Project#schema` creation method for a way to configure the destination table's schema **in addition to** the existing block support for this configuration. See #1537 for @AlfonsoUceda's use case.

[closes #1537]