### PR TITLE
Add Bucket#storage_class=

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -35,17 +35,20 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
     storage.bucket(one_off_bucket_name).wont_be :nil?
 
+    one_off_bucket.storage_class.wont_be :nil?
     one_off_bucket.website_main.must_be :nil?
     one_off_bucket.website_404.must_be :nil?
     one_off_bucket.requester_pays.must_be :nil?
     one_off_bucket.labels.must_equal({})
     one_off_bucket.update do |b|
+      b.storage_class = :nearline
       b.website_main = "index.html"
       b.website_404 = "not_found.html"
       b.requester_pays = true
       # update labels with symbols
       b.labels[:foo] = :bar
     end
+    one_off_bucket.storage_class.must_equal "NEARLINE"
     one_off_bucket.website_main.must_equal "index.html"
     one_off_bucket.website_404.must_equal "not_found.html"
     one_off_bucket.requester_pays.must_equal true
@@ -54,6 +57,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
     one_off_bucket_copy = storage.bucket one_off_bucket_name
     one_off_bucket_copy.wont_be :nil?
+    one_off_bucket_copy.storage_class.must_equal "NEARLINE"
     one_off_bucket_copy.website_main.must_equal "index.html"
     one_off_bucket_copy.website_404.must_equal "not_found.html"
     one_off_bucket_copy.requester_pays.must_equal true

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -234,10 +234,23 @@ module Google
         ##
         # The bucket's storage class. This defines how objects in the bucket are
         # stored and determines the SLA and the cost of storage. Values include
-        # `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `STANDARD`,
-        # and `DURABLE_REDUCED_AVAILABILITY`.
+        # `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, and
+        # `DURABLE_REDUCED_AVAILABILITY`.
         def storage_class
           @gapi.storage_class
+        end
+
+        ##
+        # Updates the bucket's storage class. This defines how objects in the
+        # bucket are stored and determines the SLA and the cost of storage.
+        # Accepted values include `:multi_regional`, `:regional`, `:nearline`,
+        # and `:coldline`, as well as the equivalent strings returned by
+        # {Bucket#storage_class}. For more information, see [Storage
+        # Classes](https://cloud.google.com/storage/docs/storage-classes).
+        # @param [Symbol, String] new_storage_class Storage class of the bucket.
+        def storage_class= new_storage_class
+          @gapi.storage_class = storage_class_for(new_storage_class)
+          patch_gapi! :storage_class
         end
 
         ##
@@ -615,12 +628,11 @@ module Google
         #   file as "x-goog-meta-" response headers.
         # @param [Symbol, String] storage_class Storage class of the file.
         #   Determines how the file is stored and determines the SLA and the
-        #   cost of storage. Values include `:multi_regional`, `:regional`,
-        #   `:nearline`, `:coldline`, `:standard`, and `:dra` (Durable Reduced
-        #   Availability), as well as the strings returned by
-        #   {#storage_class}. For more information, see [Storage
-        #   Classes](https://cloud.google.com/storage/docs/storage-classes) and
-        #   [Per-Object Storage
+        #   cost of storage. Accepted values include `:multi_regional`,
+        #   `:regional`, `:nearline`, and `:coldline`, as well as the equivalent
+        #   strings returned by {#storage_class}. For more information, see
+        #   [Storage Classes](https://cloud.google.com/storage/docs/storage-classes)
+        #   and [Per-Object Storage
         #   Class](https://cloud.google.com/storage/docs/per-object-storage-class).
         #   The default value is the default storage class for the bucket.
         # @param [String] encryption_key Optional. A customer-supplied, AES-256

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -314,10 +314,10 @@ module Google
 
         ##
         # Updates how the file is stored and determines the SLA and the cost of
-        # storage. Values include `:multi_regional`, `:regional`, `:nearline`,
-        # `:coldline`, `:standard`, and `:dra` (Durable Reduced Availability),
-        # as well as the strings returned by {File#storage_class} or
-        # {Bucket#storage_class}. For more information, see [Storage
+        # storage. Accepted values include `:multi_regional`, `:regional`,
+        # `:nearline`, and `:coldline`, as well as the equivalent strings
+        # returned by {File#storage_class} or {Bucket#storage_class}. For more
+        # information, see [Storage
         # Classes](https://cloud.google.com/storage/docs/storage-classes) and
         # [Per-Object Storage
         # Class](https://cloud.google.com/storage/docs/per-object-storage-class).

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -258,12 +258,11 @@ module Google
         #   Logs](https://cloud.google.com/storage/docs/access-logs).
         # @param [Symbol, String] storage_class Defines how objects in the
         #   bucket are stored and determines the SLA and the cost of storage.
-        #   Values include `:multi_regional`, `:regional`, `:nearline`,
-        #   `:coldline`, `:standard`, and `:dra` (Durable Reduced
-        #   Availability), as well as the strings returned by
+        #   Accepted values include `:multi_regional`, `:regional`, `:nearline`,
+        #   and `:coldline`, as well as the equivalent strings returned by
         #   {Bucket#storage_class}. For more information, see [Storage
         #   Classes](https://cloud.google.com/storage/docs/storage-classes). The
-        #   default value is `:standard`, which is equivalent to
+        #   default value is the Standard storage class, which is equivalent to
         #   `:multi_regional` or `:regional` depending on the bucket's location
         #   settings.
         # @param [Boolean] versioning Whether [Object
@@ -313,12 +312,13 @@ module Google
                           website_main: nil, website_404: nil, versioning: nil
           new_bucket = Google::Apis::StorageV1::Bucket.new({
             name: bucket_name,
-            location: location,
-            storage_class: storage_class_for(storage_class)
+            location: location
           }.delete_if { |_, v| v.nil? })
+          storage_class = storage_class_for(storage_class)
           updater = Bucket::Updater.new(new_bucket).tap do |b|
             b.logging_bucket = logging_bucket unless logging_bucket.nil?
             b.logging_prefix = logging_prefix unless logging_prefix.nil?
+            b.storage_class = storage_class unless storage_class.nil?
             b.website_main = website_main unless website_main.nil?
             b.website_404 = website_404 unless website_404.nil?
             b.versioning = versioning unless versioning.nil?


### PR DESCRIPTION
This PR adds `Bucket#storage_class=`. It also removes most mentions of standard and DRA storage classes from the docs, since these have also been removed from most listings of storage classes in the [official docs](https://cloud.google.com/storage/docs/storage-classes).

[closes #1603]