### PR TITLE
Speech Word Information

### DIFF
--- a/google-cloud-speech/acceptance/speech/async_test.rb
+++ b/google-cloud-speech/acceptance/speech/async_test.rb
@@ -166,4 +166,21 @@ describe "Asynchonous Recognition", :speech do
     results.first.confidence.must_be_close_to 0.9, 0.1
     results.first.alternatives.must_be :empty?
   end
+
+  it "recognizes audio with words" do
+    op = speech.process filepath, encoding: :linear16, language: "en-US", sample_rate: 16000, words: true
+
+    op.must_be_kind_of Google::Cloud::Speech::Operation
+    op.wont_be :done?
+    op.wait_until_done!
+    op.must_be :done?
+
+    results = op.results
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.9, 0.1
+    results.first.words.wont_be :empty?
+    results.first.words.map(&:word).must_equal %w{how old is the Brooklyn Bridge}
+    results.first.alternatives.must_be :empty?
+  end
 end

--- a/google-cloud-speech/acceptance/speech/sync_test.rb
+++ b/google-cloud-speech/acceptance/speech/sync_test.rb
@@ -96,4 +96,15 @@ describe "Synchonous Recognition", :speech do
     results.first.confidence.must_be_close_to 0.9, 0.1
     results.first.alternatives.must_be :empty?
   end
+
+  it "recognizes audio with words" do
+    results = speech.recognize filepath, encoding: :linear16, sample_rate: 16000, language: "en-US", words: true
+
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.9, 0.1
+    results.first.words.wont_be :empty?
+    results.first.words.map(&:word).must_equal %w{how old is the Brooklyn Bridge}
+    results.first.alternatives.must_be :empty?
+  end
 end

--- a/google-cloud-speech/lib/google/cloud/speech/audio.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/audio.rb
@@ -191,6 +191,10 @@ module Google
         #   phrases "hints" so that the speech recognition is more likely to
         #   recognize them. See [usage
         #   limits](https://cloud.google.com/speech/limits#content). Optional.
+        # @param [Boolean] words When `true`, return a list of words with
+        #   additional information about each word. Currently, the only
+        #   additional information provided is the the start and end time
+        #   offsets. See {Result#words}. Default is `false`.
         #
         # @return [Array<Result>] The transcribed text of audio recognized.
         #
@@ -209,14 +213,15 @@ module Google
         #   result.transcript #=> "how old is the Brooklyn Bridge"
         #   result.confidence #=> 0.9826789498329163
         #
-        def recognize max_alternatives: nil, profanity_filter: nil, phrases: nil
+        def recognize max_alternatives: nil, profanity_filter: nil,
+                      phrases: nil, words: nil
           ensure_speech!
 
           speech.recognize self, encoding: encoding, sample_rate: sample_rate,
                                  language: language,
                                  max_alternatives: max_alternatives,
                                  profanity_filter: profanity_filter,
-                                 phrases: phrases
+                                 phrases: phrases, words: words
         end
 
         ##
@@ -239,6 +244,10 @@ module Google
         #   phrases "hints" so that the speech recognition is more likely to
         #   recognize them. See [usage
         #   limits](https://cloud.google.com/speech/limits#content). Optional.
+        # @param [Boolean] words When `true`, return a list of words with
+        #   additional information about each word. Currently, the only
+        #   additional information provided is the the start and end time
+        #   offsets. See {Result#words}. Default is `false`.
         #
         # @return [Operation] A resource represents the long-running,
         #   asynchronous processing of a speech-recognition operation.
@@ -260,7 +269,7 @@ module Google
         #   results = op.results
         #
         def process max_alternatives: nil, profanity_filter: nil,
-                    phrases: nil
+                    phrases: nil, words: nil
           ensure_speech!
 
           speech.process self, encoding: encoding,
@@ -268,7 +277,7 @@ module Google
                                language: language,
                                max_alternatives: max_alternatives,
                                profanity_filter: profanity_filter,
