### PR TITLE
Resource manager IAM fixes

### DIFF
--- a/google-cloud-resource_manager/Rakefile
+++ b/google-cloud-resource_manager/Rakefile
@@ -26,7 +26,7 @@ end
 
 desc "Run acceptance tests."
 task :acceptance do
-  puts "The google-cloud-resource_manager gem does not have acceptance tests."
+  puts "The google-cloud-resource_manager gem does not have acceptance tests due to the lack of support for service accounts. See https://cloud.google.com/resource-manager/docs/authorizing for details."
 end
 
 namespace :acceptance do

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
@@ -100,7 +100,7 @@ module Google
         ##
         # Returns API::Policy
         def get_policy project_id
-          execute { service.get_project_iam_policy "projects/#{project_id}" }
+          execute { service.get_project_iam_policy project_id }
         end
 
         ##
@@ -108,7 +108,7 @@ module Google
         def set_policy project_id, new_policy
           req = API::SetIamPolicyRequest.new policy: new_policy
           execute do
-            service.set_project_iam_policy "projects/#{project_id}", req
+            service.set_project_iam_policy project_id, req
           end
         end
 
@@ -117,7 +117,7 @@ module Google
         def test_permissions project_id, permissions
           req = API::TestIamPermissionsRequest.new permissions: permissions
           execute do
-            service.test_project_iam_permissions "projects/#{project_id}", req
+            service.test_project_iam_permissions project_id, req
           end
         end
 

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/project_iam_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/project_iam_test.rb
@@ -51,7 +51,7 @@ describe Google::Cloud::ResourceManager::Project, :iam, :mock_res_man do
 
   it "gets the policy" do
     mock = Minitest::Mock.new
-    mock.expect :get_project_iam_policy, old_policy_gapi, ["projects/example-project-123"]
+    mock.expect :get_project_iam_policy, old_policy_gapi, ["example-project-123"]
 
     resource_manager.service.mocked_service = mock
     policy = project.policy
@@ -68,7 +68,7 @@ describe Google::Cloud::ResourceManager::Project, :iam, :mock_res_man do
   it "sets the policy" do
     mock = Minitest::Mock.new
     update_policy_request = Google::Apis::CloudresourcemanagerV1::SetIamPolicyRequest.new policy: new_policy_gapi
-    mock.expect :set_project_iam_policy, new_policy_gapi, ["projects/example-project-123", update_policy_request]
+    mock.expect :set_project_iam_policy, new_policy_gapi, ["example-project-123", update_policy_request]
 
     resource_manager.service.mocked_service = mock
     policy = project.policy = new_policy
@@ -85,10 +85,10 @@ describe Google::Cloud::ResourceManager::Project, :iam, :mock_res_man do
 
   it "sets the policy in a block" do
     mock = Minitest::Mock.new
-    mock.expect :get_project_iam_policy, old_policy_gapi, ["projects/example-project-123"]
+    mock.expect :get_project_iam_policy, old_policy_gapi, ["example-project-123"]
 
     update_policy_request = Google::Apis::CloudresourcemanagerV1::SetIamPolicyRequest.new policy: new_policy_gapi
-    mock.expect :set_project_iam_policy, new_policy_gapi, ["projects/example-project-123", update_policy_request]
+    mock.expect :set_project_iam_policy, new_policy_gapi, ["example-project-123", update_policy_request]
 
     resource_manager.service.mocked_service = mock
     policy = project.policy do |p|
@@ -109,7 +109,7 @@ describe Google::Cloud::ResourceManager::Project, :iam, :mock_res_man do
     mock = Minitest::Mock.new
     update_policy_request  = Google::Apis::CloudresourcemanagerV1::TestIamPermissionsRequest.new  permissions: ["resourcemanager.projects.get", "resourcemanager.projects.delete"]
     update_policy_response = Google::Apis::CloudresourcemanagerV1::TestIamPermissionsResponse.new permissions: ["resourcemanager.projects.get"]
-    mock.expect :test_project_iam_permissions, update_policy_response, ["projects/example-project-123", update_policy_request]
+    mock.expect :test_project_iam_permissions, update_policy_response, ["example-project-123", update_policy_request]
 
     resource_manager.service.mocked_service = mock
     permissions = project.test_permissions "resourcemanager.projects.get",


### PR DESCRIPTION
This PR updates the format of the `resource` argument to API calls.  

[fixes #1602]
