### PR TITLE
Update BigQuery #create_dataset, #create_table and #create_view

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -115,24 +115,6 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     err.message.must_equal "conditionNotMet: Precondition Failed"
   end
 
-  # TODO: Remove this test and restore original impl after acceptance test
-  # indicates that service etag bug is fixed
-  it "etag from get dataset is different from etag returned by Service#insert_dataset" do
-    service = bigquery.service
-
-    new_dataset_id = "#{prefix}_#{rand 100}_unique"
-    new_ds = Google::Apis::BigqueryV2::Dataset.new(
-      dataset_reference: Google::Apis::BigqueryV2::DatasetReference.new(
-        project_id: bigquery.project, dataset_id: new_dataset_id))
-
-    new_gapi = service.insert_dataset new_ds
-    new_gapi.etag.wont_be :nil?
-
-    fresh = bigquery.dataset new_dataset_id
-    fresh.etag.wont_be :nil?
-    fresh.etag.wont_equal new_gapi.etag
-  end
-
   it "create dataset returns valid etag equal to get dataset" do
     fresh_dataset_id = "#{prefix}_#{rand 100}_unique"
     fresh = bigquery.create_dataset fresh_dataset_id

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -150,26 +150,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     stale.etag.must_equal fresh.etag
   end
 
-  # TODO: Remove this test and restore original impl after acceptance test
-  # indicates that service etag bug is fixed
-  it "etag from get table is different from etag returned by Service#insert_table" do
-    service = bigquery.service
-    new_table_id = "#{rand 100}_kittens"
-
-    new_tb = Google::Apis::BigqueryV2::Table.new(
-      table_reference: Google::Apis::BigqueryV2::TableReference.new(
-        project_id: bigquery.project, dataset_id: dataset_id,
-        table_id: new_table_id))
-    updater = Google::Cloud::Bigquery::Table::Updater.new(new_tb)
-
-    new_gapi = service.insert_table dataset.dataset_id, updater.to_gapi
-    new_gapi.etag.wont_be :nil?
-
-    fresh = dataset.table new_table_id
-    fresh.etag.wont_be :nil?
-    fresh.etag.wont_equal new_gapi.etag
-  end
-
   it "gets and sets time partitioning" do
     partitioned_table = dataset.table "weekly_kittens"
     if partitioned_table.nil?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -401,12 +401,7 @@ module Google
           yield updater if block_given?
 
           gapi = service.insert_table dataset_id, updater.to_gapi
-
-          # TODO: restore original impl after acceptance test indicates that
-          # service etag bug is fixed
-          t = Table.from_gapi gapi, service
-          t.reload!
-          t
+          Table.from_gapi gapi, service
         end
 
         ##
@@ -468,12 +463,7 @@ module Google
           new_view = Google::Apis::BigqueryV2::Table.new new_view_opts
 
           gapi = service.insert_table dataset_id, new_view
-
-          # TODO: restore original impl after acceptance test indicates that
-          # service etag bug is fixed
-          v = Table.from_gapi gapi, service
-          v.reload!
-          v
+          Table.from_gapi gapi, service
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -556,10 +556,8 @@ module Google
             updater.check_for_mutated_access!
           end
 
-          service.insert_dataset new_ds
-          # TODO: restore original impl after acceptance test indicates that
-          # service etag bug is fixed
-          dataset dataset_id
+          gapi = service.insert_dataset new_ds
+          Dataset.from_gapi gapi, service
         end
 
         ##

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -109,7 +109,6 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigquery::Dataset" do
     mock_bigquery do |mock|
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
-      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
     end
   end
 
@@ -120,7 +119,6 @@ YARD::Doctest.configure do |doctest|
         "foo"
       end
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
-      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset, Hash]
     end
@@ -134,7 +132,6 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
   end
 
@@ -143,7 +140,6 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
   end
 
@@ -225,7 +221,6 @@ YARD::Doctest.configure do |doctest|
       end
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
-      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset, Hash]
     end
   end
@@ -282,7 +277,6 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigquery::Project#create_dataset" do
     mock_bigquery do |mock|
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
-      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
     end
   end
 
@@ -375,7 +369,6 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
@@ -391,7 +384,6 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
@@ -401,7 +393,6 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my-table-id", Hash]
       mock.expect :insert_all_table_data,
@@ -494,7 +485,6 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
       mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
@@ -523,7 +513,6 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
     end
   end
 
@@ -541,7 +530,6 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, view_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
       mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
     end
   end
@@ -568,8 +556,8 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
-      mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
       mock.expect :patch_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
     end
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -105,7 +105,6 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         project_id: project, dataset_id: dataset_id, table_id: table_id))
     return_table = create_table_gapi table_id
     mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
-    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id
@@ -129,7 +128,6 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     # Make sure the returning table has no schema
     return_table.update! schema: nil
     mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
-    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id,
@@ -158,7 +156,6 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     # Make sure the returning table has no schema
     return_table.update! schema: nil
     mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
-    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |t|
@@ -188,7 +185,6 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     return_table = create_table_gapi table_id, table_name, table_description
     return_table.schema = table_schema_gapi
     mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
-    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |t|
@@ -235,7 +231,6 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     return_table = create_table_gapi table_id, table_name, table_description
     return_table.schema = table_schema_gapi
     mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
-    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |schema|
@@ -277,7 +272,6 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     return_table = create_table_gapi table_id, table_name, table_description
     return_table.schema = table_schema_gapi
     mock.expect :insert_table, return_table, [project, dataset_id, insert_table]
-    mock.expect :get_table, return_table, [project, dataset_id, table_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |t|
@@ -317,7 +311,6 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     )
     return_view = create_view_gapi view_id, query
     mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
-    mock.expect :get_table, return_view, [project, dataset_id, view_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_view view_id, query
@@ -345,7 +338,6 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     )
     return_view = create_view_gapi view_id, query, view_name, view_description
     mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
-    mock.expect :get_table, return_view, [project, dataset_id, view_id]
     dataset.service.mocked_service = mock
 
     table = dataset.create_view view_id, query,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
@@ -27,7 +27,6 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
         project_id: project, dataset_id: dataset_id)
     )
     mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
-    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
     dataset = bigquery.create_dataset dataset_id
@@ -53,7 +52,6 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
       default_table_expiration_ms: default_expiration,
       location: location)
     mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
-    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
     dataset = bigquery.create_dataset dataset_id, name: name,
@@ -81,7 +79,6 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
         project_id: project, dataset_id: dataset_id),
       access: filled_access)
     mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
-    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
     dataset = bigquery.create_dataset dataset_id do |ds|
@@ -120,7 +117,6 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
       location: location,
       access: filled_access)
     mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
-    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
     dataset = bigquery.create_dataset dataset_id, location: location do |ds|
@@ -166,7 +162,6 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
       location: location,
       access: filled_access)
     mock.expect :insert_dataset, created_dataset, [project, inserted_dataset]
-    mock.expect :get_dataset, created_dataset, [project, dataset_id]
     bigquery.service.mocked_service = mock
 
     dataset = bigquery.create_dataset dataset_id, location: location do |ds|


### PR DESCRIPTION
Revert the get after insert behavior as this workaround for
invalid ETag values is no longer needed.

[refs #1629]