### PR TITLE
Add CI code coverage filters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -818,6 +818,7 @@ def valid_gems_with_coverage_filters
   coverage_override = {
     "google-cloud-datastore" => ["google-cloud-datastore/test/", "google-cloud-datastore/lib/google/datastore/", "google-cloud-datastore/lib/google/cloud/datastore/v1/"],
     "google-cloud-language" => ["google-cloud-language/test/", "google-cloud-language/lib/google/cloud/language/v1/"],
+    "google-cloud-logging" => ["google-cloud-logging/test/", "google-cloud-logging/lib/google/logging/", "google-cloud-logging/lib/google/cloud/logging/v2/"],
     "google-cloud-pubsub" => ["google-cloud-pubsub/test/", "google-cloud-pubsub/lib/google/pubsub/", "google-cloud-pubsub/lib/google/cloud/pubsub/v1/"]
   }
 

--- a/Rakefile
+++ b/Rakefile
@@ -821,6 +821,7 @@ def valid_gems_with_coverage_filters
     "google-cloud-logging" => ["google-cloud-logging/test/", "google-cloud-logging/lib/google/logging/", "google-cloud-logging/lib/google/cloud/logging/v2/"],
     "google-cloud-pubsub" => ["google-cloud-pubsub/test/", "google-cloud-pubsub/lib/google/pubsub/", "google-cloud-pubsub/lib/google/cloud/pubsub/v1/"],
     "google-cloud-spanner" => ["google-cloud-spanner/test/", "google-cloud-spanner/lib/google/spanner/", "google-cloud-spanner/lib/google/cloud/spanner/v1/", "google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/", "google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/"],
+    "google-cloud-speech" => ["google-cloud-speech/test/", "google-cloud-speech/lib/google/cloud/speech/v1/"]
   }
 
   coverage = Hash[valid_gems.map { |gem| [gem, ["#{gem}/test/"]] }]

--- a/Rakefile
+++ b/Rakefile
@@ -816,6 +816,7 @@ end
 
 def valid_gems_with_coverage_filters
   coverage_override = {
+    "google-cloud-datastore" => ["google-cloud-datastore/test/", "google-cloud-datastore/lib/google/datastore/", "google-cloud-datastore/lib/google/cloud/datastore/v1/"],
     "google-cloud-pubsub" => ["google-cloud-pubsub/test/", "google-cloud-pubsub/lib/google/pubsub/", "google-cloud-pubsub/lib/google/cloud/pubsub/v1/"]
   }
 

--- a/Rakefile
+++ b/Rakefile
@@ -817,6 +817,7 @@ end
 def valid_gems_with_coverage_filters
   coverage_override = {
     "google-cloud-datastore" => ["google-cloud-datastore/test/", "google-cloud-datastore/lib/google/datastore/", "google-cloud-datastore/lib/google/cloud/datastore/v1/"],
+    "google-cloud-language" => ["google-cloud-language/test/", "google-cloud-language/lib/google/cloud/language/v1/"],
     "google-cloud-pubsub" => ["google-cloud-pubsub/test/", "google-cloud-pubsub/lib/google/pubsub/", "google-cloud-pubsub/lib/google/cloud/pubsub/v1/"]
   }
 

--- a/Rakefile
+++ b/Rakefile
@@ -819,7 +819,8 @@ def valid_gems_with_coverage_filters
     "google-cloud-datastore" => ["google-cloud-datastore/test/", "google-cloud-datastore/lib/google/datastore/", "google-cloud-datastore/lib/google/cloud/datastore/v1/"],
     "google-cloud-language" => ["google-cloud-language/test/", "google-cloud-language/lib/google/cloud/language/v1/"],
     "google-cloud-logging" => ["google-cloud-logging/test/", "google-cloud-logging/lib/google/logging/", "google-cloud-logging/lib/google/cloud/logging/v2/"],
-    "google-cloud-pubsub" => ["google-cloud-pubsub/test/", "google-cloud-pubsub/lib/google/pubsub/", "google-cloud-pubsub/lib/google/cloud/pubsub/v1/"]
+    "google-cloud-pubsub" => ["google-cloud-pubsub/test/", "google-cloud-pubsub/lib/google/pubsub/", "google-cloud-pubsub/lib/google/cloud/pubsub/v1/"],
+    "google-cloud-spanner" => ["google-cloud-spanner/test/", "google-cloud-spanner/lib/google/spanner/", "google-cloud-spanner/lib/google/cloud/spanner/v1/", "google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/", "google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/"],
   }
 
   coverage = Hash[valid_gems.map { |gem| [gem, ["#{gem}/test/"]] }]

--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,10 @@ namespace :test do
       command_name :coverage
       track_files "lib/**/*.rb"
       add_filter "test/"
