### PR TITLE
Reduce integration tests flakiness

### DIFF
--- a/google-cloud-debugger/integration/common_debugger_test.rb
+++ b/google-cloud-debugger/integration/common_debugger_test.rb
@@ -67,7 +67,12 @@ describe Google::Cloud::Debugger, :debugger do
 
     keep_trying_till_true do
       debugger_info_json = send_request "test_debugger_info"
-      debugger_info = JSON.parse debugger_info_json
+      debugger_info =
+        begin
+          JSON.parse debugger_info_json
+        rescue
+          nil
+        end
 
       debuggee_id = debugger_info["debuggee_id"]
       agent_version = debugger_info["agent_version"]

--- a/google-cloud-logging/integration/common_logging_test.rb
+++ b/google-cloud-logging/integration/common_logging_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Logging do
     send_request "test_logging", "token=#{token}"
 
     logs = []
-    keep_trying_till_true 60 do
+    keep_trying_till_true 120 do
       stdout = Open3.capture3(
         "gcloud beta logging read \"logName=projects/#{gcloud_project_id}/logs/google-cloud-ruby_integration_test " \
         "AND textPayload:#{token}\" --limit 1 --format json"

--- a/google-cloud-logging/integration/gae/logging_test.rb
+++ b/google-cloud-logging/integration/gae/logging_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Logging do
     send_request "test_logging", "token=#{token}"
 
     logs = []
-    keep_trying_till_true 60 do
+    keep_trying_till_true 120 do
       stdout = Open3.capture3(
         "gcloud beta logging read \"logName=projects/#{gcloud_project_id}/logs/google-cloud-ruby_integration_test " \
         "AND textPayload:#{token}\" --limit 1 --format json"


### PR DESCRIPTION
Turn down Logging integration backoff.
Make Debugger integration test more resilient to GAE routing flakes