-                               phrases: phrases
+                               phrases: phrases, words: words
         end
         alias_method :long_running_recognize, :process
         alias_method :recognize_job, :process

--- a/google-cloud-speech/lib/google/cloud/speech/convert.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/convert.rb
@@ -1,0 +1,46 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/protobuf/duration_pb"
+
+module Google
+  module Cloud
+    module Speech
+      ##
+      # @private Helper module for converting Speech values.
+      module Convert
+        module ClassMethods
+          def number_to_duration number
+            return nil if number.nil?
+
+            Google::Protobuf::Duration.new \
+              seconds: number.to_i,
+              nanos: (number.remainder(1) * 1000000000).round
+          end
+
+          def duration_to_number duration
+            return nil if duration.nil?
+
+            return duration.seconds if duration.nanos == 0
+
+            duration.seconds + (duration.nanos / 1000000000.0)
+          end
+        end
+
+        extend ClassMethods
+      end
+    end
+  end
+end

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -266,6 +266,10 @@ module Google
         #   phrases "hints" so that the speech recognition is more likely to
         #   recognize them. See [usage
         #   limits](https://cloud.google.com/speech/limits#content). Optional.
+        # @param [Boolean] words When `true`, return a list of words with
+        #   additional information about each word. Currently, the only
+        #   additional information provided is the the start and end time
+        #   offsets. See {Result#words}. Default is `false`.
         #
         # @return [Array<Result>] The transcribed text of audio recognized.
         #
@@ -308,7 +312,8 @@ module Google
         #                              max_alternatives: 10
         #
         def recognize source, encoding: nil, language: nil, sample_rate: nil,
-                      max_alternatives: nil, profanity_filter: nil, phrases: nil
+                      max_alternatives: nil, profanity_filter: nil,
+                      phrases: nil, words: nil
           ensure_service!
 
           audio_obj = audio source, encoding: encoding, language: language,
@@ -317,7 +322,8 @@ module Google
           config = audio_config(
             encoding: audio_obj.encoding, sample_rate: audio_obj.sample_rate,
             language: audio_obj.language, max_alternatives: max_alternatives,
-            profanity_filter: profanity_filter, phrases: phrases)
+            profanity_filter: profanity_filter, phrases: phrases,
+            words: words)
 
           grpc = service.recognize_sync audio_obj.to_grpc, config
           grpc.results.map do |result_grpc|
@@ -388,6 +394,10 @@ module Google
         #   phrases "hints" so that the speech recognition is more likely to
         #   recognize them. See [usage
         #   limits](https://cloud.google.com/speech/limits#content). Optional.
+        # @param [Boolean] words When `true`, return a list of words with
+        #   additional information about each word. Currently, the only
+        #   additional information provided is the the start and end time
+        #   offsets. See {Result#words}. Default is `false`.
         #
         # @return [Operation] A resource represents the long-running,
         #   asynchronous processing of a speech-recognition operation.
@@ -440,7 +450,8 @@ module Google
         #   op.reload!
         #
         def process source, encoding: nil, sample_rate: nil, language: nil,
-                    max_alternatives: nil, profanity_filter: nil, phrases: nil
+                    max_alternatives: nil, profanity_filter: nil, phrases: nil,
+                    words: nil
           ensure_service!
 
           audio_obj = audio source, encoding: encoding, language: language,
@@ -449,7 +460,8 @@ module Google
           config = audio_config(
             encoding: audio_obj.encoding, sample_rate: audio_obj.sample_rate,
             language: audio_obj.language, max_alternatives: max_alternatives,
-            profanity_filter: profanity_filter, phrases: phrases)
+            profanity_filter: profanity_filter, phrases: phrases,
+            words: words)
 
           grpc = service.recognize_async audio_obj.to_grpc, config
           Operation.from_grpc grpc
@@ -513,6 +525,10 @@ module Google
         #   phrases "hints" so that the speech recognition is more likely to
         #   recognize them. See [usage
         #   limits](https://cloud.google.com/speech/limits#content). Optional.
