### PR TITLE
Add breakpoint and evaluation timing limit

### DIFF
--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.c
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.c
@@ -144,17 +144,13 @@ line_trace_callback(rb_event_flag_t event, VALUE data, VALUE obj, ID mid, VALUE 
     VALUE trace_binding;
     VALUE call_stack_bindings;
 
-    int i;
     VALUE matching_result = match_breakpoints(self, c_trace_path, c_trace_lineno);
-    VALUE *c_matching_breakpoints;
-    VALUE matching_breakpoint;
-    int matching_breakpoints_len;
 
     ID callers_id;
-    ID breakpoint_hit_id;
+    ID breakpoints_hit_id;
 
     CONST_ID(callers_id, "callers");
-    CONST_ID(breakpoint_hit_id, "breakpoint_hit");
+    CONST_ID(breakpoints_hit_id, "breakpoints_hit");
 
     // If matching result isn't an array, it means we're in completely wrong file,
     // or not on the right line. Turn line tracing off if we're in wrong file.
@@ -165,17 +161,11 @@ line_trace_callback(rb_event_flag_t event, VALUE data, VALUE obj, ID mid, VALUE 
         return;
     }
 
-    c_matching_breakpoints = RARRAY_PTR(matching_result);
-    matching_breakpoints_len = RARRAY_LEN(matching_result);
     trace_binding = rb_binding_new();
     call_stack_bindings = rb_funcall(trace_binding, callers_id, 0);
     rb_ary_pop(call_stack_bindings);
 
-    // Evaluate each of the matching breakpoint
-    for (i = 0; i < matching_breakpoints_len; i++) {
-        matching_breakpoint = c_matching_breakpoints[i];
-        rb_funcall(self, breakpoint_hit_id, 2, matching_breakpoint, call_stack_bindings);
-    }
+    rb_funcall(self, breakpoints_hit_id, 2, matching_result, call_stack_bindings);
 
     return;
 }

--- a/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
@@ -91,6 +91,11 @@ module Google
         attr_accessor :logger
 
         ##
+        # A quota tracking object helps tracking resource consumption during
+        # evaluations.
+        attr_accessor :quota_manager
+
+        ##
         # @private The last exception captured in the agent child thread
         attr_reader :last_exception
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/request_quota_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/request_quota_manager.rb
@@ -16,6 +16,19 @@
 module Google
   module Cloud
     module Debugger
+      ##
+      # # RequestQuotaManager
+      #
+      # Tracking object used by debugger agent to manage quota in
+      # request-based applications. This class tracks the amount of time
+      # and number of breakpoints to evaluation in a single session.
+      #
+      # The debugger agent doesn't have use a quota manager by default, which
+      # means it will evaluate all breakpoints encountered and takes as much
+      # time as needed. This class is utilized by
+      # {Google::Cloud::Debugger::Middleware} class to limit latency overhead
+      # when used in Rack-based applications.
+      #
       class RequestQuotaManager
         # Default Total time allowed to consume, in seconds
         DEFAULT_TIME_QUOTA = 0.05

--- a/google-cloud-debugger/lib/google/cloud/debugger/request_quota_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/request_quota_manager.rb
@@ -1,0 +1,82 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Debugger
+      class RequestQuotaManager
+        # Default Total time allowed to consume, in seconds
+        DEFAULT_TIME_QUOTA = 0.05
+
+        # Default max number of breakpoints to evaluate
+        DEFAULT_COUNT_QUOTA = 10
+
+        ##
+        # The time quota for this manager
+        attr_accessor :time_quota
+
+        ##
+        # The count quota for this manager
+        attr_accessor :count_quota
+
+        ##
+        # The time quota used
+        attr_accessor :time_used
+
+        ##
+        # The count quota used
+        attr_accessor :count_used
+
+        ##
+        # Construct a new RequestQuotaManager instance
+        #
+        # @param [Float] time_quota The max quota for time consumed.
+        # @param [Integer] count_quota The max quota for count usage.
+        def initialize time_quota: DEFAULT_TIME_QUOTA,
+                       count_quota: DEFAULT_COUNT_QUOTA
+          @time_quota = time_quota
+          @time_used = 0
+          @count_quota = count_quota
+          @count_used = 0
+        end
+
+        ##
+        # Check if there's more quota left.
+        #
+        # @return [Boolean] True if there's more quota; false otherwise.
+        def more?
+          (time_used < time_quota) && (count_used < count_quota)
+        end
+
+        ##
+        # Reset all the quota usage.
+        def reset
+          @time_used = 0
+          @count_used = 0
+        end
+
+        ##
+        # Notify the quota manager some resource has been consumed. Each time
+        # called increases the count quota usage.
+        #
+        # @param [Float] time Amount of time to deduct from the time quota.
+        def consume time: 0
+          @time_used += time
+          @count_used += 1
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -45,6 +45,10 @@ def mutating_func2
   $global_var = 2
 end
 
+def infinite_loop
+  infinite_loop()
+end
+
 describe Google::Cloud::Debugger::Breakpoint::Evaluator do
   let(:evaluator) { Google::Cloud::Debugger::Breakpoint::Evaluator }
 
@@ -193,6 +197,13 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
       result = evaluator.readonly_eval_expression binding, expression
       result.must_be_kind_of ArgumentError
       result.message.must_match "no method name given"
+    end
+
+    it "errors out if evaluation takes too long" do
+      expression = "infinite_loop()"
+      result = evaluator.readonly_eval_expression binding, expression
+      result.must_be_kind_of Google::Cloud::Debugger::EvaluationError
+      result.message.must_match "Evaluation exceeded time limit"
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -46,7 +46,9 @@ def mutating_func2
 end
 
 def infinite_loop
