### PR TITLE
Rename 'module_name' and 'module_version' parameters

### DIFF
--- a/google-cloud-debugger/lib/google-cloud-debugger.rb
+++ b/google-cloud-debugger/lib/google-cloud-debugger.rb
@@ -31,8 +31,8 @@ module Google
     # For more information on connecting to Google Cloud see the [Authentication
     # Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/authentication).
     #
-    # @param [String] module_name Name for the debuggee application. Optional.
-    # @param [String] module_version Version identifier for the debuggee
+    # @param [String] service_name Name for the debuggee application. Optional.
+    # @param [String] service_version Version identifier for the debuggee
     #   application. Optional.
     # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
     #   set of resources and operations that the connection can access. See
@@ -63,13 +63,14 @@ module Google
     #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
     #   debugger = gcloud.debugger scope: platform_scope
     #
-    def debugger module_name: nil, module_version: nil, scope: nil,
+    def debugger service_name: nil, service_version: nil, scope: nil,
                  timeout: nil, client_config: nil
-      Google::Cloud.debugger @project, @keyfile, module_name: module_name,
-                                                 module_version: module_version,
-                                                 scope: scope,
-                                                 timeout: (timeout || @timeout),
-                                                 client_config: client_config
+      Google::Cloud.debugger @project, @keyfile,
+                             service_name: service_name,
+                             service_version: service_version,
+                             scope: scope,
+                             timeout: (timeout || @timeout),
+                             client_config: client_config
     end
 
     ##
@@ -84,8 +85,8 @@ module Google
     #   service you are connecting to.
     # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If
     #   file path the file must be readable.
-    # @param [String] module_name Name for the debuggee application. Optional.
-    # @param [String] module_version Version identifier for the debuggee
+    # @param [String] service_name Name for the debuggee application. Optional.
+    # @param [String] service_version Version identifier for the debuggee
     # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
     #   set of resources and operations that the connection can access. See
     #   [Using OAuth 2.0 to Access Google
@@ -107,13 +108,13 @@ module Google
     #
     #   debugger.start
     #
-    def self.debugger project = nil, keyfile = nil, module_name: nil,
-                      module_version: nil, scope: nil, timeout: nil,
+    def self.debugger project = nil, keyfile = nil, service_name: nil,
+                      service_version: nil, scope: nil, timeout: nil,
                       client_config: nil
       require "google/cloud/debugger"
       Google::Cloud::Debugger.new project: project, keyfile: keyfile,
-                                  module_name: module_name,
-                                  module_version: module_version,
+                                  service_name: service_name,
+                                  service_version: service_version,
                                   scope: scope, timeout: timeout,
                                   client_config: client_config
     end

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -104,10 +104,10 @@ module Google
     # config.google_cloud.keyfile = "/path/to/keyfile.json"
     # # Google Cloud authentication json file for Stackdriver Debugger only
     # config.google_cloud.debugger.keyfile = "/path/to/debugger/keyfile.json"
-    # # Stackdriver Debugger Agent module name identifier
-    # config.google_cloud.debugger.module_name = "my-ruby-app"
-    # # Stackdriver Debugger Agent module version identifier
-    # config.google_cloud.debugger.module_version = "v1"
+    # # Stackdriver Debugger Agent service name identifier
+    # config.google_cloud.debugger.service_name = "my-ruby-app"
+    # # Stackdriver Debugger Agent service version identifier
+    # config.google_cloud.debugger.service_version = "v1"
     # ```
     #
     # See the {Google::Cloud::Debugger::Railtie} class for more information.
@@ -130,8 +130,8 @@ module Google
     # require "google/cloud/debugger"
     # use Google::Cloud::Debugger::Middleware project: "debugger-project-id",
     #                                         keyfile: "/path/to/keyfile.json",
-    #                                         module_name: "my-ruby-app",
-    #                                         module_version: "v1"
+    #                                         service_name: "my-ruby-app",
+    #                                         service_version: "v1"
     # ```
     #
     # ### Using instrumentation with other Rack-based frameworks
@@ -343,8 +343,9 @@ module Google
       #   service.
       # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud:
       #   either the JSON data or the path to a readable file.
-      # @param [String] module_name Name for the debuggee application. Optional.
-      # @param [String] module_version Version identifier for the debuggee
+      # @param [String] service_name Name for the debuggee application.
+      #   Optional.
+      # @param [String] service_version Version identifier for the debuggee
       #   application. Optional.
       # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
       #   the set of resources and operations that the connection can access.
