### PR TITLE
Support ETag in BigQuery Dataset and Table updates

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -80,6 +80,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
     empty_table.schema.field("spells").headers.wont_include :score
     empty_table.schema.field("spells").headers.must_include :properties
     empty_table.schema.field(:spells).field(:properties).headers.wont_include :grade
+    empty_table.reload! # TODO: remove after fixing etag staleness after create_table
     empty_table.schema do |schema|
       # adds to a nested field directly inline
       schema.field(:spells).integer :score, mode: :nullable

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -80,7 +80,6 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
     empty_table.schema.field("spells").headers.wont_include :score
     empty_table.schema.field("spells").headers.must_include :properties
     empty_table.schema.field(:spells).field(:properties).headers.wont_include :grade
-    empty_table.reload! # TODO: remove after fixing etag staleness after create_table
     empty_table.schema do |schema|
       # adds to a nested field directly inline
       schema.field(:spells).integer :score, mode: :nullable

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -107,7 +107,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     # Modify on the server, which will change the etag
     fresh.description = "Description 1"
     stale.etag.wont_equal fresh.etag
-    err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::Error
+    err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::FailedPreconditionError
     err.message.must_equal "conditionNotMet: Precondition Failed"
   end
 

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -111,18 +111,25 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     err.message.must_equal "conditionNotMet: Precondition Failed"
   end
 
-  it "create dataset returns an etag that is different from get dataset" do
-    fresh_dataset_id = "#{prefix}_#{rand 100}_unique"
-    fresh = bigquery.create_dataset fresh_dataset_id
-    fresh.etag.wont_be :nil?
+  # TODO: Remove this test and restore original impl after acceptance test
+  # indicates that service etag bug is fixed
+  it "etag from get dataset is different from etag returned by Service#insert_dataset" do
+    service = bigquery.service
 
-    stale = bigquery.dataset fresh_dataset_id
-    stale.etag.wont_be :nil?
-    stale.etag.wont_equal fresh.etag
+    new_dataset_id = "#{prefix}_#{rand 100}_unique"
+    new_ds = Google::Apis::BigqueryV2::Dataset.new(
+      dataset_reference: Google::Apis::BigqueryV2::DatasetReference.new(
+        project_id: bigquery.project, dataset_id: new_dataset_id))
+
+    new_gapi = service.insert_dataset new_ds
+    new_gapi.etag.wont_be :nil?
+
+    fresh = bigquery.dataset new_dataset_id
+    fresh.etag.wont_be :nil?
+    fresh.etag.wont_equal new_gapi.etag
   end
 
   it "create dataset returns valid etag equal to get dataset" do
-    skip "the etag on create is currently different from the etag on get"
     fresh_dataset_id = "#{prefix}_#{rand 100}_unique"
     fresh = bigquery.create_dataset fresh_dataset_id
     fresh.etag.wont_be :nil?

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -132,6 +132,42 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     err.message.must_equal "conditionNotMet: Precondition Failed"
   end
 
+  it "create dataset returns valid etag equal to get dataset" do
+    fresh_table_id = "#{rand 100}_kittens"
+    fresh = dataset.create_table fresh_table_id do |schema|
+      schema.integer  "id",     description: "id description",    mode: :required
+      schema.string    "breed", description: "breed description", mode: :required
+      schema.string    "name",  description: "name description",  mode: :required
+      schema.timestamp "dob",   description: "dob description",   mode: :required
+    end
+    fresh.etag.wont_be :nil?
+
+    stale = dataset.table fresh_table_id
+    stale.etag.wont_be :nil?
+    stale.etag.must_equal fresh.etag
+  end
+
+  # TODO: Remove this test and restore original impl after acceptance test
+  # indicates that service etag bug is fixed
+
+  it "etag from get table is different from etag returned by Service#insert_table" do
+    service = bigquery.service
+    new_table_id = "#{rand 100}_kittens"
+
+    new_tb = Google::Apis::BigqueryV2::Table.new(
+      table_reference: Google::Apis::BigqueryV2::TableReference.new(
+        project_id: bigquery.project, dataset_id: dataset_id,
+        table_id: new_table_id))
+    updater = Google::Cloud::Bigquery::Table::Updater.new(new_tb)
+
+    new_gapi = service.insert_table dataset.dataset_id, updater.to_gapi
+    new_gapi.etag.wont_be :nil?
+
+    fresh = dataset.table new_table_id
+    fresh.etag.wont_be :nil?
+    fresh.etag.wont_equal new_gapi.etag
+  end
+
   it "gets and sets time partitioning" do
     partitioned_table = dataset.table "weekly_kittens"
     if partitioned_table.nil?

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -105,9 +105,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   it "gets and sets metadata" do
     new_name = "New name"
     new_desc = "New description!"
-    table.reload! # TODO: remove after fixing etag staleness after create_table
     table.name = new_name
-    table.reload! # TODO: remove after fixing etag staleness after create_table
     table.description = new_desc
 
     table.reload!