-      valid_gems.each { |gem| add_group gem, "#{gem}/lib" }
+      valid_gems_with_coverage_filters.each do |gem, filters|
+        filters.each { |filter| add_filter filter }
+        add_group gem, "#{gem}/lib"
+      end
     end
 
     header "Running tests and coverage report"
@@ -809,6 +812,15 @@ def valid_gems
     spec = Gem::Specification::load("#{gem}/#{gem}.gemspec")
     spec.required_ruby_version.satisfied_by? Gem::Version.new(RUBY_VERSION)
   }
+end
+
+def valid_gems_with_coverage_filters
+  coverage_override = {
+    "google-cloud-pubsub" => ["google-cloud-pubsub/test/", "google-cloud-pubsub/lib/google/pubsub/", "google-cloud-pubsub/lib/google/cloud/pubsub/v1/"]
+  }
+
+  coverage = Hash[valid_gems.map { |gem| [gem, ["#{gem}/test/"]] }]
+  coverage.merge coverage_override
 end
 
 def header str, token = "#"

--- a/Rakefile
+++ b/Rakefile
@@ -821,7 +821,8 @@ def valid_gems_with_coverage_filters
     "google-cloud-logging" => ["google-cloud-logging/test/", "google-cloud-logging/lib/google/logging/", "google-cloud-logging/lib/google/cloud/logging/v2/"],
     "google-cloud-pubsub" => ["google-cloud-pubsub/test/", "google-cloud-pubsub/lib/google/pubsub/", "google-cloud-pubsub/lib/google/cloud/pubsub/v1/"],
     "google-cloud-spanner" => ["google-cloud-spanner/test/", "google-cloud-spanner/lib/google/spanner/", "google-cloud-spanner/lib/google/cloud/spanner/v1/", "google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/", "google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/"],
-    "google-cloud-speech" => ["google-cloud-speech/test/", "google-cloud-speech/lib/google/cloud/speech/v1/"]
+    "google-cloud-speech" => ["google-cloud-speech/test/", "google-cloud-speech/lib/google/cloud/speech/v1/"],
+    "google-cloud-vision" => ["google-cloud-vision/test/", "google-cloud-vision/lib/google/cloud/vision/v1/"]
   }
 
   coverage = Hash[valid_gems.map { |gem| [gem, ["#{gem}/test/"]] }]

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -18,6 +18,8 @@ namespace :test do
       command_name "google-cloud-datastore"
       track_files "lib/**/*.rb"
       add_filter "test/"
+      add_filter "lib/google/datastore/"
+      add_filter "lib/google/cloud/datastore/v1/"
     end
 
     Rake::Task["test"].invoke

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -18,6 +18,7 @@ namespace :test do
       command_name "google-cloud-language"
       track_files "lib/**/*.rb"
       add_filter "test/"
+      add_filter "lib/google/cloud/language/v1/"
     end
 
     Rake::Task["test"].invoke

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -18,6 +18,8 @@ namespace :test do
       command_name "google-cloud-logging"
       track_files "lib/**/*.rb"
       add_filter "test/"
+      add_filter "lib/google/logging/"
+      add_filter "lib/google/cloud/logging/v2/"
     end
 
     Rake::Task["test"].invoke

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -18,6 +18,8 @@ namespace :test do
       command_name "google-cloud-pubsub"
       track_files "lib/**/*.rb"
       add_filter "test/"
+      add_filter "lib/google/pubsub/"
+      add_filter "lib/google/cloud/pubsub/v1/"
     end
 
     Rake::Task["test"].invoke

--- a/google-cloud-spanner/Rakefile
+++ b/google-cloud-spanner/Rakefile
@@ -18,6 +18,10 @@ namespace :test do
       command_name "google-cloud-spanner"
       track_files "lib/**/*.rb"
       add_filter "test/"
+      add_filter "lib/google/spanner/"
+      add_filter "lib/google/cloud/spanner/v1/"
+      add_filter "lib/google/cloud/spanner/admin/instance/v1/"
+      add_filter "lib/google/cloud/spanner/admin/database/v1/"
     end
 
     Rake::Task["test"].invoke

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -18,6 +18,7 @@ namespace :test do
       command_name "google-cloud-speech"
       track_files "lib/**/*.rb"
       add_filter "test/"
+      add_filter "lib/google/cloud/speech/v1/"
     end
 
     Rake::Task["test"].invoke

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -18,6 +18,7 @@ namespace :test do
       command_name "google-cloud-vision"
       track_files "lib/**/*.rb"
       add_filter "test/"
+      add_filter "lib/google/cloud/vision/v1/"
     end
 
     Rake::Task["test"].invoke


### PR DESCRIPTION
Filter out the Low Level API (the generated GAPIC, Protobuf code) from the code coverage reports.

[fixes #1576]