### PR TITLE
Fix debugger acceptance tests and error reporting integration tests

### DIFF
--- a/google-cloud-debugger/acceptance/debugger_helper.rb
+++ b/google-cloud-debugger/acceptance/debugger_helper.rb
@@ -59,7 +59,7 @@ module Acceptance
     ##
     # Create a test gRPC Snappoing
     def sample_snappoint
-      file_path = File.expand_path __FILE__
+      file_path = "acceptance/debugger_helper.rb"
       line = method(:trigger_breakpoint).source_location.last + 2
 
       breakpoint_hash = {
@@ -80,7 +80,7 @@ module Acceptance
     ##
     # Create a test gRPC logpoint
     def sample_logpoint token = nil
-      file_path = File.expand_path __FILE__
+      file_path = "acceptance/debugger_helper.rb"
       line = method(:trigger_breakpoint).source_location.last + 2
 
       breakpoint_hash = {

--- a/integration/sinatra1_app/app.rb
+++ b/integration/sinatra1_app/app.rb
@@ -32,7 +32,7 @@ use Google::Cloud::Trace::Middleware
 
 
 # Set :raise_errors to expose error message in production environment
-set :raise_errors, false
+set :raise_errors, true
 set :bind, "0.0.0.0"
 set :port, 8080
 
@@ -79,10 +79,6 @@ end
 get '/test_error_reporting' do
   error_toke = params[:token]
   raise StandardError, "Test error from sinatra classic: #{error_toke}"
-end
-
-error 500 do
-  'Error message -> ' +  @env['sinatra.error'].message
 end
 
 get '/test_logging' do


### PR DESCRIPTION
Fix debugger acceptance tests, which were broken by #1669.

Also putting in another attempt to fix the integration test failure on error reporting endpoint. 