@@ -126,7 +124,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
     # Modify on the server, which will change the etag
     fresh.description = "Description 1"
-    fresh.reload! # TODO: remove after fixing etag staleness after create_table
     stale.etag.wont_equal fresh.etag
     err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::FailedPreconditionError
     err.message.must_equal "conditionNotMet: Precondition Failed"
@@ -149,7 +146,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
   # TODO: Remove this test and restore original impl after acceptance test
   # indicates that service etag bug is fixed
-
   it "etag from get table is different from etag returned by Service#insert_table" do
     service = bigquery.service
     new_table_id = "#{rand 100}_kittens"
@@ -177,7 +173,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       end
     end
 
-    partitioned_table.reload! # TODO: remove after fixing etag staleness after create_table
     partitioned_table.time_partitioning_expiration = 1
 
     partitioned_table.reload!
@@ -189,12 +184,10 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   it "updates its schema" do
     begin
       t = dataset.create_table "table_schema_test"
-      t.reload! # TODO: remove after fixing etag staleness after create_table
       t.schema do |s|
         s.boolean "available", description: "available description", mode: :nullable
       end
       t.headers.must_equal [:available]
-      t.reload! # TODO: remove after fixing etag staleness after create_table
       t.schema replace: true do |s|
         s.boolean "available", description: "available description", mode: :nullable
         s.record "countries_lived", description: "countries_lived description", mode: :repeated do |nested|

--- a/google-cloud-bigquery/acceptance/bigquery/view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/view_test.rb
@@ -55,14 +55,11 @@ describe Google::Cloud::Bigquery::View, :bigquery do
   end
 
   it "gets and sets attributes" do
-    view.reload! # TODO: remove after fixing etag staleness after create_table
     new_name = "New name!"
     new_desc = "New description!"
 
     view.name = new_name
-    view.reload! # TODO: remove after fixing etag staleness after create_table
     view.description = new_desc
-    view.reload! # TODO: remove after fixing etag staleness after create_table
     view.query = publicdata_query_2
 
     view.reload!
@@ -82,7 +79,6 @@ describe Google::Cloud::Bigquery::View, :bigquery do
 
     # Modify on the server, which will change the etag
     fresh.description = "Description 1"
-    fresh.reload! # TODO: remove after fixing etag staleness after create_table
     stale.etag.wont_equal fresh.etag
     err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::FailedPreconditionError
     err.message.must_equal "conditionNotMet: Precondition Failed"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -373,7 +373,12 @@ module Google
           yield updater if block_given?
 
           gapi = service.insert_table dataset_id, updater.to_gapi
-          Table.from_gapi gapi, service
+
+          # TODO: restore original impl after acceptance test indicates that
+          # service etag bug is fixed
+          t = Table.from_gapi gapi, service
+          t.reload!
+          t
         end
 
         ##
@@ -435,7 +440,12 @@ module Google
           new_view = Google::Apis::BigqueryV2::Table.new new_view_opts
 
           gapi = service.insert_table dataset_id, new_view
-          Table.from_gapi gapi, service
+
+          # TODO: restore original impl after acceptance test indicates that
+          # service etag bug is fixed
+          v = Table.from_gapi gapi, service
+          v.reload!
+          v
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1088,6 +1088,7 @@ module Google
             [attr, @gapi.send(attr)]
           end]
           patch_gapi = Google::Apis::BigqueryV2::Dataset.new patch_args
+          patch_gapi.etag = etag if etag
           @gapi = service.patch_dataset dataset_id, patch_gapi
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -556,8 +556,10 @@ module Google
             updater.check_for_mutated_access!
           end
 
-          gapi = service.insert_dataset new_ds
-          Dataset.from_gapi gapi, service
+          service.insert_dataset new_ds
+          # TODO: restore original impl after acceptance test indicates that
+          # service etag bug is fixed
+          dataset dataset_id
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -98,8 +98,13 @@ module Google
         # Updates information in an existing dataset, only replacing
         # fields that are provided in the submitted dataset resource.
         def patch_dataset dataset_id, patched_dataset_gapi
+          options = {}
+          if patched_dataset_gapi.etag
+            options[:header] = { "If-Match" => patched_dataset_gapi.etag }
+          end
           execute do
-            service.patch_dataset @project, dataset_id, patched_dataset_gapi
+            service.patch_dataset @project, dataset_id, patched_dataset_gapi,
+                                  options: options
           end
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -154,9 +154,13 @@ module Google
         # Updates information in an existing table, replacing fields that
         # are provided in the submitted table resource.
         def patch_table dataset_id, table_id, patched_table_gapi
+          options = {}
+          if patched_table_gapi.etag
+            options[:header] = { "If-Match" => patched_table_gapi.etag }
+          end
           execute do
             service.patch_table @project, dataset_id, table_id,
-                                patched_table_gapi
+                                patched_table_gapi, options: options
           end
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -927,6 +927,7 @@ module Google
             [attr, @gapi.send(attr)]
           end]
           patch_gapi = Google::Apis::BigqueryV2::Table.new patch_args
