### PR TITLE
Support breakpoint evaluation to use VariableTable

### DIFF
--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -30,7 +30,7 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 10
 Metrics/AbcSize:
-  Max: 30
+  Max: 25
 Metrics/MethodLength:
   Max: 20
 Metrics/ParameterLists:

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
@@ -1,0 +1,88 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "forwardable"
+
+module Google
+  module Cloud
+    module Debugger
+      class Breakpoint
+        class VariableTable
+          extend Forwardable
+
+          ##
+          # @private Array to store variables.
+          attr_accessor :variables
+
+          ##
+          # @private Item in the variables list. :orig_var is reference to the
+          # original Ruby variable. :var is the equivalent
+          # Breakpoint::Variable.
+          ListItem = Struct.new(:orig_var, :var)
+
+          ##
+          # @private Create a new VariableTable instance
+          def initialize
+            @variables = []
+          end
+
+          ##
+          # @private Create a new VariableTable instance from a variable table
+          # gRPC struct
+          def self.from_grpc grpc_table
+            return if grpc_table.nil?
+
+            new.tap do |vt|
+              vt.variables = grpc_table.map do |grpc_var|
+                ListItem.new nil, Breakpoint::Variable.from_grpc(grpc_var)
+              end
+            end
+          end
+
+          ##
+          # @private Search a variable in this VariableTable by matching
+          # object_id, return the array index if found.
+          def rb_var_index rb_var
+            variables.each_with_index do |list_item, i|
+              return i if list_item.orig_var.object_id == rb_var.object_id
+            end
+
+            nil
+          end
+
+          ##
+          # @private Add a Ruby object and it's Breakpoint::Variable equivalent
+          # to this VariableTable
+          def add_var rb_var, var = nil
+            var ||=
+              Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var rb_var
+
+            variables << ListItem.new(rb_var, var)
+          end
+
+          ##
+          # @private Export this VariableTable as a gRPC struct
+          def to_grpc
+            variables.map do |list_item|
+              list_item.var.nil? ? nil : list_item.var.to_grpc
+            end.compact
+          end
+
+          def_instance_delegators :@variables, :size, :first, :[]
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
@@ -30,7 +30,7 @@ module Google
           # @private Item in the variables list. :orig_var is reference to the
           # original Ruby variable. :var is the equivalent
           # Breakpoint::Variable.
-          ListItem = Struct.new(:orig_var, :var)
+          ListItem = Struct.new :orig_var, :var
 
           ##
           # @private Create a new VariableTable instance

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-require "google/cloud/debugger/breakpoint"
+require "google/cloud/debugger/snappoint"
+require "google/cloud/debugger/logpoint"
 
 module Google
   module Cloud

--- a/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
@@ -81,7 +81,7 @@ module Google
             index < expressions.size ? expressions[index].inspect : ""
           end
 
-          # Unescape "$" charactors
+          # Unescape "$" characters
           message.gsub(/\$\$/, "$")
         end
       end

