### PR TITLE
Improve long expression evaluation detection

### DIFF
--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/evaluator.c
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/evaluator.c
@@ -26,27 +26,20 @@ eval_trace_callback(void *data, rb_trace_arg_t *trace_arg)
     VALUE klass;
     VALUE obj;
     VALUE method_id;
-    ID trace_line_cb_id;
     ID trace_func_cb_id;
     ID trace_c_func_cb_id;
 
-    CONST_ID(trace_line_cb_id, "trace_line_callback");
     CONST_ID(trace_func_cb_id, "trace_func_callback");
     CONST_ID(trace_c_func_cb_id, "trace_c_func_callback");
 
-    if (event & RUBY_EVENT_LINE) {
-        rb_funcall(evaluator, trace_line_cb_id, 0);
-    }
-    if (event & RUBY_EVENT_CALL) {
-        obj = rb_tracearg_self(trace_arg);
-        method_id = rb_tracearg_method_id(trace_arg);
+    obj = rb_tracearg_self(trace_arg);
+    method_id = rb_tracearg_method_id(trace_arg);
 
+    if (event & RUBY_EVENT_CALL) {
         rb_funcall(evaluator, trace_func_cb_id, 2, obj, method_id);
     }
     if (event & RUBY_EVENT_C_CALL) {
         klass = rb_tracearg_defined_class(trace_arg);
-        obj = rb_tracearg_self(trace_arg);
-        method_id = rb_tracearg_method_id(trace_arg);
 
         rb_funcall(evaluator, trace_c_func_cb_id, 3, obj, klass, method_id);
     }
@@ -99,7 +92,7 @@ rb_enable_method_trace_for_thread(VALUE self)
     trace_set = rb_hash_aref(thread_variables_hash, eval_trace_thread_flag);
 
     if (!RTEST(trace_set)) {
-        rb_thread_add_event_hook2(current_thread, (rb_event_hook_func_t)eval_trace_callback, RUBY_EVENT_LINE | RUBY_EVENT_CALL | RUBY_EVENT_C_CALL, self, RUBY_EVENT_HOOK_FLAG_RAW_ARG | RUBY_EVENT_HOOK_FLAG_SAFE);
+        rb_thread_add_event_hook2(current_thread, (rb_event_hook_func_t)eval_trace_callback, RUBY_EVENT_CALL | RUBY_EVENT_C_CALL, self, RUBY_EVENT_HOOK_FLAG_RAW_ARG | RUBY_EVENT_HOOK_FLAG_SAFE);
         rb_hash_aset(thread_variables_hash, eval_trace_thread_flag, Qtrue);
     }
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
@@ -111,6 +111,7 @@ module Google
             if eval_result.is_a?(Exception) &&
                eval_result.instance_variable_get(:@mutation_cause)
               evaluated_var = Variable.new
+              evaluated_var.name = expression
               evaluated_var.set_error_state \
                 "Error: #{eval_result.message}",
                 refers_to: StatusMessage::VARIABLE_VALUE

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -46,9 +46,7 @@ def mutating_func2
 end
 
 def infinite_loop
-  while true
-    1 + 1
-  end
+  while true; end
 end
 
 describe Google::Cloud::Debugger::Breakpoint::Evaluator do


### PR DESCRIPTION
Improve long expression evaluation detection by timing the child thread. This approach is more efficient and also correctly detects one-liner while loops.

Also fixes a bug that errored expression evaluation's variable name was not set properly.