+          patch_gapi.etag = etag if etag
           @gapi = service.patch_table dataset_id, table_id, patch_gapi
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -929,6 +929,10 @@ module Google
           patch_gapi = Google::Apis::BigqueryV2::Table.new patch_args
           patch_gapi.etag = etag if etag
           @gapi = service.patch_table dataset_id, table_id, patch_gapi
+
+          # TODO: restore original impl after acceptance test indicates that
+          # service etag bug is fixed
+          reload!
         end
 
         def self.class_for gapi

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -483,6 +483,7 @@ module Google
         def patch_table_gapi patch_args
           ensure_service!
           patch_gapi = Google::Apis::BigqueryV2::Table.new patch_args
+          patch_gapi.etag = etag if etag
           @gapi = service.patch_table dataset_id, table_id, patch_gapi
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -485,6 +485,10 @@ module Google
           patch_gapi = Google::Apis::BigqueryV2::Table.new patch_args
           patch_gapi.etag = etag if etag
           @gapi = service.patch_table dataset_id, table_id, patch_gapi
+
+          # TODO: restore original impl after acceptance test indicates that
+          # service etag bug is fixed
+          reload!
         end
 
         ##

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -553,7 +553,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
-      mock.expect :patch_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view", Google::Apis::BigqueryV2::Table]
+      mock.expect :patch_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view", Google::Apis::BigqueryV2::Table, Hash]
     end
   end
 

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -134,6 +134,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
   end
 
@@ -142,6 +143,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
   end
 
@@ -373,6 +375,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
     end
   end
@@ -387,6 +390,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
     end
   end
@@ -395,7 +399,8 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my-table-id", Hash]
       mock.expect :insert_all_table_data,
                   Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(insert_errors: []),
@@ -487,6 +492,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
     end
   end
@@ -514,6 +520,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
   end
 
@@ -531,6 +538,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, view_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
       mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
     end
   end

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -369,7 +369,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
     end
   end
 
@@ -383,7 +383,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
     end
   end
 
@@ -483,7 +483,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table]
+      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
     end
   end
 

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -120,7 +120,7 @@ YARD::Doctest.configure do |doctest|
       end
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
-      mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset]
+      mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset, Hash]
     end
   end
 
@@ -221,7 +221,7 @@ YARD::Doctest.configure do |doctest|
       end
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
-      mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset]
+      mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset, Hash]
     end
   end
 

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -109,6 +109,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigquery::Dataset" do
     mock_bigquery do |mock|
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
     end
   end
 
@@ -119,6 +120,7 @@ YARD::Doctest.configure do |doctest|
         "foo"
       end
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset, Hash]
     end
@@ -221,6 +223,7 @@ YARD::Doctest.configure do |doctest|
       end
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset, Hash]
     end
   end
@@ -277,6 +280,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigquery::Project#create_dataset" do
     mock_bigquery do |mock|
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
     end
   end
 

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -377,6 +377,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
   end
 
@@ -392,6 +393,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
   end
 
@@ -494,6 +496,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
   end
 
@@ -564,6 +567,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigquery::View#query=" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
       mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
       mock.expect :patch_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view", Google::Apis::BigqueryV2::Table, Hash]
     end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
@@ -31,8 +31,8 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
     updated_gapi = dataset_gapi.dup
     new_access = Google::Apis::BigqueryV2::Dataset::Access.new role: "WRITER", user_by_email: "writer@example.com"
     updated_gapi.access = new_access
-    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access]
-    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access], etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
     dataset.access.must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
     dataset.access.must_be :frozen?
@@ -62,8 +62,8 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
     updated_gapi = dataset_gapi.dup
     new_access = Google::Apis::BigqueryV2::Dataset::Access.new role: "WRITER", group_by_email: "writers@example.com"
     updated_gapi.access = new_access
-    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access]
-    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access], etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
     dataset.access do |acl|
       refute acl.writer_group? "writers@example.com"
@@ -79,8 +79,8 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
     updated_gapi = dataset_gapi.dup
     new_access = Google::Apis::BigqueryV2::Dataset::Access.new role: "OWNER", domain: "example.com"
     updated_gapi.access = new_access
-    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access]
-    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access], etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
     dataset.access do |acl|
       refute acl.owner_domain? "example.com"
@@ -96,8 +96,8 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
     updated_gapi = dataset_gapi.dup
     new_access = Google::Apis::BigqueryV2::Dataset::Access.new role: "READER", special_group: "allAuthenticatedUsers"
     updated_gapi.access = new_access
-    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access]
-    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access], etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
     dataset.access do |acl|
       refute acl.reader_special? :all
@@ -119,8 +119,8 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
       updated_gapi = dataset_gapi.dup
       new_access = Google::Apis::BigqueryV2::Dataset::Access.new view: view_gapi.table_reference
       updated_gapi.access = new_access