+        # @param [Boolean] words When `true`, return a list of words with
+        #   additional information about each word. Currently, the only
+        #   additional information provided is the the start and end time
+        #   offsets. See {Result#words}. Default is `false`.
         # @param [Boolean] utterance When `true`, the service will perform
         #   continuous recognition (continuing to process audio even if the user
         #   pauses speaking) until the client closes the output stream (gRPC
@@ -550,7 +566,7 @@ module Google
         #
         def stream encoding: nil, language: nil, sample_rate: nil,
                    max_alternatives: nil, profanity_filter: nil, phrases: nil,
-                   utterance: nil, interim: nil
+                   words: nil, utterance: nil, interim: nil
           ensure_service!
 
           grpc_req = V1::StreamingRecognizeRequest.new(
@@ -561,7 +577,7 @@ module Google
                                      sample_rate: sample_rate,
                                      max_alternatives: max_alternatives,
                                      profanity_filter: profanity_filter,
-                                     phrases: phrases),
+                                     phrases: phrases, words: words),
                 single_utterance: utterance,
                 interim_results: interim
               }.delete_if { |_, v| v.nil? }
@@ -608,7 +624,7 @@ module Google
 
         def audio_config encoding: nil, language: nil, sample_rate: nil,
                          max_alternatives: nil, profanity_filter: nil,
-                         phrases: nil
+                         phrases: nil, words: nil
           contexts = nil
           contexts = [V1::SpeechContext.new(phrases: phrases)] if phrases
           language = String(language) unless language.nil?
@@ -618,7 +634,8 @@ module Google
             sample_rate_hertz: sample_rate,
             max_alternatives: max_alternatives,
             profanity_filter: profanity_filter,
-            speech_contexts: contexts
+            speech_contexts: contexts,
+            enable_word_time_offsets: words
           }.delete_if { |_, v| v.nil? })
         end
 

--- a/google-cloud-speech/test/google/cloud/speech/audio/process_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/process_test.rb
@@ -58,4 +58,23 @@ describe Google::Cloud::Speech::Audio, :process, :mock_speech do
     op.id.must_equal "1234567890"
     op.wont_be :done?
   end
+
+  it "recognizes audio op with words" do
+    config_grpc = Google::Cloud::Speech::V1::RecognitionConfig.new(encoding: :LINEAR16, language_code: "en-US", sample_rate_hertz: 16000, enable_word_time_offsets: true)
+
+    mock = Minitest::Mock.new
+    mock.expect :long_running_recognize, op_grpc, [config_grpc, audio_grpc, options: default_options]
+
+    audio.encoding = :linear16
+    audio.sample_rate = 16000
+    audio.language = "en-US"
+
+    speech.service.mocked_service = mock
+    op = audio.process words: true
+    mock.verify
+
+    op.must_be_kind_of Google::Cloud::Speech::Operation
+    op.id.must_equal "1234567890"
+    op.wont_be :done?
+  end
 end

--- a/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
@@ -18,6 +18,8 @@ describe Google::Cloud::Speech::Audio, :recognize, :mock_speech do
   let(:results_json) { "{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.98267895}]}]}" }
   let(:results_grpc) { Google::Cloud::Speech::V1::RecognizeResponse.decode_json results_json }
   let(:results) { results_grpc.results.map { |result_grpc| Google::Cloud::Speech::Result.from_grpc result_grpc } }