@@ -361,19 +362,19 @@ module Google
       #   debugger = Google::Cloud::Debugger.new
       #   debugger.start
       #
-      def self.new project: nil, keyfile: nil, module_name: nil,
-                   module_version: nil, scope: nil, timeout: nil,
+      def self.new project: nil, keyfile: nil, service_name: nil,
+                   service_version: nil, scope: nil, timeout: nil,
                    client_config: nil
         project ||= Debugger::Project.default_project
         project = project.to_s # Always cast to a string
-        module_name ||= Debugger::Project.default_module_name
-        module_name = module_name.to_s
-        module_version ||= Debugger::Project.default_module_version
-        module_version = module_version.to_s
+        service_name ||= Debugger::Project.default_service_name
+        service_name = service_name.to_s
+        service_version ||= Debugger::Project.default_service_version
+        service_version = service_version.to_s
 
         fail ArgumentError, "project is missing" if project.empty?
-        fail ArgumentError, "module_name is missing" if module_name.empty?
-        fail ArgumentError, "module_version is missing" if module_version.nil?
+        fail ArgumentError, "service_name is missing" if service_name.empty?
+        fail ArgumentError, "service_version is missing" if service_version.nil?
 
         credentials = Credentials.credentials_with_scope keyfile, scope
 
@@ -381,8 +382,8 @@ module Google
           Google::Cloud::Debugger::Service.new(
             project, credentials, timeout: timeout,
                                   client_config: client_config),
-          module_name: module_name,
-          module_version: module_version
+          service_name: service_name,
+          service_version: service_version
         )
       end
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
@@ -114,19 +114,19 @@ module Google
         #   object
         # @param [Google::Cloud::Logging::Logger] logger The logger used
         #   to write the results of Logpoints.
-        # @param [String] module_name Name for the debuggee application.
-        # @param [String] module_version Version identifier for the debuggee
+        # @param [String] service_name Name for the debuggee application.
+        # @param [String] service_version Version identifier for the debuggee
         #   application.
         # @param [String] app_root Absolute path to the root directory of
         #   the debuggee application. Default to Rack root.
         #
-        def initialize service, logger: nil, module_name:, module_version:,
+        def initialize service, logger: nil, service_name:, service_version:,
                        app_root: nil
           super()
 
           @service = service
-          @debuggee = Debuggee.new service, module_name: module_name,
-                                            module_version: module_version
+          @debuggee = Debuggee.new service, service_name: service_name,
+                                            service_version: service_version
           @tracer = Debugger::Tracer.new self
           @breakpoint_manager = BreakpointManager.new self, service
           @breakpoint_manager.on_breakpoints_change =

--- a/google-cloud-debugger/lib/google/cloud/debugger/debuggee.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/debuggee.rb
@@ -48,12 +48,12 @@ module Google
         ##
         # Name for the debuggee application
         # @return [String]
-        attr_reader :module_name
+        attr_reader :service_name
 
         ##
         # Version identifier for the debuggee application
         # @return [String]
-        attr_reader :module_version
+        attr_reader :service_version
 
         ##
         # Registered Debuggee ID. Set by Stackdriver Debugger service when
@@ -63,10 +63,10 @@ module Google
 
         ##
         # @private Construct a new instance of Debuggee
-        def initialize service, module_name:, module_version:
+        def initialize service, service_name:, service_version:
           @service = service
-          @module_name = module_name
-          @module_version = module_version
+          @service_name = service_name
+          @service_version = service_version
           @computed_uniquifier = nil
           @id = nil
         end
@@ -142,8 +142,8 @@ module Google
         def labels
           {
             "projectid" => String(project_id),
-            "module" => String(module_name),
-            "version" => String(module_version)
+            "module" => String(service_name),
+            "version" => String(service_version)
           }
         end
 
@@ -155,10 +155,10 @@ module Google
         # @return [String] A compact debuggee description.
         #
         def description
-          if module_version.nil? || module_version.empty?
-            module_name
+          if service_version.nil? || service_version.empty?
+            service_name
           else
-            "#{module_name} - #{module_version}"
+            "#{service_name} - #{service_version}"
           end
         end
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -51,8 +51,8 @@ module Google
             @debugger =
               Debugger.new(project: configuration.project_id,
                            keyfile: configuration.keyfile,
-                           module_name: configuration.module_name,
-                           module_version: configuration.module_version)
+                           service_name: configuration.service_name,
+                           service_version: configuration.service_version)
 
             @debugger.agent.quota_manager =
               Google::Cloud::Debugger::RequestQuotaManager.new