--- a/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
@@ -1,0 +1,90 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/debugger/breakpoint"
+
+module Google
+  module Cloud
+    module Debugger
+      class Logpoint < Breakpoint
+        ##
+        # Evaluate the breakpoint unless it's already marked as completed.
+        # Store evaluted expressions and stack frame variables in
+        # @evaluated_expressions and @evaluated_log_message.
+        #
+        # @param [Array<Binding>] call_stack_bindings An array of Ruby Binding
+        #   objects, from the call stack that leads to the triggering of the
+        #   breakpoints.
+        #
+        # @return [Boolean] True if evaluated successfully; false otherwise.
+        #
+        def evaluate call_stack_bindings
+          synchronize do
+            binding = call_stack_bindings[0]
+
+            return false if complete? || !check_condition(binding)
+
+            begin
+              evaluate_log_message binding
+            rescue
+              return false
+            end
+          end
+
+          true
+        end
+
+        ##
+        # @private Evaluate the expressions and log message. Store the result
+        # in @evaluated_log_message
+        def evaluate_log_message binding
+          evaluated_expressions = expressions.map do |expression|
+            Evaluator.readonly_eval_expression binding, expression
+          end
+
+          @evaluated_log_message =
+            format_message log_message_format, evaluated_expressions
+        end
+
+        ##
+        # @private Format log message by interpolate expressions.
+        #
+        # @example
+        #   Evaluator.format_log_message("Hello $0",
+        #                                ["World"]) #=> "Hello World"
+        #
+        # @param [String] message_format The message with with
+        #   expression placeholders such as `$0`, `$1`, etc.
+        # @param [Array<Google::Cloud::Debugger::Breakpoint::Variable>]
+        #   expressions An array of evaluated expression variables to be
+        #   placed into message_format's placeholders. The variables need
+        #   to have type equal String.
+        #
+        # @return [String] The formatted message string
+        #
+        def format_message message_format, expressions
+          # Substitute placeholders with expressions
+          message = message_format.gsub(/(?<!\$)\$\d+/) do |placeholder|
+            index = placeholder.match(/\$(\d+)/)[1].to_i
+            index < expressions.size ? expressions[index].inspect : ""
+          end
+
+          # Unescape "$" charactors
+          message.gsub(/\$\$/, "$")
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
@@ -1,0 +1,113 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/debugger/breakpoint"
+
+module Google
+  module Cloud
+    module Debugger
+      class Snappoint < Breakpoint
+        ##
+        # Max number of top stacks to collect local variables information
+        STACK_EVAL_DEPTH = 5
+
+        ##
+        # Evaluate the breakpoint unless it's already marked as completed.
+        # Store evaluted expressions and stack frame variables in
+        # @evaluated_expressions, @stack_frames. Mark breakpoint complete if
+        # successfully evaluated.
+        #
+        # @param [Array<Binding>] call_stack_bindings An array of Ruby Binding
+        #   objects, from the call stack that leads to the triggering of the
+        #   breakpoints.
+        #
+        # @return [Boolean] True if evaluated successfully; false otherwise.
+        #
+        def evaluate call_stack_bindings
+          synchronize do
+            top_binding = call_stack_bindings[0]
+
+            return false if complete? || !check_condition(top_binding)
+
+            begin
+              eval_expressions top_binding
+              eval_call_stack call_stack_bindings
+
+              complete
+            rescue
+              return false
+            end
+          end
+
+          true
+        end
+
+        ##
+        # @private Evaluates the breakpoint expressions at the point that
+        # triggered the breakpoint. The expressions subject to the read-only
+        # rules. If the expressions do any write operations, the evaluations
+        # abort and show an error message in place of the real result.
+        #
+        # @param [Binding] binding The binding object from the context
+        #
+        def eval_expressions binding
+          @evaluated_expressions = expressions.map do |expression|
+            eval_result = Evaluator.readonly_eval_expression binding, expression
+            evaluated_var = Variable.from_rb_var eval_result,
+                                                 var_table: variable_table
+            evaluated_var.name = expression
+            evaluated_var
+          end
+        end
+
+        ##
+        # @private Evaluates call stack. Collects function name and location of
+        # each frame from given binding objects. Collects local variable
+        # information from top frames.
+        #
+        # @param [Array<Binding>] call_stack_bindings A list of binding
+        #   objects that come from each of the call stack frames.
+        # @return [Array<Google::Cloud::Debugger::Breakpoint::StackFrame>]
+        #   A list of StackFrame objects that represent state of the
+        #   call stack
+        #
+        def eval_call_stack call_stack_bindings
+          call_stack_bindings.each_with_index do |frame_binding, i|
+            frame_info = StackFrame.new.tap do |sf|
+              sf.function = frame_binding.eval("__method__").to_s
+              sf.location = SourceLocation.new.tap do |l|
+                l.path =
+                  frame_binding.eval("::File.absolute_path(__FILE__)")
+                l.line = frame_binding.eval("__LINE__")
+              end
+            end
+
+            if i < STACK_EVAL_DEPTH
+              frame_info.locals =
+                frame_binding.local_variables.map do |local_var_name|
+                  local_var = frame_binding.local_variable_get(local_var_name)
+
+                  Variable.from_rb_var local_var, name: local_var_name,
+                                                  var_table: variable_table
+                end
+            end
+
+            @stack_frames << frame_info
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
@@ -89,15 +89,15 @@ module Google
               sf.function = frame_binding.eval("__method__").to_s
               sf.location = SourceLocation.new.tap do |l|
                 l.path =
