### PR TITLE
Properly set failed expression evaluations to error state

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
@@ -266,9 +266,9 @@ module Google
         # state if exception happens.
         #
         # @param [Binding] binding A Ruby Binding object
-        # @return [Boolean] True if condition evalutes to true, false if
-        #   condition evaluates to false or error raised during evaluation.
-        #
+        # @return [Boolean] True if condition evalutes to true or there isn't a
+        #   condition. False if condition evaluates to false or error raised
+        #   during evaluation.
         def check_condition binding
           return true if condition.nil? || condition.empty?
           condition_result =

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/status_message.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/status_message.rb
@@ -83,11 +83,10 @@ module Google
               Google::Devtools::Clouddebugger::V2::FormatMessage.new \
                 format: description.to_s
 
-            Google::Devtools::Clouddebugger::V2::StatusMessage.new(
+            Google::Devtools::Clouddebugger::V2::StatusMessage.new \
               is_error: true,
               refers_to: refers_to,
               description: description_grpc
-            )
           end
         end
       end

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/status_message.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/status_message.rb
@@ -1,0 +1,96 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Debugger
+      class Breakpoint
+        ##
+        # # StatusMessage
+        #
+        # Represents a contextual status message. The message can indicate an
+        # error or informational status, and refer to specific parts of the
+        # containing object. For example, the Breakpoint.status field can
+        # indicate an error referring to the BREAKPOINT_SOURCE_LOCATION with
+        # the message Location not found.
+        class StatusMessage
+          ##
+          # Constants used as references to which the message applies.
+          UNSPECIFIED = :UNSPECIFIED
+          BREAKPOINT_SOURCE_LOCATION = :BREAKPOINT_SOURCE_LOCATION
+          BREAKPOINT_CONDITION = :BREAKPOINT_CONDITION
+          BREAKPOINT_EXPRESSION = :BREAKPOINT_EXPRESSION
+          BREAKPOINT_AGE = :BREAKPOINT_AGE
+          VARIABLE_NAME = :VARIABLE_NAME
+          VARIABLE_VALUE = :VARIABLE_VALUE
+
+          ##
+          # Distinguishes errors from informational messages.
+          attr_accessor :is_error
+
+          ##
+          # Reference to which the message applies.
+          attr_accessor :refers_to
+
+          ##
+          # Status message text.
+          attr_accessor :description
+
+          ##
+          # New Google::Cloud::Debugger::Breakpoint::StatusMessage
+          # from a Google::Devtools::Clouddebugger::V2::StatusMessage object.
+          def self.from_grpc grpc
+            return nil if grpc.nil?
+            new.tap do |s|
+              s.is_error = grpc.is_error
+              s.refers_to = grpc.refers_to
+              s.description = grpc.description.format
+            end
+          end
+
+          ##
+          # @private Construct a new StatusMessage instance.
+          def initialize
+            @refers_to = UNSPECIFIED
+          end
+
+          ##
+          # @private Determines if the Variable has any data.
+          def empty?
+            is_error.nil? &&
+              refers_to.nil? &&
+              description.nil?
+          end
+
+          ##
+          # Exports the StatusMessage to a
+          # Google::Devtools::Clouddebugger::V2::StatusMessage object.
+          def to_grpc
+            return nil if empty?
+            description_grpc =
+              Google::Devtools::Clouddebugger::V2::FormatMessage.new \
+                format: description.to_s
+
+            Google::Devtools::Clouddebugger::V2::StatusMessage.new(
+              is_error: true,
+              refers_to: refers_to,
+              description: description_grpc
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -357,7 +357,7 @@ module Google
           end
 
           ##
-          # @private Exports the Variable to a
+          # Exports the Variable to a
           # Google::Devtools::Clouddebugger::V2::Variable object.
           def to_grpc
             return nil if empty?
@@ -369,6 +369,16 @@ module Google
               members: members_to_grpc || [],
               status: status_to_grpc
             )
