### PR TITLE
Pub/Sub Message#published_at

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/async_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/async_test.rb
@@ -53,6 +53,7 @@ describe Google::Cloud::Pubsub, :async, :pubsub do
     event = events.first
     event.wont_be :nil?
     event.msg.data.must_equal publish_result.data
+    event.msg.published_at.wont_be :nil?
     # Acknowledge the message
     sub.ack event.ack_id
     # Remove the subscription

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -204,6 +204,7 @@ describe Google::Cloud::Pubsub, :pubsub do
       event = events.first
       event.wont_be :nil?
       event.msg.data.must_equal msg.data
+      event.msg.published_at.wont_be :nil?
       # Acknowledge the message
       subscription.ack event.ack_id
       # Remove the subscription
@@ -231,6 +232,7 @@ describe Google::Cloud::Pubsub, :pubsub do
       event = events.first
       event.wont_be :nil?
       event.msg.data.must_equal msg.data
+      event.msg.published_at.wont_be :nil?
       # Acknowledge the message
       subscription.ack event.ack_id
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/convert.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/convert.rb
@@ -1,0 +1,47 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "time"
+
+module Google
+  module Cloud
+    module Pubsub
+      ##
+      # @private Helper module for converting Pub/Sub values.
+      module Convert
+        module ClassMethods
+          def time_to_timestamp time
+            return nil if time.nil?
+
+            # Force the object to be a Time object.
+            time = time.to_time
+
+            Google::Protobuf::Timestamp.new \
+              seconds: time.to_i,
+              nanos: time.nsec
+          end
+
+          def timestamp_to_time timestamp
+            return nil if timestamp.nil?
+
+            Time.at timestamp.seconds, Rational(timestamp.nanos, 1000)
+          end
+        end
+
+        extend ClassMethods
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+require "google/cloud/pubsub/convert"
 require "google/cloud/errors"
 
 module Google
@@ -82,6 +83,13 @@ module Google
           @grpc.message_id
         end
         alias_method :msg_id, :message_id
+
+        ##
+        # The time at which the message was published.
+        def published_at
+          Convert.timestamp_to_time @grpc.publish_time
+        end
+        alias_method :publish_time, :published_at
 
         ##
         # @private New Message from a Google::Pubsub::V1::PubsubMessage object.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
@@ -55,6 +55,13 @@ module Google
         alias_method :msg_id, :message_id
 
         ##
+        # The time at which the message was published.
+        def published_at
+          message.published_at
+        end
+        alias_method :publish_time, :published_at
+
+        ##
         # The error that was raised when published, if any.
         def error
           @error

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -87,6 +87,13 @@ module Google
         alias_method :msg_id, :message_id
 
         ##
+        # The time at which the message was published.
+        def published_at
+          message.published_at
+        end
+        alias_method :publish_time, :published_at
+
+        ##
         # Acknowledges receipt of the message.
         #
         # @example

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
@@ -54,5 +54,16 @@ describe Google::Cloud::Pubsub::Message, :mock_pubsub do
       msg.msg_id.must_equal     rec_message_data["message"]["message_id"]
       msg.message_id.must_equal rec_message_data["message"]["message_id"]
     end
+
+    it "knows its published_at" do
+      msg.published_at.must_be :nil?
+      msg.publish_time.must_be :nil?
+
+      publish_time = Time.now
+      rec_message_grpc.publish_time = Google::Cloud::Pubsub::Convert.time_to_timestamp publish_time
+
+      msg.published_at.must_equal publish_time
+      msg.publish_time.must_equal publish_time
+    end
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
@@ -36,6 +36,14 @@ describe Google::Cloud::Pubsub::PublishResult, :mock_pubsub do
     result.message.message_id.must_be :empty?
     result.msg.message_id.must_be :empty?
 
+    result.published_at.must_be :nil?
+    result.message.published_at.must_be :nil?
+    result.msg.published_at.must_be :nil?
+
+    result.publish_time.must_be :nil?
+    result.message.publish_time.must_be :nil?
+    result.msg.publish_time.must_be :nil?
+
     result.message.must_equal msg
     result.msg.must_equal msg
 
@@ -64,6 +72,14 @@ describe Google::Cloud::Pubsub::PublishResult, :mock_pubsub do
       result.message_id.must_be :empty?
       result.message.message_id.must_be :empty?
       result.msg.message_id.must_be :empty?
+
+      result.published_at.must_be :nil?
+      result.message.published_at.must_be :nil?
+      result.msg.published_at.must_be :nil?
+
+      result.publish_time.must_be :nil?
+      result.message.publish_time.must_be :nil?
+      result.msg.publish_time.must_be :nil?
 
       result.message.must_equal msg
       result.msg.must_equal msg

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -59,6 +59,17 @@ describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
     rec_message.message_id.must_equal rec_message.message.message_id
   end
 
+  it "knows its published_at" do
+    rec_message.published_at.must_be :nil?
+    rec_message.publish_time.must_be :nil?
+
+    publish_time = Time.now
+    rec_message_grpc.message.publish_time = Google::Cloud::Pubsub::Convert.time_to_timestamp publish_time
+
+    rec_message.published_at.must_equal publish_time
+    rec_message.publish_time.must_equal publish_time
+  end
+
   it "can acknowledge" do
     ack_res = nil
     mock = Minitest::Mock.new


### PR DESCRIPTION
This PR adds `Message#published_at`, which was missing. It is also setting this value on messages when they are published. Messages pulled from the API will have this attribute populated.