### PR TITLE
Validate breakpoints from backend service

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
@@ -96,6 +96,14 @@ module Google
         attr_accessor :quota_manager
 
         ##
+        # Absolute path to the debuggee Ruby application root directory. The
+        # Stackdriver Debugger service creates canonical breakpoints with only
+        # relative path. So the debugger agent combines the relative path to
+        # the application directory to trace and evaluate breakpoints.
+        # @return [String]
+        attr_accessor :app_root
+
+        ##
         # @private The last exception captured in the agent child thread
         attr_reader :last_exception
 
@@ -107,11 +115,13 @@ module Google
         # @param [Google::Cloud::Logging::Logger] logger The logger used
         #   to write the results of Logpoints.
         # @param [String] module_name Name for the debuggee application.
-        #   Optional.
         # @param [String] module_version Version identifier for the debuggee
-        #   application. Optional.
+        #   application.
+        # @param [String] app_root Absolute path to the root directory of
+        #   the debuggee application. Default to Rack root.
         #
-        def initialize service, logger: nil, module_name:, module_version:
+        def initialize service, logger: nil, module_name:, module_version:,
+                       app_root: nil
           super()
 
           @service = service
@@ -125,6 +135,9 @@ module Google
           @transmitter = Transmitter.new self, service
 
           @logger = logger || default_logger
+
+          @app_root = app_root
+          @app_root ||= Rack::Directory.new("").root if defined? Rack::Directory
 
           # Agent actor thread needs to force exit immediately.
           set_cleanup_options timeout: 0

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/validator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/validator.rb
@@ -1,0 +1,91 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Debugger
+      class Breakpoint
+        ##
+        # # Validator
+        #
+        # A collection of static methods to help validate a given breakpoint.
+        module Validator
+          FILE_NOT_FOUND_MSG = "File not found."
+          WRONG_FILE_TYPE_MSG = "File must be a `.rb` file."
+          INVALID_LINE_MSG = "Invalid line."
+
+          ##
+          # Validate a given breakpoint. Set breakpoint to error state if
+          # the breakpoint fails validation.
+          def self.validate breakpoint
+            error_msg = nil
+            if !verify_file_path breakpoint.full_path
+              error_msg = FILE_NOT_FOUND_MSG
+            elsif !verify_file_type breakpoint.full_path
+              error_msg = WRONG_FILE_TYPE_MSG
+            elsif !verify_line breakpoint.full_path, breakpoint.line
+              error_msg = INVALID_LINE_MSG
+            end
+
+            if error_msg
+              cause = Breakpoint::StatusMessage::BREAKPOINT_SOURCE_LOCATION
+              breakpoint.set_error_state error_msg, refers_to: cause
+              false
+            else
+              true
+            end
+          end
+
+          ##
+          # @private Verifies the given file path exists
+          def self.verify_file_path file_path
+            File.exist? file_path
+          rescue
+            false
+          end
+
+          ##
+          # @private Check the file from given file path is a ".rb" file
+          def self.verify_file_type file_path
+            File.extname(file_path) == ".rb"
+          rescue
+            false
+          end
+
+          ##
+          # @private Verifies the given line from a Ruby
+          def self.verify_line file_path, line
+            file = File.open file_path, "r"
+
+            # Skip through lines from beginning
+            file.gets while file.lineno < line - 1 && !file.eof?
+
+            line = file.gets
+
+            # Make sure we have a line (not eof)
+            return false unless line
+
+            blank_line = line =~ /^\s*$/
+            commit_line = line =~ /^\s*#.*$/
+
+            blank_line || commit_line ? false : true
+          rescue
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/validator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/validator.rb
@@ -78,9 +78,9 @@ module Google
             return false unless line
 
             blank_line = line =~ /^\s*$/
-            commit_line = line =~ /^\s*#.*$/
+            comment_line = line =~ /^\s*#.*$/
 
-            blank_line || commit_line ? false : true
+            blank_line || comment_line ? false : true
           rescue
             false
           end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/validator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/validator_test.rb