-      patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access]
-      mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+      patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access], etag: dataset_gapi.etag
+      mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
       dataset.access do |acl|
         acl.add_reader_view view
@@ -137,8 +137,8 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
                                                                      table_id: "test-view_id"
       new_access = Google::Apis::BigqueryV2::Dataset::Access.new view: view_reference
       updated_gapi.access = new_access
-      patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access]
-      mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+      patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access], etag: dataset_gapi.etag
+      mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
       dataset.access do |acl|
         acl.add_reader_view "test-project_id:test-dataset_id.test-view_id"
@@ -154,8 +154,8 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
     new_access = Google::Apis::BigqueryV2::Dataset::Access.new role: "WRITER", user_by_email: "writer@example.com"
     new_access_2 = Google::Apis::BigqueryV2::Dataset::Access.new role: "READER", group_by_email: "readers@example.com"
     updated_gapi.access = new_access
-    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access, new_access_2]
-    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+    patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access, new_access_2], etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
     dataset.access do |acl|
       refute acl.writer_user? "writer@example.com"
@@ -193,8 +193,8 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
       updated_gapi = dataset_gapi.dup
       new_access = Google::Apis::BigqueryV2::Dataset::Access.new role: "WRITER", user_by_email: "writer@example.com"
       updated_gapi.access = new_access
-      patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access]
-      mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+      patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access], etag: dataset_gapi.etag
+      mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
       dataset.access do |acl|
         assert acl.writer_user? "writer@example.com"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -101,8 +101,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       table_reference: Google::Apis::BigqueryV2::TableReference.new(
         project_id: project, dataset_id: dataset_id, table_id: table_id))
     return_table = create_table_gapi table_id
-    mock.expect :insert_table, return_table,
-      [project, dataset_id, insert_table]
+    mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
+    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id
@@ -125,8 +125,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     return_table = create_table_gapi table_id, table_name, table_description
     # Make sure the returning table has no schema
     return_table.update! schema: nil
-    mock.expect :insert_table, return_table,
-      [project, dataset_id, insert_table]
+    mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
+    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id,
@@ -154,8 +154,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     return_table = create_table_gapi table_id, table_name, table_description
     # Make sure the returning table has no schema
     return_table.update! schema: nil
-    mock.expect :insert_table, return_table,
-      [project, dataset_id, insert_table]
+    mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
+    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |t|
@@ -184,8 +184,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema: table_schema_gapi)
     return_table = create_table_gapi table_id, table_name, table_description
     return_table.schema = table_schema_gapi
-    mock.expect :insert_table, return_table,
-      [project, dataset_id, insert_table]
+    mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
+    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |t|
@@ -231,8 +231,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         ]))
     return_table = create_table_gapi table_id, table_name, table_description
     return_table.schema = table_schema_gapi
-    mock.expect :insert_table, return_table,
-      [project, dataset_id, insert_table]
+    mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
+    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |schema|
@@ -273,8 +273,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema: table_schema_gapi)
     return_table = create_table_gapi table_id, table_name, table_description
     return_table.schema = table_schema_gapi
-    mock.expect :insert_table, return_table,
-      [project, dataset_id, insert_table]
+    mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
+    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |t|
@@ -313,8 +313,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       )
     )
     return_view = create_view_gapi view_id, query
-    mock.expect :insert_table, return_view,
-      [project, dataset_id, insert_view]
+    mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
+    mock.expect :get_table, return_view, [project, dataset_id, view_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_view view_id, query
@@ -341,8 +341,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       )
     )
     return_view = create_view_gapi view_id, query, view_name, view_description
-    mock.expect :insert_table, return_view,
-      [project, dataset_id, insert_view]
+    mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
+    mock.expect :get_table, return_view, [project, dataset_id, view_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_view view_id, query,
@@ -533,8 +533,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     found_table_id = "found_table"
 
     mock = Minitest::Mock.new
-    mock.expect :get_table, find_table_gapi(found_table_id),
-      [project, dataset_id, found_table_id]
+    mock.expect :get_table, find_table_gapi(found_table_id), [project, dataset_id, found_table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.table found_table_id

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
@@ -31,8 +31,8 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
     bigquery.service.mocked_service = mock
     updated_gapi = dataset_gapi.dup
     updated_gapi.friendly_name = new_dataset_name
-    patch_dataset_gapi = Google::Apis::BigqueryV2::Dataset.new friendly_name: new_dataset_name
-    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_dataset_gapi]
+    patch_dataset_gapi = Google::Apis::BigqueryV2::Dataset.new friendly_name: new_dataset_name, etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_dataset_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
     dataset.name.must_equal dataset_name
     dataset.description.must_equal description
@@ -53,8 +53,8 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
     bigquery.service.mocked_service = mock
     updated_gapi = dataset_gapi.dup
     updated_gapi.description = new_description
-    patch_gapi = Google::Apis::BigqueryV2::Dataset.new description: new_description
-    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+    patch_gapi = Google::Apis::BigqueryV2::Dataset.new description: new_description, etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
     dataset.name.must_equal dataset_name
     dataset.description.must_equal description
@@ -75,8 +75,8 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
     bigquery.service.mocked_service = mock
     updated_gapi = dataset_gapi.dup
     updated_gapi.default_table_expiration_ms = new_default_expiration
-    patch_gapi = Google::Apis::BigqueryV2::Dataset.new default_table_expiration_ms: new_default_expiration
-    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi]
+    patch_gapi = Google::Apis::BigqueryV2::Dataset.new default_table_expiration_ms: new_default_expiration, etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
     dataset.name.must_equal dataset_name
     dataset.description.must_equal description

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
@@ -16,18 +16,20 @@ require "helper"
 require "json"
 
 describe Google::Cloud::Bigquery::Project, :mock_bigquery do