@@ -104,10 +104,10 @@ module Google
           configuration.keyfile = kwargs[:keyfile] ||
                                   configuration.keyfile
 
-          configuration.module_name = kwargs[:module_name] ||
-                                      configuration.module_name
-          configuration.module_version = kwargs[:module_version] ||
-                                         configuration.module_version
+          configuration.service_name = kwargs[:service_name] ||
+                                       configuration.service_name
+          configuration.service_version = kwargs[:service_version] ||
+                                          configuration.service_version
 
           init_default_config
         end
@@ -119,9 +119,9 @@ module Google
                                        Debugger::Project.default_project
           configuration.keyfile ||= Cloud.configure.keyfile
 
-          configuration.module_name ||= Debugger::Project.default_module_name
-          configuration.module_version ||=
-            Debugger::Project.default_module_version
+          configuration.service_name ||= Debugger::Project.default_service_name
+          configuration.service_version ||=
+            Debugger::Project.default_service_version
         end
 
         ##

--- a/google-cloud-debugger/lib/google/cloud/debugger/project.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/project.rb
@@ -50,10 +50,10 @@ module Google
 
         ##
         # @private Creates a new Project instance.
-        def initialize service, module_name:, module_version:
+        def initialize service, service_name:, service_version:
           @service = service
-          @agent = Agent.new service, module_name: module_name,
-                                      module_version: module_version
+          @agent = Agent.new service, service_name: service_name,
+                                      service_version: service_version
         end
 
         ##
@@ -85,17 +85,17 @@ module Google
         end
 
         ##
-        # @private Default module name identifier.
-        def self.default_module_name
-          ENV["DEBUGGER_MODULE_NAME"] ||
+        # @private Default service name identifier.
+        def self.default_service_name
+          ENV["DEBUGGER_SERVICE_NAME"] ||
             Google::Cloud.env.app_engine_service_id ||
             "ruby-app"
         end
 
         ##
-        # @private Default module version identifier.
-        def self.default_module_version
-          ENV["DEBUGGER_MODULE_VERSION"] ||
+        # @private Default service version identifier.
+        def self.default_service_version
+          ENV["DEBUGGER_SERVICE_VERSION"] ||
             Google::Cloud.env.app_engine_service_version ||
             ""
         end

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -101,8 +101,8 @@ module Google
           Debugger.configure do |config|
             config.project_id ||= dbg_config.project_id || gcp_config.project_id
             config.keyfile ||= dbg_config.keyfile || gcp_config.keyfile
-            config.module_name ||= dbg_config.module_name
-            config.module_version ||= dbg_config.module_version
+            config.service_name ||= dbg_config.service_name
+            config.service_version ||= dbg_config.service_version
           end
         end
 
@@ -111,8 +111,8 @@ module Google
         def self.init_default_config
           config = Debugger.configure
           config.project_id ||= Debugger::Project.default_project
-          config.module_name ||= Debugger::Project.default_module_name
-          config.module_version ||= Debugger::Project.default_module_version
+          config.service_name ||= Debugger::Project.default_service_name
+          config.service_version ||= Debugger::Project.default_service_version
         end
 
         ##

--- a/google-cloud-debugger/support/doctest_helper.rb
+++ b/google-cloud-debugger/support/doctest_helper.rb
@@ -48,7 +48,7 @@ def mock_debugger
     credentials = OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {}))
     debugger = Google::Cloud::Debugger::Project.new(
       Google::Cloud::Debugger::Service.new("my-project", credentials),
-      module_name: nil, module_version: nil)
+      service_name: nil, service_version: nil)
 
     debugger.service.mocked_debugger = Minitest::Mock.new
     debugger.service.mocked_transmitter = Minitest::Mock.new

--- a/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
@@ -33,8 +33,8 @@ describe Google::Cloud::Debugger::Agent, :mock_debugger do
 
     it "uses the logger passed in" do
       new_agent = Google::Cloud::Debugger::Agent.new nil, logger: "test-logger",
-                                                          module_name: nil,
-                                                          module_version: nil
+                                                          service_name: nil,
+                                                          service_version: nil
       new_agent.logger.must_equal "test-logger"
     end
   end

