### PR TITLE
Switch gae integration tests to use beta deploy

### DIFF
--- a/integration/deploy.rb
+++ b/integration/deploy.rb
@@ -29,7 +29,7 @@ def deploy_gae_flex app_dir
     ensure_gcloud_beta!
 
     last_gae_version = get_gae_versions.last
-    sh "gcloud app deploy -q" do |ok, res|
+    sh "gcloud beta app deploy -q" do |ok, res|
       if ok
         # Wait couple minutes for load balancer to stablize
         sleep 120


### PR DESCRIPTION
This will use the new "runtime builder" version of the App Engine runtime in integration tests.