+  let(:dataset_id) { "my_dataset" }
+
   it "creates an empty dataset" do
     mock = Minitest::Mock.new
-    created_dataset = create_dataset_gapi "my_dataset"
+    created_dataset = create_dataset_gapi dataset_id
     inserted_dataset = Google::Apis::BigqueryV2::Dataset.new(
       dataset_reference: Google::Apis::BigqueryV2::DatasetReference.new(
-        project_id: project, dataset_id: "my_dataset")
+        project_id: project, dataset_id: dataset_id)
     )
-    mock.expect :insert_dataset, created_dataset,
-      [project, inserted_dataset]
+    mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
+    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
-    dataset = bigquery.create_dataset "my_dataset"
+    dataset = bigquery.create_dataset dataset_id
 
     mock.verify
 
@@ -35,26 +37,25 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
   end
 
   it "creates a dataset with options" do
-    id = "my_dataset"
     name = "My Dataset"
     description = "This is my dataset"
     default_expiration = 999
     location = "EU"
 
     mock = Minitest::Mock.new
-    created_dataset = create_dataset_gapi id, name, description, default_expiration, location
+    created_dataset = create_dataset_gapi dataset_id, name, description, default_expiration, location
     inserted_dataset = Google::Apis::BigqueryV2::Dataset.new(
       dataset_reference: Google::Apis::BigqueryV2::DatasetReference.new(
-        project_id: project, dataset_id: "my_dataset"),
+        project_id: project, dataset_id: dataset_id),
       friendly_name: name,
       description: description,
       default_table_expiration_ms: default_expiration,
       location: location)
-    mock.expect :insert_dataset, created_dataset,
-      [project, inserted_dataset]
+    mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
+    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
-    dataset = bigquery.create_dataset id, name: name,
+    dataset = bigquery.create_dataset dataset_id, name: name,
                                       description: description,
                                       expiration: default_expiration,
                                       location: location
@@ -72,17 +73,17 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock = Minitest::Mock.new
     filled_access = [Google::Apis::BigqueryV2::Dataset::Access.new(
       role: "WRITER", user_by_email: "writers@example.com")]
-    created_dataset = create_dataset_gapi "my_dataset"
+    created_dataset = create_dataset_gapi dataset_id
     created_dataset.access = filled_access
     inserted_dataset = Google::Apis::BigqueryV2::Dataset.new(
       dataset_reference: Google::Apis::BigqueryV2::DatasetReference.new(
-        project_id: project, dataset_id: "my_dataset"),
+        project_id: project, dataset_id: dataset_id),
       access: filled_access)
-    mock.expect :insert_dataset, created_dataset,
-      [project, inserted_dataset]
+    mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
+    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
-    dataset = bigquery.create_dataset "my_dataset" do |ds|
+    dataset = bigquery.create_dataset dataset_id do |ds|
       ds.access do |acl|
         refute acl.writer_user? "writers@example.com"
         acl.add_writer_user "writers@example.com"
@@ -97,7 +98,6 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
   end
 
   it "creates a dataset with options and access rules using a block" do
-    id = "my_dataset"
     name = "My Dataset"
     description = "This is my dataset"
     default_expiration = 999
@@ -106,21 +106,21 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock = Minitest::Mock.new
     filled_access = [Google::Apis::BigqueryV2::Dataset::Access.new(
       role: "WRITER", user_by_email: "writers@example.com")]
-    created_dataset = create_dataset_gapi id, name, description, default_expiration, location
+    created_dataset = create_dataset_gapi dataset_id, name, description, default_expiration, location
     created_dataset.access = filled_access
     inserted_dataset = Google::Apis::BigqueryV2::Dataset.new(
       dataset_reference: Google::Apis::BigqueryV2::DatasetReference.new(
-        project_id: project, dataset_id: "my_dataset"),
+        project_id: project, dataset_id: dataset_id),
       friendly_name: name,
       description: description,
       default_table_expiration_ms: default_expiration,
       location: location,
       access: filled_access)
-    mock.expect :insert_dataset, created_dataset,
-      [project, inserted_dataset]
+    mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
+    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
-    dataset = bigquery.create_dataset "my_dataset", location: location do |ds|
+    dataset = bigquery.create_dataset dataset_id, location: location do |ds|
       ds.name = name
       ds.description = description
       ds.default_expiration = default_expiration