-  infinite_loop()
+  while true
+    1 + 1
+  end
 end
 
 describe Google::Cloud::Debugger::Breakpoint::Evaluator do

--- a/google-cloud-debugger/test/google/cloud/debugger/request_quota_manager_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/request_quota_manager_test.rb
@@ -1,0 +1,68 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Debugger::RequestQuotaManager, :mock_debugger do
+  let(:quota_manager) { Google::Cloud::Debugger::RequestQuotaManager.new }
+
+  describe "#more?" do
+    it "returns false when all the time quota is used up" do
+      quota_manager.more?.must_equal true
+
+      quota_manager.consume time: (quota_manager.time_quota + 1)
+
+      quota_manager.more?.must_equal false
+    end
+
+    it "returns false when all the count quota is used up" do
+      quota_manager.more?.must_equal true
+
+      quota_manager.count_quota.times do
+        quota_manager.consume
+      end
+
+      quota_manager.more?.must_equal false
+    end
+  end
+
+  describe "#reset" do
+    it "resets time quota" do
+      quota_manager.more?.must_equal true
+
+      quota_manager.consume time: (quota_manager.time_quota + 1)
+
+      quota_manager.more?.must_equal false
+
+      quota_manager.reset
+
+      quota_manager.more?.must_equal true
+    end
+
+    it "resets count quota" do
+      quota_manager.more?.must_equal true
+
+      quota_manager.count_quota.times do
+        quota_manager.consume
+      end
+
+      quota_manager.more?.must_equal false
+
+      quota_manager.reset
+
+      quota_manager.more?.must_equal true
+    end
+  end
+end

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
@@ -41,8 +41,8 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
   it "catches breakpoint from function call" do
     hit = false
-    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
-      breakpoint.must_equal breakpoint1
+    stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
+      breakpoints.first.must_equal breakpoint1
       hit = true
     end
 
@@ -50,7 +50,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
+    tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
       tracer_test_func
       tracer.stop
@@ -61,8 +61,8 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
   it "catches breakpoint called from a child thread" do
     hit = false
-    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
-      assert_equal breakpoint, breakpoint1
+    stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
+      assert_equal breakpoints.first, breakpoint1
       hit = true
     end
 
@@ -70,7 +70,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
+    tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
       thr = Thread.new do
         tracer_test_func
@@ -84,8 +84,8 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
   it "catches breakpoint from block yield" do
     hit = false
-    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
-      breakpoint.must_equal breakpoint2
+    stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
+      breakpoints.first.must_equal breakpoint2
       hit = true
     end
 
@@ -93,7 +93,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
+    tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
       tracer_test_func3
       tracer.stop
@@ -104,8 +104,8 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
   it "catches breakpoint when function interleave files" do
     hit = false
-    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
-      breakpoint.must_equal breakpoint3
+    stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
+      breakpoints.first.must_equal breakpoint3
       hit = true
     end
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
+    tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
       tracer_test_func4
       tracer.stop
@@ -124,8 +124,8 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
   it "catches breakpoint from lambda function" do
     hit = false
-    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
-      breakpoint.must_equal breakpoint4
+    stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
+      breakpoints.first.must_equal breakpoint4
       hit = true
     end
 
@@ -133,7 +133,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
+    tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
       tracer_test_lambda.call
       tracer.stop
@@ -144,8 +144,8 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
   it "catches breakpoint from proc" do
     hit = false
-    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
-      breakpoint.must_equal breakpoint5
+    stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
+      breakpoints.first.must_equal breakpoint5
       hit = true
     end
 
@@ -153,7 +153,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
+    tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
       tracer_test_proc.call
       tracer.stop
@@ -164,8 +164,8 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
   it "catches breakpoint from fiber" do
     hit = false
-    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
-      assert_equal breakpoint, breakpoint6
+    stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
+      assert_equal breakpoints.first, breakpoint6
       hit = true
     end
 
@@ -173,7 +173,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
+    tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
       tracer_test_fiber.resume
       tracer.stop
@@ -184,8 +184,8 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
   it "catches breakpoint from fiber after fiber yields" do
     hit = false
-    stubbed_breakpoint_hit = ->(breakpoint, call_stack_bindings) do
-      assert_equal breakpoint, breakpoint7
+    stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
+      assert_equal breakpoints.first, breakpoint7
       hit = true
     end
 
@@ -193,7 +193,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     tracer = debugger.agent.tracer
     tracer.app_root = ""
 
-    tracer.stub :breakpoint_hit, stubbed_breakpoint_hit do
+    tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
       test_filber = tracer_test_fiber
       test_filber.resume

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     end
   end
 
-  describe "#breakpoint_hit" do
+  describe "#breakpoints_hit" do
     let(:breakpoint) {
       Google::Cloud::Debugger::Snappoint.new nil, "path/to/file.rb", 123
     }
@@ -56,7 +56,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
       breakpoint_manager.stub :breakpoint_hit, stubbed_breakpoint_hit do
         breakpoint.stub :complete?, true do
-          tracer.breakpoint_hit breakpoint, nil
+          tracer.breakpoints_hit [breakpoint], nil
         end
       end
     end
@@ -74,7 +74,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       breakpoint.stub :evaluate, stubbed_evaluate do
         transmitter.stub :submit, nil do
           tracer.stub :disable_traces, mocked_disable_traces do
-            tracer.breakpoint_hit breakpoint, nil
+            tracer.breakpoints_hit [breakpoint], nil
           end
         end
       end


### PR DESCRIPTION
Put timing limit on both breakpoints evaluations and expressions evaluations to limit the maximum latency overhead added onto application request.