### PR TITLE
Print captured exceptions from child threads

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
@@ -183,6 +183,7 @@ module Google
             debuggee.revoke_registration unless sync_result
           end
         rescue => e
+          warn ["#{e.class}: #{e.message}", e.backtrace].join("\n\t")
           @last_exception = e
         end
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
@@ -98,6 +98,7 @@ module Google
           begin
             service.update_active_breakpoint agent.debuggee.id, breakpoint
           rescue => e
+            warn ["#{e.class}: #{e.message}", e.backtrace].join("\n\t")
             @last_exception = e
           end
         end

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
@@ -82,6 +82,8 @@ module Google
           begin
             error_reporting.report error_event
           rescue => e
+            warn error_event.message if error_event.message
+            warn ["#{e.class}: #{e.message}", e.backtrace].join("\n\t")
             @last_exception = e
           end
         end

--- a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
@@ -78,6 +78,7 @@ module Google
           begin
             service.patch_traces traces
           rescue => e
+            warn ["#{e.class}: #{e.message}", e.backtrace].join("\n\t")
             @last_exception = e
           end
         end

--- a/stackdriver-core/test/stackdriver/core/async_actor_test.rb
+++ b/stackdriver-core/test/stackdriver/core/async_actor_test.rb
@@ -328,6 +328,7 @@ describe Stackdriver::Core::AsyncActor do
       mock = Minitest::Mock.new
       mock.expect :async_stop!, true, []
 
+      Stackdriver::Core::AsyncActor.instance_variable_set :@cleanup_list,  nil
       Stackdriver::Core::AsyncActor.register_for_cleanup mock
       Stackdriver::Core::AsyncActor.send :run_cleanup
 


### PR DESCRIPTION
The Error Reporting, Trace, and Debugger APIs are not enabled by default on GCP projects, so the gems often appear to be broken with no errors when use on new projects. This PR changes the gems to print the captured exceptions in children threads, except in Logging, which may get too spammy if something goes wrong with Logging API.