@@ -142,7 +142,6 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
   end
 
   it "creates a dataset with block options and access rules not using a block" do
-    id = "my_dataset"
     name = "My Dataset"
     description = "This is my dataset"
     default_expiration = 999
@@ -151,21 +150,21 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock = Minitest::Mock.new
     filled_access = [Google::Apis::BigqueryV2::Dataset::Access.new(
       role: "WRITER", user_by_email: "writers@example.com")]
-    created_dataset = create_dataset_gapi id, name, description, default_expiration, location
+    created_dataset = create_dataset_gapi dataset_id, name, description, default_expiration, location
     created_dataset.access = filled_access
     inserted_dataset = Google::Apis::BigqueryV2::Dataset.new(
       dataset_reference: Google::Apis::BigqueryV2::DatasetReference.new(
-        project_id: project, dataset_id: "my_dataset"),
+        project_id: project, dataset_id: dataset_id),
       friendly_name: name,
       description: description,
       default_table_expiration_ms: default_expiration,
       location: location,
       access: filled_access)
-    mock.expect :insert_dataset, created_dataset,
-      [project, inserted_dataset]
+    mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
+    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
-    dataset = bigquery.create_dataset "my_dataset", location: location do |ds|
+    dataset = bigquery.create_dataset dataset_id, location: location do |ds|
       ds.name = name
       ds.description = description
       ds.default_expiration = default_expiration

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -127,6 +127,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -156,6 +157,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
     table.schema do |schema|
@@ -176,6 +178,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -196,6 +199,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -222,6 +226,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -243,6 +248,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_next_table_gapi = Google::Apis::BigqueryV2::Table.new schema: next_schema_gapi, etag: etag
     mock.expect :patch_table, next_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_next_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
     table.schema do |schema|
@@ -282,6 +288,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: nested_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -52,6 +52,8 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_timestamp) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_timestamp_gapi }
   let(:field_record_repeated) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_record_repeated_gapi }
 
+  let(:etag) { "etag123456789" }
+
   it "gets the schema, fields, and headers" do
     table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
     table.schema.must_be :frozen?
@@ -108,7 +110,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   end
 
   it "sets a flat schema via a block with replace option true" do
-    new_schema = Google::Apis::BigqueryV2::TableSchema.new(
+    new_schema_gapi = Google::Apis::BigqueryV2::TableSchema.new(
       fields: [field_string_required_gapi,
                field_integer_gapi,
                field_float_gapi,
@@ -121,10 +123,10 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
 
     mock = Minitest::Mock.new
     returned_table_gapi = table_gapi.dup
-    returned_table_gapi.schema = new_schema
-    patch_table_gapi = Google::Apis::BigqueryV2::Table.new(schema: new_schema)
+    returned_table_gapi.schema = new_schema_gapi
+    patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
-      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi]
+      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -151,9 +153,9 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     new_schema_gapi.fields << end_date_timestamp_gapi
     returned_table_gapi = table_gapi.dup
     returned_table_gapi.schema = new_schema_gapi
-    patch_table_gapi = Google::Apis::BigqueryV2::Table.new(schema: new_schema_gapi)
+    patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
-      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi]
+      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.schema do |schema|
@@ -171,9 +173,9 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       fields: [field_timestamp_gapi])
     returned_table_gapi = table_gapi.dup
     returned_table_gapi.schema = new_schema_gapi
-    patch_table_gapi = Google::Apis::BigqueryV2::Table.new(schema: new_schema_gapi)
+    patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
-      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi]
+      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -191,9 +193,9 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       fields: [field_string_required_gapi, field_record_repeated_gapi])
     returned_table_gapi = table_gapi.dup
     returned_table_gapi.schema = new_schema_gapi
-    patch_table_gapi = Google::Apis::BigqueryV2::Table.new(schema: new_schema_gapi)
+    patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
-      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi]
+      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -217,9 +219,9 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       fields: [field_string_required_gapi, field_record_repeated_gapi])
     returned_table_gapi = table_gapi.dup
     returned_table_gapi.schema = new_schema_gapi
-    patch_table_gapi = Google::Apis::BigqueryV2::Table.new(schema: new_schema_gapi)
+    patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
-      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi]
+      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -233,12 +235,14 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     mock.verify
 
     next_schema_gapi = Google::Apis::BigqueryV2::TableSchema.new(
-      fields: [field_string_required_gapi, Google::Apis::BigqueryV2::TableFieldSchema.new(name: "cities_lived", type: "RECORD", mode: "REPEATED", description: nil, fields: [ field_integer_gapi, field_timestamp_gapi, field_string_required_gapi ])])
+      fields: [field_string_required_gapi, Google::Apis::BigqueryV2::TableFieldSchema.new(name: "cities_lived", type: "RECORD", mode: "REPEATED", description: nil, fields: [ field_integer_gapi, field_timestamp_gapi, field_string_required_gapi ])],
+      etag: etag
+    )
     next_table_gapi = table_gapi.dup
     next_table_gapi.schema = next_schema_gapi
