### PR TITLE
Allow tables to be created with time_partitioning enabled

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -118,6 +118,16 @@ module Google
           table_ref
         end
 
+        ###
+        # The gapi fragment containing TimePartitioning ExpirationMS and Type
+        # as a camel-cased hash.
+        def time_partitioning
+          ensure_full_data!
+          time_part = @gapi.time_partitioning
+          time_part = time_part.to_hash if time_part.respond_to? :to_hash
+          time_part
+        end
+
         ##
         # The combined Project ID, Dataset ID, and Table ID for this table, in
         # the format specified by the [Legacy SQL Query
@@ -1215,6 +1225,10 @@ module Google
           def to_gapi
             check_for_mutated_schema!
             @gapi
+          end
+
+          def time_partitioning type: 'DAY', expire_ms: nil
+            @gapi.time_partitioning = { type: type, expire_ms: expire_ms }
           end
 
           protected

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1227,8 +1227,8 @@ module Google
             @gapi
           end
 
-          def time_partitioning type: 'DAY', expire_ms: nil
-            @gapi.time_partitioning = { type: type, expire_ms: expire_ms }
+          def time_partitioning type: 'DAY', expiration_ms: nil
+            @gapi.time_partitioning = { type: type, expiration_ms: expiration_ms }
           end
 
           protected

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1227,8 +1227,11 @@ module Google
             @gapi
           end
 
-          def time_partitioning type: 'DAY', expiration_ms: nil
-            @gapi.time_partitioning = { type: type, expiration_ms: expiration_ms }
+          def time_partitioning type: "DAY", expiration_ms: nil
+            @gapi.time_partitioning = {
+              type: type,
+              expiration_ms: expiration_ms
+            }
           end
 
           protected


### PR DESCRIPTION
I would like to be able to create tables with time_partitioning enabled. I know it misses unit tests and acceptance tests. For now I would like to be sure this is the right way to do things. Example use:

```ruby
my_table = bigquery.dataset('test').create_table('TimePartTable') do |t|
  t.time_partitioning
  t.schema { ... }
end
my_table.time_partitioning # { type: "DAY", expiration_ms: nil }
```