### PR TITLE
Storage File#delete generation

### DIFF
--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -84,7 +84,9 @@ namespace :acceptance do
     puts "Cleaning up Storage buckets and files"
     Google::Cloud.storage.buckets.all do |b|
       begin
-        b.files.all &:delete
+        b.files(versions: true).all do |file|
+          file.delete generation: true
+        end
         # Add one second delay between bucket deletes to avoid rate limiting errors
         sleep 1
         b.delete

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -93,7 +93,9 @@ def clean_up_storage_buckets
   $bucket_names.each do |bucket_name|
     if b = $storage.bucket(bucket_name)
       begin
-        b.files.all &:delete
+        b.files(versions: true).all do |file|
+          file.delete generation: true
+        end
         # Add one second delay between bucket deletes to avoid rate limiting errors
         sleep 1
         b.delete

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -639,6 +639,11 @@ module Google
         # Permanently deletes the file.
         #
         # @return [Boolean] Returns `true` if the file was deleted.
+        # @param [Boolean, Integer] generation Specify a version of the file to
+        #   delete. When `true`, it will delete the version returned by
+        #   {#generation}. The default behavior is to delete the latest version
+        #   of the file (regardless of the version to which the file is set,
+        #   which is the version returned by {#generation}.)
         #
         # @example
         #   require "google/cloud/storage"
@@ -650,9 +655,31 @@ module Google
         #   file = bucket.file "path/to/my-file.ext"
         #   file.delete
         #
-        def delete
+        # @example The file's generation can used by passing `true`:
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   file = bucket.file "path/to/my-file.ext"
+        #   file.delete generation: true
+        #
+        # @example A generation can also be specified:
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   file = bucket.file "path/to/my-file.ext"
+        #   file.delete generation: 123456
+        #
+        def delete generation: nil
           ensure_service!
-          service.delete_file bucket, name, user_project: user_project
+          generation = self.generation if generation == true
+          service.delete_file bucket, name, generation: generation,
+                                            user_project: user_project
           true
         end
 

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -326,9 +326,11 @@ module Google
 
         ##
         # Permanently deletes a file.
-        def delete_file bucket_name, file_path, user_project: nil
+        def delete_file bucket_name, file_path, generation: nil,
+                        user_project: nil
           execute do
             service.delete_object bucket_name, file_path,
+                                  generation: generation,
                                   user_project: user_project(user_project)
           end
         end

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -85,7 +85,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket.name, file.name, { user_project: nil }]
+    mock.expect :delete_object, nil, [bucket.name, file.name, { generation: nil, user_project: nil }]
 
     file.service.mocked_service = mock
 
@@ -94,13 +94,58 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.verify
   end
 
+  it "can delete itself with generation set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_object, nil, [bucket.name, file.name, { generation: 1234567890, user_project: nil }]
+
+    file.service.mocked_service = mock
+
+    file.generation.must_equal 1234567890
+    file.delete generation: true
+
+    mock.verify
+  end
+
+  it "can delete itself with generation set to a generation" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_object, nil, [bucket.name, file.name, { generation: 1234567894, user_project: nil }]
+
+    file.service.mocked_service = mock
+
+    file.delete generation: 1234567894
+
+    mock.verify
+  end
+
   it "can delete itself with user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket.name, file_user_project.name, { user_project: "test" }]
+    mock.expect :delete_object, nil, [bucket.name, file_user_project.name, { generation: nil, user_project: "test" }]
 
     file_user_project.service.mocked_service = mock
 
     file_user_project.delete
+
+    mock.verify
+  end
+
+  it "can delete itself with generation set to true and user_project set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_object, nil, [bucket.name, file.name, { generation: 1234567890, user_project: "test" }]
+
+    file_user_project.service.mocked_service = mock
+
+    file_user_project.delete generation: true
+
+    mock.verify
+  end
+
+  it "can delete itself with generation set to a generation and user_project set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_object, nil, [bucket.name, file.name, { generation: 1234567894, user_project: "test" }]
+
+    file_user_project.service.mocked_service = mock
+
+    file_user_project.delete generation: 1234567894
 
     mock.verify
   end


### PR DESCRIPTION
Allow users to remove older versions of files.

Also update the acceptance cleanup task to remove all generations of files.