### PR TITLE
Update documentation

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -21,31 +21,67 @@ module Google
   module Cloud
     module Pubsub
       ##
-      # # Subscriber
+      # Subscriber object used to stream and process messages from a
+      # Subscription. See {Google::Cloud::Pubsub::Subscription#listen}
+      #
+      # @example
+      #   require "google/cloud/pubsub"
+      #
+      #   pubsub = Google::Cloud::Pubsub.new
+      #
+      #   sub = pubsub.subscription "my-topic-sub"
+      #
+      #   subscriber = sub.listen do |msg|
+      #     # process msg
+      #     msg.ack!
+      #   end
+      #
+      #   subscriber.start
+      #
+      # @attr_reader [String] subscription_name The name of the subscription the
+      #   messages are pulled from.
+      # @attr_reader [Proc] callback The procedure that will handle the messages
+      #   received from the subscription.
+      # @attr_reader [Numeric] deadline The default number of seconds the stream
+      #   will hold received messages before modifying the message's ack
+      #   deadline. The minimum is 10, the maximum is 600. Default is 60.
+      # @attr_reader [Integer] streams The number of concurrent streams to open
+      #   to pull messages from the subscription. Default is 4.
+      # @attr_reader [Integer] inventory The number of received messages to be
+      #   collected by subscriber. Default is 1,000.
+      # @attr_reader [Integer] callback_threads The number of threads used to
+      #   handle the received messages. Default is 8.
+      # @attr_reader [Integer] push_threads The number of threads to handle
+      #   acknowledgement ({ReceivedMessage#ack!}) and delay messages
+      #   ({ReceivedMessage#nack!}, {ReceivedMessage#delay!}). Default is 4.
       #
       class Subscriber
         include MonitorMixin
 
-        ##
-        # Subscriber attributes.
         attr_reader :subscription_name, :callback, :deadline, :streams,
-                    :inventory, :threads
+                    :inventory, :callback_threads, :push_threads
 
         ##
         # @private Implementation attributes.
-        attr_reader :stream_pool, :thread_pool, :service
+        attr_reader :stream_inventory, :stream_pool, :thread_pool, :service
 
         ##
         # @private Create an empty {Subscriber} object.
         def initialize subscription_name, callback, deadline: nil, streams: nil,
-                       inventory: nil, threads: nil, service: nil
+                       inventory: nil, threads: {}, service: nil
           @callback = callback
           @subscription_name = subscription_name
           @deadline = deadline || 60
-          @streams = streams || 1
-          @inventory = inventory || 100
-          @threads = threads || 4
+          @streams = streams || 4
+          @inventory = inventory || 1000
+          @callback_threads = (threads[:callback] || 8).to_i
+          @push_threads = (threads[:push] || 4).to_i
+
+          @stream_inventory = (@streams/@inventory).ceil
           @service = service
+
+          @started = nil
+          @stopped = nil
 
           stream_pool = @streams.times.map do
             Thread.new { Stream.new self }
@@ -55,8 +91,16 @@ module Google
           super() # to init MonitorMixin
         end
 
+        ##
+        # Starts the subscriber pulling from the subscription and processing the
+        # received messages.
+        #
+        # @return [Subscriber] returns self so calls can be chained.
         def start
           start_pool = synchronize do
+            @started = true
+            @stopped = false
+
             @stream_pool.map do |stream|
               Thread.new { stream.start }
             end
@@ -66,8 +110,18 @@ module Google
           self
         end
 
+        ##
+        # Begins the process of stopping the subscriber. Unhandled received
+        # messages will be processed, but no new messages will be pulled from
+        # the subscription. Use {#wait!} to block until the subscriber is fully
+        # stopped and all received messages have been processed.
+        #
+        # @return [Subscriber] returns self so calls can be chained.
         def stop
           stop_pool = synchronize do
+            @started = false
+            @stopped = true
+
             @stream_pool.map do |stream|
               Thread.new { stream.stop }
             end
@@ -77,6 +131,13 @@ module Google
           self
         end
 
+        ##
+        # Blocks until the subscriber is fully stopped and all received messages
+        # have been handled. Does not stop the subscriber. To stop the
+        # subscriber, first call {#stop} and then call {#wait!} to block until
+        # the subscriber is stopped.
+        #
+        # @return [Subscriber] returns self so calls can be chained.
         def wait!
           wait_pool = synchronize do
             @stream_pool.map do |stream|
@@ -88,11 +149,29 @@ module Google
           self
         end
 