-                  frame_binding.eval("::File.absolute_path(__FILE__)")
-                l.line = frame_binding.eval("__LINE__")
+                  frame_binding.eval "::File.absolute_path(__FILE__)"
+                l.line = frame_binding.eval "__LINE__"
               end
             end
 
             if i < STACK_EVAL_DEPTH
               frame_info.locals =
                 frame_binding.local_variables.map do |local_var_name|
-                  local_var = frame_binding.local_variable_get(local_var_name)
+                  local_var = frame_binding.local_variable_get local_var_name
 
                   Variable.from_rb_var local_var, name: local_var_name,
                                                   var_table: variable_table

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -48,26 +48,6 @@ end
 describe Google::Cloud::Debugger::Breakpoint::Evaluator do
   let(:evaluator) { Google::Cloud::Debugger::Breakpoint::Evaluator }
 
-  describe ".eval_expressions" do
-    it "calls readonly_eval_expression and return Debugger::Variable of result" do
-      mock_binding = "A binding"
-      mock_expressions = ["1 + 1"]
-
-      stubbed_readonly_eval_expression = ->(b, e) {
-        b.must_equal mock_binding
-        e.must_equal mock_expressions.first
-        "Readonly Evaluated"
-      }
-
-      evaluator.stub :readonly_eval_expression, stubbed_readonly_eval_expression do
-        result = evaluator.eval_expressions mock_binding, mock_expressions
-        result.size.must_equal 1
-        result.first.value.must_equal Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var("Readonly Evaluated").value
-        result.first.name.must_equal mock_expressions.first
-      end
-    end
-  end
-
   describe ".readonly_eval_expression" do
     it "uses the binding object passed in" do
       mock_binding = MiniTest::Mock.new
@@ -220,28 +200,6 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
       expression = "nil.send"
       result = evaluator.readonly_eval_expression binding, expression
       result.must_match "no method name given"
-    end
-  end
-
-  describe ".format_message" do
-    it "formats basic message" do
-      evaluator.format_message("Hello World", []).must_equal "Hello World"
-    end
-
-    it "formats message with expressions" do
-      evaluator.format_message("Hello $0$1", ["World", :!]).must_equal "Hello \"World\":!"
-    end
-
-    it "formats message with extra expressions" do
-      evaluator.format_message("Hello $0$1", ["World", :!, :zomg]).must_equal "Hello \"World\":!"
-    end
-
-    it "formats message with extra placeholder" do
-      evaluator.format_message("Hello $0$1$2", ["World", :!]).must_equal "Hello \"World\":!"
-    end
-
-    it "doesn't substitute escaped placeholder and unescape them" do
-      evaluator.format_message("Hello 0 $0 $$0 $$$$0", ["World"]).must_equal "Hello 0 \"World\" $0 $$0"
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
@@ -1,0 +1,90 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+require "json"
+
+describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
+  let(:var_table) do
+    Google::Cloud::Debugger::Breakpoint::VariableTable.new
+  end
+
+  describe ".from_grpc" do
+    it "knows all the attributes" do
+      variable_grpc = Google::Devtools::Clouddebugger::V2::Variable.decode_json \
+                        random_variable_integer_hash.to_json
+      variable = Google::Cloud::Debugger::Breakpoint::Variable.from_grpc variable_grpc
+      var_table_grpc = [variable_grpc, variable_grpc]
+
+      var_table = Google::Cloud::Debugger::Breakpoint::VariableTable.from_grpc var_table_grpc
+      var_table.must_be_kind_of Google::Cloud::Debugger::Breakpoint::VariableTable
+      var_table.size.must_equal 2
+      var_table[0].orig_var.must_be_nil
+      var_table[0].var.name.must_equal variable.name
+      var_table[0].var.type.must_equal variable.type
+      var_table[0].var.value.must_equal variable.value
+      var_table[0].var.members.must_equal variable.members
+    end
+  end
+
+  describe ".to_grpc" do
+    it "converts all the attributes" do
+      variable_grpc = Google::Devtools::Clouddebugger::V2::Variable.decode_json \
+                        random_variable_integer_hash.to_json
+      variable = Google::Cloud::Debugger::Breakpoint::Variable.from_grpc variable_grpc
+
+      var_table.add_var nil, variable
+      var_table.add_var nil, variable
+
+      var_table_grpc = var_table.to_grpc
+
+      var_table_grpc.size.must_equal 2
+      var_table_grpc[0].name.must_equal variable_grpc.name
+      var_table_grpc[0].value.must_equal variable_grpc.value
+      var_table_grpc[0].type.must_equal variable_grpc.type
+      var_table_grpc[0].members.must_equal variable_grpc.members
+    end
+  end
+
+  describe "#add_var" do
+    it "automatically creates a Breakpoint::Variable if one isn't given" do
+      var_table.add_var 1
+
+      var_table[0].orig_var.must_equal 1
+      var_table[0].var.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      var_table[0].var.value.must_equal "1"
+    end
+  end
+
+  describe "#rb_var_index" do
+    it "returns index of the item found" do
+      var_table.add_var 4
+      var_table.add_var 5
+      var_table.add_var 6
+
+      var_table.rb_var_index(4).must_equal 0
+      var_table.rb_var_index(5).must_equal 1
+      var_table.rb_var_index(6).must_equal 2
+    end
+
+    it "returns nil if item not found" do
+      var_table.add_var 4
+      var_table.add_var 5
+      var_table.add_var 6
+
+      var_table.rb_var_index(8).must_be_nil
+    end
+  end
+end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
@@ -48,12 +48,10 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
 
   describe ".from_grpc" do
     it "knows its attributes" do
