### PR TITLE
Datastore Protobuf Upgrade

### DIFF
--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "google-gax", "~> 0.8.0"
-  gem.add_dependency "google-protobuf", "~> 3.2.0"
+  gem.add_dependency "google-protobuf", "~> 3.3"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
@@ -53,17 +53,6 @@ module Google
           end
         end
 
-        ##
-        # @private Convert a Google::Protobuf::Map to a Hash
-        def self.map_to_hash map
-          if map.respond_to? :to_h
-            map.to_h
-          else
-            # Enumerable doesn't have to_h on ruby 2.0...
-            Hash[map.to_a]
-          end
-        end
-
         PROP_FILTER_OPS = { "<"            => :LESS_THAN,
                             "lt"           => :LESS_THAN,
                             "<="           => :LESS_THAN_OR_EQUAL,

--- a/google-cloud-datastore/lib/google/cloud/datastore/properties.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/properties.rb
@@ -73,17 +73,13 @@ module Google
         alias_method :to_hash, :to_h
 
         def to_grpc
-          Hash[@hash.map { |(k, v)| [k.to_s, Convert.to_value(v)] }]
+          # Convert to Hash with Google::Datastore::V1::Value values.
+          Hash[@hash.map { |k, v| [k.to_s, Convert.to_value(v)] }]
         end
 
         def self.from_grpc grpc_map
-          # For some reason Google::Protobuf::Map#map isn't returning the value.
-          # It returns nil every time. COnvert to Hash to get actual objects.
-          grpc_hash = Convert.map_to_hash grpc_map
-          grpc_array = grpc_hash.map do |(k, v)|
-            [k.to_s, Convert.from_value(v)]
-          end
-          new Hash[grpc_array]
+          # Convert to Hash of string keys and raw values.
+          new Hash[grpc_map.map { |k, v| [k.to_s, Convert.from_value(v)] }]
         end
 
         protected


### PR DESCRIPTION
Update to latest google-protobuf, which has changed the behavior of `Message#to_h`. It now creates a nested hash. Update Datastore to work with the new behavior.

[fixes #1457]