### PR TITLE
Add Pub/Sub nack!

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -138,6 +138,31 @@ module Google
         end
 
         ##
+        # Resets the acknowledge deadline for the message without acknowledging
+        # it.
+        #
+        # This will make the message available for redelivery.
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #   received_message = sub.pull.first
+        #   if received_message
+        #     puts received_message.message.data
+        #     # Release message back to the API.
+        #     received_message.reject!
+        #   end
+        #
+        def reject!
+          delay! 0
+        end
+        alias_method :nack!, :reject!
+        alias_method :ignore!, :reject!
+
+        ##
         # @private New ReceivedMessage from a
         # Google::Pubsub::V1::ReceivedMessage object.
         def self.from_grpc grpc, subscription

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -136,6 +136,7 @@ module Google
           ensure_subscription!
           subscription.delay new_deadline, ack_id
         end
+        alias_method :modify_ack_deadline!, :delay!
 
         ##
         # Resets the acknowledge deadline for the message without acknowledging

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -388,6 +388,7 @@ module Google
           service.modify_ack_deadline name, ack_ids, new_deadline
           true
         end
+        alias_method :modify_ack_deadline, :delay
 
         ##
         # Creates a new {Snapshot} from the subscription. The created snapshot

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -232,6 +232,28 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Pubsub::ReceivedMessage#reject!" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :pull, OpenStruct.new(received_messages: [Google::Pubsub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]), ["projects/my-project/subscriptions/my-sub", 100, Hash]
+      mock_subscriber.expect :modify_ack_deadline, nil, ["projects/my-project/subscriptions/my-sub", ["2"], 0, Hash]
+    end
+  end
+  doctest.before "Google::Cloud::Pubsub::ReceivedMessage#nack!" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :pull, OpenStruct.new(received_messages: [Google::Pubsub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]), ["projects/my-project/subscriptions/my-sub", 100, Hash]
+      mock_subscriber.expect :modify_ack_deadline, nil, ["projects/my-project/subscriptions/my-sub", ["2"], 0, Hash]
+    end
+  end
+  doctest.before "Google::Cloud::Pubsub::ReceivedMessage#ignore!" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :pull, OpenStruct.new(received_messages: [Google::Pubsub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]), ["projects/my-project/subscriptions/my-sub", 100, Hash]
+      mock_subscriber.expect :modify_ack_deadline, nil, ["projects/my-project/subscriptions/my-sub", ["2"], 0, Hash]
+    end
+  end
+
   ##
   # Snapshot
 

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -231,6 +231,13 @@ YARD::Doctest.configure do |doctest|
       mock_subscriber.expect :modify_ack_deadline, nil, ["projects/my-project/subscriptions/my-sub", ["2"], 120, Hash]
     end
   end
+  doctest.before "Google::Cloud::Pubsub::ReceivedMessage#modify_ack_deadline!" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp, ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :pull, OpenStruct.new(received_messages: [Google::Pubsub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]), ["projects/my-project/subscriptions/my-sub", 100, Hash]
+      mock_subscriber.expect :modify_ack_deadline, nil, ["projects/my-project/subscriptions/my-sub", ["2"], 120, Hash]
+    end
+  end
 
   doctest.before "Google::Cloud::Pubsub::ReceivedMessage#reject!" do
     mock_pubsub do |mock_publisher, mock_subscriber|
@@ -296,6 +303,13 @@ YARD::Doctest.configure do |doctest|
   end
 
   doctest.before "Google::Cloud::Pubsub::Subscription#delay" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :pull, OpenStruct.new(received_messages: [Google::Pubsub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]), ["projects/my-project/subscriptions/my-topic-sub", 100, Hash]
+      mock_subscriber.expect :modify_ack_deadline, nil, ["projects/my-project/subscriptions/my-topic-sub", ["2"], 120, Hash]
+    end
+  end
+  doctest.before "Google::Cloud::Pubsub::Subscription#modify_ack_deadline" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", Hash]
       mock_subscriber.expect :pull, OpenStruct.new(received_messages: [Google::Pubsub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]), ["projects/my-project/subscriptions/my-topic-sub", 100, Hash]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -92,4 +92,34 @@ describe Google::Cloud::Pubsub::ReceivedMessage, :mock_pubsub do
 
     mock.verify
   end
+
+  it "can reject" do
+    mock = Minitest::Mock.new
+    mock.expect :modify_ack_deadline, nil, [subscription_path(subscription_name), [rec_message.ack_id], 0, options: default_options]
+    subscription.service.mocked_subscriber = mock
+
+    rec_message.reject!
+
+    mock.verify
+  end
+
+  it "can nack" do
+    mock = Minitest::Mock.new
+    mock.expect :modify_ack_deadline, nil, [subscription_path(subscription_name), [rec_message.ack_id], 0, options: default_options]
+    subscription.service.mocked_subscriber = mock
+
+    rec_message.nack!
+
+    mock.verify
+  end
+
+  it "can ignore" do
+    mock = Minitest::Mock.new
+    mock.expect :modify_ack_deadline, nil, [subscription_path(subscription_name), [rec_message.ack_id], 0, options: default_options]
+    subscription.service.mocked_subscriber = mock
+
+    rec_message.ignore!
+
+    mock.verify
+  end
 end


### PR DESCRIPTION
This PR adds the `nack!` method, which is used to indicate that the message is no longer being processed and should be available to be pulled from the API again.