### PR TITLE
Fix sinatra integration test app

### DIFF
--- a/integration/sinatra1_app/app.rb
+++ b/integration/sinatra1_app/app.rb
@@ -32,10 +32,9 @@ use Google::Cloud::Trace::Middleware
 
 
 # Set :raise_errors to expose error message in production environment
-set :raise_errors, true
+set :raise_errors, false
 set :bind, "0.0.0.0"
 set :port, 8080
-
 
 get '/' do
   "google-cloud-ruby classic sinatra app up and running"
@@ -71,9 +70,19 @@ get '/test_debugger' do
   "breakpoint triggered"
 end
 
+# Sinatra error handling code randomly fails with Runtime Error. Monkey patch
+# the bad method.
+settings.define_singleton_method :use_code? do
+  false
+end
+
 get '/test_error_reporting' do
   error_toke = params[:token]
   raise StandardError, "Test error from sinatra classic: #{error_toke}"
+end
+
+error 500 do
+  'Error message -> ' +  @env['sinatra.error'].message
 end
 
 get '/test_logging' do


### PR DESCRIPTION
Integration tests are now failing again on Sinatra code. Monkey patch the bad code in the test app.