### PR TITLE
Add table partitions to BigQuery

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -118,6 +118,96 @@ module Google
           table_ref
         end
 
+        ###
+        # Is the table partitioned?
+        #
+        # @!group Attributes
+        #
+        def time_partitioning?
+          !@gapi.time_partitioning.nil?
+        end
+
+        ###
+        # The period for which the table is partitioned, if any.
+        #
+        # @!group Attributes
+        #
+        def time_partitioning_type
+          ensure_full_data!
+          @gapi.time_partitioning.type if time_partitioning?
+        end
+
+        ##
+        # Sets the partitioning for the table. See [Partitioned Tables
+        # ](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        #
+        # You can only set partitioning when creating a table as in
+        # the example below. BigQuery does not allow you to change partitioning
+        # on an existing table.
+        #
+        # @param [String] type The partition type. Currently the only
+        # supported value is "DAY".
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.create_table "my_table" do |table|
+        #     table.time_partitioning_type = "DAY"
+        #   end
+        #
+        # @!group Attributes
+        #
+        def time_partitioning_type= type
+          @gapi.time_partitioning ||=
+              Google::Apis::BigqueryV2::TimePartitioning.new
+          @gapi.time_partitioning.type = type
+          patch_gapi! :time_partitioning
+        end
+
+
+        ###
+        # The expiration for the table partitions, if any, in seconds.
+        #
+        # @!group Attributes
+        #
+        def time_partitioning_expiration
+          ensure_full_data!
+          @gapi.time_partitioning.expiration_ms / 1_000 if
+              time_partitioning? &&
+              !@gapi.time_partitioning.expiration_ms.nil?
+        end
+
+        ##
+        # Sets the partition expiration for the table. See [Partitioned Tables
+        # ](https://cloud.google.com/bigquery/docs/partitioned-tables). The
+        # table must also be partitioned.
+        #
+        # See {Table#time_partitioning_type=}.
+        #
+        # @param [Integer] expiration An expiration time, in seconds,
+        # for data in partitions.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.create_table "my_table" do |table|
+        #     table.time_partitioning_type = "DAY"
+        #     table.time_partitioning_expiration = 86_400
+        #   end
+        #
+        # @!group Attributes
+        #
+        def time_partitioning_expiration= expiration
+          @gapi.time_partitioning ||=
+              Google::Apis::BigqueryV2::TimePartitioning.new
+          @gapi.time_partitioning.expiration_ms = expiration * 1000
+          patch_gapi! :time_partitioning
+        end
+
         ##
         # The combined Project ID, Dataset ID, and Table ID for this table, in
         # the format specified by the [Legacy SQL Query

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -38,12 +38,16 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.name.must_equal table_name
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_expiration.must_be_nil
 
     table.name = new_table_name
 
     table.name.must_equal new_table_name
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_expiration.must_be_nil
 
     mock.verify
   end
@@ -61,13 +65,81 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.name.must_equal table_name
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_expiration.must_be_nil
 
     table.description = new_description
 
     table.name.must_equal table_name
     table.description.must_equal new_description
     table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_expiration.must_be_nil
 
     mock.verify
   end
+
+  it "updates time partitioning type" do
+    type = "DAY"
+
+    mock = Minitest::Mock.new
+    table_hash = random_table_hash dataset_id, table_id, table_name, description
+    table_hash["timePartitioning"] = {
+        "type"  => type,
+    }
+    partitioning = Google::Apis::BigqueryV2::TimePartitioning.new type: type
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning
+    mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
+      [project, dataset_id, table_id, request_table_gapi]
+    table.service.mocked_service = mock
+
+    table.name.must_equal table_name
+    table.description.must_equal description
+    table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_expiration.must_be_nil
+
+    table.time_partitioning_type = type
+
+    table.name.must_equal table_name
+    table.description.must_equal description
+    table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_equal type
+    table.time_partitioning_expiration.must_be_nil
+
+    mock.verify
+  end
+
+  it "updates time partitioning expiration" do
+    expiration = 86_400
+    expiration_ms = expiration * 1_000
+
+    mock = Minitest::Mock.new
+    table_hash = random_table_hash dataset_id, table_id, table_name, description
+    table_hash["timePartitioning"] = {
+        "expirationMs" => expiration_ms,
+    }
+    partitioning = Google::Apis::BigqueryV2::TimePartitioning.new expiration_ms: expiration_ms
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning
+    mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
+      [project, dataset_id, table_id, request_table_gapi]
+    table.service.mocked_service = mock
+
+    table.name.must_equal table_name
+    table.description.must_equal description
+    table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_expiration.must_be_nil
+
+    table.time_partitioning_expiration = expiration
+
+    table.name.must_equal table_name
+    table.description.must_equal description
+    table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_expiration.must_equal expiration
+
+    mock.verify
+  end
+
 end


### PR DESCRIPTION
See #1591 

This is an extension of @zedalaye's work to add the requested fixes.

I can squash and rebase after review.

Question: what do you think about using, e.g., `partition_type` instead of `time_partitioning_type` as the property name. That would be easier to read and understand (and matches the docs), although it diverges from the JSON API. I don't know which is more important to the gem.

Also, as @quartzmo mentioned, need a decision about whether to change expiration to seconds, as the rest of the gem uses, or retain milliseconds as is done with [`Dataset#default_expiration`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/9306c3840caf5bf106fdbd14249fffbc552effcd/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb#L149-L172).

This should resolve #1627 as well.