+        ##
+        # Whether the subscriber has been started.
+        #
+        # @return [boolean] `true` when started, `false` otherwise.
+        def started?
+          synchronize { @started }
+        end
+
+        ##
+        # Whether the subscriber has been stopped.
+        #
+        # @return [boolean] `true` when stopped, `false` otherwise.
+        def stopped?
+          synchronize { @stopped }
+        end
+
+        ##
         # @private
         def to_s
           format "(subscription: %s, streams: %i)", subscription_name, streams
         end
 
+        ##
         # @private
         def inspect
           "#<#{self.class.name} #{self}>"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_acknowledger.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_acknowledger.rb
@@ -30,7 +30,7 @@ module Google
           attr_reader :batch
           attr_reader :max_bytes, :interval
 
-          def initialize stream, max_bytes: 8388608, interval: 0.25
+          def initialize stream, max_bytes: 10000000, interval: 0.25
             @stream = stream
 
             @max_bytes = max_bytes
@@ -144,7 +144,7 @@ module Google
           class Batch
             attr_reader :ack_ids
 
-            def initialize max_bytes: 8388608
+            def initialize max_bytes: 10000000
               @max_bytes = max_bytes
               @ack_ids = []
             end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_delayer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_delayer.rb
@@ -30,7 +30,7 @@ module Google
           attr_reader :batch
           attr_reader :max_bytes, :interval
 
-          def initialize stream, max_bytes: 8388608, interval: 0.25
+          def initialize stream, max_bytes: 10000000, interval: 0.25
             @stream = stream
 
             @max_bytes = max_bytes
@@ -144,7 +144,7 @@ module Google
           class Batch
             attr_reader :ack_ids, :request
 
-            def initialize max_bytes: 8388608
+            def initialize max_bytes: 10000000
               @max_bytes = max_bytes
               @request = Google::Pubsub::V1::StreamingPullRequest.new
             end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -25,6 +25,7 @@ module Google
   module Cloud
     module Pubsub
       class Subscriber
+        ##
         # @private
         class Stream
           include MonitorMixin
@@ -47,11 +48,11 @@ module Google
             @paused  = nil
             @pause_cond = new_cond
 
-            @inventory = Inventory.new self, subscriber.inventory
+            @inventory = Inventory.new self, subscriber.stream_inventory
             @callback_thread_pool = Concurrent::FixedThreadPool.new \
-              subscriber.threads
+              subscriber.callback_threads
             @push_thread_pool = Concurrent::FixedThreadPool.new \
-              subscriber.threads
+              subscriber.push_threads
 
             super() # to init MonitorMixin
           end
@@ -288,6 +289,7 @@ module Google
             end
           end
 
+          ##
           # @private
           class Inventory
             include MonitorMixin

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -289,6 +289,26 @@ module Google
         # Create a {Subscriber} object that polls the backend for new messages
         # and processes them with the code provided in the callback.
         #
+        # @param [Numeric] deadline The default number of seconds the stream
+        #   will hold received messages before modifying the message's ack
+        #   deadline. The minimum is 10, the maximum is 600. Default is
+        #   {#deadline}. Optional.
+        # @param [Integer] streams The number of concurrent streams to open to
+        #   pull messages from the subscription. Default is 4. Optional.
+        # @param [Integer] inventory The number of received messages to be
+        #   collected by subscriber. Default is 1,000. Optional.
+        # @param [Hash] threads The number of threads to create to handle
+        #   concurrent calls by each stream opened by the subscriber. Optional.
+        #
+        #   Hash keys and values may include the following:
+        #
+        #     * `:callback` (Integer) The number of threads used to handle the
+        #       received messages. Default is 8.
+        #     * `:push` (Integer) The number of threads to handle
+        #       acknowledgement ({ReceivedMessage#ack!}) and delay messages
+        #       ({ReceivedMessage#nack!}, {ReceivedMessage#delay!}). Default is
+        #       4.
+        #
         # @yield [msg] a block for processing new messages
         # @yieldparam [ReceivedMessage] msg the newly received message
         #
@@ -308,7 +328,22 @@ module Google
         #
         #   subscriber.start
         #
-        def listen deadline: nil, streams: nil, inventory: nil, threads: nil,
+        # @example Configuring to increase concurrent callbacks:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #
+        #   subscriber = sub.listen threads: { callback: 16 } do |msg|
+        #     # store the message somewhere before acknowledging
+        #     store_in_backend msg.data # takes a few seconds
+        #     msg.ack!
+        #   end
+        #
+        #   subscriber.start
+        #
+        def listen deadline: nil, streams: nil, inventory: nil, threads: {},
                    &block
           ensure_service!
           deadline ||= self.deadline

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -55,6 +55,28 @@ module Google
           @async_opts = {}
         end
 