+          end
+
+          ##
+          # Set this variable to an error state by setting the status field
+          def set_error_state message, refers_to: StatusMessage::UNSPECIFIED
+            @status = StatusMessage.new.tap do |s|
+              s.is_error = true
+              s.refers_to = refers_to
+              s.description = message
+            end
           end
 
           private

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+require "google/cloud/debugger/breakpoint/status_message"
+
 module Google
   module Cloud
     module Debugger
@@ -127,8 +129,7 @@ module Google
           # VARIABLE_NAME. Alternatively refers_to will be set to
           # VARIABLE_VALUE. In either case variable value and members will be
           # unset.
-          # TODO: Implement variable status
-          # attr_accessor :status
+          attr_accessor :status
 
           ##
           # @private Create an empty Variable object.
@@ -317,6 +318,7 @@ module Google
               o.type    = grpc.type
               o.members = from_grpc_list grpc.members
               o.var_table_index = var_table_index_from_grpc grpc.var_table_index
+              o.status = Breakpoint::StatusMessage.from_grpc grpc.status
             end
           end
 
@@ -350,8 +352,8 @@ module Google
               value.nil? &&
               type.nil? &&
               members.nil? &&
-              var_table_index.nil?
-            # TODO: Add status when implementing variable status
+              var_table_index.nil? &&
+              status.nil?
           end
 
           ##
@@ -364,11 +366,18 @@ module Google
               value: value.to_s,
               type: type.to_s,
               var_table_index: var_table_index_to_grpc,
-              members: members_to_grpc || []
+              members: members_to_grpc || [],
+              status: status_to_grpc
             )
           end
 
           private
+
+          ##
+          # @private Exports the Variable status to grpc
+          def status_to_grpc
+            status.nil? ? nil : status.to_grpc
+          end
 
           ##
           # @private Exports the Variable var_table_index attribute to

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
@@ -160,6 +160,7 @@ module Google
             # Take this completed breakpoint off manager's active breakpoints
             # list, submit the breakpoint snapshot, and update Tracer's
             # breakpoints_cache.
+
             return unless breakpoint.complete?
 
             # Remove this breakpoint from active list

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
@@ -60,15 +60,15 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow .exist? method" do
-      expression_not_allowed "File.exist? './file.rb'"
+      expression_prohibited "File.exist? './file.rb'"
     end
 
     it "doesn't allow .size method" do
-      expression_not_allowed "File.size './file.rb'"
+      expression_prohibited "File.size './file.rb'"
     end
 
     it "doesn't allow .open method" do
-      expression_not_allowed "File.open './file.rb'"
+      expression_prohibited "File.open './file.rb'"
     end
   end
 
@@ -106,15 +106,15 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow .new" do
-      expression_not_allowed "Thread.new {}"
+      expression_prohibited "Thread.new {}"
     end
 
     it "doesn't allow .fork" do
-      expression_not_allowed "Thread.fork {}"
+      expression_prohibited "Thread.fork {}"
     end
 
     it "doesn't allow .exit" do
-      expression_not_allowed "Thread.exit"
+      expression_prohibited "Thread.exit"
     end
   end
 

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/expression_test_helper.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/expression_test_helper.rb
@@ -15,16 +15,23 @@
 require "helper"
 
 def expression_must_equal expression, expected, binding = binding()
-  result = evaluator.readonly_eval_expression binding, expression
+  result = Google::Cloud::Debugger::Breakpoint::Evaluator.readonly_eval_expression binding, expression
   result.must_equal expected
 end
 
 def expression_must_be_kind_of expression, expected, binding = binding()
-  result = evaluator.readonly_eval_expression binding, expression
+  result = Google::Cloud::Debugger::Breakpoint::Evaluator.readonly_eval_expression binding, expression
   result.must_be_kind_of expected
 end
 