+  let(:words_results_json) { "{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.987629,\"words\":[{\"startTime\":{},\"endTime\":{\"nanos\":300000000},\"word\":\"how\"},{\"startTime\":{\"nanos\":300000000},\"endTime\":{\"nanos\":600000000},\"word\":\"old\"},{\"startTime\":{\"nanos\":600000000},\"endTime\":{\"nanos\":800000000},\"word\":\"is\"},{\"startTime\":{\"nanos\":800000000},\"endTime\":{\"nanos\":900000000},\"word\":\"the\"},{\"startTime\":{\"nanos\":900000000},\"endTime\":{\"seconds\":1,\"nanos\":100000000},\"word\":\"Brooklyn\"},{\"startTime\":{\"seconds\":1,\"nanos\":100000000},\"endTime\":{\"seconds\":1,\"nanos\":500000000},\"word\":\"Bridge\"}]}]}]}" }
+  let(:words_results_grpc) { Google::Cloud::Speech::V1::RecognizeResponse.decode_json words_results_json }
   let(:filepath) { "acceptance/data/audio.raw" }
   let(:audio_grpc) { Google::Cloud::Speech::V1::RecognitionAudio.new(content: File.read(filepath, mode: "rb")) }
   let(:audio) { Google::Cloud::Speech::Audio.from_source filepath, speech }
@@ -59,6 +61,34 @@ describe Google::Cloud::Speech::Audio, :recognize, :mock_speech do
     results.count.must_equal 1
     results.first.transcript.must_equal "how old is the Brooklyn Bridge"
     results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+  end
+
+  it "recognizes audio with word times" do
+    config_grpc = Google::Cloud::Speech::V1::RecognitionConfig.new(encoding: :LINEAR16, language_code: "en-US", sample_rate_hertz: 16000, enable_word_time_offsets: true)
+
+    mock = Minitest::Mock.new
+    mock.expect :recognize, words_results_grpc, [config_grpc, audio_grpc, options: default_options]
+
+    audio.encoding = :linear16
+    audio.sample_rate = 16000
+    audio.language = "en-US"
+
+    speech.service.mocked_service = mock
+    results = audio.recognize words: true
+    mock.verify
+
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98762899
+    results.first.words.wont_be :empty?
+    results.first.words.map(&:word).must_equal %w{how old is the Brooklyn Bridge}
+    results.first.words.each do |word|
+      word.must_be_kind_of Google::Cloud::Speech::Result::Word
+      word.word.must_be_kind_of String
+      word.start_time.must_be_kind_of Numeric
+      word.end_time.must_be_kind_of Numeric
+    end
     results.first.alternatives.must_be :empty?
   end
 end

--- a/google-cloud-speech/test/google/cloud/speech/convert/duration_to_number_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/convert/duration_to_number_test.rb
@@ -1,0 +1,76 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Speech::Convert, :duration_to_number, :mock_speech do
+  # This tests is a sanity check on the implementation of the conversion method.
+  # We are testing the private method. This functionality is also covered elsewhere,
+  # but it was thought that since this conversion is so important we might as well
+  # also test it apart from the other tests.
+
+  it "converts an integer" do
+    duration = Google::Protobuf::Duration.new seconds: 42, nanos: 0
+    number = Google::Cloud::Speech::Convert.duration_to_number duration
+    number.must_equal 42
+  end
+
+  it "converts a negative integer" do
+    duration = Google::Protobuf::Duration.new seconds: -42, nanos: 0
+    number = Google::Cloud::Speech::Convert.duration_to_number duration
+    number.must_equal -42
+  end
+
+  it "converts a small number" do
+    duration = Google::Protobuf::Duration.new seconds: 1, nanos: 500000000
+    number = Google::Cloud::Speech::Convert.duration_to_number duration
+    number.must_equal 1.5
+  end
+
+  it "converts a negative small number" do
+    duration = Google::Protobuf::Duration.new seconds: -1, nanos: -500000000
+    number = Google::Cloud::Speech::Convert.duration_to_number duration
+    number.must_equal -1.5
+  end
+
+  it "converts a big number" do
+    duration = Google::Protobuf::Duration.new seconds: 643383279502884, nanos: 197169399
+    number = Google::Cloud::Speech::Convert.duration_to_number duration
+    number.must_equal 643383279502884.197169399
+  end
+
+  it "converts a negative big number" do
+    duration = Google::Protobuf::Duration.new seconds: -643383279502884, nanos: -197169399
+    number = Google::Cloud::Speech::Convert.duration_to_number duration
+    number.must_equal -643383279502884.197169399
+  end
+
+  it "converts pi" do
+    duration = Google::Protobuf::Duration.new seconds: 3, nanos: 141592654
+    number = Google::Cloud::Speech::Convert.duration_to_number duration
+    number.must_equal 3.141592654
+  end
+
+  it "converts a negative pi" do
+    duration = Google::Protobuf::Duration.new seconds: -3, nanos: -141592654
+    number = Google::Cloud::Speech::Convert.duration_to_number duration
+    number.must_equal -3.141592654
+  end
+
+  it "returns nil when given nil" do
+    duration = nil
+    number = Google::Cloud::Speech::Convert.duration_to_number duration
+    number.must_be :nil?
+  end
+end