--- a/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
@@ -26,8 +26,8 @@ describe Google::Cloud::Debugger::Railtie do
     config.google_cloud.debugger = ::ActiveSupport::OrderedOptions.new
     config.google_cloud.project_id = "test-project"
     config.google_cloud.keyfile = "test/keyfile"
-    config.google_cloud.debugger.module_name = "test-module"
-    config.google_cloud.debugger.module_version = "test-version"
+    config.google_cloud.debugger.service_name = "test-module"
+    config.google_cloud.debugger.service_version = "test-version"
     config
   end
 
@@ -44,8 +44,8 @@ describe Google::Cloud::Debugger::Railtie do
         Google::Cloud::Debugger.configure do |config|
           config.project_id.must_equal "test-project"
           config.keyfile.must_equal "test/keyfile"
-          config.module_name.must_equal "test-module"
-          config.module_version.must_equal "test-version"
+          config.service_name.must_equal "test-module"
+          config.service_version.must_equal "test-version"
         end
       end
     end
@@ -54,8 +54,8 @@ describe Google::Cloud::Debugger::Railtie do
       Google::Cloud::Debugger.configure do |config|
         config.project_id = "another-test-project"
         config.keyfile = "/another/test/keyfile"
-        config.module_name = "another-test-module"
-        config.module_version = "another-test-version"
+        config.service_name = "another-test-module"
+        config.service_version = "another-test-version"
       end
 
       STDOUT.stub :puts, nil do
@@ -64,8 +64,8 @@ describe Google::Cloud::Debugger::Railtie do
         Google::Cloud::Debugger.configure do |config|
           config.project_id.must_equal "another-test-project"
           config.keyfile.must_equal "/another/test/keyfile"
-          config.module_name.must_equal "another-test-module"
-          config.module_version.must_equal "another-test-version"
+          config.service_name.must_equal "another-test-module"
+          config.service_version.must_equal "another-test-version"
         end
       end
     end

--- a/google-cloud-debugger/test/google/cloud/debugger_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger_test.rb
@@ -19,12 +19,12 @@ describe Google::Cloud do
   describe "#debugger" do
     it "calls out to Google::Cloud.debugger" do
       gcloud = Google::Cloud.new