-def expression_not_allowed expression, binding = binding()
-  result = evaluator.readonly_eval_expression binding, expression
-  result.must_match "Invalid operation detected"
+def expression_prohibited expression, binding = binding()
+  result = Google::Cloud::Debugger::Breakpoint::Evaluator.readonly_eval_expression binding, expression
+  result.must_be_kind_of Google::Cloud::Debugger::MutationError
+  result.message.must_match Google::Cloud::Debugger::Breakpoint::Evaluator::PROHIBITED_OPERATION_MSG
+end
+
+def expression_triggers_mutation expression, binding = binding()
+  result = Google::Cloud::Debugger::Breakpoint::Evaluator.readonly_eval_expression binding, expression
+  result.must_be_kind_of Google::Cloud::Debugger::MutationError
+  result.message.must_match Google::Cloud::Debugger::Breakpoint::Evaluator::MUTATION_DETECTED_MSG
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
@@ -33,11 +33,11 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #push" do
-      expression_not_allowed "[].push 1"
+      expression_prohibited "[].push 1"
     end
 
     it "doesn't allow #compact!" do
-      expression_not_allowed "[nil].compact!"
+      expression_prohibited "[nil].compact!"
     end
   end
 
@@ -47,7 +47,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #instance_eval" do
-      expression_not_allowed "[].instance_eval { |a| a == self }"
+      expression_prohibited "[].instance_eval { |a| a == self }"
     end
   end
 
@@ -57,7 +57,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #eval" do
-      expression_not_allowed "binding.eval ''"
+      expression_prohibited "binding.eval ''"
     end
   end
 
@@ -68,7 +68,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #new" do
-      expression_not_allowed "Class.new"
+      expression_prohibited "Class.new"
     end
   end
 
@@ -80,7 +80,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
 
     it "doesn't allow #each" do
       dir = Dir.new ".."
-      expression_not_allowed "dir.each", binding
+      expression_prohibited "dir.each", binding
     end
   end
 
@@ -90,7 +90,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #set_backtrace" do
-      expression_not_allowed "Exception.new.set_backtrace []"
+      expression_prohibited "Exception.new.set_backtrace []"
     end
   end
 
@@ -100,7 +100,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #next" do
-      expression_not_allowed "[].each.next"
+      expression_prohibited "[].each.next"
     end
   end
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
 
     it "doesn't allow #resume" do
       fiber = Fiber.new {}
-      expression_not_allowed "fiber.resume", binding
+      expression_prohibited "fiber.resume", binding
     end
   end
 
@@ -125,7 +125,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
 
     it "doesn't allow #chmod" do
       file = File.new __FILE__
-      expression_not_allowed "file.chmod 0777", binding
+      expression_prohibited "file.chmod 0777", binding
     end
   end
 
@@ -143,11 +143,11 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #delete" do
-      expression_not_allowed "{}.delete :a"
+      expression_prohibited "{}.delete :a"
     end
 
     it "doesn't allow #select!" do
-      expression_not_allowed "{}.select! {}"
+      expression_prohibited "{}.select! {}"
     end
   end
 
@@ -159,7 +159,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
 
     it "doesn't allow #readlines" do
       io = IO.new 1
-      expression_not_allowed "io.readlines", binding
+      expression_prohibited "io.readlines", binding
     end
   end
 
@@ -169,7 +169,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #unbind" do
-      expression_not_allowed "[].method(:each).unbind"
+      expression_prohibited "[].method(:each).unbind"
     end
   end
 
@@ -181,7 +181,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
 
     it "doesn't allow #lock" do
       mutex = Mutex.new
-      expression_not_allowed "mutex.lock", binding
+      expression_prohibited "mutex.lock", binding
     end
   end
 
@@ -199,11 +199,11 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #reverse!" do
-      expression_not_allowed "'abc'.reverse!"
+      expression_prohibited "'abc'.reverse!"
     end
 
     it "doesn't allow capitalize!" do
-      expression_not_allowed "'abc'.capitalize!"
+      expression_prohibited "'abc'.capitalize!"
     end
   end
 
@@ -216,7 +216,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     it "doesn't allow #add" do
       tg = ThreadGroup.new
       thr = Thread.new {}
-      expression_not_allowed "tg.add thr", binding
+      expression_prohibited "tg.add thr", binding
     end
   end
 
@@ -241,12 +241,12 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
 
     it "doesn't allow #exit" do
       thr = Thread.new {}
-      expression_not_allowed "thr.exit", binding
+      expression_prohibited "thr.exit", binding
     end
 
     it "doesn't allow #join" do
       thr = Thread.new {}
-      expression_not_allowed "thr.join", binding
+      expression_prohibited "thr.join", binding
     end
   end
 
