### PR TITLE
Fix 'no implicit conversion of nil into String' error from tracer

### DIFF
--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
@@ -50,6 +50,8 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     Google::Cloud::Debugger::Breakpoint.new "8", breakpoint_path, 82 }
   let(:breakpoint9) {
     Google::Cloud::Debugger::Breakpoint.new "9", breakpoint_path, 89 }
+  let(:breakpoint10) {
+    Google::Cloud::Debugger::Breakpoint.new "10", breakpoint_path, 97 }
 
   it "catches breakpoint from function call" do
     hit = false
@@ -246,5 +248,16 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
     end
 
     hit.must_equal true
+  end
+
+  it "doesn't raise error when tracing dynamically defined methods" do
+    breakpoint_manager.update_breakpoints [breakpoint10]
+    tracer = debugger.agent.tracer
+
+    tracer.stub :breakpoints_hit, nil do
+      tracer.start
+      dynamic_define_method.must_equal 42
+      tracer.stop
+    end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper.rb
@@ -88,3 +88,11 @@ def tracer_test_func7
   tracer_distraction_method3
   true
 end
+
+def dynamic_define_method
+  eval "def foo1; 6 * 7; end"
+  eval "def foo2; foo1; end"
+
+  result = foo2
+  result
+end

--- a/integration/sinatra1_app/app.rb
+++ b/integration/sinatra1_app/app.rb
@@ -70,12 +70,6 @@ get '/test_debugger' do
   "breakpoint triggered"
 end
 
-# Sinatra error handling code randomly fails with Runtime Error. Monkey patch
-# the bad method.
-settings.define_singleton_method :use_code? do
-  false
-end
-
 get '/test_error_reporting' do
   error_toke = params[:token]
   raise StandardError, "Test error from sinatra classic: #{error_toke}"


### PR DESCRIPTION
PR #1660 and #1673 changed Debugger tracer to always use absolute file path for tracing breakpoints. But apparently dynamically defined methods don't have absolute file paths. So the tracer may break with "no implicit conversion of nil into String". This PR puts checks in tracer to handle this case, and adds test for it.