-      int_class = 1.class.to_s
-
       variable_grpc.name.must_equal "local_var"
       variable_grpc.type.must_equal "Array"
       variable_grpc.members[0].name.must_equal "[0]"
-      variable_grpc.members[0].type.must_equal int_class
+      variable_grpc.members[0].type.must_equal "Integer"
       variable_grpc.members[0].value.must_equal "3"
       variable_grpc.members[0].members.must_equal []
     end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
@@ -16,16 +16,17 @@
 require "helper"
 
 describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
-  describe "#to_grpc" do
-    let(:variable_hash) { random_variable_array_hash }
-    let(:variable_grpc) {
-      Google::Devtools::Clouddebugger::V2::Variable.decode_json \
+  let(:variable_hash) { random_variable_array_hash }
+  let(:variable_grpc) {
+    Google::Devtools::Clouddebugger::V2::Variable.decode_json \
         variable_hash.to_json
-    }
-    let(:variable) {
-      Google::Cloud::Debugger::Breakpoint::Variable.from_grpc variable_grpc
-    }
+  }
+  let(:variable) {
+    Google::Cloud::Debugger::Breakpoint::Variable.from_grpc variable_grpc
+  }
+  let(:var_table) { Google::Cloud::Debugger::Breakpoint::VariableTable.new }
 
+  describe "#to_grpc" do
     it "gets all the attributes" do
       grpc = variable.to_grpc
 
@@ -46,17 +47,13 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
   end
 
   describe ".from_grpc" do
-    let(:variable_hash) { random_variable_array_hash }
-    let(:variable_grpc) {
-      Google::Devtools::Clouddebugger::V2::Variable.decode_json \
-        variable_hash.to_json
-    }
-
     it "knows its attributes" do
+      int_class = 1.class.to_s
+
       variable_grpc.name.must_equal "local_var"
       variable_grpc.type.must_equal "Array"
       variable_grpc.members[0].name.must_equal "[0]"
-      variable_grpc.members[0].type.must_equal "Integer"
+      variable_grpc.members[0].type.must_equal int_class
       variable_grpc.members[0].value.must_equal "3"
       variable_grpc.members[0].members.must_equal []
     end
@@ -71,15 +68,6 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
   end
 
   describe ".from_grpc_list" do