--- a/google-cloud-speech/test/google/cloud/speech/convert/number_to_duration_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/convert/number_to_duration_test.rb
@@ -1,0 +1,94 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "bigdecimal"
+
+describe Google::Cloud::Speech::Convert, :number_to_duration, :mock_speech do
+  # This tests is a sanity check on the implementation of the conversion method.
+  # We are testing the private method. This functionality is also covered elsewhere,
+  # but it was thought that since this conversion is so important we might as well
+  # also test it apart from the other tests.
+
+  it "converts an Integer" do
+    number = 42
+    duration = Google::Cloud::Speech::Convert.number_to_duration number
+    duration.must_be_kind_of Google::Protobuf::Duration
+    duration.seconds.must_equal 42
+    duration.nanos.must_equal 0
+  end
+
+  it "converts a negative Integer" do
+    number = -42
+    duration = Google::Cloud::Speech::Convert.number_to_duration number
+    duration.must_be_kind_of Google::Protobuf::Duration
+    duration.seconds.must_equal -42
+    duration.nanos.must_equal 0
+  end
+
+  it "converts a Float" do
+    number = 1.5
+    duration = Google::Cloud::Speech::Convert.number_to_duration number
+    duration.must_be_kind_of Google::Protobuf::Duration
+    duration.seconds.must_equal 1
+    duration.nanos.must_equal 500000000
+  end
+
+  it "converts a negative Float" do
+    number = -1.5
+    duration = Google::Cloud::Speech::Convert.number_to_duration number
+    duration.must_be_kind_of Google::Protobuf::Duration
+    duration.seconds.must_equal -1
+    duration.nanos.must_equal -500000000
+  end
+
+  it "converts a BigDecimal" do
+    number = BigDecimal.new "643383279502884.1971693993751058209749445923078164062"
+    duration = Google::Cloud::Speech::Convert.number_to_duration number
+    duration.must_be_kind_of Google::Protobuf::Duration
+    duration.seconds.must_equal 643383279502884
+    duration.nanos.must_equal 197169399
+  end
+
+  it "converts a negative BigDecimal" do
+    number = BigDecimal.new "-643383279502884.1971693993751058209749445923078164062"
+    duration = Google::Cloud::Speech::Convert.number_to_duration number
+    duration.must_be_kind_of Google::Protobuf::Duration
+    # This should really be -643383279502884, but BigDecimal is doing something here...
+    duration.seconds.must_equal -643383279502885
+    duration.nanos.must_equal -197169399
+  end
+
+  it "converts a Rational" do
+    number = Rational "3.14159265358979323846264338327950288419716939937510582097"
+    duration = Google::Cloud::Speech::Convert.number_to_duration number
+    duration.must_be_kind_of Google::Protobuf::Duration
+    duration.seconds.must_equal 3
+    duration.nanos.must_equal 141592654
+  end
+
+  it "converts a negative Rational" do
+    number = Rational "-3.14159265358979323846264338327950288419716939937510582097"
+    duration = Google::Cloud::Speech::Convert.number_to_duration number
+    duration.must_be_kind_of Google::Protobuf::Duration
+    duration.seconds.must_equal -3
+    duration.nanos.must_equal -141592654
+  end
+
+  it "returns nil when given nil" do
+    number = nil
+    duration = Google::Cloud::Speech::Convert.number_to_duration number
+    duration.must_be :nil?
+  end
+end

