### PR TITLE
Change Logger#labels to default to empty hash

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -146,11 +146,11 @@ module Google
         #                                               env: :production
         #   logger.info "Job started."
         #
-        def initialize writer, log_name, resource, labels = {}
+        def initialize writer, log_name, resource, labels = nil
           @writer = writer
           @log_name = log_name
           @resource = resource
-          @labels = labels
+          @labels = labels || {}
           @level = 0 # DEBUG is the default behavior
           @request_info = {}
           @closed = false

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -146,7 +146,7 @@ module Google
         #                                               env: :production
         #   logger.info "Job started."
         #
-        def initialize writer, log_name, resource, labels = nil
+        def initialize writer, log_name, resource, labels = {}
           @writer = writer
           @log_name = log_name
           @resource = resource

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -549,7 +549,7 @@ module Google
             end
           end
 
-          labels.nil? ? merged_labels : labels.merge(merged_labels)
+          labels.merge(merged_labels)
         end
 
         ##

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -46,6 +46,11 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     ]
   end
 
+  it "@labels instance variable is default to empty hash if not given" do
+    logger = Google::Cloud::Logging::Logger.new logging, log_name, resource
+    logger.labels.must_be_kind_of Hash
+  end
+
   it "creates a DEBUG log entry with #debug" do
     mock = Minitest::Mock.new
     mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -49,6 +49,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
   it "@labels instance variable is default to empty hash if not given" do
     logger = Google::Cloud::Logging::Logger.new logging, log_name, resource
     logger.labels.must_be_kind_of Hash
+    logger.labels.must_be :empty?
   end
 
   it "creates a DEBUG log entry with #debug" do


### PR DESCRIPTION
Make Logger#labels default to empty hash. So users can set custom labels down stream without need to explicitly initialize logger with empty hash label.