@@ -1,0 +1,90 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Debugger::Breakpoint::Validator, :mock_debugger do
+  let(:breakpoint) { Google::Cloud::Debugger::Snappoint.new nil, __FILE__, __LINE__}
+  let(:validator) { Google::Cloud::Debugger::Breakpoint::Validator }
+
+  describe ".validate" do
+    it "return true if breakpoint is valid" do
+      validator.validate(breakpoint).must_equal true
+    end
+
+    it "returns false if breakpoint's target file doesn't exist" do
+      breakpoint.location.path = "/path/to/not-exist.rb"
+
+      validator.validate(breakpoint).must_equal false
+
+      breakpoint.complete?.must_equal true
+      breakpoint.status.description.must_equal validator::FILE_NOT_FOUND_MSG
+    end
+
+    it "returns false if breakpoints target file isn't a ruby file" do
+      breakpoint.location.path = "/path/to/not-ruby-file"
+
+      validator.stub :verify_file_path, true do
+        validator.validate(breakpoint).must_equal false
+      end
+
+      breakpoint.complete?.must_equal true
+      breakpoint.status.description.must_equal validator::WRONG_FILE_TYPE_MSG
+    end
+
+    it "returns false if breakpoint line number is too large" do
+      breakpoint.location.line = 999999
+
+      validator.validate(breakpoint).must_equal false
+
+      breakpoint.complete?.must_equal true
+      breakpoint.status.description.must_equal validator::INVALID_LINE_MSG
+    end
+
+    it "returns false if breakpoint is on a blank line" do
+      breakpoint.location.line = __LINE__ + 3
+
+      # Intentional blank line below
+
+      # End blank line
+
+      validator.stub :verify_file_path, true do
+        validator.stub :verify_file_type, true do
+          validator.validate(breakpoint).must_equal false
+        end
+      end
+
+      breakpoint.complete?.must_equal true
+      breakpoint.status.description.must_equal validator::INVALID_LINE_MSG
+    end
+
+    it "returns false if breakpoint is on a blank line" do
+      breakpoint.location.line = __LINE__ + 3
+
+      #####
+      # Intentional comment block for test
+      #####
+
+      validator.stub :verify_file_path, true do
+        validator.stub :verify_file_type, true do
+          validator.validate(breakpoint).must_equal false
+        end
+      end
+
+      breakpoint.complete?.must_equal true
+      breakpoint.status.description.must_equal validator::INVALID_LINE_MSG
+    end
+  end
+end

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
@@ -48,7 +48,6 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
     breakpoint_manager.update_breakpoints [breakpoint1]
     tracer = debugger.agent.tracer
-    tracer.app_root = ""
 
     tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
@@ -68,7 +67,6 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
     breakpoint_manager.update_breakpoints [breakpoint1]
     tracer = debugger.agent.tracer
-    tracer.app_root = ""
 
     tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
@@ -91,7 +89,6 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
     breakpoint_manager.update_breakpoints [breakpoint2]
     tracer = debugger.agent.tracer
-    tracer.app_root = ""
 
     tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
@@ -111,7 +108,6 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
     breakpoint_manager.update_breakpoints [breakpoint3]
     tracer = debugger.agent.tracer
-    tracer.app_root = ""
 
     tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
@@ -131,7 +127,6 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
     breakpoint_manager.update_breakpoints [breakpoint4]
     tracer = debugger.agent.tracer
-    tracer.app_root = ""
 
     tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
@@ -151,7 +146,6 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
     breakpoint_manager.update_breakpoints [breakpoint5]
     tracer = debugger.agent.tracer
-    tracer.app_root = ""
 
     tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
@@ -171,7 +165,6 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
     breakpoint_manager.update_breakpoints [breakpoint6]
     tracer = debugger.agent.tracer
-    tracer.app_root = ""
 
     tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start
@@ -191,7 +184,6 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
     breakpoint_manager.update_breakpoints [breakpoint7]
     tracer = debugger.agent.tracer
-    tracer.app_root = ""
 
     tracer.stub :breakpoints_hit, stubbed_breakpoints_hit do
       tracer.start

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
@@ -27,21 +27,17 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     end
 
     it "sets @breakpoints_cache with a nested hash" do
-      breakpoint1 = OpenStruct.new line: 123, path: "path/to/file1.rb"
-      breakpoint2 = OpenStruct.new line: 345, path: "path/to/file1.rb"
-      breakpoint3 = OpenStruct.new line: 987, path: "path/to/file2.rb"
-      breakpoint4 = OpenStruct.new line: 987, path: "path/to/file2.rb"
-
-      stubbed_full_path = ->(path) { path }
+      breakpoint1 = OpenStruct.new line: 123, full_path: "path/to/file1.rb"
+      breakpoint2 = OpenStruct.new line: 345, full_path: "path/to/file1.rb"
+      breakpoint3 = OpenStruct.new line: 987, full_path: "path/to/file2.rb"
+      breakpoint4 = OpenStruct.new line: 987, full_path: "path/to/file2.rb"
 
       breakpoint_manager.stub :active_breakpoints, [breakpoint1, breakpoint2, breakpoint3, breakpoint4] do
-        tracer.stub :full_breakpoint_path, stubbed_full_path do
-          breakpoints_hash = agent.tracer.update_breakpoints_cache
+        breakpoints_hash = agent.tracer.update_breakpoints_cache
 
-          breakpoints_hash["path/to/file1.rb"][123].must_equal [breakpoint1]
-          breakpoints_hash["path/to/file1.rb"][345].must_equal [breakpoint2]
-          breakpoints_hash["path/to/file2.rb"][987].must_equal [breakpoint3, breakpoint4]
-        end
+        breakpoints_hash["path/to/file1.rb"][123].must_equal [breakpoint1]
+        breakpoints_hash["path/to/file1.rb"][345].must_equal [breakpoint2]
+        breakpoints_hash["path/to/file2.rb"][987].must_equal [breakpoint3, breakpoint4]
       end
     end
   end


### PR DESCRIPTION
Validate breakpoints received from backend Stackdriver Debugger service. Immediately fail invalid breakpoints and submit them back to backend service.