@@ -262,11 +262,11 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     end
 
     it "doesn't allow #utc" do
-      expression_not_allowed "Time.now.utc"
+      expression_prohibited "Time.now.utc"
     end
 
     it "doesn't allow #gmtime" do
-      expression_not_allowed "Time.now.gmtime"
+      expression_prohibited "Time.now.gmtime"
     end
   end
 
@@ -278,7 +278,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
 
     it "doesn't allow #bind" do
       meth = [].method(:size).unbind
-      expression_not_allowed "meth.bind []", binding
+      expression_prohibited "meth.bind []", binding
     end
   end
 
@@ -308,45 +308,45 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
 
     it "doesn't allow #instance_variable_set" do
       obj = Object.new
-      expression_not_allowed "obj.instance_variable_set :@a, 3", binding
+      expression_prohibited "obj.instance_variable_set :@a, 3", binding
     end
 
     it "doesn't allow #exit" do
-      expression_not_allowed "exit"
+      expression_prohibited "exit"
     end
 
     it "doesn't allow #fail" do
-      expression_not_allowed "fail"
+      expression_prohibited "fail"
     end
 
     it "doesn't allow #fork" do
-      expression_not_allowed "fork"
+      expression_prohibited "fork"
     end
 
     it "doesn't allow #raise" do
-      expression_not_allowed "raise"
+      expression_prohibited "raise"
     end
 
     it "doesn't allow #sleep" do
-      expression_not_allowed "sleep"
+      expression_prohibited "sleep"
     end
 
     it "doesn't allow #system" do
-      expression_not_allowed "system"
+      expression_prohibited "system"
     end
 
     it "doesn't allow #`" do
       result = evaluator.readonly_eval_expression binding, "`ls`"
-
-      result.match("Mutation detected|Invalid operation detected").wont_be_nil
+      result.must_be_kind_of Google::Cloud::Debugger::MutationError
+      result.message.match("#{evaluator::MUTATION_DETECTED_MSG}|#{evaluator::PROHIBITED_OPERATION_MSG}").wont_be_nil
     end
 
     it "doesn't allow #eval" do
-      expression_not_allowed "eval '[]'"
+      expression_prohibited "eval '[]'"
     end
 
     it "doesn't allow #exec" do
-      expression_not_allowed "exec 'ls'"
+      expression_prohibited "exec 'ls'"
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -81,8 +81,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     it "doesn't allow setting local variable from expression" do
       local_var = "original local var"
       expression = "local_var = 'new local var'"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
       local_var.must_equal "original local var"
     end
 
@@ -93,54 +92,47 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     it "doesn't allow setting global variables" do
       $global_var = "original global var"
       expression = "$global_var = 'new global var'"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
       $global_var.must_equal "original global var"
     end
 
     it "doesn't allow setting instance variable" do
       @instance_var = "original instance var"
       expression = "@instance_var = 'new instance var'"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
       @instance_var.must_equal "original instance var"
     end
 
     it "doesn't allow setting class variable" do
       expression = "@@class_var = 'new class var'"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
     end
 
     it "doesn't allow setting constant" do
       TEST_CONST  = "original constant"
       expression = "TEST_CONST = 'new constant'"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
       TEST_CONST.must_equal "original constant"
     end
 
     it "doesn't allow << operator" do
       ary = [1,2]
       expression = "ary << 3"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
       ary.size.must_equal 2
     end
 
     it "doesn't allow array set" do
       ary = [1,2]
       expression = "ary[0] = 2"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
       ary.must_include 1
     end
 
     it "doesn't allow hash set with string key" do
       hsh = {"abc" => 123}
       expression = "hsh['abc'] = 456"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
       hsh["abc"].must_equal 123
     end
 
@@ -148,17 +140,16 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
       expression = "return"
       result = evaluator.readonly_eval_expression binding, expression
       if RUBY_VERSION.to_f >= 2.4
-        result.must_match "Invalid operation detected"
+        result.message.must_match evaluator::PROHIBITED_OPERATION_MSG
       else