-    let(:variable_hash) { random_variable_integer_hash }
-    let(:variable_grpc) {
-      Google::Devtools::Clouddebugger::V2::Variable.decode_json \
-        variable_hash.to_json
-    }
-    let(:variable) {
-      Google::Cloud::Debugger::Breakpoint::Variable.from_grpc variable_grpc
-    }
-
     it "converts all the elements" do
       grpc_ary = [variable_grpc, variable_grpc]
       ary = Google::Cloud::Debugger::Breakpoint::Variable.from_grpc_list grpc_ary
@@ -88,12 +76,12 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       ary[0].name.must_equal variable.name
       ary[0].type.must_equal variable.type
       ary[0].value.must_equal variable.value
-      ary[0].members.must_be_empty
+      ary[0].members.wont_be_empty
 
       ary[1].name.must_equal variable.name
       ary[1].type.must_equal variable.type
       ary[1].value.must_equal variable.value
-      ary[1].members.must_be_empty
+      ary[1].members.wont_be_empty
     end
   end
 
@@ -280,6 +268,60 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       var.name.must_be_nil
       var.value.size.must_equal str_max
       var.members.must_be_empty
+    end
+
+    it "uses var_table to store repeated variables" do
+      hash = { a: 1 }
+      ary = [hash, hash]
+      int_class = 1.class.to_s
+
+      var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var ary, var_table: var_table
+      var.type.must_be_nil
+      var.var_table_index.must_equal 0
+      var.members.must_be_empty
+      var.value.must_be_nil
+
+      var_table.size.must_equal 2
+      var_table[0].var.type.must_equal "Array"
+      var_table[0].var.members.size.must_equal 2
+      var_table[0].var.members[0].var_table_index.must_equal 1
+      var_table[0].var.members[1].var_table_index.must_equal 1
+
+      var_table[1].var.type.must_equal "Hash"
+      var_table[1].var.members.size.must_equal 1
+      var_table[1].var.members[0].name.must_equal "a"
+      var_table[1].var.members[0].type.must_equal int_class
+      var_table[1].var.members[0].value.must_equal "1"
+    end
+
+    it "uses var_table for nested compound variable" do
+      ary = [1, [2]]
+      int_class = 1.class.to_s
+
+      var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var ary, var_table: var_table
+
+      var.type.must_be_nil
+      var.var_table_index.must_equal 0
+      var.members.must_be_empty
+      var.value.must_be_nil
+
+      var_table.size.must_equal 2
+      var_table[0].var.type.must_equal "Array"
+      var_table[0].var.members.size.must_equal 2
+      var_table[0].var.members[0].name.must_equal "[0]"
+      var_table[0].var.members[0].type.must_equal int_class
+      var_table[0].var.members[0].value .must_equal "1"
+
+      var_table[0].var.members[1].name.must_equal "[1]"
+      var_table[0].var.members[1].type.must_be_nil
+      var_table[0].var.members[1].members.must_be_empty
+      var_table[0].var.members[1].var_table_index.must_equal 1
+
+      var_table[1].var.type.must_equal "Array"
+      var_table[1].var.name.must_be_nil
+      var_table[1].var.members.size.must_equal 1
+      var_table[1].var.members[0].type.must_equal int_class
+      var_table[1].var.members[0].value .must_equal "2"
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
@@ -146,7 +146,7 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
 
   describe "#breakpoint_hit" do
     let(:breakpoint) {
-      Google::Cloud::Debugger::Breakpoint.new nil, "path/to/file.rb", 123
+      Google::Cloud::Debugger::Snappoint.new nil, "path/to/file.rb", 123
     }
 
     it "marks breakpoint off and submits breakpoint" do

