### PR TITLE
Add acceptance tests for google-cloud-debugger

### DIFF
--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "google-cloud-debugger.gemspec"
     - "lib/google/devtools/**/*"
     # GAPIC client has too many violations. Exclude for now.

--- a/google-cloud-debugger/Rakefile
+++ b/google-cloud-debugger/Rakefile
@@ -29,14 +29,47 @@ namespace :test do
 end
 
 # Acceptance tests
-desc "Run the debugger acceptance tests."
-task :acceptance, [:project, :keyfile] => :compile do |t, args|
-  puts "This gem does not have acceptance tests."
+desc "Runs the trace acceptance tests."
+task :acceptance, :project, :keyfile do |t, args|
+  project = args[:project]
+  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DEBUGGER_TEST_PROJECT"]
+  keyfile = args[:keyfile]
+  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DEBUGGER_TEST_KEYFILE"]
+  if keyfile
+    keyfile = File.read keyfile
+  else
+    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DEBUGGER_TEST_KEYFILE_JSON"]
+  end
+  if project.nil? || keyfile.nil?
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123,/path/to/keyfile.json] or DEBUGGER_TEST_PROJECT=test123 DEBUGGER_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+  end
+  # always overwrite when running tests
+  ENV["DEBUGGER_PROJECT"] = project
+  ENV["DEBUGGER_KEYFILE"] = nil
+  ENV["DEBUGGER_KEYFILE_JSON"] = keyfile
+  ENV["LOGGING_PROJECT"] = project
+  ENV["LOGGING_KEYFILE"] = nil
+  ENV["LOGGING_KEYFILE_JSON"] = keyfile
+
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
-  task :run => :compile do
-    puts "This gem does not have acceptance tests."
+  desc "Runs acceptance tests with coverage."
+  task :coverage, :project, :keyfile do |t, args|
+    require "simplecov"
+    SimpleCov.start do
+      command_name "google-cloud-debugger"
+      track_files "lib/**/*.rb"
+      add_filter "acceptance/"
+    end
+
+    Rake::Task["acceptance"].invoke
+  end
+
+  task :run do
+    $LOAD_PATH.unshift "lib", "acceptance"
+    Dir.glob("acceptance/debugger/**/*_test.rb").each { |file| require_relative file }
   end
 end
 

--- a/google-cloud-debugger/acceptance/debugger/debugger_test.rb
+++ b/google-cloud-debugger/acceptance/debugger/debugger_test.rb
@@ -1,0 +1,68 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "debugger_helper"
+
+describe Google::Cloud::Debugger, :debugger do
+  it "catches and evaluates snappoint" do
+    breakpoint_id = set_test_snappoint
+
+    debuggee_id = @debugger.agent.debuggee.id
+
+    breakpoint = nil
+    wait_until do
+      trigger_breakpoint
+
+      response = @vtk_debugger_client.get_breakpoint(debuggee_id, breakpoint_id, @agent_version)
+      breakpoint = response.breakpoint
+
+      breakpoint.is_final_state
+    end
+
+    stack_frame = breakpoint.stack_frames[0]
+    stack_frame.function.must_equal "trigger_breakpoint"
+    stack_frame.locals.size.must_equal 1
+    stack_frame.locals.first.name.must_equal "local_var"
+    stack_frame.locals.first.value.must_equal "42"
+
+    breakpoint.evaluated_expressions.size.must_equal 1
+    breakpoint.evaluated_expressions.first.name.must_equal "local_var"
+    breakpoint.evaluated_expressions.first.value.must_equal "42"
+  end
+
+  it "catches and evaluates logpoint" do
+    token = rand 0x10000000000
+
+    set_test_logpoint token
+
+    project_id = @debugger.project
+    credentials = @debugger.service.credentials
+    logging = Google::Cloud::Logging::Project.new(
+      Google::Cloud::Logging::Service.new(
+        project_id, credentials))
+
+    log_name = @debugger.agent.logger.log_name
+    filter = "logName=projects/#{project_id}/logs/#{log_name} AND resource.type=\"global\" AND textPayload:#{token}"
+    entries = nil
+    wait_until do
+      trigger_breakpoint
+      entries = logging.entries filter: filter
+      !entries.empty?
+    end
+
+    entries.first.payload.must_match "LOGPOINT"
+    entries.first.payload.must_match "local_var is 42"
+    entries.first.payload.must_match token.to_s
+  end
+end

