### PR TITLE
Update Natural Language .yardopts

### DIFF
--- a/google-cloud-language/.yardopts
+++ b/google-cloud-language/.yardopts
@@ -1,6 +1,10 @@
 --no-private
 --title=Google Cloud Language
 --exclude lib/google/cloud/language/v1.rb
+--exclude lib/google/cloud/language/v1/language_service_pb.rb
+--exclude lib/google/cloud/language/v1/language_service_services_pb.rb
+--exclude lib/google/cloud/language/v1beta2/language_service_pb.rb
+--exclude lib/google/cloud/language/v1beta2/language_service_services_pb.rb
 --markup markdown
 
 ./lib/**/*.rb


### PR DESCRIPTION
Exclude non-documentation GAPIC files. This fixes an issue caused by the inclusion of files such as [`language_service_pb.rb`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_pb.rb) in the YARD output. The `Document` constant in `language_service_pb.rb` shadows the `Document` class in the `docs` directory.

[closes #1480]