-      stubbed_debugger = ->(project, keyfile, module_name: nil, module_version: nil,
+      stubbed_debugger = ->(project, keyfile, service_name: nil, service_version: nil,
         scope: nil, timeout: nil, client_config: nil) {
         project.must_be_nil
         keyfile.must_be_nil
-        module_name.must_be_nil
-        module_version.must_be_nil
+        service_name.must_be_nil
+        service_version.must_be_nil
         scope.must_be_nil
         timeout.must_be_nil
         client_config.must_be_nil
@@ -38,12 +38,12 @@ describe Google::Cloud do
 
     it "passes project and keyfile to Google::Cloud.debugger" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_debugger = ->(project, keyfile, module_name: nil, module_version: nil,
+      stubbed_debugger = ->(project, keyfile, service_name: nil, service_version: nil,
         scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
-        module_name.must_be_nil
-        module_version.must_be_nil
+        service_name.must_be_nil
+        service_version.must_be_nil
         scope.must_be_nil
         timeout.must_be_nil
         client_config.must_be_nil
@@ -57,19 +57,19 @@ describe Google::Cloud do
 
     it "passes project and keyfile and options to Google::Cloud.debugger" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_debugger = ->(project, keyfile, module_name: nil, module_version: nil,
+      stubbed_debugger = ->(project, keyfile, service_name: nil, service_version: nil,
         scope: nil, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         keyfile.must_equal "keyfile-path"
-        module_name.must_equal "utest-service"
-        module_version.must_equal "vUTest"
+        service_name.must_equal "utest-service"
+        service_version.must_equal "vUTest"
         scope.must_equal "http://example.com/scope"
         timeout.must_equal 60
         client_config.must_equal({ "gax" => "options" })
         "debugger-project-object-scoped"
       }
       Google::Cloud.stub :debugger, stubbed_debugger do
-        project = gcloud.debugger module_name: "utest-service", module_version: "vUTest", scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
+        project = gcloud.debugger service_name: "utest-service", service_version: "vUTest", scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
         project.must_equal "debugger-project-object-scoped"
       end
     end
@@ -77,14 +77,14 @@ describe Google::Cloud do
 
   describe ".debugger" do
     let(:default_credentials) { OpenStruct.new empty: true }
-    let(:default_module_name) { "default-utest-service" }
-    let(:default_module_version) { "vDefaultUTest" }
+    let(:default_service_name) { "default-utest-service" }
+    let(:default_service_version) { "vDefaultUTest" }
     let(:found_credentials) { "{}" }
 
     it "gets defaults for project_id and keyfile" do
       stubbed_env = OpenStruct.new project_id: "project-id",
-                                   app_engine_service_id: default_module_name,
-                                   app_engine_service_version: default_module_version
+                                   app_engine_service_id: default_service_name,
+                                   app_engine_service_version: default_service_version
       # Clear all environment variables
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
@@ -93,8 +93,8 @@ describe Google::Cloud do
             debugger = Google::Cloud.debugger
             debugger.must_be_kind_of Google::Cloud::Debugger::Project
             debugger.project.must_equal "project-id"
-            debugger.agent.debuggee.module_name.must_equal default_module_name
-            debugger.agent.debuggee.module_version.must_equal default_module_version
+            debugger.agent.debuggee.service_name.must_equal default_service_name
+            debugger.agent.debuggee.service_version.must_equal default_service_version
             debugger.service.credentials.must_equal default_credentials
           end
         end
@@ -107,8 +107,8 @@ describe Google::Cloud do
         scope.must_be_nil
         "debugger-credentials"
       }
-      stubbed_module_name = "utest-service"
-      stubbed_module_version = "vUTest"
+      stubbed_service_name = "utest-service"
+      stubbed_service_version = "vUTest"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "debugger-credentials"
@@ -123,11 +123,11 @@ describe Google::Cloud do
           File.stub :read, found_credentials, ["path/to/keyfile.json"] do
             Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Debugger::Service.stub :new, stubbed_service do
-                debugger = Google::Cloud.debugger "project-id", "path/to/keyfile.json", module_name: stubbed_module_name, module_version: stubbed_module_version
+                debugger = Google::Cloud.debugger "project-id", "path/to/keyfile.json", service_name: stubbed_service_name, service_version: stubbed_service_version
                 debugger.must_be_kind_of Google::Cloud::Debugger::Project
                 debugger.project.must_equal "project-id"
-                debugger.agent.debuggee.module_name.must_equal stubbed_module_name
-                debugger.agent.debuggee.module_version.must_equal stubbed_module_version
+                debugger.agent.debuggee.service_name.must_equal stubbed_service_name
+                debugger.agent.debuggee.service_version.must_equal stubbed_service_version
                 debugger.service.must_be_kind_of OpenStruct
               end
             end
@@ -149,14 +149,14 @@ describe Google::Cloud do
 
   describe "Debugger.new" do
     let(:default_credentials) { OpenStruct.new empty: true }
-    let(:default_module_name) { "default-utest-service" }
-    let(:default_module_version) { "vDefaultUTest" }
+    let(:default_service_name) { "default-utest-service" }
+    let(:default_service_version) { "vDefaultUTest" }
     let(:found_credentials) { "{}" }
 
-    it "gets defaults for project_id, keyfile, module_name, and module_version" do
+    it "gets defaults for project_id, keyfile, service_name, and service_version" do
       stubbed_env = OpenStruct.new project_id: "project-id",
-                                   app_engine_service_id: default_module_name,
-                                   app_engine_service_version: default_module_version
+                                   app_engine_service_id: default_service_name,
+                                   app_engine_service_version: default_service_version
 
       # Clear all environment variables
       ENV.stub :[], nil do
@@ -166,22 +166,22 @@ describe Google::Cloud do
             debugger = Google::Cloud::Debugger.new
             debugger.must_be_kind_of Google::Cloud::Debugger::Project
             debugger.project.must_equal "project-id"
-            debugger.agent.debuggee.module_name.must_equal default_module_name
-            debugger.agent.debuggee.module_version.must_equal default_module_version
+            debugger.agent.debuggee.service_name.must_equal default_service_name
+            debugger.agent.debuggee.service_version.must_equal default_service_version
             debugger.service.credentials.must_equal default_credentials
           end
         end
       end
     end
 
-    it "uses provided project_id, keyfile, module_name, and module_version" do
+    it "uses provided project_id, keyfile, service_name, and service_version" do
       stubbed_credentials = ->(keyfile, scope: nil) {
         keyfile.must_equal "path/to/keyfile.json"
         scope.must_be_nil
         "debugger-credentials"
       }
-      stubbed_module_name = "utest-service"
-      stubbed_module_version = "vUTest"
+      stubbed_service_name = "utest-service"
+      stubbed_service_version = "vUTest"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil) {
         project.must_equal "project-id"
         credentials.must_equal "debugger-credentials"
@@ -196,11 +196,11 @@ describe Google::Cloud do
           File.stub :read, found_credentials, ["path/to/keyfile.json"] do
             Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Debugger::Service.stub :new, stubbed_service do
-                debugger = Google::Cloud::Debugger.new project: "project-id", keyfile: "path/to/keyfile.json", module_name: stubbed_module_name, module_version: stubbed_module_version
+                debugger = Google::Cloud::Debugger.new project: "project-id", keyfile: "path/to/keyfile.json", service_name: stubbed_service_name, service_version: stubbed_service_version
                 debugger.must_be_kind_of Google::Cloud::Debugger::Project
                 debugger.project.must_equal "project-id"
-                debugger.agent.debuggee.module_name.must_equal stubbed_module_name
-                debugger.agent.debuggee.module_version.must_equal stubbed_module_version
+                debugger.agent.debuggee.service_name.must_equal stubbed_service_name
+                debugger.agent.debuggee.service_version.must_equal stubbed_service_version
                 debugger.service.must_be_kind_of OpenStruct
               end
             end

--- a/google-cloud-debugger/test/helper.rb
+++ b/google-cloud-debugger/test/helper.rb
@@ -25,8 +25,8 @@ class MockDebugger < Minitest::Spec
   let(:project) { "test" }
   let(:default_options) { Google::Gax::CallOptions.new(kwargs: { "google-cloud-resource-prefix" => "projects/#{project}" }) }
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
-  let(:module_name) { "test-service" }
-  let(:module_version) { "vTest" }
+  let(:service_name) { "test-service" }
+  let(:service_version) { "vTest" }
   let(:service) {
     service = Google::Cloud::Debugger::Service.new(project, credentials)
     mocked_debugger = Object.new
@@ -42,8 +42,8 @@ class MockDebugger < Minitest::Spec
   let(:debugger) {
     Google::Cloud::Debugger::Project.new(
       service,
-      module_name: module_name,
-      module_version: module_version
+      service_name: service_name,
+      service_version: service_version
     )
   }
   let(:debuggee_id) { "test debuggee id" }

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
@@ -58,7 +58,7 @@ module Google
 
         ##
         # Find default service_name from `ERROR_REPORTING_SERVICE`,
-        # `GAE_MODULE_NAME` environment Variables, or just "ruby".
+        # `GAE_SERVICE` environment Variables, or just "ruby".
         #
         # @return [String] default GCP service_name
         #
@@ -70,7 +70,7 @@ module Google
 
         ##
         # Find default service_version from `ERROR_REPORTING_VERSION` or
-        # `GAE_MODULE_VERSION` environment varaibles.
+        # `GAE_VERSION` environment varaibles.
         #
         # @return [String] default GCP service_version
         #

--- a/stackdriver/docs/configuration.md
+++ b/stackdriver/docs/configuration.md
@@ -45,7 +45,7 @@ end
 # Debugger specific configurations 
 Google::Cloud::Debugger.configure do |config|
   config.project_id = "debugger-project"
-  config.module_name = "my-service"
+  config.service_name = "my-service"
 end
 
 # Logging specific configurations 
@@ -88,8 +88,8 @@ end
 
 * `debugger.project_id`: [`String`] Google Cloud Platform Project identifier just for Debugger. Self discovered on GCP.
 * `debugger.keyfile`: [`String`] Path to service account JSON keyfile. Self discovered on GCP.
-* `debugger.module_name`: [`String`] Identifier to running service. Self discovered on GCP. Default: `"ruby-app"`
-* `debugger.module_version`: [`String`] Version identifier to running service. Self discovered on GCP.
+* `debugger.service_name`: [`String`] Identifier to running service. Self discovered on GCP. Default: `"ruby-app"`
+* `debugger.service_version`: [`String`] Version identifier to running service. Self discovered on GCP.
 * `debugger.root`: [`String`] The root directory of the debuggee application in absolute file path form. Default: `Rack::Directory#root` if the application framework is rack-based,i.e. Ruby on Rails, Sinatra. Otherwise use current working directory.
 
 #### Logging


### PR DESCRIPTION
`module_name` and `module_version` are old names used in protobuf. Debugger should change the parameter names to `service_name` and `service_version` like google-cloud-error_reporting.

Doing this as a API breaking change, since google-cloud-debugger gem is still in Alpha with low usage.