### PR TITLE
Improve Debugger expression UX on ActiveRecord

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -107,6 +107,7 @@ module Google
             Complex,
             FalseClass,
             Float,
+            Integer,
             MatchData,
             NilClass,
             Numeric,
@@ -120,7 +121,7 @@ module Google
             Enumerable,
             Math
           ].concat(
-            RUBY_VERSION.to_f >= 2.4 ? [Integer] : [Bignum, Fixnum]
+            RUBY_VERSION.to_f >= 2.4 ? [] : [Bignum, Fixnum]
           ).freeze
 
           ##
@@ -1006,10 +1007,10 @@ module Google
       # @private Custom error type used to identify evaluation error during
       # breakpoint expression evaluation.
       class EvaluationError < StandardError
-        UNKNOWN_CAUSE = Object.new.freeze
-        PROHIBITED_YARV = Object.new.freeze
-        PROHIBITED_C_FUNC = Object.new.freeze
-        META_PROGRAMMING = Object.new.freeze
+        UNKNOWN_CAUSE = :unknown_cause
+        PROHIBITED_YARV = :prohibited_yarv
+        PROHIBITED_C_FUNC = :prohibited_c_func
+        META_PROGRAMMING = :meta_programming
 
         attr_reader :mutation_cause
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -938,7 +938,7 @@ module Google
               begin
                 meth = receiver.method mid
               rescue
-                fail Google::Cloud::Debugger::EvaluationError.new(
+                raise Google::Cloud::Debugger::EvaluationError.new(
                   PROHIBITED_OPERATION_MSG,
                   Google::Cloud::Debugger::EvaluationError::META_PROGRAMMING)
               end

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -934,7 +934,15 @@ module Google
             #   Otherwise raise Google::Cloud::Debugger::MutationError error.
             #
             def trace_func_callback receiver, mid
-              meth = receiver.method mid
+              meth = nil
+              begin
+                meth = receiver.method mid
+              rescue
+                fail Google::Cloud::Debugger::EvaluationError.new(
+                  PROHIBITED_OPERATION_MSG,
+                  Google::Cloud::Debugger::EvaluationError::META_PROGRAMMING)
+              end
+
               yarv_instructions = RubyVM::InstructionSequence.disasm meth
 
               return if immutable_yarv_instructions?(yarv_instructions,
@@ -1001,6 +1009,7 @@ module Google
         UNKNOWN_CAUSE = Object.new.freeze
         PROHIBITED_YARV = Object.new.freeze
         PROHIBITED_C_FUNC = Object.new.freeze
+        META_PROGRAMMING = Object.new.freeze
 
         attr_reader :mutation_cause
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -197,11 +197,11 @@ module Google
           # @example Custom compound variable conversion
           #   foo = Foo.new(a: 1.0, b: [])
           #   foo.inspect  #=> "#<Foo:0xXXXXXX @a=1.0, @b=[]>"
-          #   var_table = Google::Cloud::Debugger::Breakpoint::VariableTable.new
           #   var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var \
           #           foo, name: "foo"
           #   var.name  #=> "foo"
           #   var.type  #=> "Foo"
+          #   var.inspect #=> ""
           #   var.members[0].name  #=> "@a"
           #   var.members[0].value #=> "1.0"
           #   var.members[0].type  #=> "Float"

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -103,7 +103,7 @@ module Google
 
           ##
           # @private Error message when variable can't be converted.
-          FAIL_CONVERSION_MSG = "Error: Variable couldn't be evaluated."
+          FAIL_CONVERSION_MSG = "Error: Unable to inspect value"
 
           ##
           # @private Name of the variable, if any.


### PR DESCRIPTION
This PR makes two improvements on how Debugger handles user defined expressions on complex components such as ActiveRecord.
~~* ActiveRecord defines a very complex `#inspect` method that can actually make db queries, which is really dangerous during snapshot evaluation. So now we wraps all user defined expressions' `#inspect` calls with readonly evaluation trace, so custom `#inspect` calls with mutation behaviors will be blocked. Down side is that expression evaluation on complex data structure becomes significantly slower.~~
* ActiveRecord's attribute accessing methods are defined using super complex meta programming (that breaks the fundamental principles of OOP). It manages to trigger Ruby function trace callback with a method ID on a receiver that doesn't have that method defined. So I added a guard to gracefully handle complex methods like this that be traced.

EDIT: After discussion with @dazuma, we decided to allow `#inspect` method to be called unguarded on user defined expressions.