### PR TITLE
Add File#generations method

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   after do
-    bucket.files.all { |f| f.delete rescue nil }
+    bucket.files(versions: true).all { |f| f.delete generation: true rescue nil }
   end
 
   it "should upload and download a file" do
@@ -301,6 +301,14 @@ describe Google::Cloud::Storage::File, :storage do
 
     uploaded.content_type.must_equal meta[:content_type]
     uploaded.metadata["title"].must_equal meta[:metadata][:title]
+  end
+
+  it "should list generations" do
+    uploaded = bucket.create_file files[:logo][:path],
+                                  "CloudLogo"
+
+    uploaded.generation.wont_be :nil?
+    uploaded.generations.wont_be :nil?
   end
 
   it "should create and update storage_class" do

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -330,6 +330,45 @@ module Google
         end
 
         ##
+        # Retrieves a list of versioned files for the current object.
+        #
+        # Useful for listing archived versions of the file, restoring the live
+        # version of the file to an older version, or deleting an archived
+        # version. You can turn versioning on or off for a bucket at any time
+        # with {Bucket#versioning=}. Turning versioning off leaves existing file
+        # versions in place and causes the bucket to stop accumulating new
+        # archived object versions. (See {Bucket#versioning} and
+        # {File#generation})
+        #
+        # @see https://cloud.google.com/storage/docs/object-versioning Object
+        #   Versioning
+        #
+        # @return [Array<Google::Cloud::Storage::File>] (See
+        #   {Google::Cloud::Storage::File::List})
+        #
+        # @example
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   file = bucket.file "path/to/my-file.ext"
+        #   file.generation #=> 1234567890
+        #   file.generations.each do |versioned_file|
+        #     versioned_file.generation
+        #   end
+        #
+        def generations
+          ensure_service!
+          gapi = service.list_files bucket, prefix: name,
+                                            versions: true,
+                                            user_project: user_project
+          File::List.from_gapi gapi, service, bucket, name, nil, nil, true,
+                               user_project: user_project
+        end
+
+        ##
         # Updates the file with changes made in the given block in a single
         # PATCH request. The following attributes may be set: {#cache_control=},
         # {#content_disposition=}, {#content_encoding=}, {#content_language=},

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -519,6 +519,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::File#generations" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :list_objects, list_files_gapi, ["my-bucket", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Storage::File#update" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -835,4 +835,67 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     mock.verify
   end
+
+  it "can list its generations" do
+    file_name = "file.ext"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567894).to_json),
+      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :list_objects, Google::Apis::StorageV1::Objects.new(kind: "storage#objects", items: [
+                                 Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567894).to_json),
+                                 Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567893).to_json),
+                                 Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567892).to_json),
+                                 Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567891).to_json)
+                               ]),
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: file_name, versions: true, user_project: nil]
+
+    bucket.service.mocked_service = mock
+    file.service.mocked_service = mock
+
+    file = bucket.file file_name
+    file.generation.must_equal 1234567894
+
+    generations = file.generations
+    generations.count.must_equal 4
+    generations.each do |f|
+      f.must_be_kind_of Google::Cloud::Storage::File
+      f.user_project.must_be :nil?
+    end
+    generations.map(&:generation).must_equal [1234567894, 1234567893, 1234567892, 1234567891]
+
+    mock.verify
+  end
+
+  it "can list its generations with user_project set to true" do
+    file_name = "file.ext"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_project.name, file_name, 1234567894).to_json),
+      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :list_objects, Google::Apis::StorageV1::Objects.new(kind: "storage#objects", items: [
+                                 Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567894).to_json),
+                                 Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567893).to_json),
+                                 Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567892).to_json),
+                                 Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, 1234567891).to_json)
+                               ]),
+      [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: file_name, versions: true, user_project: "test"]
+
+    bucket_user_project.service.mocked_service = mock
+    file.service.mocked_service = mock
+
+    file = bucket_user_project.file file_name
+    file.generation.must_equal 1234567894
+    file.user_project.must_equal true
+
+    generations = file.generations
+    generations.count.must_equal 4
+    generations.each do |f|
+      f.must_be_kind_of Google::Cloud::Storage::File
+      f.user_project.must_equal true
+    end
+    generations.map(&:generation).must_equal [1234567894, 1234567893, 1234567892, 1234567891]
+
+    mock.verify
+  end
 end


### PR DESCRIPTION
The `File#generations` method returns a list of `File` objects for each generation of the path in GCS.
It is the same as calling the following:

```ruby
require "google/cloud/storage"

storage = Google::Cloud::Storage.new

bucket = storage.bucket "my-bucket"
file = bucket.file "/path/to/my/file.ext"
generations = bucket.files prefix: file.name, versions: true
```

[refs #1601]