--- a/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
@@ -1,0 +1,85 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Debugger::Logpoint, :mock_debugger do
+  let(:breakpoint_hash) { random_breakpoint_hash }
+  let(:breakpoint_json) { breakpoint_hash.to_json }
+  let(:breakpoint_grpc) {
+    Google::Devtools::Clouddebugger::V2::Breakpoint.decode_json breakpoint_json
+  }
+  let(:logpoint) {
+    breakpoint_hash[:action] = :LOG
+    breakpoint_hash[:log_message_format] = "Hello $0"
+    breakpoint_hash[:expressions] = ["World"]
+
+    Google::Cloud::Debugger::Logpoint.from_grpc breakpoint_grpc
+  }
+
+  describe "#format_message" do
+    it "formats basic message" do
+      logpoint.format_message("Hello World", []).must_equal "Hello World"
+    end
+
+    it "formats message with expressions" do
+      logpoint.format_message("Hello $0$1", ["World", :!]).must_equal "Hello \"World\":!"
+    end
+
+    it "formats message with extra expressions" do
+      logpoint.format_message("Hello $0$1", ["World", :!, :zomg]).must_equal "Hello \"World\":!"
+    end
+
+    it "formats message with extra placeholder" do
+      logpoint.format_message("Hello $0$1$2", ["World", :!]).must_equal "Hello \"World\":!"
+    end
+
+    it "doesn't substitute escaped placeholder and unescape them" do
+      logpoint.format_message("Hello 0 $0 $$0 $$$$0", ["World"]).must_equal "Hello 0 \"World\" $0 $$0"
+    end
+  end
+
+  describe "#evaluate" do
+    it "returns false if logpoint is evaluated already" do
+      logpoint.complete
+
+      logpoint.evaluate([]).must_equal false
+    end
+
+    it "returns false if logpoint condition check fails" do
+      logpoint.stub :check_condition, false do
+        logpoint.evaluate [nil]
+      end
+    end
+
+    it "sets @evaluated_log_message for logpoint" do
+      stubbed_format_message = -> (_, _) { "test log message" }
+
+      logpoint.stub :format_message, stubbed_format_message do
+        logpoint.stub :check_condition, true do
+          logpoint.evaluate([nil])
+
+          logpoint.evaluated_log_message.must_equal "test log message"
+        end
+      end
+    end
+
+    it "doesn't complete logpoints" do
+      logpoint.evaluate []
+
+      logpoint.complete?.must_equal false
+    end
+  end
+end