-        result.must_match "Unable to compile expression"
+        result.message.must_match evaluator::COMPILATION_FAIL_MSG
       end
     end
 
     it "doesn't allow using proc as block" do
       proc = Proc.new { |arg| "arg: #{arg}" }
       expression = "readonly_func4(123, &proc)"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
     end
 
     it "allows function call with block" do
@@ -168,38 +159,40 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
 
     it "doesn't allow function with rescue block" do
       expression = "mutating_func1()"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
     end
 
     it "doesn't allow function that sets global variable with" do
       expression = "mutating_func2()"
-      result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "Mutation detected!"
+      expression_triggers_mutation expression, binding
     end
 
-    it "returns ZeroDivisionError error message" do
+    it "returns ZeroDivisionError" do
       expression = "1/0"
       result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "divided by 0"
+      result.must_be_kind_of ZeroDivisionError
+      result.message.must_match "divided by 0"
     end
 
-    it "returns NameError error message" do
+    it "returns NameError" do
       expression = "a_thing_that_is_not_defined"
       result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "undefined local variable or method"
+      result.must_be_kind_of NameError
+      result.message.must_match "undefined local variable or method"
     end
 
-    it "returns NoMethodError error message" do
+    it "returns NoMethodError" do
       expression = "nil.blahblahblah"
       result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "undefined method"
+      result.must_be_kind_of NoMethodError
+      result.message.must_match "undefined method"
     end
 
-    it "returns Argument error message" do
+    it "returns ArgumentError" do
       expression = "nil.send"
       result = evaluator.readonly_eval_expression binding, expression
-      result.must_match "no method name given"
+      result.must_be_kind_of ArgumentError
+      result.message.must_match "no method name given"
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/status_message_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/status_message_test.rb
@@ -1,0 +1,55 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Debugger::Breakpoint::StatusMessage, :mock_debugger do
+  let(:status_message_hash) do
+    {
+      is_error: true,
+      refers_to: :UNSPECIFIED,
+      description: {
+        format: "test error message",
+        parameters: ["test param"]
+      }
+    }
+  end
+  let(:status_message_json) { status_message_hash.to_json }
+  let(:status_message_grpc) {
+    Google::Devtools::Clouddebugger::V2::StatusMessage.decode_json status_message_json
+  }
+  let(:status_message) {
+    Google::Cloud::Debugger::Breakpoint::StatusMessage.from_grpc status_message_grpc
+  }
+
+  describe ".from_grpc" do
+    it "knows all of its attributes" do
+      status_message.is_error.must_equal true
+      status_message.refers_to.must_equal Google::Cloud::Debugger::Breakpoint::StatusMessage::UNSPECIFIED
+      status_message.description.must_equal "test error message"
+    end
+  end
+
+  describe "#to_grpc" do
+    it "exports all of the content" do
+      grpc = status_message.to_grpc
+
+      grpc.must_be_kind_of Google::Devtools::Clouddebugger::V2::StatusMessage
+      grpc.is_error.must_equal true
+      grpc.refers_to.must_equal :UNSPECIFIED
+      grpc.description.format.must_equal "test error message"
+    end
+  end
+end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
@@ -244,9 +244,9 @@ describe Google::Cloud::Debugger::Breakpoint, :mock_debugger do
       status = breakpoint.set_error_state error_message, refers_to: :BREAKPOINT_CONDITION
 
       breakpoint.status.must_equal status
-      breakpoint.status.must_be_kind_of Google::Devtools::Clouddebugger::V2::StatusMessage
+      breakpoint.status.must_be_kind_of Google::Cloud::Debugger::Breakpoint::StatusMessage
 
-      status.description.format.must_equal error_message
+      status.description.must_equal error_message
       status.is_error.must_equal true
       status.refers_to.must_equal :BREAKPOINT_CONDITION
     end

--- a/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
@@ -77,6 +77,8 @@ describe Google::Cloud::Debugger::Logpoint, :mock_debugger do
     end
 
     it "doesn't complete logpoints" do
+      logpoint.condition = nil
+
       logpoint.evaluate []
 
       logpoint.complete?.must_equal false


### PR DESCRIPTION
Properly set failed expression evaluations to a variable with error state instead of just error message String.