### PR TITLE
Fix bad retry configuration

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client_config.json
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client_config.json
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client_config.json
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client_config.json
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client_config.json
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client_config.json
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-language/lib/google/cloud/language/v1/language_service_client_config.json
+++ b/google-cloud-language/lib/google/cloud/language/v1/language_service_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client_config.json
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client_config.json
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client_config.json
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client_config.json
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client_config.json
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client_config.json
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client_config.json
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client_config.json
@@ -15,9 +15,7 @@
           "INTERNAL",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client_config.json
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ],
+        "non_idempotent": [],
         "pull": [
           "CANCELLED",
           "DEADLINE_EXCEEDED",

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client_config.json
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client_config.json
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client_config.json
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client_config.json
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_config.json
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client_config.json
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client_config.json
@@ -6,9 +6,7 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "non_idempotent": [
-          "UNAVAILABLE"
-        ]
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {


### PR DESCRIPTION
This configuration was originally made under the mistaken belief that
UNAVAILABLE indicated that no data had been transmitted to the server.
In fact, this is not necessarily true, so it is unsafe to retry on
that code for non-idempotent RPCs.