### PR TITLE
Accept response content type/disposition as query string parameters for signed URLs

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -731,6 +731,8 @@ module Google
         #   Private Key.
         # @param [OpenSSL::PKey::RSA, String] private_key Service Account's
         #   Private Key.
+        # @param [Hash] query Query string parameters to include in the signed
+        #   URL, such as response-content-type and response-content-disposition.
         #
         # @example
         #   require "google/cloud/storage"
@@ -778,14 +780,16 @@ module Google
         #
         def signed_url method: nil, expires: nil, content_type: nil,
                        content_md5: nil, headers: nil, issuer: nil,
-                       client_email: nil, signing_key: nil, private_key: nil
+                       client_email: nil, signing_key: nil, private_key: nil,
+                       query: nil
           ensure_service!
           signer = File::Signer.from_file self
           signer.signed_url method: method, expires: expires, headers: headers,
                             content_type: content_type,
                             content_md5: content_md5,
                             issuer: issuer, client_email: client_email,
-                            signing_key: signing_key, private_key: private_key
+                            signing_key: signing_key, private_key: private_key,
+                            query: query
         end
 
         ##

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
@@ -109,7 +109,7 @@ module Google
             fail SignedUrlUnavailable unless i && s
 
             sig = generate_signature s, signature_str(options)
-            generate_signed_url i, sig, options[:expires]
+            generate_signed_url i, sig, options[:expires], options[:query]
           end
 
           def generate_signature signing_key, secret
@@ -120,10 +120,18 @@ module Google
             Base64.strict_encode64(signature).delete("\n")
           end
 
-          def generate_signed_url issuer, signed_string, expires
-            "#{ext_url}?GoogleAccessId=#{CGI.escape issuer}" \
+          def generate_signed_url issuer, signed_string, expires, query
+            url = "#{ext_url}?GoogleAccessId=#{CGI.escape issuer}" \
               "&Expires=#{expires}" \
               "&Signature=#{CGI.escape signed_string}"
+
+            if query
+              query.each do |name, value|
+                url << "&#{CGI.escape name}=#{CGI.escape value}"
+              end
+            end
+
+            url
           end
 
           def format_extension_headers headers

--- a/google-cloud-storage/test/google/cloud/storage/signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/signed_url_test.rb
@@ -102,6 +102,26 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
     end
   end
 
+  it "allows response content type and disposition to be passed in as options" do
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = signing_key_mock
+
+      signed_url = file.signed_url query: { "response-content-type" => "image/png",
+                                            "response-content-disposition" => "attachment; filename=\"test.png\"" }
+
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params["response-content-type"].must_equal ["image/png"]
+      signed_url_params["response-content-disposition"].must_equal ["attachment; filename=\"test.png\""]
+
+      signing_key_mock.verify
+    end
+  end
+
   it "raises when missing issuer" do
     credentials.issuer = nil
     credentials.signing_key = PoisonSigningKey.new


### PR DESCRIPTION
Google Cloud Storage allows the `Content-Type` and `Content-Disposition` response headers to be overridden via query string parameters on GET requests: `response-content-type` and `response-content-disposition`, respectively. These query string parameters are [explicitly documented](https://cloud.google.com/storage/docs/xml-api/reference-headers) for the XML API, but they work with the JSON API as well.

This PR facilitates passing the `response-content-type` and `response-content-disposition` query string parameters to `Google::Cloud::Storage::File#signed_url` for inclusion in the resulting URL.