### PR TITLE
Dynamic log label API

### DIFF
--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -9,7 +9,6 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
-    - "lib/google/cloud/logging/rails.rb"
 
 Documentation:
   Enabled: false

--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+    - "lib/google/cloud/logging/rails.rb"
 
 Documentation:
   Enabled: false

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -83,7 +83,8 @@ module Google
           env["rack.logger"] = logger
           trace_id = get_trace_id env
           log_name = get_log_name env
-          logger.add_request_info trace_id: trace_id, log_name: log_name
+          logger.add_request_info trace_id: trace_id, log_name: log_name,
+                                  env: env
           begin
             @app.call env
           ensure

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -362,7 +362,8 @@ module Google
         # @param [Google::Cloud::Logging::Resource] resource The monitored
         #   resource to be associated with written log entries.
         # @param [Hash] labels A set of user-defined data to be associated with
-        #   written log entries.
+        #   written log entries. Values can be strings or Procs which are
+        #   functions of the request environment.
         #
         # @return [Google::Cloud::Logging::Logger] a Logger object that can be
         #   used in place of a ruby standard library logger object.

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -63,6 +63,7 @@ module Google
           resource_type = Logging.configure.monitored_resource.type
           resource_labels = Logging.configure.monitored_resource.labels
           log_name = Logging.configure.log_name
+          labels = Logging.configure.labels
 
           logging = Google::Cloud::Logging.new project: project_id,
                                                keyfile: keyfile
@@ -70,7 +71,7 @@ module Google
             Logging::Middleware.build_monitored_resource resource_type,
                                                          resource_labels
 
-          app.config.logger = logging.logger log_name, resource
+          app.config.logger = logging.logger log_name, resource, labels
           app.middleware.insert_before Rails::Rack::Logger,
                                        Google::Cloud::Logging::Middleware,
                                        logger: app.config.logger
@@ -119,6 +120,7 @@ module Google
                                   gcp_config.project_id
             config.keyfile ||= logging_config.keyfile || gcp_config.keyfile
             config.log_name ||= logging_config.log_name
+            config.labels ||= logging_config.labels
             config.log_name_map ||= logging_config.log_name_map
             config.monitored_resource.type ||=
               logging_config.monitored_resource.type

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -110,7 +110,7 @@ module Google
         ##
         # @private Merge Rails configuration into Logging instrumentation
         # configuration.
-        def self.merge_rails_config rails_config
+        def self.merge_rails_config rails_config # rubocop:disable AbcSize
           gcp_config = rails_config.google_cloud
           logging_config = gcp_config.logging
 

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -89,6 +89,7 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
       stubbed_add_request_info = ->(args) {
         args[:trace_id].must_equal trace_id
         args[:log_name].must_equal "ruby_health_check_log"
+        args[:env].must_equal rack_env
       }
       logger.stub :add_request_info, stubbed_add_request_info do
         middleware.call rack_env

--- a/stackdriver/docs/configuration.md
+++ b/stackdriver/docs/configuration.md
@@ -52,6 +52,10 @@ end
 Google::Cloud::Logging.configure do |config|
   config.project_id = "error-reporting-project"
   config.log_name = "my-app-log"
+  config.google_cloud.labels = {
+    "my-static-label" => "static-label-value",
+    "my-dynamic-label" => ->(rack_env) { rack_env["HTTP_X_MY_HEADER"] }
+  }
 end
 
 # Trace specific configurations 
@@ -95,6 +99,7 @@ end
 * `logging.log_name_map`: [`Hash`] Map specific request routes to other log. Default: `{ "/_ah/health" => "ruby_health_check_log" }`
 * `logging.monitored_resource.type`: [`String`] Resource type name. See [full list](https://cloud.google.com/logging/docs/api/v2/resource-list). Self discovered on GCP.
 * `logging.monitored_resource.labels`: [`Hash`] Resource labels. See [full list](https://cloud.google.com/logging/docs/api/v2/resource-list). Self discovered on GCP.
+* `logging.labels`: [`Hash`] User defined labels. A `Hash` of label names to string label values or callables/`Proc` which are functions of the Rack environment.
 
 #### Trace
 


### PR DESCRIPTION
This PR introduces dynamic log labelling and a Rails-like API for configuration them for Rack applications.

Label values can take the form of either static strings or a
user-defined function (any object that responds to `#call`) which is
passed the current Rack request environment at the moment of generating
the log entry.

The label key remains static and the return value of the function
becomes the label value in the log entry.

The tests show an example of writing labelling log entries with a value
from an HTTP header.

We use this in production to tie together all traces from a user session.