--- a/google-cloud-debugger/test/google/cloud/debugger/snappoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/snappoint_test.rb
@@ -1,0 +1,157 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
+  let(:breakpoint_hash) { random_breakpoint_hash }
+  let(:breakpoint_json) { breakpoint_hash.to_json }
+  let(:breakpoint_grpc) {
+    Google::Devtools::Clouddebugger::V2::Breakpoint.decode_json breakpoint_json
+  }
+  let(:snappoint) {
+    Google::Cloud::Debugger::Snappoint.from_grpc breakpoint_grpc
+  }
+
+  let(:evaluator) { Google::Cloud::Debugger::Breakpoint::Evaluator }
+
+  describe ".eval_expressions" do
+    it "calls readonly_eval_expression and return Debugger::Variable of result" do
+      mock_binding = "A binding"
+      mock_expressions = ["1 + 1"]
+      snappoint.expressions = mock_expressions
+
+      stubbed_readonly_eval_expression = ->(b, e) {
+        b.must_equal mock_binding
+        e.must_equal mock_expressions.first
+        "Readonly Evaluated"
+      }
+
+      evaluator.stub :readonly_eval_expression, stubbed_readonly_eval_expression do
+        snappoint.eval_expressions mock_binding
+
+        snappoint.evaluated_expressions.size.must_equal 1
+        snappoint.evaluated_expressions.first.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+        snappoint.evaluated_expressions.first.value.must_equal "Readonly Evaluated".inspect
+        snappoint.evaluated_expressions.first.name.must_equal mock_expressions.first
+      end
+    end
+  end
+
+  describe "#evaluate" do
+    it "returns false if breakpoint is evaluated already" do
+      snappoint.complete
+
+      snappoint.evaluate([]).must_equal false
+    end
+
+    it "returns false if condition check fails" do
+      snappoint.stub :check_condition, false do
+        snappoint.evaluate [nil]
+      end
+    end
+
+    it "returns false if Evaluator.eval_condition raises exception" do
+      stubbed_eval_call_stack = ->(_) { raise }
+      snappoint.stub :eval_call_stack, stubbed_eval_call_stack do
+        snappoint.stub :check_condition, true do
+          snappoint.evaluate([nil]).must_equal false
+        end
+      end
+    end
+
+    it "returns false if #eval_expressions raises exception" do
+      stubbed_eval_expressions = ->(_) { raise }
+
+      snappoint.stub :eval_call_stack, nil do
+        snappoint.stub :eval_expressions, stubbed_eval_expressions do
+          snappoint.stub :check_condition, true do
+            snappoint.evaluate([nil]).must_equal false
+          end
+        end
+      end
+    end
+
+    it "sets @evaluated_expressions and @stack_frames for breakpoint" do
+      snappoint.evaluated_expressions = []
+      snappoint.stack_frames = []
+
+      snappoint.stub :check_condition, true do
+        snappoint.evaluate([binding])
+
+        snappoint.evaluated_expressions.wont_be_empty
+        snappoint.stack_frames.wont_be_empty
+      end
+    end
+
+    it "calls complete if finishes evaluation" do
+      mocked_complete = Minitest::Mock.new
+      mocked_complete.expect :call, nil
+
+      snappoint.stub :eval_call_stack, [] do
+        snappoint.stub :eval_expressions, [] do
+          snappoint.stub :check_condition, true do
+            snappoint.stub :complete, mocked_complete do
+              snappoint.evaluate([nil]).must_equal true
+            end
+          end
+        end
+      end
+
+      mocked_complete.verify
+    end
+  end
+
+  describe "#eval_expressions" do
+    it "set @evaluated_expressions to array of Breakpoint::Variable" do
+      snappoint.evaluated_expressions = []
+      snappoint.eval_expressions binding
+      snappoint.evaluated_expressions.must_be_kind_of Array
+      snappoint.evaluated_expressions.all? { |var| var.is_a? Google::Cloud::Debugger::Breakpoint::Variable }.must_equal true
+    end
+
+    it "sets the Breakpoint::Variable name to the expression itself" do
+      snappoint.evaluated_expressions = []
+      snappoint.eval_expressions binding
+
+      snappoint.evaluated_expressions.wont_be_empty
+      snappoint.evaluated_expressions.first.name.must_equal snappoint.expressions.first
+    end
+  end
+
+  describe "#eval_call_stack" do
+    it "set @stack_frames to array of Breakpoint::StackFrame" do
+      snappoint.stack_frames = []
+      snappoint.eval_call_stack binding.callers
+
+      snappoint.stack_frames.all? { |sf| sf.is_a? Google::Cloud::Debugger::Breakpoint::StackFrame }.must_equal true
+    end
+
+    it "gets local variables within STACK_EVAL_DEPTH level" do
+      local_var = "test-local-var"
+
+      snappoint.stack_frames = []
+      snappoint.eval_call_stack [binding, *binding.callers]
+
+      snappoint.stack_frames.wont_be_empty
+      snappoint.stack_frames.first.locals.first.value.must_equal "test-local-var".inspect
+      snappoint.stack_frames.each_with_index do |sf, i|
+        if i >= Google::Cloud::Debugger::Snappoint::STACK_EVAL_DEPTH
+          sf.locals.must_be_empty
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
@@ -48,7 +48,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
   describe "#breakpoint_hit" do
     let(:breakpoint) {
-      Google::Cloud::Debugger::Breakpoint.new nil, "path/to/file.rb", 123
+      Google::Cloud::Debugger::Snappoint.new nil, "path/to/file.rb", 123
     }
 
     it "doesn't call BreakpointManager#breakpoint_hit if breakpoint is already completed" do

--- a/google-cloud-debugger/test/helper.rb
+++ b/google-cloud-debugger/test/helper.rb
@@ -120,7 +120,8 @@ class MockDebugger < Minitest::Spec
       "evaluated_expressions" => [random_variable_array_hash],
       "labels" => {
         "tag" => "hello"
-      }
+      },
+      "variable_table" => [random_variable_array_hash]
     }
   end
 end


### PR DESCRIPTION
* Created `Snappoint` and `Logpoint` classes. Both inherit from the original `Breakpoint`.
* Refactored `Evaluator` to move a lot of evaluation logic into `Snappoint` and `Logpoint` classes for upcoming evaluation related features
* Introduces `Snappoint` evaluation using `VariableTable` to store compound variables. So repeatedly referenced compound variables can be defined once in `VariableTable` and reused during evaluation.