-    patch_next_table_gapi = Google::Apis::BigqueryV2::Table.new(schema: next_schema_gapi)
+    patch_next_table_gapi = Google::Apis::BigqueryV2::Table.new schema: next_schema_gapi, etag: etag
     mock.expect :patch_table, next_table_gapi,
-      [table.project_id, table.dataset_id, table.table_id, patch_next_table_gapi]
+      [table.project_id, table.dataset_id, table.table_id, patch_next_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.schema do |schema|
@@ -275,9 +279,9 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     nested_schema_gapi = Google::Apis::BigqueryV2::TableSchema.from_json nested_schema_hash.to_json
     returned_table_gapi = table_gapi.dup
     returned_table_gapi.schema = nested_schema_gapi
-    patch_table_gapi = Google::Apis::BigqueryV2::Table.new(schema: nested_schema_gapi)
+    patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: nested_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
-      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi]
+      [table.project_id, table.dataset_id, table.table_id, patch_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -24,15 +24,16 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
                                                   bigquery.service }
 
   let(:schema) { table.schema.dup }
+  let(:etag) { "etag123456789" }
 
   it "updates its name" do
     new_table_name = "My Updated Table"
 
     mock = Minitest::Mock.new
     table_hash = random_table_hash dataset_id, table_id, new_table_name, description
-    request_table_gapi = Google::Apis::BigqueryV2::Table.new friendly_name: "My Updated Table"
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new friendly_name: "My Updated Table", etag: etag
     mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
-      [project, dataset_id, table_id, request_table_gapi]
+      [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.name.must_equal table_name
@@ -57,9 +58,9 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
 
     mock = Minitest::Mock.new
     table_hash = random_table_hash dataset_id, table_id, table_name, new_description
-    request_table_gapi = Google::Apis::BigqueryV2::Table.new description: "This is my updated table"
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new description: "This is my updated table", etag: etag
     mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
-      [project, dataset_id, table_id, request_table_gapi]
+      [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.name.must_equal table_name
@@ -88,9 +89,9 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
         "type"  => type,
     }
     partitioning = Google::Apis::BigqueryV2::TimePartitioning.new type: type
-    request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
     mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
-      [project, dataset_id, table_id, request_table_gapi]
+      [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.name.must_equal table_name
@@ -120,9 +121,9 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
         "expirationMs" => expiration_ms,
     }
     partitioning = Google::Apis::BigqueryV2::TimePartitioning.new expiration_ms: expiration_ms
-    request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
     mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
-      [project, dataset_id, table_id, request_table_gapi]
+      [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
     table.service.mocked_service = mock
 
     table.name.must_equal table_name

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -32,8 +32,10 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock = Minitest::Mock.new
     table_hash = random_table_hash dataset_id, table_id, new_table_name, description
     request_table_gapi = Google::Apis::BigqueryV2::Table.new friendly_name: "My Updated Table", etag: etag
-    mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
+    mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
+
     table.service.mocked_service = mock
 
     table.name.must_equal table_name
@@ -59,8 +61,9 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock = Minitest::Mock.new
     table_hash = random_table_hash dataset_id, table_id, table_name, new_description
     request_table_gapi = Google::Apis::BigqueryV2::Table.new description: "This is my updated table", etag: etag
-    mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
+    mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
     table.name.must_equal table_name
@@ -90,8 +93,9 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     }
     partitioning = Google::Apis::BigqueryV2::TimePartitioning.new type: type
     request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
-    mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
+    mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
     table.name.must_equal table_name
@@ -122,8 +126,9 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     }
     partitioning = Google::Apis::BigqueryV2::TimePartitioning.new expiration_ms: expiration_ms
     request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
-    mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json),
+    mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
     table.service.mocked_service = mock
 
     table.name.must_equal table_name
@@ -141,6 +146,10 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.time_partitioning_expiration.must_equal expiration
 
     mock.verify
+  end
+
+  def return_table table_hash
+    Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json)
   end
 
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
@@ -34,8 +34,9 @@ describe Google::Cloud::Bigquery::View, :update, :mock_bigquery do
     mock = Minitest::Mock.new
     view_hash = random_view_hash dataset_id, table_id, new_table_name, description
     request_view_gapi = Google::Apis::BigqueryV2::Table.new friendly_name: "My Updated View", etag: etag
-    mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(view_hash.to_json),
+    mock.expect :patch_table, return_view(view_hash),
       [project, dataset_id, table_id, request_view_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_view(view_hash), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
     view.name.must_equal table_name
@@ -57,8 +58,9 @@ describe Google::Cloud::Bigquery::View, :update, :mock_bigquery do
     mock = Minitest::Mock.new
     view_hash = random_view_hash dataset_id, table_id, table_name, new_description
     request_view_gapi = Google::Apis::BigqueryV2::Table.new description: "This is my updated view", etag: etag
-    mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(view_hash.to_json),
+    mock.expect :patch_table, return_view(view_hash),
       [project, dataset_id, table_id, request_view_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_view(view_hash), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
     view.name.must_equal table_name
@@ -86,8 +88,9 @@ describe Google::Cloud::Bigquery::View, :update, :mock_bigquery do
       ),
       etag: etag
     )
