### PR TITLE
Fix GAPIC YARD docs

### DIFF
--- a/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
@@ -56,8 +56,7 @@ module Google
             "https://www.googleapis.com/auth/cloud-platform"
           ].freeze
 
-          # @param credentials
-          #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+          # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This parameter can
           #   be many types.
           #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for


### PR DESCRIPTION
This change is needed to correct the GAPIC documentation by moving the types to the same line as the method argument. Otherwise the types will be defined as `null` in the JSON documentation files, and the angular app will puke on itself.