### PR TITLE
Check before cleanup compilation files

### DIFF
--- a/google-cloud-debugger/Rakefile
+++ b/google-cloud-debugger/Rakefile
@@ -17,10 +17,9 @@ namespace :compile do
       puts "remove #{f}"
       File.delete f
     end
-    if File.directory? "tmp"
-      puts "remove directory ./tmp"
-      FileUtils.remove_dir "tmp"
-    end
+
+    puts "remove directory ./tmp"
+    FileUtils.remove_dir "tmp", true
   end
 end
 

--- a/google-cloud-debugger/Rakefile
+++ b/google-cloud-debugger/Rakefile
@@ -13,12 +13,14 @@ Rake::ExtensionTask.new(ext_name, spec)
 namespace :compile do
   desc "Cleanup compilation files"
   task :cleanup do
-    puts "remove #{ext_name}.*"
     Dir.glob "lib/google/cloud/debugger/debugger_c.*" do |f|
+      puts "remove #{f}"
       File.delete f
     end
-    puts "remove directory tmp"
-    FileUtils.remove_dir "tmp"
+    if File.directory? "tmp"
+      puts "remove directory ./tmp"
+      FileUtils.remove_dir "tmp"
+    end
   end
 end
 


### PR DESCRIPTION
The `rake recompile` task current fails when the assumed compilation files and directories don't exist. Add check before attempting to delete the files and directories.