### PR TITLE
Implement breakpoint variable evaluation dynamic sizing

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
@@ -24,6 +24,13 @@ require "google/cloud/debugger/breakpoint/variable_table"
 module Google
   module Cloud
     module Debugger
+      ##
+      # # Breakpoint
+      #
+      # Abstract class that represents a breakpoint, which can be set and
+      # triggered in a debuggee application. Maps to gRPC struct
+      # {Google::Devtools::Clouddebugger::V2::Breakpoint}.
+      #
       class Breakpoint
         include MonitorMixin
 
@@ -154,7 +161,7 @@ module Google
           @evaluated_expressions = []
           @stack_frames = []
           @labels = {}
-          @variable_table = []
+          @variable_table = VariableTable.new
         end
 
         ##

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -531,7 +531,6 @@ module Google
           # reference variable to the shared buffer full variable
           def buffer_full_variable?
             if (status &&
-               status.is_error == true &&
                status.description == BUFFER_FULL_MSG) ||
                (var_table &&
                  reference_variable? &&

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -85,12 +85,21 @@ module Google
 
           ##
           # Max number of member variables to evaluate in compound variables
-          MAX_MEMBERS = 10
+          MAX_MEMBERS = 1000
 
           ##
           # Max length on variable inspect results. Truncate extra and replace
           # with ellipsis.
-          MAX_STRING_LENGTH = 260
+          MAX_STRING_LENGTH = 500
+
+          ##
+          # @private Minimum amoutn of size limit needed for evaluation.
+          MIN_REQUIRED_SIZE = 100
+
+          ##
+          # @private Message to display on variables when snapshot buffer is
+          # full.
+          BUFFER_FULL_MSG = "Buffer full. Use an expression to see more data."
 
           ##
           # @private Name of the variable, if any.
@@ -120,6 +129,11 @@ module Google
           attr_accessor :var_table_index
 
           ##
+          # @private The variable table this variable references to (if
+          # var_table_index is set).
+          attr_accessor :var_table
+
+          ##
           # @private Status associated with the variable. This field will
           # usually stay unset. A status of a single variable only applies to
           # that variable or expression. The rest of breakpoint data still
@@ -130,6 +144,11 @@ module Google
           # VARIABLE_VALUE. In either case variable value and members will be
           # unset.
           attr_accessor :status
+
+          ##
+          # @private The original Ruby object this Breakpoint::Variable is based
+          # upon.
+          attr_accessor :source_var
 
           ##
           # @private Create an empty Variable object.
@@ -150,6 +169,9 @@ module Google
           #   {Google::Cloud::Debugger::Breakpoint::Variable::MAX_DEPTH}
           # @param [Breakpoint::VariableTable] var_table A variable table
           #   to store shared compound variables. Optional.
+          # @param [Integer] limit Maximum number of bytes this convertion
+          #   should take. This include nested compound member variables'
+          #   convertions.
           #
           # @example Simple variable convertion
           #   x = 3
@@ -204,42 +226,55 @@ module Google
           #   variable.
           #
           def self.from_rb_var source, name: nil, depth: MAX_DEPTH,
-                               var_table: nil
+                               var_table: nil, limit: nil
             return source if source.is_a? Variable
+
+            if limit && limit < MIN_REQUIRED_SIZE
+              return buffer_full_variable var_table
+            end
 
             # If source is a non-empty Array or Hash, or source has instance
             # variables, evaluate source as a compound variable.
             if compound_var?(source) && depth > 0
               from_compound_var source, name: name, depth: depth,
-                                        var_table: var_table
+                                        var_table: var_table, limit: limit
             else
-              var = Variable.new
-              var.name = name.to_s if name
-              var.type = source.class.to_s
-              var.value = truncate_value(source.inspect)
-
-              var
+              new.tap do |var|
+                var.name = name.to_s if name
+                var.type = source.class.to_s
+                limit = deduct_limit limit,
+                                     var.name.to_s.bytesize + var.type.bytesize
+                var.value = truncate_value source.inspect, limit
+                var.source_var = source
+              end
             end
           end
 
           ##
           # @private Helper method that converts compound variables.
           def self.from_compound_var source, name: nil, depth: MAX_DEPTH,
-                                     var_table: nil
+                                     var_table: nil, limit: nil
             return source if source.is_a? Variable
 
-            var = Variable.new
-            var.name = name.to_s if name
-
-            if var_table
-              var.var_table_index =
-                var_table.rb_var_index(source) ||
-                add_shared_compound_var(source, depth, var_table)
-            else
-              var.type = source.class.to_s
-              add_compound_members var, source, depth
+            if limit && limit < MIN_REQUIRED_SIZE
+              return buffer_full_variable var_table
             end
 
+            var = new
+            var.name = name.to_s if name
+            var.source_var = source
+            limit = deduct_limit limit, var.name.to_s.bytesize
+
+            if var_table
+              var.var_table = var_table
+              var.var_table_index =
+                var_table.rb_var_index(source) ||
+                add_shared_compound_var(source, depth, var_table, limit: limit)
+            else
+              var.type = source.class.to_s
+              limit = deduct_limit limit, var.type.bytesize
+              add_compound_members var, source, depth, limit: limit
+            end
             var
           end
 
@@ -253,36 +288,41 @@ module Google
           ##
           # @private Add a shared compound variable to the breakpoint
           # variable table.
-          def self.add_shared_compound_var source, depth, var_table
-            var = Variable.new
+          def self.add_shared_compound_var source, depth, var_table, limit: nil
+            var = new
             var.type = source.class.to_s
+            var.source_var = source
+            limit = deduct_limit limit, var.type.bytesize
 
             table_index = var_table.size
-            var_table.add_var source, var
+            var_table.add var
 
-            add_compound_members var, source, depth, var_table
+            add_compound_members var, source, depth, var_table, limit: limit
 
             table_index
           end
 
           ##
           # @private Add member variables to a compound variable.
-          def self.add_compound_members var, source, depth, var_table = nil
+          def self.add_compound_members var, source, depth, var_table = nil,
+                                        limit: nil
             case source
             when Hash
-              add_member_vars var, source do |(k, v)|
-                from_rb_var v, name: k, depth: depth - 1, var_table: var_table
+              add_member_vars var, source, limit: limit do |(k, v), _, lmt|
+                from_rb_var v, name: k, depth: depth - 1, var_table: var_table,
+                               limit: lmt
               end
             when Array
-              add_member_vars var, source do |el, i|
+              add_member_vars var, source, limit: limit do |el, i, lmt|
                 from_rb_var el, name: "[#{i}]", depth: depth - 1,
-                                var_table: var_table
+                                var_table: var_table, limit: lmt
               end
             else
-              add_member_vars var, source.instance_variables do |var_name|
+              members = source.instance_variables
+              add_member_vars var, members, limit: limit do |var_name, _, lmt|
                 instance_var = source.instance_variable_get var_name
                 from_rb_var instance_var, name: var_name, depth: depth - 1,
-                                          var_table: var_table
+                                          var_table: var_table, limit: lmt
               end
             end
           end
@@ -290,22 +330,60 @@ module Google
           ##
           # @private Help interate through collection of member variables for
           # compound variables.
-          def self.add_member_vars var, members
-            members.each_with_index do |el, i|
-              if i < MAX_MEMBERS
-                var.members << yield(el, i)
-              else
+          def self.add_member_vars var, members, limit: nil
+            members.each_with_index do |member, i|
+              member_var = yield(member, i, limit)
+
+              limit = deduct_limit limit, member_var.total_size
+
+              buffer_full = (limit && limit < 0) ||
+                            i >= MAX_MEMBERS ||
+                            member_var.buffer_full_variable?
+
+              if buffer_full
                 var.members << Variable.new.tap do |last_var|
-                  last_var.value =
-                    "(Only first #{MAX_MEMBERS} items were captured)"
+                  last_var.set_error_state \
+                    "Only first #{i} items were captured. Use in " \
+                    "an expression to see all items.",
+                    refers_to: StatusMessage::VARIABLE_VALUE
                 end
                 break
+              else
+                var.members << member_var
               end
             end
           end
 
-          private_class_method :add_compound_members, :add_shared_compound_var,
-                               :add_member_vars, :compound_var?
+          ##
+          # @private Create an empty variable that points to the shared
+          # "Buffer Full" variable in the given variable table (always index 0)
+          # if a variable table is passed in. Otherwise create an error variable
+          # with the buffer full message.
+          def self.buffer_full_variable var_table = nil, name: nil
+            new.tap do |var|
+              var.name = name if name
+
+              if var_table && var_table.first &&
+                 var_table.first.buffer_full_variable?
+                var.var_table = var_table
+                var.var_table_index = 0
+              else
+                var.set_error_state BUFFER_FULL_MSG,
+                                    refers_to: StatusMessage::VARIABLE_VALUE
+              end
+            end
+          end
+
+          ##
+          # @private Helper method to calculate bytesize limit deduction.
+          def self.deduct_limit limit, used
+            limit.nil? ? nil : limit - used
+          end
+
+          private_class_method :add_compound_members,
+                               :add_shared_compound_var,
+                               :add_member_vars, :compound_var?,
+                               :deduct_limit
 
           ##
           # @private New Google::Cloud::Debugger::Breakpoint::Variable
@@ -340,8 +418,9 @@ module Google
           ##
           # @private Limit string to MAX_STRING_LENTH. Replace extra characters
           # with ellipsis
-          def self.truncate_value str
-            str.gsub(/(.{#{MAX_STRING_LENGTH - 3}}).+/, '\1...')
+          def self.truncate_value str, limit = nil
+            limit ||= MAX_STRING_LENGTH
+            str.gsub(/(.{#{limit - 3}}).+/, '\1...')
           end
           private_class_method :add_compound_members, :truncate_value
 
@@ -378,6 +457,91 @@ module Google
               s.is_error = true
               s.refers_to = refers_to
               s.description = message
+            end
+          end
+
+          ##
+          # Calculate the total bytesize of all the attributes and that of the
+          # member variables, plus references into other variables in the
+          # variable table.
+          #
+          # @return [Integer] The total payload size of this variable in bytes.
+          def total_size
+            unless @total_size
+              vars = [self, *(unique_members || [])]
+
+              @total_size = vars.inject(payload_size) do |sum, var|
+                if var.var_table && var.var_table_index
+                  sum + var.var_table[var.var_table_index].total_size
+                else
+                  sum
+                end
+              end
+            end
+
+            @total_size
+          end
+
+          ##
+          # Calculate the bytesize of all the attributes and that of the
+          # member variables.
+          #
+          # @return [Integer] The total payload size of this variable in bytes.
+          def payload_size
+            unless @payload_size
+              @payload_size = name.to_s.bytesize +
+                              type.to_s.bytesize +
+                              value.to_s.bytesize
+
+              unless members.nil?
+                @payload_size = members.inject(@payload_size) do |sum, member|
+                  sum + member.payload_size
+                end
+              end
+            end
+
+            @payload_size
+          end
+
+          ##
+          # @private Get a unique array of members that don't reference
+          # same object in variable table
+          def unique_members
+            seen_indices = {}
+
+            members.select do |member|
+              if seen_indices[member.var_table_index]
+                false
+              else
+                seen_indices[member.var_table_index] = true
+                true
+              end
+            end
+          end
+
+          ##
+          # @private Whether this variable is a reference variable into
+          # the shared variable table or not.
+          def reference_variable?
+            value.nil? && members.empty? && !var_table_index.nil?
+          end
+
+          ##
+          # @private Check if a given variable is a buffer full variable, or an
+          # reference variable to the shared buffer full variable
+          def buffer_full_variable?
+            if (status &&
+               status.is_error == true &&
+               status.description == BUFFER_FULL_MSG) ||
+               (var_table &&
+                 reference_variable? &&
+                 var_table_index.zero? &&
+                 var_table[0] &&
+                 var_table[0].status &&
+                 var_table[0].status.description == BUFFER_FULL_MSG)
+              true
+            else
+              false
             end
           end
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -93,7 +93,7 @@ module Google
           MAX_STRING_LENGTH = 500
 
           ##
-          # @private Minimum amoutn of size limit needed for evaluation.
+          # @private Minimum amount of size limit needed for evaluation.
           MIN_REQUIRED_SIZE = 100
 
           ##
@@ -169,18 +169,18 @@ module Google
           #   {Google::Cloud::Debugger::Breakpoint::Variable::MAX_DEPTH}
           # @param [Breakpoint::VariableTable] var_table A variable table
           #   to store shared compound variables. Optional.
-          # @param [Integer] limit Maximum number of bytes this convertion
+          # @param [Integer] limit Maximum number of bytes this conversion
           #   should take. This include nested compound member variables'
-          #   convertions.
+          #   conversions.
           #
-          # @example Simple variable convertion
+          # @example Simple variable conversion
           #   x = 3
           #   var = Variable.from_rb_var x, name: "x"
           #   var.name  #=> "x"
           #   var.value #=> "3"
           #   var.type  #=> "Integer"
           #
-          # @example Hash convertion
+          # @example Hash conversion
           #   hash = {a: 1, b: :two}
           #   var = Variable.from_rb_var hash, name: "hash"
           #   var.name  #=> "hash"
@@ -192,7 +192,7 @@ module Google
           #   var.members[1].value #=> "two"
           #   var.members[1].type  #=> "Symbol"
           #
-          # @example Custom compound variable convertion
+          # @example Custom compound variable conversion
           #   foo = Foo.new(a: 1, b: []) #=> #<Foo:0x0000 @a: 1, @b: []>
           #   var_table = VariableTable.new
           #   var = Variable.from_rb_var foo, name: "foo"

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
@@ -95,7 +95,9 @@ module Google
 
           server_breakpoints = response.breakpoints || []
           server_breakpoints = server_breakpoints.map do |grpc_b|
-            Breakpoint.from_grpc grpc_b
+            breakpoint = Breakpoint.from_grpc grpc_b
+            breakpoint.init_var_table if breakpoint.is_a? Debugger::Snappoint
+            breakpoint
           end
 
           update_breakpoints server_breakpoints

--- a/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
@@ -18,6 +18,13 @@ require "google/cloud/debugger/breakpoint"
 module Google
   module Cloud
     module Debugger
+      ##
+      # # Logpoint
+      #
+      # A kind of {Google::Cloud::Debugger::Breakpoint} that can be evaluated
+      # to generate a formatted log string, which later can be submitted to
+      # Stackdriver Logging service
+      #
       class Logpoint < Breakpoint
         ##
         # Evaluate the breakpoint unless it's already marked as completed.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
@@ -31,11 +31,11 @@ describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
       var_table = Google::Cloud::Debugger::Breakpoint::VariableTable.from_grpc var_table_grpc
       var_table.must_be_kind_of Google::Cloud::Debugger::Breakpoint::VariableTable
       var_table.size.must_equal 2
-      var_table[0].orig_var.must_be_nil
-      var_table[0].var.name.must_equal variable.name
-      var_table[0].var.type.must_equal variable.type
-      var_table[0].var.value.must_equal variable.value
-      var_table[0].var.members.must_equal variable.members
+      var_table[0].source_var.must_be_nil
+      var_table[0].name.must_equal variable.name
+      var_table[0].type.must_equal variable.type
+      var_table[0].value.must_equal variable.value
+      var_table[0].members.must_equal variable.members
     end
   end
 
@@ -45,8 +45,8 @@ describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
                         random_variable_integer_hash.to_json
       variable = Google::Cloud::Debugger::Breakpoint::Variable.from_grpc variable_grpc
 
-      var_table.add_var nil, variable
-      var_table.add_var nil, variable
+      var_table.add variable
+      var_table.add variable
 
       var_table_grpc = var_table.to_grpc
 
@@ -58,21 +58,27 @@ describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
     end
   end
 
-  describe "#add_var" do
-    it "automatically creates a Breakpoint::Variable if one isn't given" do
-      var_table.add_var 1
+  describe "#add" do
+    it "doesn't add variable to the list unless it's a Breakpoint::Variable" do
+      variable = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var 1
 
-      var_table[0].orig_var.must_equal 1
-      var_table[0].var.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var_table[0].var.value.must_equal "1"
+      var_table.add "Doesn't add"
+      var_table.add variable
+
+      var_table.size.must_equal 1
+      var_table.first.must_equal variable
     end
   end
 
   describe "#rb_var_index" do
     it "returns index of the item found" do
-      var_table.add_var 4
-      var_table.add_var 5
-      var_table.add_var 6
+      variable1 = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var 4
+      variable2 = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var 5
+      variable3 = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var 6
+
+      var_table.add variable1
+      var_table.add variable2
+      var_table.add variable3
 
       var_table.rb_var_index(4).must_equal 0
       var_table.rb_var_index(5).must_equal 1
@@ -80,9 +86,13 @@ describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
     end
 
     it "returns nil if item not found" do
-      var_table.add_var 4
-      var_table.add_var 5
-      var_table.add_var 6
+      variable1 = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var 4
+      variable2 = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var 5
+      variable3 = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var 6
+
+      var_table.add variable1
+      var_table.add variable2
+      var_table.add variable3
 
       var_table.rb_var_index(8).must_be_nil
     end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
@@ -58,10 +58,10 @@ describe Google::Cloud::Debugger::Breakpoint, :mock_debugger do
       breakpoint.labels.must_equal({"tag" => "hello"})
       breakpoint.is_final_state.wont_equal true
       variable_table_var = breakpoint.variable_table.first
-      variable_table_var.var.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      variable_table_var.var.name.must_equal "local_var"
-      variable_table_var.var.type.must_equal "Array"
-      variable_table_var.var.members.wont_be_empty
+      variable_table_var.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      variable_table_var.name.must_equal "local_var"
+      variable_table_var.type.must_equal "Array"
+      variable_table_var.members.wont_be_empty
     end
 
     it "knows all of the attributes for logpoint" do


### PR DESCRIPTION
Add a total maximum evaluation size on breakpoints (32KB). When breakpoint evaluation will happen normally until the total size of all the evaluated variables exceed the maximum limit, then further variable evaluations will return with a "buffer full" warning message.

Each variable evaluation now also has a size limit. User defined expressions have 32KB limit, while normal stack frame local variables only has 1KB limit.