--- a/google-cloud-speech/test/google/cloud/speech/project/process_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/process_test.rb
@@ -134,4 +134,20 @@ describe Google::Cloud::Speech::Project, :process, :mock_speech do
     op.id.must_equal "1234567890"
     op.wont_be :done?
   end
+
+  it "recognizes audio with words" do
+    config_grpc = Google::Cloud::Speech::V1::RecognitionConfig.new(encoding: :LINEAR16, language_code: "en-US", sample_rate_hertz: 16000, enable_word_time_offsets: true)
+    audio_grpc = Google::Cloud::Speech::V1::RecognitionAudio.new(content: File.read("acceptance/data/audio.raw", mode: "rb"))
+
+    mock = Minitest::Mock.new
+    mock.expect :long_running_recognize, op_grpc, [config_grpc, audio_grpc, options: default_options]
+
+    speech.service.mocked_service = mock
+    op = speech.process "acceptance/data/audio.raw", encoding: :linear16, language: "en-US", sample_rate: 16000, words: true
+    mock.verify
+
+    op.must_be_kind_of Google::Cloud::Speech::Operation
+    op.id.must_equal "1234567890"
+    op.wont_be :done?
+  end
 end

--- a/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
@@ -18,6 +18,8 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
   let(:results_json) { "{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.98267895}]}]}" }
   let(:results_grpc) { Google::Cloud::Speech::V1::RecognizeResponse.decode_json results_json }
   let(:results) { results_grpc.results.map { |result_grpc| Google::Cloud::Speech::Result.from_grpc result_grpc } }
+  let(:words_results_json) { "{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.987629,\"words\":[{\"startTime\":{},\"endTime\":{\"nanos\":300000000},\"word\":\"how\"},{\"startTime\":{\"nanos\":300000000},\"endTime\":{\"nanos\":600000000},\"word\":\"old\"},{\"startTime\":{\"nanos\":600000000},\"endTime\":{\"nanos\":800000000},\"word\":\"is\"},{\"startTime\":{\"nanos\":800000000},\"endTime\":{\"nanos\":900000000},\"word\":\"the\"},{\"startTime\":{\"nanos\":900000000},\"endTime\":{\"seconds\":1,\"nanos\":100000000},\"word\":\"Brooklyn\"},{\"startTime\":{\"seconds\":1,\"nanos\":100000000},\"endTime\":{\"seconds\":1,\"nanos\":500000000},\"word\":\"Bridge\"}]}]}]}" }
+  let(:words_results_grpc) { Google::Cloud::Speech::V1::RecognizeResponse.decode_json words_results_json }
   let(:filepath) { "acceptance/data/audio.raw" }
 
   it "recognizes audio from local file path" do
@@ -140,6 +142,31 @@ describe Google::Cloud::Speech::Project, :recognize, :mock_speech do
     results.count.must_equal 1
     results.first.transcript.must_equal "how old is the Brooklyn Bridge"
     results.first.confidence.must_be_close_to 0.98267895
+    results.first.alternatives.must_be :empty?
+  end
+
+  it "recognizes audio with words" do
+    config_grpc = Google::Cloud::Speech::V1::RecognitionConfig.new(encoding: :LINEAR16, language_code: "en-US", sample_rate_hertz: 16000, enable_word_time_offsets: true)
+    audio_grpc = Google::Cloud::Speech::V1::RecognitionAudio.new(content: File.read(filepath, mode: "rb"))
+
+    mock = Minitest::Mock.new
+    mock.expect :recognize, words_results_grpc, [config_grpc, audio_grpc, options: default_options]
+
+    speech.service.mocked_service = mock
+    results = speech.recognize filepath, encoding: :linear16, language: "en-US", sample_rate: 16000, words: true
+    mock.verify
+
+    results.count.must_equal 1
+    results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+    results.first.confidence.must_be_close_to 0.98762899
+    results.first.words.wont_be :empty?
+    results.first.words.map(&:word).must_equal %w{how old is the Brooklyn Bridge}
+    results.first.words.each do |word|
+      word.must_be_kind_of Google::Cloud::Speech::Result::Word
+      word.word.must_be_kind_of String
+      word.start_time.must_be_kind_of Numeric
+      word.end_time.must_be_kind_of Numeric
+    end
     results.first.alternatives.must_be :empty?
   end
 end

