### PR TITLE
Debugger support none rack-based apps

### DIFF
--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.c
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.c
@@ -171,7 +171,6 @@ line_trace_callback(rb_event_flag_t event, VALUE data, VALUE obj, ID mid, VALUE 
 
     trace_binding = rb_binding_new();
     call_stack_bindings = rb_funcall(trace_binding, callers_id, 0);
-    rb_ary_pop(call_stack_bindings);
 
     rb_funcall(self, breakpoints_hit_id, 2, matching_result, call_stack_bindings);
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
@@ -136,8 +136,7 @@ module Google
 
           @logger = logger || default_logger
 
-          @app_root = app_root
-          @app_root ||= Rack::Directory.new("").root if defined? Rack::Directory
+          init_app_root app_root
 
           # Agent actor thread needs to force exit immediately.
           set_cleanup_options timeout: 0
@@ -198,6 +197,16 @@ module Google
         end
 
         private
+
+        ##
+        # @private Initialize `@app_root` instance variable.
+        def init_app_root app_root = nil
+          app_root ||= Google::Cloud::Debugger.configure.app_root
+          app_root ||= Rack::Directory.new("").root if defined? Rack::Directory
+          app_root ||= Dir.pwd
+
+          @app_root = app_root
+        end
 
         ##
         # @private Callback function for breakpoint manager when any updates

--- a/stackdriver/docs/configuration.md
+++ b/stackdriver/docs/configuration.md
@@ -90,6 +90,7 @@ end
 * `debugger.keyfile`: [`String`] Path to service account JSON keyfile. Self discovered on GCP.
 * `debugger.module_name`: [`String`] Identifier to running service. Self discovered on GCP. Default: `"ruby-app"`
 * `debugger.module_version`: [`String`] Version identifier to running service. Self discovered on GCP.
+* `debugger.root`: [`String`] The root directory of the debuggee application in absolute file path form. Default: `Rack::Directory#root` if the application framework is rack-based,i.e. Ruby on Rails, Sinatra. Otherwise use current working directory.
 
 #### Logging
 


### PR DESCRIPTION
Make Debugger agent compatible with none rack-based applications by exposing the `app_root` parameter  to be configurable and make it fallback to current working directory. Now any Ruby programs/scripts just need `Google::Cloud::Debugger.new.start` in order to use Stackdriver Debugger service.

Also fix a bug in C extension that incorrectly left out the first frame during evaluation.