--- a/google-cloud-debugger/acceptance/debugger_helper.rb
+++ b/google-cloud-debugger/acceptance/debugger_helper.rb
@@ -1,0 +1,157 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+gem "minitest"
+require "minitest/autorun"
+require "minitest/focus"
+require "minitest/rg"
+require "google/cloud/debugger"
+
+# Create shared debugger clients so we don't create new for each test
+$vtk_debugger_client = Google::Cloud::Debugger::V2::Debugger2Client.new
+$debugger = Google::Cloud::Debugger.new
+
+module Acceptance
+  class DebuggerTest < Minitest::Test
+    MIN_DELAY = 2
+    MAX_DELAY = 11
+
+    attr_accessor :debugger
+
+    ##
+    # Setup project based on available ENV variables
+    def setup
+      $debugger.start
+
+      @debugger = $debugger
+      @agent_version = @debugger.agent.debuggee.send :agent_version
+      @vtk_debugger_client = $vtk_debugger_client
+
+      refute_nil @debugger, "You do not have an active debugger to run the tests."
+      refute_nil @vtk_debugger_client, "You do not have an active debugger vtk client to run the tests."
+      super
+    end
+
+    ##
+    # Cleanup test objects after tests are finished.
+    def teardown
+      $debugger.stop
+      super
+    end
+
+    ##
+    # Code where the sample breakpoints will be pointing at. Calling the
+    # function may trigger breakpoints if set correctly.
+    def trigger_breakpoint
+      local_var = 6 * 7
+      local_var
+    end
+
+    ##
+    # Create a test gRPC Snappoing
+    def sample_snappoint
+      file_path = File.expand_path __FILE__
+      line = method(:trigger_breakpoint).source_location.last + 2
+
+      breakpoint_hash = {
+        "location" => {
+          "path" => file_path,
+          "line" => line
+        },
+        "create_time" => {
+          "seconds" => Time.now.to_i,
+          "nanos"   => Time.now.nsec
+        },
+        "expressions" => ["local_var"]
+      }
+
+      Google::Devtools::Clouddebugger::V2::Breakpoint.decode_json breakpoint_hash.to_json
+    end
+
+    ##
+    # Create a test gRPC logpoint
+    def sample_logpoint token = nil
+      file_path = File.expand_path __FILE__
+      line = method(:trigger_breakpoint).source_location.last + 2
+
+      breakpoint_hash = {
+        "action" => :LOG,
+        "log_level" => :INFO,
+        "location" => {
+          "path" => file_path,
+          "line" => line
+        },
+        "create_time" => {
+          "seconds" => Time.now.to_i,
+          "nanos"   => Time.now.nsec
+        },
+        "log_message_format" => "local_var is $0. #{token}",
+        "expressions" => ["local_var"]
+      }
+
+      Google::Devtools::Clouddebugger::V2::Breakpoint.decode_json breakpoint_hash.to_json
+    end
+
+    ##
+    # Submit a test Snappoint through VTK client
+    def set_test_snappoint
+      debuggee_id = nil
+
+      wait_until do
+        debuggee_id = @debugger.agent.debuggee.id
+        !debuggee_id.nil?
+      end
+
+      breakpoint = sample_snappoint
+
+      response = @vtk_debugger_client.set_breakpoint debuggee_id, breakpoint, @agent_version
+      response.breakpoint.id
+    end
+
+    ##
+    # Submit a test Logpoint through VTK client
+    def set_test_logpoint token
+      debuggee_id = nil
+
+      wait_until do
+        debuggee_id = @debugger.agent.debuggee.id
+        !debuggee_id.nil?
+      end
+
+      breakpoint = sample_logpoint token
+
+      response = @vtk_debugger_client.set_breakpoint debuggee_id, breakpoint, @agent_version
+      response.breakpoint.id
+    end
+
+    # Add spec DSL
+    extend Minitest::Spec::DSL
+
+    def wait_until
+      delay = MIN_DELAY
+      while delay <= MAX_DELAY
+        sleep delay
+        result = yield
+        return result if result
+        delay += 1
+      end
+      nil
+    end
+
+    # Register this spec type for when :trace is used.
+    register_spec_type(self) do |desc, *addl|
+      addl.include? :debugger
+    end
+  end
+end

--- a/google-cloud-debugger/lib/google/cloud/debugger/credentials.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/credentials.rb
@@ -21,7 +21,8 @@ module Google
       ##
       # @private Represents the OAuth 2.0 signing logic for Debugger.
       class Credentials < Google::Cloud::Credentials
-        SCOPE = ["https://www.googleapis.com/auth/cloud_debugger"]
+        SCOPE = ["https://www.googleapis.com/auth/cloud_debugger"] +
+                Google::Cloud::Logging::Credentials::SCOPE
         PATH_ENV_VARS = %w(DEBUGGER_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
         JSON_ENV_VARS = %w(DEBUGGER_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON
                            GCLOUD_KEYFILE_JSON)


### PR DESCRIPTION
Add acceptance.

Also fix a bug in Debugger Logpoints workflow, where logger doesn't have enough sufficient authentication scope. Now debugger agent will authenticate once with both Debugger and Logging API scopes.