--- a/google-cloud-speech/test/google/cloud/speech/result_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/result_test.rb
@@ -25,4 +25,48 @@ describe Google::Cloud::Speech::Result, :mock_speech do
     results.first.confidence.must_be_close_to 0.98267895
     results.first.alternatives.must_be :empty?
   end
+
+  describe Google::Cloud::Speech::Result::Word do
+    let(:results_json) { "{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.98267895}]}]}" }
+    let(:results_json) { "{\"results\":[{\"alternatives\":[{\"transcript\":\"how old is the Brooklyn Bridge\",\"confidence\":0.987629,\"words\":[{\"startTime\":{},\"endTime\":{\"nanos\":300000000},\"word\":\"how\"},{\"startTime\":{\"nanos\":300000000},\"endTime\":{\"nanos\":600000000},\"word\":\"old\"},{\"startTime\":{\"nanos\":600000000},\"endTime\":{\"nanos\":800000000},\"word\":\"is\"},{\"startTime\":{\"nanos\":800000000},\"endTime\":{\"nanos\":900000000},\"word\":\"the\"},{\"startTime\":{\"nanos\":900000000},\"endTime\":{\"seconds\":1,\"nanos\":100000000},\"word\":\"Brooklyn\"},{\"startTime\":{\"seconds\":1,\"nanos\":100000000},\"endTime\":{\"seconds\":1,\"nanos\":500000000},\"word\":\"Bridge\"}]}]}]}" }
+
+    it "knows itself" do
+      results.count.must_equal 1
+      results.first.transcript.must_equal "how old is the Brooklyn Bridge"
+      results.first.confidence.must_be_close_to 0.98762899
+      results.first.words.wont_be :empty?
+
+      results.first.words[0].must_be_kind_of Google::Cloud::Speech::Result::Word
+      results.first.words[0].word.must_equal "how"
+      results.first.words[0].start_time.must_be_close_to 0
+      results.first.words[0].end_time.must_be_close_to 0.3
+
+      results.first.words[1].must_be_kind_of Google::Cloud::Speech::Result::Word
+      results.first.words[1].word.must_equal "old"
+      results.first.words[1].start_time.must_be_close_to 0.3
+      results.first.words[1].end_time.must_be_close_to 0.6
+
+      results.first.words[2].must_be_kind_of Google::Cloud::Speech::Result::Word
+      results.first.words[2].word.must_equal "is"
+      results.first.words[2].start_time.must_be_close_to 0.6
+      results.first.words[2].end_time.must_be_close_to 0.8
+
+      results.first.words[3].must_be_kind_of Google::Cloud::Speech::Result::Word
+      results.first.words[3].word.must_equal "the"
+      results.first.words[3].start_time.must_be_close_to 0.8
+      results.first.words[3].end_time.must_be_close_to 0.9
+
+      results.first.words[4].must_be_kind_of Google::Cloud::Speech::Result::Word
+      results.first.words[4].word.must_equal "Brooklyn"
+      results.first.words[4].start_time.must_be_close_to 0.9
+      results.first.words[4].end_time.must_be_close_to 1.1
+
+      results.first.words[5].must_be_kind_of Google::Cloud::Speech::Result::Word
+      results.first.words[5].word.must_equal "Bridge"
+      results.first.words[5].start_time.must_be_close_to 1.1
+      results.first.words[5].end_time.must_be_close_to 1.5
+
+      results.first.alternatives.must_be :empty?
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for returning word time offsets in the recognition results. The `words` argument is added to all appropriate recognize methods, and `Result#words` is added to return an array of `Result::Word` objects that represent the word with the start and end times.