### PR TITLE
Update READMEs for GA libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ This client supports the following Google Cloud Platform services at a [General 
 * [Cloud Datastore](#cloud-datastore-ga) (GA)
 * [Stackdriver Logging](#stackdriver-logging-ga) (GA)
 * [Cloud Storage](#cloud-storage-ga) (GA)
+* [Cloud Translation API](#cloud-translation-api-ga) (GA)
 
 This client supports the following Google Cloud Platform services at a [Beta](#versioning) quality level:
 
 * [BigQuery](#bigquery-beta) (Beta)
-* [Cloud Translation API](#cloud-translation-api-beta) (Beta)
 
 This client supports the following Google Cloud Platform services at an [Alpha](#versioning) quality level:
 
@@ -485,7 +485,7 @@ backup = storage.bucket "task-attachment-backups"
 file.copy backup, file.name
 ```
 
-### Cloud Translation API (Beta)
+### Cloud Translation API (GA)
 
 - [google-cloud-translate README](google-cloud-translate/README.md)
 - [google-cloud-translate API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-translate/latest)

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -55,8 +55,6 @@ This library is supported on Ruby 2.0+.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-It is currently in major version zero (0.y.z), which means that anything may change at any time and the public API should not be considered stable.
-
 ## Contributing
 
 Contributions to this library are always welcome and highly encouraged.

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -95,8 +95,6 @@ This library is supported on Ruby 2.0+.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-It is currently in major version zero (0.y.z), which means that anything may change at any time and the public API should not be considered stable.
-
 ## Contributing
 
 Contributions to this library are always welcome and highly encouraged.

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -48,8 +48,6 @@ This library is supported on Ruby 2.0+.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-It is currently in major version zero (0.y.z), which means that anything may change at any time and the public API should not be considered stable.
-
 ## Contributing
 
 Contributions to this library are always welcome and highly encouraged.

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -48,8 +48,6 @@ This library is supported on Ruby 2.0+.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-It is currently in major version zero (0.y.z), which means that anything may change at any time and the public API should not be considered stable.
-
 ## Contributing
 
 Contributions to this library are always welcome and highly encouraged.


### PR DESCRIPTION
- Mark translate as GA
- Remove references to semver 0.x.y in 1.x.y libraries