-    mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(view_hash.to_json),
+    mock.expect :patch_table, return_view(view_hash),
       [project, dataset_id, table_id, request_view_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_view(view_hash), [project, dataset_id, table_id]
     view.service.mocked_service = mock
 
     view.name.must_equal table_name
@@ -102,5 +105,9 @@ describe Google::Cloud::Bigquery::View, :update, :mock_bigquery do
     view.query.must_equal new_query
 
     mock.verify
+  end
+
+  def return_view view_hash
+    Google::Apis::BigqueryV2::Table.from_json(view_hash.to_json)
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
@@ -26,15 +26,16 @@ describe Google::Cloud::Bigquery::View, :update, :mock_bigquery do
 
 
   let(:schema) { view.schema.dup }
+  let(:etag) { "etag123456789" }
 
   it "updates its name" do
     new_table_name = "My Updated View"
 
     mock = Minitest::Mock.new
     view_hash = random_view_hash dataset_id, table_id, new_table_name, description
-    request_view_gapi = Google::Apis::BigqueryV2::Table.new friendly_name: "My Updated View"
+    request_view_gapi = Google::Apis::BigqueryV2::Table.new friendly_name: "My Updated View", etag: etag
     mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(view_hash.to_json),
-      [project, dataset_id, table_id, request_view_gapi]
+      [project, dataset_id, table_id, request_view_gapi, {options: {header: {"If-Match" => etag}}}]
     view.service.mocked_service = mock
 
     view.name.must_equal table_name
@@ -55,9 +56,9 @@ describe Google::Cloud::Bigquery::View, :update, :mock_bigquery do
 
     mock = Minitest::Mock.new
     view_hash = random_view_hash dataset_id, table_id, table_name, new_description
-    request_view_gapi = Google::Apis::BigqueryV2::Table.new description: "This is my updated view"
+    request_view_gapi = Google::Apis::BigqueryV2::Table.new description: "This is my updated view", etag: etag
     mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(view_hash.to_json),
-      [project, dataset_id, table_id, request_view_gapi]
+      [project, dataset_id, table_id, request_view_gapi, {options: {header: {"If-Match" => etag}}}]
     view.service.mocked_service = mock
 
     view.name.must_equal table_name
@@ -82,10 +83,11 @@ describe Google::Cloud::Bigquery::View, :update, :mock_bigquery do
     request_view_gapi = Google::Apis::BigqueryV2::Table.new(
       view: Google::Apis::BigqueryV2::ViewDefinition.new(
         query: new_query
-      )
+      ),
+      etag: etag
     )
     mock.expect :patch_table, Google::Apis::BigqueryV2::Table.from_json(view_hash.to_json),
-      [project, dataset_id, table_id, request_view_gapi]
+      [project, dataset_id, table_id, request_view_gapi, {options: {header: {"If-Match" => etag}}}]
     view.service.mocked_service = mock
 
     view.name.must_equal table_name

--- a/google-cloud-core/lib/google/cloud/errors.rb
+++ b/google-cloud-core/lib/google/cloud/errors.rb
@@ -50,6 +50,7 @@ module Google
           403 => PermissionDeniedError,
           404 => NotFoundError,
           409 => AlreadyExistsError, # AbortedError
+          412 => FailedPreconditionError,
           429 => ResourceExhaustedError,
           499 => CanceledError,
           500 => InternalError, # UnknownError/DataLossError

--- a/google-cloud-core/test/google/cloud/errors/gapi_errors_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/gapi_errors_test.rb
@@ -70,6 +70,11 @@ describe Google::Cloud::Error, :gapi do
     mapped_error.must_be_kind_of Google::Cloud::Error
   end
 
+  it "identifies FailedPreconditionError" do
+    mapped_error = Google::Cloud::Error.from_error gapi_error("conditionNotMet", 412)
+    mapped_error.must_be_kind_of Google::Cloud::FailedPreconditionError
+  end
+
   it "identifies ResourceExhaustedError" do
     mapped_error = Google::Cloud::Error.from_error gapi_error("exhausted", 429)
     mapped_error.must_be_kind_of Google::Cloud::ResourceExhaustedError


### PR DESCRIPTION
This PR sends the `If-Match` header with the current ETag value on the client for every update to Dataset and Table. The use of the ETag is transparent, but not optional. If the local ETag value does not match the ETag value on the service, a `FailedPreconditionError` will be raised.

The final 3 commits of the PR also add additional RPC `get` calls to load valid ETag values, due to unusual behavior in the service. See discussion on #1629 for details.

[closes #1629, closes #1630]