+        ##
+        # AsyncPublisher object used to publish multiple messages in batches.
+        #
+        # @return [Topic::AsyncPublisher] Returns publisher object if calls to
+        #   {#publish_async} have been made, returns `nil` otherwise.
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::Pubsub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #   topic.publish_async "task completed" do |result|
+        #     if result.succeeded?
+        #       log_publish_success result.data
+        #     else
+        #       log_publish_failure result.data, result.error
+        #     end
+        #   end
+        #
+        #   topic.async_publisher.stop.wait!
+        #
         def async_publisher
           @async_publisher
         end
@@ -322,8 +344,14 @@ module Google
         #
         #   topic = pubsub.topic "my-topic"
         #   topic.publish_async "task completed" do |result|
-        #     puts result.msg_id if result.succeeded?
+        #     if result.succeeded?
+        #       log_publish_success result.data
+        #     else
+        #       log_publish_failure result.data, result.error
+        #     end
         #   end
+        #
+        #   topic.async_publisher.stop.wait!
         #
         # @example A message can be published using a File object:
         #   require "google/cloud/pubsub"
@@ -334,6 +362,8 @@ module Google
         #   file = File.open "message.txt", mode: "rb"
         #   topic.publish_async file
         #
+        #   topic.async_publisher.stop.wait!
+        #
         # @example Additionally, a message can be published with attributes:
         #   require "google/cloud/pubsub"
         #
@@ -342,6 +372,8 @@ module Google
         #   topic = pubsub.topic "my-topic"
         #   topic.publish_async "task completed",
         #                       foo: :bar, this: :that
+        #
+        #   topic.async_publisher.stop.wait!
         #
         def publish_async data = nil, attributes = {}, &block
           ensure_service!

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/batch_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/batch_publisher.rb
@@ -48,8 +48,8 @@ module Google
           end
 
           ##
-          # Add multiple messages to the topic.
-          # All messages added will be published at once.
+          # Add a message to the batch to be published to the topic.
+          # All messages added to the batch will be published at once.
           # See {Google::Cloud::Pubsub::Topic#publish}
           def publish data, attributes = {}
             @messages << create_pubsub_message(data, attributes)

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -18,10 +18,11 @@ describe Google::Cloud::Pubsub::Subscriber, :mock_pubsub do
   let(:callback) { Proc.new { |msg| puts msg.inspect } }
   let(:subscription_name) { "subscription-name-goes-here" }
   let(:deadline) { 120 }
-  let(:streams) { 4 }
+  let(:streams) { 8 }
   let(:inventory) { 250 }
-  let(:threads) { 8 }
-  let(:subscriber) { Google::Cloud::Pubsub::Subscriber.new subscription_name, callback, deadline: deadline, streams: streams, inventory: inventory, threads: threads, service: pubsub.service }
+  let(:callback_threads) { 16 }
+  let(:push_threads) { 8 }
+  let(:subscriber) { Google::Cloud::Pubsub::Subscriber.new subscription_name, callback, deadline: deadline, streams: streams, inventory: inventory, threads: { callback: callback_threads, push: push_threads}, service: pubsub.service }
 
   it "knows itself" do
     subscriber.must_be_kind_of Google::Cloud::Pubsub::Subscriber
@@ -30,6 +31,7 @@ describe Google::Cloud::Pubsub::Subscriber, :mock_pubsub do
     subscriber.deadline.must_equal deadline
     subscriber.streams.must_equal streams
     subscriber.inventory.must_equal inventory
-    subscriber.threads.must_equal threads
+    subscriber.callback_threads.must_equal callback_threads
+    subscriber.push_threads.must_equal push_threads
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Pubsub::Subscription, :listen, :mock_pubsub do
     subscriber.must_be_kind_of Google::Cloud::Pubsub::Subscriber
     subscriber.subscription_name.must_equal subscription.name
     subscriber.deadline.must_equal 60
-    subscriber.streams.must_equal 1
+    subscriber.streams.must_equal 4
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -39,7 +39,7 @@ describe Google::Cloud::Pubsub::Subscription, :listen, :mock_pubsub do
     subscriber.must_be_kind_of Google::Cloud::Pubsub::Subscriber
     subscriber.subscription_name.must_equal subscription.name
     subscriber.deadline.must_equal 120
-    subscriber.streams.must_equal 1
+    subscriber.streams.must_equal 4
   end
 
   it "will set deadline while creating a Subscriber" do


### PR DESCRIPTION
Update documentation for AsyncPublisher and Subscriber classes. Ensure documented behavior matches requested features, including minor changes for the following:

- [x] Inventory is per Subscriber, not per Stream
- [x] Separate thread pool values
- [x] Add `async` options to `Project#create_topic`