### PR TITLE
BigQuery External Tables

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
@@ -1,0 +1,78 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bigquery_helper"
+require "csv"
+
+describe Google::Cloud::Bigquery::External, :bigquery do
+  let(:dataset_id) { "#{prefix}_dataset" }
+  let(:dataset) do
+    d = bigquery.dataset dataset_id
+    if d.nil?
+      d = bigquery.create_dataset dataset_id
+    end
+    d
+  end
+  let(:data) do
+    [
+      ["id", "name", "breed"],
+      [4, "silvano", "the cat kind"],
+      [5, "ryan", "golden retriever?"],
+      [6, "stephen", "idkanycatbreeds"]
+    ]
+  end
+  let(:data_csv) { CSV.generate { |csv| data.each { |row| csv << row } } }
+  let(:data_io) { StringIO.new data_csv }
+  let(:storage) { Google::Cloud.storage }
+  let(:bucket) { Google::Cloud.storage.bucket("#{prefix}_external") || Google::Cloud.storage.create_bucket("#{prefix}_external") }
+  let(:file) { bucket.file("pets.csv") || bucket.create_file(data_io, "pets.csv") }
+
+  after do
+    bucket.files.all.map(&:delete)
+    bucket.delete
+  end
+
+  it "queries an external table (with autodetect)" do
+    ext_table = dataset.external file.to_gs_url
+    ext_table.autodetect = true
+    ext_table.skip_leading_rows = 1
+
+    data = dataset.query "SELECT * FROM pets", external: { pets: ext_table }
+    data.count.must_equal 3
+    data.must_equal [
+      { id: 4, name: "silvano", breed: "the cat kind" },
+      { id: 5, name: "ryan", breed: "golden retriever?" },
+      { id: 6, name: "stephen", breed: "idkanycatbreeds" }
+    ]
+  end
+
+  it "queries an external table (with schema)" do
+    ext_table = dataset.external file.to_gs_url do |t|
+      t.skip_leading_rows = 1
+      t.schema do |s|
+        s.integer   "id",    description: "id description",    mode: :required
+        s.string    "name",  description: "name description",  mode: :required
+        s.string    "breed", description: "breed description", mode: :required
+      end
+    end
+
+    data = dataset.query "SELECT id, name, breed FROM pets", external: { pets: ext_table }
+    data.count.must_equal 3
+    data.must_equal [
+      { id: 4, name: "silvano", breed: "the cat kind" },
+      { id: 5, name: "ryan", breed: "golden retriever?" },
+      { id: 6, name: "stephen", breed: "idkanycatbreeds" }
+    ]
+  end
+end

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -384,7 +384,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   end
 
   it "extracts data to a url in your bucket" do
-    skip "The BigQuery to Storage acceptance tests are failing with internalError"
     begin
       # Make sure there is data to extract...
       load_job = table.load local_file
@@ -400,7 +399,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       load_job.iso8859_1?.must_equal false
       load_job.quote.must_equal "\""
       load_job.max_bad_records.must_equal 0
-      load_job.quoted_newlines?.must_equal true
+      load_job.quoted_newlines?.must_equal false
       load_job.json?.must_equal true
       load_job.csv?.must_equal false
       load_job.backup?.must_equal false
@@ -446,7 +445,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   end
 
   it "extracts data to a file in your bucket" do
-    skip "The BigQuery to Storage acceptance tests are failing with internalError"
     begin
       # Make sure there is data to extract...
       load_job = table.load local_file

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
@@ -1,0 +1,2202 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/apis/bigquery_v2"
+require "base64"
+
+module Google
+  module Cloud
+    module Bigquery
+      ##
+      # # External
+      #
+      # Creates a new {External::Table} (or subclass) object that represents the
+      # external data source that can be queried from directly, even though
+      # the data is not stored in BigQuery. Instead of loading or streaming
+      # the data, this object references the external data source.
+      #
+      # See {External::Table}, {External::CsvTable}, {External::JsonTable},
+      # {External::SheetsTable}, {External::BigtableTable}
+      #
+      # @example
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #
+      #   csv_url = "gs://bucket/path/to/data.csv"
+      #   csv_table = bigquery.external csv_url do |csv|
+      #     csv.autodetect = true
+      #     csv.skip_leading_rows = 1
+      #   end
+      #
+      #   data = bigquery.query "SELECT * FROM my_ext_table",
+      #                         external: { my_ext_table: csv_table }
+      #
+      #   data.each do |row|
+      #     puts row[:name]
+      #   end
+      #
+      module External
+        ##
+        # @private New External from URLs and format
+        def self.from_urls urls, format = nil
+          external_format = source_format_for urls, format
+          if external_format.nil?
+            fail ArgumentError, "Unable to determine external table format"
+          end
+          external_class = table_class_for external_format
+          external_class.new.tap do |e|
+            e.gapi.source_uris = Array(urls)
+            e.gapi.source_format = external_format
+          end
+        end
+
+        ##
+        # @private Determine source_format from inputs
+        def self.source_format_for urls, format
+          val = { "csv"                    => "CSV",
+                  "json"                   => "NEWLINE_DELIMITED_JSON",
+                  "newline_delimited_json" => "NEWLINE_DELIMITED_JSON",
+                  "sheets"                 => "GOOGLE_SHEETS",
+                  "google_sheets"          => "GOOGLE_SHEETS",
+                  "avro"                   => "AVRO",
+                  "datastore"              => "DATASTORE_BACKUP",
+                  "backup"                 => "DATASTORE_BACKUP",
+                  "datastore_backup"       => "DATASTORE_BACKUP",
+                  "bigtable"               => "BIGTABLE"
+                }[format.to_s.downcase]
+          return val unless val.nil?
+          Array(urls).each do |url|
+            return "CSV" if url.end_with? ".csv"
+            return "NEWLINE_DELIMITED_JSON" if url.end_with? ".json"
+            return "AVRO" if url.end_with? ".avro"
+            return "DATASTORE_BACKUP" if url.end_with? ".backup_info"
+            if url.start_with? "https://docs.google.com/spreadsheets/"
+              return "GOOGLE_SHEETS"
+            end
+            if url.start_with? "https://googleapis.com/bigtable/projects/"
+              return "BIGTABLE"
+            end
+          end
+          nil
+        end
+
+        ##
+        # @private Determine table class from source_format
+        def self.table_class_for format
+          case format
+          when "CSV"                    then External::CsvTable
+          when "NEWLINE_DELIMITED_JSON" then External::JsonTable
+          when "GOOGLE_SHEETS"          then External::SheetsTable
+          when "BIGTABLE"               then External::BigtableTable
+          else
+            # AVRO and DATASTORE_BACKUP
+            External::Table
+          end
+        end
+
+        ##
+        # # Table
+        #
+        # External::Table and its subclasses represents an external data source
+        # that can be queried from directly, even though the data is not stored
+        # in BigQuery. Instead of loading or streaming the data, this object
+        # references the external data source.
+        #
+        # The AVRO and Datastore Backup formats use {External::Table}. See
+        # {External::CsvTable}, {External::JsonTable}, {External::SheetsTable},
+        # {External::BigtableTable} for the other formats.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   avro_url = "gs://bucket/path/to/data.avro"
+        #   avro_table = bigquery.external avro_url do |avro|
+        #     avro.autodetect = true
+        #   end
+        #
+        #   data = bigquery.query "SELECT * FROM my_ext_table",
+        #                         external: { my_ext_table: avro_table }
+        #
+        #   data.each do |row|
+        #     puts row[:name]
+        #   end
+        #
+        class Table
+          ##
+          # @private The Google API Client object.
+          attr_accessor :gapi
+
+          ##
+          # @private Create an empty Table object.
+          def initialize
+            @gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new
+          end
+
+          ##
+          # The data format. For CSV files, specify "CSV". For Google sheets,
+          # specify "GOOGLE_SHEETS". For newline-delimited JSON, specify
+          # "NEWLINE_DELIMITED_JSON". For Avro files, specify "AVRO". For Google
+          # Cloud Datastore backups, specify "DATASTORE_BACKUP". [Beta] For
+          # Google Cloud Bigtable, specify "BIGTABLE".
+          #
+          # @return [String]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url
+          #
+          #   csv_table.format #=> "CSV"
+          #
+          def format
+            @gapi.source_format
+          end
+
+          ##
+          # Whether the data format is "CSV".
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url
+          #
+          #   csv_table.format #=> "CSV"
+          #   csv_table.csv? #=> true
+          #
+          def csv?
+            @gapi.source_format == "CSV"
+          end
+
+          ##
+          # Whether the data format is "NEWLINE_DELIMITED_JSON".
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   json_url = "gs://bucket/path/to/data.json"
+          #   json_table = bigquery.external json_url
+          #
+          #   json_table.format #=> "NEWLINE_DELIMITED_JSON"
+          #   json_table.json? #=> true
+          #
+          def json?
+            @gapi.source_format == "NEWLINE_DELIMITED_JSON"
+          end
+
+          ##
+          # Whether the data format is "GOOGLE_SHEETS".
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   sheets_url = "https://docs.google.com/spreadsheets/d/1234567980"
+          #   sheets_table = bigquery.external sheets_url
+          #
+          #   sheets_table.format #=> "GOOGLE_SHEETS"
+          #   sheets_table.sheets? #=> true
+          #
+          def sheets?
+            @gapi.source_format == "GOOGLE_SHEETS"
+          end
+
+          ##
+          # Whether the data format is "AVRO".
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   avro_url = "gs://bucket/path/to/data.avro"
+          #   avro_table = bigquery.external avro_url
+          #
+          #   avro_table.format #=> "AVRO"
+          #   avro_table.avro? #=> true
+          #
+          def avro?
+            @gapi.source_format == "AVRO"
+          end
+
+          ##
+          # Whether the data format is "DATASTORE_BACKUP".
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   backup_url = "gs://bucket/path/to/data.backup_info"
+          #   backup_table = bigquery.external backup_url
+          #
+          #   backup_table.format #=> "DATASTORE_BACKUP"
+          #   backup_table.backup? #=> true
+          #
+          def backup?
+            @gapi.source_format == "DATASTORE_BACKUP"
+          end
+
+          ##
+          # Whether the data format is "BIGTABLE".
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+          #   bigtable_table = bigquery.external bigtable_url
+          #
+          #   bigtable_table.format #=> "BIGTABLE"
+          #   bigtable_table.bigtable? #=> true
+          #
+          def bigtable?
+            @gapi.source_format == "BIGTABLE"
+          end
+
+          ##
+          # The fully-qualified URIs that point to your data in Google Cloud.
+          # For Google Cloud Storage URIs: Each URI can contain one '*' wildcard
+          # character and it must come after the 'bucket' name. Size limits
+          # related to load jobs apply to external data sources. For Google
+          # Cloud Bigtable URIs: Exactly one URI can be specified and it has be
+          # a fully specified and valid HTTPS URL for a Google Cloud Bigtable
+          # table. For Google Cloud Datastore backups, exactly one URI can be
+          # specified, and it must end with '.backup_info'. Also, the '*'
+          # wildcard character is not allowed.
+          #
+          # @return [Array<String>]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url
+          #
+          #   csv_table.urls #=> ["gs://bucket/path/to/data.csv"]
+          #
+          def urls
+            @gapi.source_uris
+          end
+
+          ##
+          # Indicates if the schema and format options are detected
+          # automatically.
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.autodetect = true
+          #   end
+          #
+          #   csv_table.autodetect #=> true
+          #
+          def autodetect
+            @gapi.autodetect
+          end
+
+          ##
+          # Set whether to detect schema and format options automatically. Any
+          # option specified explicitly will be honored.
+          #
+          # @param [Boolean] new_autodetect New autodetect value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.autodetect = true
+          #   end
+          #
+          #   csv_table.autodetect #=> true
+          #
+          def autodetect= new_autodetect
+            @gapi.autodetect = new_autodetect
+          end
+
+          ##
+          # The compression type of the data source. Possible values include
+          # `"GZIP"` and `nil`. The default value is `nil`. This setting is
+          # ignored for Google Cloud Bigtable, Google Cloud Datastore backups
+          # and Avro formats. Optional.
+          #
+          # @return [String]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.compression = "GZIP"
+          #   end
+          #
+          #   csv_table.compression #=> "GZIP"
+          def compression
+            @gapi.compression
+          end
+
+          ##
+          # Set the compression type of the data source. Possible values include
+          # `"GZIP"` and `nil`. The default value is `nil`. This setting is
+          # ignored for Google Cloud Bigtable, Google Cloud Datastore backups
+          # and Avro formats. Optional.
+          #
+          # @param [String] new_compression New compression value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.compression = "GZIP"
+          #   end
+          #
+          #   csv_table.compression #=> "GZIP"
+          #
+          def compression= new_compression
+            @gapi.compression = new_compression
+          end
+
+          ##
+          # Indicates if BigQuery should allow extra values that are not
+          # represented in the table schema. If `true`, the extra values are
+          # ignored. If `false`, records with extra columns are treated as bad
+          # records, and if there are too many bad records, an invalid error is
+          # returned in the job result. The default value is `false`.
+          #
+          # BigQuery treats trailing columns as an extra in `CSV`, named values
+          # that don't match any column names in `JSON`. This setting is ignored
+          # for Google Cloud Bigtable, Google Cloud Datastore backups and Avro
+          # formats. Optional.
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.ignore_unknown = true
+          #   end
+          #
+          #   csv_table.ignore_unknown #=> true
+          #
+          def ignore_unknown
+            @gapi.ignore_unknown_values
+          end
+
+          ##
+          # Set whether BigQuery should allow extra values that are not
+          # represented in the table schema. If `true`, the extra values are
+          # ignored. If `false`, records with extra columns are treated as bad
+          # records, and if there are too many bad records, an invalid error is
+          # returned in the job result. The default value is `false`.
+          #
+          # BigQuery treats trailing columns as an extra in `CSV`, named values
+          # that don't match any column names in `JSON`. This setting is ignored
+          # for Google Cloud Bigtable, Google Cloud Datastore backups and Avro
+          # formats. Optional.
+          #
+          # @param [Boolean] new_ignore_unknown New ignore_unknown value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.ignore_unknown = true
+          #   end
+          #
+          #   csv_table.ignore_unknown #=> true
+          #
+          def ignore_unknown= new_ignore_unknown
+            @gapi.ignore_unknown_values = new_ignore_unknown
+          end
+
+          ##
+          # The maximum number of bad records that BigQuery can ignore when
+          # reading data. If the number of bad records exceeds this value, an
+          # invalid error is returned in the job result. The default value is 0,
+          # which requires that all records are valid. This setting is ignored
+          # for Google Cloud Bigtable, Google Cloud Datastore backups and Avro
+          # formats.
+          #
+          # @return [Integer]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.max_bad_records = 10
+          #   end
+          #
+          #   csv_table.max_bad_records #=> 10
+          #
+          def max_bad_records
+            @gapi.max_bad_records
+          end
+
+          ##
+          # Set the maximum number of bad records that BigQuery can ignore when
+          # reading data. If the number of bad records exceeds this value, an
+          # invalid error is returned in the job result. The default value is 0,
+          # which requires that all records are valid. This setting is ignored
+          # for Google Cloud Bigtable, Google Cloud Datastore backups and Avro
+          # formats.
+          #
+          # @param [Integer] new_max_bad_records New max_bad_records value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.max_bad_records = 10
+          #   end
+          #
+          #   csv_table.max_bad_records #=> 10
+          #
+          def max_bad_records= new_max_bad_records
+            @gapi.max_bad_records = new_max_bad_records
+          end
+
+          ##
+          # @private Google API Client object.
+          def to_gapi
+            @gapi
+          end
+        end
+
+        ##
+        # # CsvTable
+        #
+        # {External::CsvTable} is a subclass of {External::Table} and represents
+        # a CSV external data source that can be queried from directly, such as
+        # Google Cloud Storage or Google Drive, even though the data is not
+        # stored in BigQuery. Instead of loading or streaming the data, this
+        # object references the external data source.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   csv_url = "gs://bucket/path/to/data.csv"
+        #   csv_table = bigquery.external csv_url do |csv|
+        #     csv.autodetect = true
+        #     csv.skip_leading_rows = 1
+        #   end
+        #
+        #   data = bigquery.query "SELECT * FROM my_ext_table",
+        #                         external: { my_ext_table: csv_table }
+        #
+        #   data.each do |row|
+        #     puts row[:name]
+        #   end
+        #
+        class CsvTable < External::Table
+          ##
+          # @private Create an empty CsvTable object.
+          def initialize
+            super
+            @gapi.csv_options = Google::Apis::BigqueryV2::CsvOptions.new
+          end
+
+          ##
+          # Indicates if BigQuery should accept rows that are missing trailing
+          # optional columns.
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.jagged_rows = true
+          #   end
+          #
+          #   csv_table.jagged_rows #=> true
+          #
+          def jagged_rows
+            @gapi.csv_options.allow_jagged_rows
+          end
+
+          ##
+          # Set whether BigQuery should accept rows that are missing trailing
+          # optional columns.
+          #
+          # @param [Boolean] new_jagged_rows New jagged_rows value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.jagged_rows = true
+          #   end
+          #
+          #   csv_table.jagged_rows #=> true
+          #
+          def jagged_rows= new_jagged_rows
+            @gapi.csv_options.allow_jagged_rows = new_jagged_rows
+          end
+
+          ##
+          # Indicates if BigQuery should allow quoted data sections that contain
+          # newline characters in a CSV file.
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.quoted_newlines = true
+          #   end
+          #
+          #   csv_table.quoted_newlines #=> true
+          #
+          def quoted_newlines
+            @gapi.csv_options.allow_quoted_newlines
+          end
+
+          ##
+          # Set whether BigQuery should allow quoted data sections that contain
+          # newline characters in a CSV file.
+          #
+          # @param [Boolean] new_quoted_newlines New quoted_newlines value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.quoted_newlines = true
+          #   end
+          #
+          #   csv_table.quoted_newlines #=> true
+          #
+          def quoted_newlines= new_quoted_newlines
+            @gapi.csv_options.allow_quoted_newlines = new_quoted_newlines
+          end
+
+          ##
+          # The character encoding of the data.
+          #
+          # @return [String]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.encoding = "UTF-8"
+          #   end
+          #
+          #   csv_table.encoding #=> "UTF-8"
+          #
+          def encoding
+            @gapi.csv_options.encoding
+          end
+
+          ##
+          # Set the character encoding of the data.
+          #
+          # @param [String] new_encoding New encoding value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.encoding = "UTF-8"
+          #   end
+          #
+          #   csv_table.encoding #=> "UTF-8"
+          #
+          def encoding= new_encoding
+            @gapi.csv_options.encoding = new_encoding
+          end
+
+          ##
+          # Checks if the character encoding of the data is "UTF-8". This is the
+          # default.
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.encoding = "UTF-8"
+          #   end
+          #
+          #   csv_table.encoding #=> "UTF-8"
+          #   csv_table.utf8? #=> true
+          #
+          def utf8?
+            return true if encoding.nil?
+            encoding == "UTF-8"
+          end
+
+          ##
+          # Checks if the character encoding of the data is "ISO-8859-1".
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.encoding = "ISO-8859-1"
+          #   end
+          #
+          #   csv_table.encoding #=> "ISO-8859-1"
+          #   csv_table.iso8859_1? #=> true
+          #
+          def iso8859_1?
+            encoding == "ISO-8859-1"
+          end
+
+          ##
+          # The separator for fields in a CSV file.
+          #
+          # @return [String]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.delimiter = "|"
+          #   end
+          #
+          #   csv_table.delimiter #=> "|"
+          #
+          def delimiter
+            @gapi.csv_options.field_delimiter
+          end
+
+          ##
+          # Set the separator for fields in a CSV file.
+          #
+          # @param [String] new_delimiter New delimiter value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.delimiter = "|"
+          #   end
+          #
+          #   csv_table.delimiter #=> "|"
+          #
+          def delimiter= new_delimiter
+            @gapi.csv_options.field_delimiter = new_delimiter
+          end
+
+          ##
+          # The value that is used to quote data sections in a CSV file.
+          #
+          # @return [String]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.quote = "'"
+          #   end
+          #
+          #   csv_table.quote #=> "'"
+          #
+          def quote
+            @gapi.csv_options.quote
+          end
+
+          ##
+          # Set the value that is used to quote data sections in a CSV file.
+          #
+          # @param [String] new_quote New quote value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.quote = "'"
+          #   end
+          #
+          #   csv_table.quote #=> "'"
+          #
+          def quote= new_quote
+            @gapi.csv_options.quote = new_quote
+          end
+
+          ##
+          # The number of rows at the top of a CSV file that BigQuery will skip
+          # when reading the data.
+          #
+          # @return [Integer]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.skip_leading_rows = 1
+          #   end
+          #
+          #   csv_table.skip_leading_rows #=> 1
+          #
+          def skip_leading_rows
+            @gapi.csv_options.skip_leading_rows
+          end
+
+          ##
+          # Set the number of rows at the top of a CSV file that BigQuery will
+          # skip when reading the data.
+          #
+          # @param [Integer] row_count New skip_leading_rows value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.skip_leading_rows = 1
+          #   end
+          #
+          #   csv_table.skip_leading_rows #=> 1
+          #
+          def skip_leading_rows= row_count
+            @gapi.csv_options.skip_leading_rows = row_count
+          end
+
+          ##
+          # The schema for the data.
+          #
+          # @param [Boolean] replace Whether to replace the existing schema with
+          #   the new schema. If `true`, the fields will replace the existing
+          #   schema. If `false`, the fields will be added to the existing
+          #   schema. The default value is `false`.
+          # @yield [schema] a block for setting the schema
+          # @yieldparam [Schema] schema the object accepting the schema
+          #
+          # @return [Google::Cloud::Bigquery::Schema]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.schema do |schema|
+          #       schema.string "name", mode: :required
+          #       schema.string "email", mode: :required
+          #       schema.integer "age", mode: :required
+          #       schema.boolean "active", mode: :required
+          #     end
+          #   end
+          #
+          def schema replace: false
+            @schema ||= Schema.from_gapi @gapi.schema
+            @schema = Schema.from_gapi if replace
+            yield @schema if block_given?
+            @schema
+          end
+
+          ##
+          # Set the schema for the data.
+          #
+          # @param [Schema] new_schema The schema object.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_shema = bigquery.schema do |schema|
+          #     schema.string "name", mode: :required
+          #     schema.string "email", mode: :required
+          #     schema.integer "age", mode: :required
+          #     schema.boolean "active", mode: :required
+          #   end
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url
+          #   csv_table.schema = csv_shema
+          #
+          def schema= new_schema
+            @schema = new_schema
+          end
+
+          ##
+          # The fields of the schema.
+          #
+          def fields
+            schema.fields
+          end
+
+          ##
+          # The names of the columns in the schema.
+          #
+          def headers
+            schema.headers
+          end
+
+          ##
+          # @private Google API Client object.
+          def to_gapi
+            @gapi.schema = @schema.to_gapi if @schema
+            @gapi
+          end
+        end
+
+        ##
+        # # JsonTable
+        #
+        # {External::JsonTable} is a subclass of {External::Table} and
+        # represents a JSON external data source that can be queried from
+        # directly, such as Google Cloud Storage or Google Drive, even though
+        # the data is not stored in BigQuery. Instead of loading or streaming
+        # the data, this object references the external data source.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   json_url = "gs://bucket/path/to/data.json"
+        #   json_table = bigquery.external json_url do |json|
+        #     json.schema do |schema|
+        #       schema.string "name", mode: :required
+        #       schema.string "email", mode: :required
+        #       schema.integer "age", mode: :required
+        #       schema.boolean "active", mode: :required
+        #     end
+        #   end
+        #
+        #   data = bigquery.query "SELECT * FROM my_ext_table",
+        #                         external: { my_ext_table: json_table }
+        #
+        #   data.each do |row|
+        #     puts row[:name]
+        #   end
+        #
+        class JsonTable < External::Table
+          ##
+          # The schema for the data.
+          #
+          # @param [Boolean] replace Whether to replace the existing schema with
+          #   the new schema. If `true`, the fields will replace the existing
+          #   schema. If `false`, the fields will be added to the existing
+          #   schema. The default value is `false`.
+          # @yield [schema] a block for setting the schema
+          # @yieldparam [Schema] schema the object accepting the schema
+          #
+          # @return [Google::Cloud::Bigquery::Schema]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   json_url = "gs://bucket/path/to/data.json"
+          #   json_table = bigquery.external json_url do |json|
+          #     json.schema do |schema|
+          #       schema.string "name", mode: :required
+          #       schema.string "email", mode: :required
+          #       schema.integer "age", mode: :required
+          #       schema.boolean "active", mode: :required
+          #     end
+          #   end
+          #
+          def schema replace: false
+            @schema ||= Schema.from_gapi @gapi.schema
+            @schema = Schema.from_gapi if replace
+            yield @schema if block_given?
+            @schema
+          end
+
+          ##
+          # Set the schema for the data.
+          #
+          # @param [Schema] new_schema The schema object.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   json_shema = bigquery.schema do |schema|
+          #     schema.string "name", mode: :required
+          #     schema.string "email", mode: :required
+          #     schema.integer "age", mode: :required
+          #     schema.boolean "active", mode: :required
+          #   end
+          #
+          #   json_url = "gs://bucket/path/to/data.json"
+          #   json_table = bigquery.external json_url
+          #   json_table.schema = json_shema
+          #
+          def schema= new_schema
+            @schema = new_schema
+          end
+
+          ##
+          # The fields of the schema.
+          #
+          def fields
+            schema.fields
+          end
+
+          ##
+          # The names of the columns in the schema.
+          #
+          def headers
+            schema.headers
+          end
+
+          ##
+          # @private Google API Client object.
+          def to_gapi
+            @gapi.schema = @schema.to_gapi if @schema
+            @gapi
+          end
+        end
+
+        ##
+        # # SheetsTable
+        #
+        # {External::SheetsTable} is a subclass of {External::Table} and
+        # represents a Google Sheets external data source that can be queried
+        # from directly, even though the data is not stored in BigQuery. Instead
+        # of loading or streaming the data, this object references the external
+        # data source.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   sheets_url = "https://docs.google.com/spreadsheets/d/1234567980"
+        #   sheets_table = bigquery.external sheets_url do |sheets|
+        #     sheets.skip_leading_rows = 1
+        #   end
+        #
+        #   data = bigquery.query "SELECT * FROM my_ext_table",
+        #                         external: { my_ext_table: sheets_table }
+        #
+        #   data.each do |row|
+        #     puts row[:name]
+        #   end
+        #
+        class SheetsTable < External::Table
+          ##
+          # @private Create an empty SheetsTable object.
+          def initialize
+            super
+            @gapi.google_sheets_options = \
+              Google::Apis::BigqueryV2::GoogleSheetsOptions.new
+          end
+
+          ##
+          # The number of rows at the top of a sheet that BigQuery will skip
+          # when reading the data. The default value is `0`.
+          #
+          # This property is useful if you have header rows that should be
+          # skipped. When `autodetect` is on, behavior is the following:
+          #
+          # * `nil` - Autodetect tries to detect headers in the first row. If
+          #   they are not detected, the row is read as data. Otherwise data is
+          #   read starting from the second row.
+          # * `0` - Instructs autodetect that there are no headers and data
+          #   should be read starting from the first row.
+          # * `N > 0` - Autodetect skips `N-1` rows and tries to detect headers
+          #   in row `N`. If headers are not detected, row `N` is just skipped.
+          #   Otherwise row `N` is used to extract column names for the detected
+          #   schema.
+          #
+          # @return [Integer]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   sheets_url = "https://docs.google.com/spreadsheets/d/1234567980"
+          #   sheets_table = bigquery.external sheets_url do |sheets|
+          #     sheets.skip_leading_rows = 1
+          #   end
+          #
+          #   sheets_table.skip_leading_rows #=> 1
+          #
+          def skip_leading_rows
+            @gapi.google_sheets_options.skip_leading_rows
+          end
+
+          ##
+          # Set the number of rows at the top of a sheet that BigQuery will skip
+          # when reading the data.
+          #
+          # @param [Integer] row_count New skip_leading_rows value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   sheets_url = "https://docs.google.com/spreadsheets/d/1234567980"
+          #   sheets_table = bigquery.external sheets_url do |sheets|
+          #     sheets.skip_leading_rows = 1
+          #   end
+          #
+          #   sheets_table.skip_leading_rows #=> 1
+          #
+          def skip_leading_rows= row_count
+            @gapi.google_sheets_options.skip_leading_rows = row_count
+          end
+        end
+
+        ##
+        # # BigtableTable
+        #
+        # {External::BigtableTable} is a subclass of {External::Table} and
+        # represents a Bigtable external data source that can be queried from
+        # directly, even though the data is not stored in BigQuery. Instead of
+        # loading or streaming the data, this object references the external
+        # data source.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #
+        #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+        #   bigtable_table = bigquery.external bigtable_url do |bt|
+        #     bt.rowkey_as_string = true
+        #     bt.add_family "user" do |u|
+        #       u.add_string "name"
+        #       u.add_string "email"
+        #       u.add_integer "age"
+        #       u.add_boolean "active"
+        #     end
+        #   end
+        #
+        #   data = bigquery.query "SELECT * FROM my_ext_table",
+        #                         external: { my_ext_table: bigtable_table }
+        #
+        #   data.each do |row|
+        #     puts row[:name]
+        #   end
+        #
+        class BigtableTable < External::Table
+          ##
+          # @private Create an empty BigtableTable object.
+          def initialize
+            super
+            @gapi.bigtable_options = \
+              Google::Apis::BigqueryV2::BigtableOptions.new
+            @families = []
+          end
+
+          ##
+          # List of column families to expose in the table schema along with
+          # their types. This list restricts the column families that can be
+          # referenced in queries and specifies their value types. You can use
+          # this list to do type conversions - see
+          # {BigtableTable::ColumnFamily#type} for more details. If you leave
+          # this list empty, all column families are present in the table schema
+          # and their values are read as `BYTES`. During a query only the column
+          # families referenced in that query are read from Bigtable.
+          #
+          # @return [Array<BigtableTable::ColumnFamily>]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+          #   bigtable_table = bigquery.external bigtable_url do |bt|
+          #     bt.rowkey_as_string = true
+          #     bt.add_family "user" do |u|
+          #       u.add_string "name"
+          #       u.add_string "email"
+          #       u.add_integer "age"
+          #       u.add_boolean "active"
+          #     end
+          #   end
+          #
+          #   bigtable_table.families.count #=> 1
+          #
+          def families
+            @families
+          end
+
+          ##
+          # Add a column family to expose in the table schema along with its
+          # types. Columns belonging to the column family may also be exposed.
+          #
+          # @param [String] family_id Identifier of the column family. See
+          #   {BigtableTable::ColumnFamily#family_id}.
+          # @param [String] encoding The encoding of the values when the type is
+          #   not `STRING`. See {BigtableTable::ColumnFamily#encoding}.
+          # @param [Boolean] latest Whether only the latest version of value are
+          #   exposed for all columns in this column family. See
+          #   {BigtableTable::ColumnFamily#latest}.
+          # @param [String] type The type to convert the value in cells of this
+          #   column. See {BigtableTable::ColumnFamily#type}.
+          #
+          # @yield [family] a block for setting the family
+          # @yieldparam [BigtableTable::ColumnFamily] family the family object
+          #
+          # @return [BigtableTable::ColumnFamily]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+          #   bigtable_table = bigquery.external bigtable_url do |bt|
+          #     bt.rowkey_as_string = true
+          #     bt.add_family "user" do |u|
+          #       u.add_string "name"
+          #       u.add_string "email"
+          #       u.add_integer "age"
+          #       u.add_boolean "active"
+          #     end
+          #   end
+          #
+          def add_family family_id, encoding: nil, latest: nil, type: nil
+            fam = BigtableTable::ColumnFamily.new
+            fam.family_id = family_id
+            fam.encoding = encoding if encoding
+            fam.latest = latest if latest
+            fam.type = type if type
+            yield fam if block_given?
+            @families << fam
+            fam
+          end
+
+          ##
+          # Whether the rowkey column families will be read and converted to
+          # string. Otherwise they are read with `BYTES` type values and users
+          # need to manually cast them with `CAST` if necessary. The default
+          # value is `false`.
+          #
+          # @return [Boolean]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+          #   bigtable_table = bigquery.external bigtable_url do |bt|
+          #     bt.rowkey_as_string = true
+          #   end
+          #
+          #   bigtable_table.rowkey_as_string #=> true
+          #
+          def rowkey_as_string
+            @gapi.bigtable_options.read_rowkey_as_string
+          end
+
+          ##
+          # Set the number of rows at the top of a sheet that BigQuery will skip
+          # when reading the data.
+          #
+          # @param [Boolean] row_rowkey New rowkey_as_string value
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+          #   bigtable_table = bigquery.external bigtable_url do |bt|
+          #     bt.rowkey_as_string = true
+          #   end
+          #
+          #   bigtable_table.rowkey_as_string #=> true
+          #
+          def rowkey_as_string= row_rowkey
+            @gapi.bigtable_options.read_rowkey_as_string = row_rowkey
+          end
+
+          ##
+          # @private Google API Client object.
+          def to_gapi
+            @gapi.bigtable_options.column_families = @families.map(&:to_gapi)
+            @gapi
+          end
+
+          ##
+          # # BigtableTable::ColumnFamily
+          #
+          # A Bigtable column family used to expose in the table schema along
+          # with its types and columns.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+          #   bigtable_table = bigquery.external bigtable_url do |bt|
+          #     bt.rowkey_as_string = true
+          #     bt.add_family "user" do |u|
+          #       u.add_string "name"
+          #       u.add_string "email"
+          #       u.add_integer "age"
+          #       u.add_boolean "active"
+          #     end
+          #   end
+          #
+          #   data = bigquery.query "SELECT * FROM my_ext_table",
+          #                         external: { my_ext_table: bigtable_table }
+          #
+          #   data.each do |row|
+          #     puts row[:name]
+          #   end
+          #
+          class ColumnFamily
+            ##
+            # @private Create an empty BigtableTable::ColumnFamily object.
+            def initialize
+              @gapi = Google::Apis::BigqueryV2::BigtableColumnFamily.new
+              @columns = []
+            end
+
+            ##
+            # The encoding of the values when the type is not `STRING`.
+            #
+            # @return [String]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.encoding = "UTF-8"
+            #     end
+            #   end
+            #
+            #   bigtable_table.families[0].encoding #=> "UTF-8"
+            #
+            def encoding
+              @gapi.encoding
+            end
+
+            ##
+            # Set the encoding of the values when the type is not `STRING`.
+            # Acceptable encoding values are:
+            #
+            # * `TEXT` - indicates values are alphanumeric text strings.
+            # * `BINARY` - indicates values are encoded using HBase
+            #   `Bytes.toBytes` family of functions. This can be overridden on a
+            #   column.
+            #
+            # @param [String] new_encoding New encoding value
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.encoding = "UTF-8"
+            #     end
+            #   end
+            #
+            #   bigtable_table.families[0].encoding #=> "UTF-8"
+            #
+            def encoding= new_encoding
+              @gapi.encoding = new_encoding
+            end
+
+            ##
+            # Identifier of the column family.
+            #
+            # @return [String]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user"
+            #   end
+            #
+            #   bigtable_table.families[0].family_id #=> "user"
+            #
+            def family_id
+              @gapi.family_id
+            end
+
+            ##
+            # Set the identifier of the column family.
+            #
+            # @param [String] new_family_id New family_id value
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user"
+            #   end
+            #
+            #   bigtable_table.families[0].family_id #=> "user"
+            #   bigtable_table.families[0].family_id = "User"
+            #   bigtable_table.families[0].family_id #=> "User"
+            #
+            def family_id= new_family_id
+              @gapi.family_id = new_family_id
+            end
+
+            ##
+            # Whether only the latest version of value are exposed for all
+            # columns in this column family.
+            #
+            # @return [Boolean]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.latest = true
+            #     end
+            #   end
+            #
+            #   bigtable_table.families[0].latest #=> true
+            #
+            def latest
+              @gapi.only_read_latest
+            end
+
+            ##
+            # Set whether only the latest version of value are exposed for all
+            # columns in this column family.
+            #
+            # @param [Boolean] new_latest New latest value
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.latest = true
+            #     end
+            #   end
+            #
+            #   bigtable_table.families[0].latest #=> true
+            #
+            def latest= new_latest
+              @gapi.only_read_latest = new_latest
+            end
+
+            ##
+            # The type to convert the value in cells of this column family. The
+            # values are expected to be encoded using HBase `Bytes.toBytes`
+            # function when using the `BINARY` encoding value. The following
+            # BigQuery types are allowed:
+            #
+            # * `BYTES`
+            # * `STRING`
+            # * `INTEGER`
+            # * `FLOAT`
+            # * `BOOLEAN`
+            #
+            # Default type is `BYTES`. This can be overridden on a column.
+            #
+            # @return [String]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.type = "STRING"
+            #     end
+            #   end
+            #
+            #   bigtable_table.families[0].type #=> "STRING"
+            #
+            def type
+              @gapi.type
+            end
+
+            ##
+            # Set the type to convert the value in cells of this column family.
+            # The values are expected to be encoded using HBase `Bytes.toBytes`
+            # function when using the `BINARY` encoding value. The following
+            # BigQuery types are allowed:
+            #
+            # * `BYTES`
+            # * `STRING`
+            # * `INTEGER`
+            # * `FLOAT`
+            # * `BOOLEAN`
+            #
+            # Default type is `BYTES`. This can be overridden on a column.
+            #
+            # @param [String] new_type New type value
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.type = "STRING"
+            #     end
+            #   end
+            #
+            #   bigtable_table.families[0].type #=> "STRING"
+            #
+            def type= new_type
+              @gapi.type = new_type
+            end
+
+            ##
+            # Lists of columns that should be exposed as individual fields.
+            #
+            # @return [Array<BigtableTable::Column>]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.rowkey_as_string = true
+            #     bt.add_family "user" do |u|
+            #       u.add_string "name"
+            #       u.add_string "email"
+            #       u.add_integer "age"
+            #       u.add_boolean "active"
+            #     end
+            #   end
+            #
+            #   bigtable_table.families[0].columns.count #=> 4
+            #
+            def columns
+              @columns
+            end
+
+            ##
+            # Add a column to the column family to expose in the table schema
+            # along with its types.
+            #
+            # @param [String] qualifier Qualifier of the column. See
+            #   {BigtableTable::Column#qualifier}.
+            # @param [String] as A valid identifier to be used as the column
+            #   field name if the qualifier is not a valid BigQuery field
+            #   identifier (i.e. does not match `[a-zA-Z][a-zA-Z0-9_]*`). See
+            #   {BigtableTable::Column#field_name}.
+            # @param [String] type The type to convert the value in cells of
+            #   this column. See {BigtableTable::Column#type}. The following
+            #   BigQuery types are allowed:
+            #
+            # * `BYTES`
+            # * `STRING`
+            # * `INTEGER`
+            # * `FLOAT`
+            # * `BOOLEAN`
+            #
+            # @yield [column] a block for setting the column
+            # @yieldparam [BigtableTable::Column] column the column object
+            #
+            # @return [Array<BigtableTable::Column>]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.rowkey_as_string = true
+            #     bt.add_family "user" do |u|
+            #       u.add_column "name", type: "STRING"
+            #     end
+            #   end
+            #
+            def add_column qualifier, as: nil, type: nil
+              col = BigtableTable::Column.new
+              col.qualifier = qualifier
+              col.field_name = as if as
+              col.type = type if type
+              yield col if block_given?
+              @columns << col
+              col
+            end
+
+            ##
+            # Add a column to the column family to expose in the table schema
+            # that is specified as the `BYTES` type.
+            #
+            # @param [String] qualifier Qualifier of the column. See
+            #   {BigtableTable::Column#qualifier}.
+            # @param [String] as A valid identifier to be used as the column
+            #   field name if the qualifier is not a valid BigQuery field
+            #   identifier (i.e. does not match `[a-zA-Z][a-zA-Z0-9_]*`). See
+            #   {BigtableTable::Column#field_name}.
+            #
+            # @yield [column] a block for setting the column
+            # @yieldparam [BigtableTable::Column] column the column object
+            #
+            # @return [Array<BigtableTable::Column>]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.rowkey_as_string = true
+            #     bt.add_family "user" do |u|
+            #       u.add_bytes "avatar"
+            #     end
+            #   end
+            #
+            def add_bytes qualifier, as: nil
+              col = add_column qualifier, as: as, type: "BYTES"
+              yield col if block_given?
+              col
+            end
+
+            ##
+            # Add a column to the column family to expose in the table schema
+            # that is specified as the `STRING` type.
+            #
+            # @param [String] qualifier Qualifier of the column. See
+            #   {BigtableTable::Column#qualifier}.
+            # @param [String] as A valid identifier to be used as the column
+            #   field name if the qualifier is not a valid BigQuery field
+            #   identifier (i.e. does not match `[a-zA-Z][a-zA-Z0-9_]*`). See
+            #   {BigtableTable::Column#field_name}.
+            #
+            # @yield [column] a block for setting the column
+            # @yieldparam [BigtableTable::Column] column the column object
+            #
+            # @return [Array<BigtableTable::Column>]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.rowkey_as_string = true
+            #     bt.add_family "user" do |u|
+            #       u.add_string "name"
+            #     end
+            #   end
+            #
+            def add_string qualifier, as: nil
+              col = add_column qualifier, as: as, type: "STRING"
+              yield col if block_given?
+              col
+            end
+
+            ##
+            # Add a column to the column family to expose in the table schema
+            # that is specified as the `INTEGER` type.
+            #
+            # @param [String] qualifier Qualifier of the column. See
+            #   {BigtableTable::Column#qualifier}.
+            # @param [String] as A valid identifier to be used as the column
+            #   field name if the qualifier is not a valid BigQuery field
+            #   identifier (i.e. does not match `[a-zA-Z][a-zA-Z0-9_]*`). See
+            #   {BigtableTable::Column#field_name}.
+            #
+            # @yield [column] a block for setting the column
+            # @yieldparam [BigtableTable::Column] column the column object
+            #
+            # @return [Array<BigtableTable::Column>]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.rowkey_as_string = true
+            #     bt.add_family "user" do |u|
+            #       u.add_integer "age"
+            #     end
+            #   end
+            #
+            def add_integer qualifier, as: nil
+              col = add_column qualifier, as: as, type: "INTEGER"
+              yield col if block_given?
+              col
+            end
+
+            ##
+            # Add a column to the column family to expose in the table schema
+            # that is specified as the `FLOAT` type.
+            #
+            # @param [String] qualifier Qualifier of the column. See
+            #   {BigtableTable::Column#qualifier}.
+            # @param [String] as A valid identifier to be used as the column
+            #   field name if the qualifier is not a valid BigQuery field
+            #   identifier (i.e. does not match `[a-zA-Z][a-zA-Z0-9_]*`). See
+            #   {BigtableTable::Column#field_name}.
+            #
+            # @yield [column] a block for setting the column
+            # @yieldparam [BigtableTable::Column] column the column object
+            #
+            # @return [Array<BigtableTable::Column>]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.rowkey_as_string = true
+            #     bt.add_family "user" do |u|
+            #       u.add_float "score"
+            #     end
+            #   end
+            #
+            def add_float qualifier, as: nil
+              col = add_column qualifier, as: as, type: "FLOAT"
+              yield col if block_given?
+              col
+            end
+
+            ##
+            # Add a column to the column family to expose in the table schema
+            # that is specified as the `BOOLEAN` type.
+            #
+            # @param [String] qualifier Qualifier of the column. See
+            #   {BigtableTable::Column#qualifier}.
+            # @param [String] as A valid identifier to be used as the column
+            #   field name if the qualifier is not a valid BigQuery field
+            #   identifier (i.e. does not match `[a-zA-Z][a-zA-Z0-9_]*`). See
+            #   {BigtableTable::Column#field_name}.
+            #
+            # @yield [column] a block for setting the column
+            # @yieldparam [BigtableTable::Column] column the column object
+            #
+            # @return [Array<BigtableTable::Column>]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.rowkey_as_string = true
+            #     bt.add_family "user" do |u|
+            #       u.add_boolean "active"
+            #     end
+            #   end
+            #
+            def add_boolean qualifier, as: nil
+              col = add_column qualifier, as: as, type: "BOOLEAN"
+              yield col if block_given?
+              col
+            end
+
+            ##
+            # @private Google API Client object.
+            def to_gapi
+              @gapi.columns = @columns.map(&:to_gapi)
+              @gapi
+            end
+          end
+
+          ##
+          # # BigtableTable::Column
+          #
+          # A Bigtable column to expose in the table schema along with its
+          # types.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+          #   bigtable_table = bigquery.external bigtable_url do |bt|
+          #     bt.rowkey_as_string = true
+          #     bt.add_family "user" do |u|
+          #       u.add_string "name"
+          #       u.add_string "email"
+          #       u.add_integer "age"
+          #       u.add_boolean "active"
+          #     end
+          #   end
+          #
+          #   data = bigquery.query "SELECT * FROM my_ext_table",
+          #                         external: { my_ext_table: bigtable_table }
+          #
+          #   data.each do |row|
+          #     puts row[:name]
+          #   end
+          #
+          class Column
+            ##
+            # @private Create an empty BigtableTable::Column object.
+            def initialize
+              @gapi = Google::Apis::BigqueryV2::BigtableColumn.new
+            end
+
+            ##
+            # Qualifier of the column. Columns in the parent column family that
+            # has this exact qualifier are exposed as `.` field. If the
+            # qualifier is valid UTF-8 string, it will be represented as a UTF-8
+            # string. Otherwise, it will represented as a ASCII-8BIT string.
+            #
+            # If the qualifier is not a valid BigQuery field identifier (does
+            # not match `[a-zA-Z][a-zA-Z0-9_]*`) a valid identifier must be
+            # provided as `field_name`.
+            #
+            # @return [String]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_string "name" do |col|
+            #         col.qualifier # "user"
+            #         col.qualifier = "User"
+            #         col.qualifier # "User"
+            #       end
+            #     end
+            #   end
+            #
+            def qualifier
+              @gapi.qualifier_string || \
+                Base64.strict_decode64(@gapi.qualifier_encoded.to_s)
+            end
+
+            ##
+            # Set the qualifier of the column. Columns in the parent column
+            # family that has this exact qualifier are exposed as `.` field.
+            # Values that are valid UTF-8 strings will be treated as such. All
+            # other values will be treated as `BINARY`.
+            #
+            # @param [String] new_qualifier New qualifier value
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_string "name" do |col|
+            #         col.qualifier # "user"
+            #         col.qualifier = "User"
+            #         col.qualifier # "User"
+            #       end
+            #     end
+            #   end
+            #
+            def qualifier= new_qualifier
+              fail ArgumentError if new_qualifier.nil?
+
+              utf8_qualifier = new_qualifier.encode Encoding::UTF_8
+              if utf8_qualifier.valid_encoding?
+                @gapi.qualifier_string = utf8_qualifier
+                if @gapi.instance_variables.include? :@qualifier_encoded
+                  @gapi.remove_instance_variable :@qualifier_encoded
+                end
+              else
+                @gapi.qualifier_encoded = Base64.strict_encode64 new_qualifier
+                if @gapi.instance_variables.include? :@qualifier_string
+                  @gapi.remove_instance_variable :@qualifier_string
+                end
+              end
+            rescue EncodingError
+              @gapi.qualifier_encoded = Base64.strict_encode64 new_qualifier
+              if @gapi.instance_variables.include? :@qualifier_string
+                @gapi.remove_instance_variable :@qualifier_string
+              end
+            end
+
+            ##
+            # The encoding of the values when the type is not `STRING`.
+            #
+            # @return [String]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_bytes "name" do |col|
+            #         col.encoding = "TEXT"
+            #         col.encoding # "TEXT"
+            #       end
+            #     end
+            #   end
+            #
+            def encoding
+              @gapi.encoding
+            end
+
+            ##
+            # Set the encoding of the values when the type is not `STRING`.
+            # Acceptable encoding values are:
+            #
+            # * `TEXT` - indicates values are alphanumeric text strings.
+            # * `BINARY` - indicates values are encoded using HBase
+            #   `Bytes.toBytes` family of functions. This can be overridden on a
+            #   column.
+            #
+            # @param [String] new_encoding New encoding value
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_bytes "name" do |col|
+            #         col.encoding = "TEXT"
+            #         col.encoding # "TEXT"
+            #       end
+            #     end
+            #   end
+            #
+            def encoding= new_encoding
+              @gapi.encoding = new_encoding
+            end
+
+            ##
+            # If the qualifier is not a valid BigQuery field identifier  (does
+            # not match `[a-zA-Z][a-zA-Z0-9_]*`) a valid identifier must be
+            # provided as the column field name and is used as field name in
+            # queries.
+            #
+            # @return [String]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_string "001_name", as: "user" do |col|
+            #         col.field_name # "user"
+            #         col.field_name = "User"
+            #         col.field_name # "User"
+            #       end
+            #     end
+            #   end
+            #
+            def field_name
+              @gapi.field_name
+            end
+
+            ##
+            # Sets the identifier to be used as the column field name in queries
+            # when the qualifier is not a valid BigQuery field identifier  (does
+            # not match `[a-zA-Z][a-zA-Z0-9_]*`).
+            #
+            # @param [String] new_field_name New field_name value
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_string "001_name", as: "user" do |col|
+            #         col.field_name # "user"
+            #         col.field_name = "User"
+            #         col.field_name # "User"
+            #       end
+            #     end
+            #   end
+            #
+            def field_name= new_field_name
+              @gapi.field_name = new_field_name
+            end
+
+            ##
+            # Whether only the latest version of value in this column are
+            # exposed. Can also be set at the column family level. However, this
+            # value takes precedence when set at both levels.
+            #
+            # @return [Boolean]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_string "name" do |col|
+            #         col.latest = true
+            #         col.latest # true
+            #       end
+            #     end
+            #   end
+            #
+            def latest
+              @gapi.only_read_latest
+            end
+
+            ##
+            # Set whether only the latest version of value in this column are
+            # exposed. Can also be set at the column family level. However, this
+            # value takes precedence when set at both levels.
+            #
+            # @param [Boolean] new_latest New latest value
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_string "name" do |col|
+            #         col.latest = true
+            #         col.latest # true
+            #       end
+            #     end
+            #   end
+            #
+            def latest= new_latest
+              @gapi.only_read_latest = new_latest
+            end
+
+            ##
+            # The type to convert the value in cells of this column. The values
+            # are expected to be encoded using HBase `Bytes.toBytes` function
+            # when using the `BINARY` encoding value. The following BigQuery
+            # types are allowed:
+            #
+            # * `BYTES`
+            # * `STRING`
+            # * `INTEGER`
+            # * `FLOAT`
+            # * `BOOLEAN`
+            #
+            # Default type is `BYTES`. Can also be set at the column family
+            # level. However, this value takes precedence when set at both
+            # levels.
+            #
+            # @return [String]
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_string "name" do |col|
+            #         col.type # "STRING"
+            #       end
+            #     end
+            #   end
+            #
+            def type
+              @gapi.type
+            end
+
+            ##
+            # Set the type to convert the value in cells of this column. The
+            # values are expected to be encoded using HBase `Bytes.toBytes`
+            # function when using the `BINARY` encoding value. The following
+            # BigQuery types are allowed:
+            #
+            # * `BYTES`
+            # * `STRING`
+            # * `INTEGER`
+            # * `FLOAT`
+            # * `BOOLEAN`
+            #
+            # Default type is `BYTES`. Can also be set at the column family
+            # level. However, this value takes precedence when set at both
+            # levels.
+            #
+            # @param [String] new_type New type value
+            #
+            # @example
+            #   require "google/cloud/bigquery"
+            #
+            #   bigquery = Google::Cloud::Bigquery.new
+            #
+            #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
+            #   bigtable_table = bigquery.external bigtable_url do |bt|
+            #     bt.add_family "user" do |u|
+            #       u.add_string "name" do |col|
+            #         col.type # "STRING"
+            #         col.type = "BYTES"
+            #         col.type # "BYTES"
+            #       end
+            #     end
+            #   end
+            #
+            def type= new_type
+              @gapi.type = new_type
+            end
+
+            ##
+            # @private Google API Client object.
+            def to_gapi
+              @gapi
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -474,6 +474,14 @@ module Google
             end
           end
 
+          if options[:external]
+            external_table_pairs = options[:external].map do |name, obj|
+              [String(name), obj.to_gapi]
+            end
+            external_table_hash = Hash[external_table_pairs]
+            req.configuration.query.table_definitions = external_table_hash
+          end
+
           req
         end
 
@@ -591,6 +599,7 @@ module Google
                   "newline_delimited_json" => "NEWLINE_DELIMITED_JSON",
                   "avro" => "AVRO",
                   "datastore" => "DATASTORE_BACKUP",
+                  "backup" => "DATASTORE_BACKUP",
                   "datastore_backup" => "DATASTORE_BACKUP"
                 }[format.to_s.downcase]
           return val unless val.nil?

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -580,6 +580,31 @@ YARD::Doctest.configure do |doctest|
       mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
+
+  doctest.before "Google::Cloud::Bigquery::Project#external" do
+    mock_bigquery do |mock|
+      mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
+      mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::Dataset#external" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
+      mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::External" do
+    mock_bigquery do |mock|
+      mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
+      mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+    end
+  end
 end
 
 # Fixture helpers

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -52,22 +52,22 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[1][:age].must_equal 42
     data[1][:score].must_equal 8.15
     data[1][:active].must_equal false
-    data[1][:avatar].must_equal nil
-    data[1][:started_at].must_equal nil
+    data[1][:avatar].must_be :nil?
+    data[1][:started_at].must_be :nil?
     data[1][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
-    data[1][:target_end].must_equal nil
-    data[1][:birthday].must_equal nil
+    data[1][:target_end].must_be :nil?
+    data[1][:birthday].must_be :nil?
 
     data[2].must_be_kind_of Hash
     data[2][:name].must_equal "Sally"
-    data[2][:age].must_equal nil
-    data[2][:score].must_equal nil
-    data[2][:active].must_equal nil
-    data[2][:avatar].must_equal nil
-    data[2][:started_at].must_equal nil
-    data[2][:duration].must_equal nil
-    data[2][:target_end].must_equal nil
-    data[2][:birthday].must_equal nil
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
+    data[2][:avatar].must_be :nil?
+    data[2][:started_at].must_be :nil?
+    data[2][:duration].must_be :nil?
+    data[2][:target_end].must_be :nil?
+    data[2][:birthday].must_be :nil?
   end
 
   it "knows the data metadata" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
@@ -1,0 +1,462 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+                                                      bigquery.service }
+
+  it "raises if not given valid arguments" do
+    expect { dataset.external nil }.must_raise ArgumentError
+  end
+
+  it "creates a simple external table" do
+    external = dataset.external "gs://my-bucket/path/to/file.csv"
+    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+    external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
+    external.must_be :csv?
+    external.format.must_equal "CSV"
+  end
+
+  describe "CSV" do
+    it "determines CSV from one URL" do
+      external = dataset.external "gs://my-bucket/path/to/file.csv"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from multiple URL" do
+      external = dataset.external ["some url", "gs://my-bucket/path/to/file.csv"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from the format (:csv)" do
+      external = dataset.external "some url", format: :csv
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from the format (csv)" do
+      external = dataset.external "some url", format: "csv"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from the format (:CSV)" do
+      external = dataset.external "some url", format: :CSV
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from the format (CSV)" do
+      external = dataset.external "some url", format: "CSV"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+  end
+
+  describe "JSON" do
+    it "determines JSON from one URL" do
+      external = dataset.external "gs://my-bucket/path/to/file.json"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from multiple URL" do
+      external = dataset.external ["some url", "gs://my-bucket/path/to/file.json"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.json"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (:json)" do
+      external = dataset.external "some url", format: :json
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (json)" do
+      external = dataset.external "some url", format: "json"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (:JSON)" do
+      external = dataset.external "some url", format: :JSON
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (JSON)" do
+      external = dataset.external "some url", format: "JSON"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (:newline_delimited_json)" do
+      external = dataset.external "some url", format: :newline_delimited_json
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (newline_delimited_json)" do
+      external = dataset.external "some url", format: "newline_delimited_json"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (:NEWLINE_DELIMITED_JSON)" do
+      external = dataset.external "some url", format: :NEWLINE_DELIMITED_JSON
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (NEWLINE_DELIMITED_JSON)" do
+      external = dataset.external "some url", format: "NEWLINE_DELIMITED_JSON"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+  end
+
+  describe "Google Sheets" do
+    it "determines CSV from one URL" do
+      external = dataset.external "https://docs.google.com/spreadsheets/d/1234567980"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines CSV from multiple URL" do
+      external = dataset.external ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (:sheets)" do
+      external = dataset.external "some url", format: :sheets
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (sheets)" do
+      external = dataset.external "some url", format: "sheets"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (:SHEETS)" do
+      external = dataset.external "some url", format: :SHEETS
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (SHEETS)" do
+      external = dataset.external "some url", format: "SHEETS"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (:google_sheets)" do
+      external = dataset.external "some url", format: :google_sheets
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (google_sheets)" do
+      external = dataset.external "some url", format: "google_sheets"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (:GOOGLE_SHEETS)" do
+      external = dataset.external "some url", format: :GOOGLE_SHEETS
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (GOOGLE_SHEETS)" do
+      external = dataset.external "some url", format: "GOOGLE_SHEETS"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+  end
+
+  describe "AVRO" do
+    it "determines AVRO from one URL" do
+      external = dataset.external "gs://my-bucket/path/to/file.avro"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["gs://my-bucket/path/to/file.avro"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from multiple URL" do
+      external = dataset.external ["some url", "gs://my-bucket/path/to/file.avro"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.avro"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from the format (:avro)" do
+      external = dataset.external "some url", format: :avro
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from the format (avro)" do
+      external = dataset.external "some url", format: "avro"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from the format (:AVRO)" do
+      external = dataset.external "some url", format: :AVRO
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from the format (AVRO)" do
+      external = dataset.external "some url", format: "AVRO"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+  end
+
+  describe "Datastore Backup" do
+    it "determines BACKUP from one URL" do
+      external = dataset.external "gs://my-bucket/path/to/file.backup_info"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["gs://my-bucket/path/to/file.backup_info"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from multiple URL" do
+      external = dataset.external ["some url", "gs://my-bucket/path/to/file.backup_info"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.backup_info"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:backup)" do
+      external = dataset.external "some url", format: :backup
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (backup)" do
+      external = dataset.external "some url", format: "backup"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:BACKUP)" do
+      external = dataset.external "some url", format: :BACKUP
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (BACKUP)" do
+      external = dataset.external "some url", format: "BACKUP"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:datastore)" do
+      external = dataset.external "some url", format: :datastore
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (datastore)" do
+      external = dataset.external "some url", format: "datastore"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:DATASTORE)" do
+      external = dataset.external "some url", format: :DATASTORE
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (DATASTORE)" do
+      external = dataset.external "some url", format: "DATASTORE"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:datastore_backup)" do
+      external = dataset.external "some url", format: :datastore_backup
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (datastore_backup)" do
+      external = dataset.external "some url", format: "datastore_backup"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:DATASTORE_BACKUP)" do
+      external = dataset.external "some url", format: :DATASTORE_BACKUP
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (DATASTORE_BACKUP)" do
+      external = dataset.external "some url", format: "DATASTORE_BACKUP"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+  end
+
+  describe "BIGTABLE" do
+    it "determines BIGTABLE from one URL" do
+      external = dataset.external "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from multiple URL" do
+      external = dataset.external ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from the format (:bigtable)" do
+      external = dataset.external "some url", format: :bigtable
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from the format (bigtable)" do
+      external = dataset.external "some url", format: "bigtable"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from the format (:BIGTABLE)" do
+      external = dataset.external "some url", format: :BIGTABLE
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from the format (BIGTABLE)" do
+      external = dataset.external "some url", format: "BIGTABLE"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
@@ -1,0 +1,73 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Dataset, :query, :external, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM my_csv" }
+  let(:job_id) { "job_9876543210" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  it "queries with external data" do
+    job_gapi = query_job_gapi query
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(dataset_id: dataset_id, project_id: project)
+    job_gapi.configuration.query.table_definitions = {
+      "my_csv" => Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+        source_uris: ["gs://my-bucket/path/to/file.csv"],
+        source_format: "CSV",
+        csv_options: Google::Apis::BigqueryV2::CsvOptions.new()
+      )
+    }
+
+    mock = Minitest::Mock.new
+    dataset.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+
+    external_csv = dataset.external "gs://my-bucket/path/to/file.csv"
+    data = dataset.query query, external: { my_csv: external_csv }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
+  def assert_valid_data data
+    data.count.must_equal 3
+    data[0].must_be_kind_of Hash
+    data[0][:name].must_equal "Heidi"
+    data[0][:age].must_equal 36
+    data[0][:score].must_equal 7.65
+    data[0][:active].must_equal true
+    data[1].must_be_kind_of Hash
+    data[1][:name].must_equal "Aaron"
+    data[1][:age].must_equal 42
+    data[1][:score].must_equal 8.15
+    data[1][:active].must_equal false
+    data[2].must_be_kind_of Hash
+    data[2][:name].must_equal "Sally"
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
@@ -1,0 +1,47 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Dataset, :query_job, :external, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM my_csv" }
+  let(:job_id) { "job_9876543210" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  it "queries with external data" do
+    job_gapi = query_job_gapi query
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(dataset_id: dataset_id, project_id: project)
+    job_gapi.configuration.query.table_definitions = {
+      "my_csv" => Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+        source_uris: ["gs://my-bucket/path/to/file.csv"],
+        source_format: "CSV",
+        csv_options: Google::Apis::BigqueryV2::CsvOptions.new()
+      )
+    }
+
+    mock = Minitest::Mock.new
+    dataset.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+
+    external_csv = dataset.external "gs://my-bucket/path/to/file.csv"
+    job = dataset.query_job query, external: { my_csv: external_csv }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -590,8 +590,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data[1][:active].must_equal false
     data[2].must_be_kind_of Hash
     data[2][:name].must_equal "Sally"
-    data[2][:age].must_equal nil
-    data[2][:score].must_equal nil
-    data[2][:active].must_equal nil
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -566,8 +566,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data[1][:active].must_equal false
     data[2].must_be_kind_of Hash
     data[2][:name].must_equal "Sally"
-    data[2][:age].must_equal nil
-    data[2][:score].must_equal nil
-    data[2][:active].must_equal nil
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtabletable_column_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtabletable_column_test.rb
@@ -1,0 +1,70 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::External::BigtableTable::Column, :mock_bigquery do
+  it "raises if not given valid arguments" do
+    expect { bigquery.external nil }.must_raise ArgumentError
+  end
+
+  it "creates a simple external table" do
+    external = bigquery.external "gs://my-bucket/path/to/file.csv"
+    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+    external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
+    external.format.must_equal "CSV"
+  end
+
+  it "determines CSV from one URL" do
+    external = bigquery.external "gs://my-bucket/path/to/file.csv"
+    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+    external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
+    external.format.must_equal "CSV"
+  end
+
+  it "determines CSV from multiple URL" do
+    external = bigquery.external ["some url", "gs://my-bucket/path/to/file.csv"]
+    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+    external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
+    external.format.must_equal "CSV"
+  end
+
+  it "determines CSV from the format (:csv)" do
+    external = bigquery.external "some url", format: :csv
+    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+    external.urls.must_equal ["some url"]
+    external.format.must_equal "CSV"
+  end
+
+  it "determines CSV from the format (csv)" do
+    external = bigquery.external "some url", format: "csv"
+    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+    external.urls.must_equal ["some url"]
+    external.format.must_equal "CSV"
+  end
+
+  it "determines CSV from the format (:CSV)" do
+    external = bigquery.external "some url", format: :CSV
+    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+    external.urls.must_equal ["some url"]
+    external.format.must_equal "CSV"
+  end
+
+  it "determines CSV from the format (CSV)" do
+    external = bigquery.external "some url", format: "CSV"
+    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+    external.urls.must_equal ["some url"]
+    external.format.must_equal "CSV"
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtabletable_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtabletable_test.rb
@@ -1,0 +1,180 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::External::BigtableTable do
+  it "can be used for BIGTABLE" do
+    table = Google::Cloud::Bigquery::External::BigtableTable.new.tap do |e|
+      e.gapi.source_uris = ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      e.gapi.source_format = "BIGTABLE"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"],
+      source_format: "BIGTABLE",
+      bigtable_options: Google::Apis::BigqueryV2::BigtableOptions.new(
+        column_families: []
+      )
+    )
+
+    table.must_be_kind_of Google::Cloud::Bigquery::External::Table
+    table.urls.must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+    table.must_be :bigtable?
+    table.format.must_equal "BIGTABLE"
+
+    table.wont_be :csv?
+    table.wont_be :json?
+    table.wont_be :sheets?
+    table.wont_be :avro?
+    table.wont_be :backup?
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets rowkey_as_string" do
+    table = Google::Cloud::Bigquery::External::BigtableTable.new.tap do |e|
+      e.gapi.source_uris = ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      e.gapi.source_format = "BIGTABLE"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"],
+      source_format: "BIGTABLE",
+      bigtable_options: Google::Apis::BigqueryV2::BigtableOptions.new(
+        read_rowkey_as_string: true,
+        column_families: []
+      )
+    )
+
+    table.rowkey_as_string.must_be :nil?
+
+    table.rowkey_as_string = true
+
+    table.rowkey_as_string.must_equal true
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "adds column families using block" do
+    table = Google::Cloud::Bigquery::External::BigtableTable.new.tap do |e|
+      e.gapi.source_uris = ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      e.gapi.source_format = "BIGTABLE"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"],
+      source_format: "BIGTABLE",
+      bigtable_options: Google::Apis::BigqueryV2::BigtableOptions.new(
+        column_families: [
+          Google::Apis::BigqueryV2::BigtableColumnFamily.new(
+          family_id: "user",
+          columns: [
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "name", type: "STRING"),
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "age", type: "INTEGER"),
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "score", type: "FLOAT"),
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "active", type: "BOOLEAN"),
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "avatar", type: "BYTES")
+          ])
+        ]
+      )
+    )
+
+    table.families.must_be :empty?
+
+    table.add_family "user" do |u|
+      u.add_string  "name"
+      u.add_integer "age"
+      u.add_float   "score"
+      u.add_boolean "active"
+      u.add_bytes   "avatar"
+    end
+
+    table.families.wont_be :empty?
+    table.families.count.must_equal 1
+    table.families[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::ColumnFamily
+    table.families[0].family_id.must_equal "user"
+    table.families[0].columns.count.must_equal 5
+    table.families[0].columns[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[0].qualifier.must_equal "name"
+    table.families[0].columns[0].type.must_equal "STRING"
+    table.families[0].columns[1].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[1].qualifier.must_equal "age"
+    table.families[0].columns[1].type.must_equal "INTEGER"
+    table.families[0].columns[2].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[2].qualifier.must_equal "score"
+    table.families[0].columns[2].type.must_equal "FLOAT"
+    table.families[0].columns[3].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[3].qualifier.must_equal "active"
+    table.families[0].columns[3].type.must_equal "BOOLEAN"
+    table.families[0].columns[4].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[4].qualifier.must_equal "avatar"
+    table.families[0].columns[4].type.must_equal "BYTES"
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "adds column families inline" do
+    table = Google::Cloud::Bigquery::External::BigtableTable.new.tap do |e|
+      e.gapi.source_uris = ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      e.gapi.source_format = "BIGTABLE"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"],
+      source_format: "BIGTABLE",
+      bigtable_options: Google::Apis::BigqueryV2::BigtableOptions.new(
+        column_families: [
+          Google::Apis::BigqueryV2::BigtableColumnFamily.new(
+          family_id: "user",
+          columns: [
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "name", type: "STRING"),
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "age", type: "INTEGER"),
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "score", type: "FLOAT"),
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "active", type: "BOOLEAN"),
+            Google::Apis::BigqueryV2::BigtableColumn.new(qualifier_string: "avatar", type: "BYTES")
+          ])
+        ]
+      )
+    )
+
+    table.families.must_be :empty?
+
+    family = table.add_family "user"
+    family.add_string  "name"
+    family.add_integer "age"
+    family.add_float   "score"
+    family.add_boolean "active"
+    family.add_bytes   "avatar"
+
+    table.families.wont_be :empty?
+    table.families.count.must_equal 1
+    table.families[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::ColumnFamily
+    table.families[0].family_id.must_equal "user"
+    table.families[0].columns.count.must_equal 5
+    table.families[0].columns[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[0].qualifier.must_equal "name"
+    table.families[0].columns[0].type.must_equal "STRING"
+    table.families[0].columns[1].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[1].qualifier.must_equal "age"
+    table.families[0].columns[1].type.must_equal "INTEGER"
+    table.families[0].columns[2].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[2].qualifier.must_equal "score"
+    table.families[0].columns[2].type.must_equal "FLOAT"
+    table.families[0].columns[3].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[3].qualifier.must_equal "active"
+    table.families[0].columns[3].type.must_equal "BOOLEAN"
+    table.families[0].columns[4].must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable::Column
+    table.families[0].columns[4].qualifier.must_equal "avatar"
+    table.families[0].columns[4].type.must_equal "BYTES"
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_csvtable_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_csvtable_test.rb
@@ -1,0 +1,276 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::External::CsvTable do
+  it "can be used for CSV" do
+    table = Google::Cloud::Bigquery::External::CsvTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new
+    )
+
+    table.must_be_kind_of Google::Cloud::Bigquery::External::Table
+    table.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
+    table.must_be :csv?
+    table.format.must_equal "CSV"
+
+    table.wont_be :json?
+    table.wont_be :sheets?
+    table.wont_be :avro?
+    table.wont_be :backup?
+    table.wont_be :bigtable?
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets jagged_rows" do
+    table = Google::Cloud::Bigquery::External::CsvTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new(
+        allow_jagged_rows: true
+      )
+    )
+
+    table.jagged_rows.must_be :nil?
+
+    table.jagged_rows = true
+
+    table.jagged_rows.must_equal true
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets quoted_newlines" do
+    table = Google::Cloud::Bigquery::External::CsvTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new(
+        allow_quoted_newlines: true
+      )
+    )
+
+    table.quoted_newlines.must_be :nil?
+
+    table.quoted_newlines = true
+
+    table.quoted_newlines.must_equal true
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets encoding" do
+    table = Google::Cloud::Bigquery::External::CsvTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new(
+        encoding: "UTF-8"
+      )
+    )
+
+    table.encoding.must_be :nil?
+    table.must_be :utf8? # default is UTF-8, even when encoding is not specifically set
+    table.wont_be :iso8859_1?
+
+    table.encoding = "ISO-8859-1"
+
+    table.encoding.must_equal "ISO-8859-1"
+    table.wont_be :utf8?
+    table.must_be :iso8859_1?
+
+    table.encoding = "UTF-8"
+
+    table.encoding.must_equal "UTF-8"
+    table.must_be :utf8?
+    table.wont_be :iso8859_1?
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets delimiter" do
+    table = Google::Cloud::Bigquery::External::CsvTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new(
+        field_delimiter: "|"
+      )
+    )
+
+    table.delimiter.must_be :nil?
+
+    table.delimiter = "|"
+
+    table.delimiter.must_equal "|"
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets quote" do
+    table = Google::Cloud::Bigquery::External::CsvTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new(
+        quote: "'"
+      )
+    )
+
+    table.quote.must_be :nil?
+
+    table.quote = "'"
+
+    table.quote.must_equal "'"
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets skip_leading_rows" do
+    table = Google::Cloud::Bigquery::External::CsvTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new(
+        skip_leading_rows: true
+      )
+    )
+
+    table.skip_leading_rows.must_be :nil?
+
+    table.skip_leading_rows = true
+
+    table.skip_leading_rows.must_equal true
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets schema using block" do
+    table = Google::Cloud::Bigquery::External::CsvTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      schema: Google::Apis::BigqueryV2::TableSchema.new(fields: [
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "started_at",    type: "TIMESTAMP", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "birthday",      type: "DATE", description: nil, fields: [])
+      ]),
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new
+    )
+
+    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be :empty?
+
+    table.schema do |s|
+      s.string "name", mode: :required
+      s.integer "age"
+      s.float "score", description: "A score from 0.0 to 10.0"
+      s.boolean "active"
+      s.bytes "avatar"
+      s.timestamp "started_at"
+      s.time "duration"
+      s.datetime "target_end"
+      s.date "birthday"
+    end
+
+    table.schema.wont_be :empty?
+    table.fields.must_equal table.schema.fields
+    table.headers.must_equal table.schema.headers
+    table.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets schema using object" do
+    table = Google::Cloud::Bigquery::External::CsvTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      schema: Google::Apis::BigqueryV2::TableSchema.new(fields: [
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "started_at",    type: "TIMESTAMP", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "birthday",      type: "DATE", description: nil, fields: [])
+      ]),
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new
+    )
+
+    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be :empty?
+
+    # this object is usually created by calling bigquery.schema
+    schema = Google::Cloud::Bigquery::Schema.from_gapi
+    schema.string "name", mode: :required
+    schema.integer "age"
+    schema.float "score", description: "A score from 0.0 to 10.0"
+    schema.boolean "active"
+    schema.bytes "avatar"
+    schema.timestamp "started_at"
+    schema.time "duration"
+    schema.datetime "target_end"
+    schema.date "birthday"
+
+    table.schema = schema
+
+    table.schema.wont_be :empty?
+    table.fields.must_equal table.schema.fields
+    table.headers.must_equal table.schema.headers
+    table.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_jsontable_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_jsontable_test.rb
@@ -1,0 +1,131 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::External::JsonTable do
+  it "can be used for JSON" do
+    table = Google::Cloud::Bigquery::External::JsonTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.json"]
+      e.gapi.source_format = "NEWLINE_DELIMITED_JSON"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.json"],
+      source_format: "NEWLINE_DELIMITED_JSON"
+    )
+
+    table.must_be_kind_of Google::Cloud::Bigquery::External::Table
+    table.urls.must_equal ["gs://my-bucket/path/to/file.json"]
+    table.must_be :json?
+    table.format.must_equal "NEWLINE_DELIMITED_JSON"
+
+    table.wont_be :csv?
+    table.wont_be :sheets?
+    table.wont_be :avro?
+    table.wont_be :backup?
+    table.wont_be :bigtable?
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets schema using block" do
+    table = Google::Cloud::Bigquery::External::JsonTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.json"]
+      e.gapi.source_format = "NEWLINE_DELIMITED_JSON"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.json"],
+      source_format: "NEWLINE_DELIMITED_JSON",
+      schema: Google::Apis::BigqueryV2::TableSchema.new(fields: [
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "started_at",    type: "TIMESTAMP", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "birthday",      type: "DATE", description: nil, fields: [])
+      ])
+    )
+
+    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be :empty?
+
+    table.schema do |s|
+      s.string "name", mode: :required
+      s.integer "age"
+      s.float "score", description: "A score from 0.0 to 10.0"
+      s.boolean "active"
+      s.bytes "avatar"
+      s.timestamp "started_at"
+      s.time "duration"
+      s.datetime "target_end"
+      s.date "birthday"
+    end
+
+    table.schema.wont_be :empty?
+    table.fields.must_equal table.schema.fields
+    table.headers.must_equal table.schema.headers
+    table.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets schema using object" do
+    table = Google::Cloud::Bigquery::External::JsonTable.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.json"]
+      e.gapi.source_format = "NEWLINE_DELIMITED_JSON"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.json"],
+      source_format: "NEWLINE_DELIMITED_JSON",
+      schema: Google::Apis::BigqueryV2::TableSchema.new(fields: [
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "started_at",    type: "TIMESTAMP", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "birthday",      type: "DATE", description: nil, fields: [])
+      ])
+    )
+
+    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be :empty?
+
+    # this object is usually created by calling bigquery.schema
+    schema = Google::Cloud::Bigquery::Schema.from_gapi
+    schema.string "name", mode: :required
+    schema.integer "age"
+    schema.float "score", description: "A score from 0.0 to 10.0"
+    schema.boolean "active"
+    schema.bytes "avatar"
+    schema.timestamp "started_at"
+    schema.time "duration"
+    schema.datetime "target_end"
+    schema.date "birthday"
+
+    table.schema = schema
+
+    table.schema.wont_be :empty?
+    table.fields.must_equal table.schema.fields
+    table.headers.must_equal table.schema.headers
+    table.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_sheetstable_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_sheetstable_test.rb
@@ -1,0 +1,64 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::External::SheetsTable do
+  it "can be used for CSV" do
+    table = Google::Cloud::Bigquery::External::SheetsTable.new.tap do |e|
+      e.gapi.source_uris = ["https://docs.google.com/spreadsheets/d/1234567980"]
+      e.gapi.source_format = "GOOGLE_SHEETS"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["https://docs.google.com/spreadsheets/d/1234567980"],
+      source_format: "GOOGLE_SHEETS",
+      google_sheets_options: Google::Apis::BigqueryV2::GoogleSheetsOptions.new
+    )
+
+    table.must_be_kind_of Google::Cloud::Bigquery::External::Table
+    table.urls.must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
+    table.must_be :sheets?
+    table.format.must_equal "GOOGLE_SHEETS"
+
+    table.wont_be :csv?
+    table.wont_be :json?
+    table.wont_be :avro?
+    table.wont_be :backup?
+    table.wont_be :bigtable?
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets skip_leading_rows" do
+    table = Google::Cloud::Bigquery::External::SheetsTable.new.tap do |e|
+      e.gapi.source_uris = ["https://docs.google.com/spreadsheets/d/1234567980"]
+      e.gapi.source_format = "GOOGLE_SHEETS"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["https://docs.google.com/spreadsheets/d/1234567980"],
+      source_format: "GOOGLE_SHEETS",
+      google_sheets_options: Google::Apis::BigqueryV2::GoogleSheetsOptions.new(
+        skip_leading_rows: true
+      )
+    )
+
+    table.skip_leading_rows.must_be :nil?
+
+    table.skip_leading_rows = true
+
+    table.skip_leading_rows.must_equal true
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_table_test.rb
@@ -1,0 +1,145 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::External::Table do
+  it "can be used for AVRO" do
+    table = Google::Cloud::Bigquery::External::Table.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
+      e.gapi.source_format = "AVRO"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.avro"],
+      source_format: "AVRO"
+    )
+
+    table.must_be_kind_of Google::Cloud::Bigquery::External::Table
+    table.urls.must_equal ["gs://my-bucket/path/to/file.avro"]
+    table.must_be :avro?
+    table.format.must_equal "AVRO"
+
+    table.wont_be :csv?
+    table.wont_be :json?
+    table.wont_be :sheets?
+    table.wont_be :backup?
+    table.wont_be :bigtable?
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "can be used for DATASTORE_BACKUP" do
+    table = Google::Cloud::Bigquery::External::Table.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.backup_info"]
+      e.gapi.source_format = "DATASTORE_BACKUP"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.backup_info"],
+      source_format: "DATASTORE_BACKUP"
+    )
+
+    table.must_be_kind_of Google::Cloud::Bigquery::External::Table
+    table.urls.must_equal ["gs://my-bucket/path/to/file.backup_info"]
+    table.must_be :backup?
+    table.format.must_equal "DATASTORE_BACKUP"
+
+    table.wont_be :csv?
+    table.wont_be :json?
+    table.wont_be :sheets?
+    table.wont_be :avro?
+    table.wont_be :bigtable?
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets autodetect" do
+    table = Google::Cloud::Bigquery::External::Table.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
+      e.gapi.source_format = "AVRO"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.avro"],
+      source_format: "AVRO",
+      autodetect: true
+    )
+
+    table.autodetect.must_be :nil?
+
+    table.autodetect = true
+
+    table.autodetect.must_equal true
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets compression" do
+    table = Google::Cloud::Bigquery::External::Table.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
+      e.gapi.source_format = "AVRO"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.avro"],
+      source_format: "AVRO",
+      compression: "GZIP"
+    )
+
+    table.compression.must_be :nil?
+
+    table.compression = "GZIP"
+
+    table.compression.must_equal "GZIP"
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets ignore_unknown" do
+    table = Google::Cloud::Bigquery::External::Table.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
+      e.gapi.source_format = "AVRO"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.avro"],
+      source_format: "AVRO",
+      ignore_unknown_values: true
+    )
+
+    table.ignore_unknown.must_be :nil?
+
+    table.ignore_unknown = true
+
+    table.ignore_unknown.must_equal true
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+
+  it "sets max_bad_records" do
+    table = Google::Cloud::Bigquery::External::Table.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
+      e.gapi.source_format = "AVRO"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.avro"],
+      source_format: "AVRO",
+      max_bad_records: 10
+    )
+
+    table.max_bad_records.must_be :nil?
+
+    table.max_bad_records = 10
+
+    table.max_bad_records.must_equal 10
+
+    table.to_gapi.to_h.must_equal table_gapi.to_h
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
@@ -101,7 +101,7 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
     job.wont_be :failed?
 
     job.gapi.status.state = nil
-    job.state.must_equal nil
+    job.state.must_be :nil?
     job.wont_be :running?
     job.wont_be :pending?
     job.wont_be :done?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
@@ -1,0 +1,457 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
+  it "raises if not given valid arguments" do
+    expect { bigquery.external nil }.must_raise ArgumentError
+  end
+
+  it "creates a simple external table" do
+    external = bigquery.external "gs://my-bucket/path/to/file.csv"
+    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+    external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
+    external.must_be :csv?
+    external.format.must_equal "CSV"
+  end
+
+  describe "CSV" do
+    it "determines CSV from one URL" do
+      external = bigquery.external "gs://my-bucket/path/to/file.csv"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from multiple URL" do
+      external = bigquery.external ["some url", "gs://my-bucket/path/to/file.csv"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from the format (:csv)" do
+      external = bigquery.external "some url", format: :csv
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from the format (csv)" do
+      external = bigquery.external "some url", format: "csv"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from the format (:CSV)" do
+      external = bigquery.external "some url", format: :CSV
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+
+    it "determines CSV from the format (CSV)" do
+      external = bigquery.external "some url", format: "CSV"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvTable
+      external.urls.must_equal ["some url"]
+      external.must_be :csv?
+      external.format.must_equal "CSV"
+    end
+  end
+
+  describe "JSON" do
+    it "determines JSON from one URL" do
+      external = bigquery.external "gs://my-bucket/path/to/file.json"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from multiple URL" do
+      external = bigquery.external ["some url", "gs://my-bucket/path/to/file.json"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.json"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (:json)" do
+      external = bigquery.external "some url", format: :json
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (json)" do
+      external = bigquery.external "some url", format: "json"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (:JSON)" do
+      external = bigquery.external "some url", format: :JSON
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (JSON)" do
+      external = bigquery.external "some url", format: "JSON"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (:newline_delimited_json)" do
+      external = bigquery.external "some url", format: :newline_delimited_json
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (newline_delimited_json)" do
+      external = bigquery.external "some url", format: "newline_delimited_json"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (:NEWLINE_DELIMITED_JSON)" do
+      external = bigquery.external "some url", format: :NEWLINE_DELIMITED_JSON
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+
+    it "determines JSON from the format (NEWLINE_DELIMITED_JSON)" do
+      external = bigquery.external "some url", format: "NEWLINE_DELIMITED_JSON"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonTable
+      external.urls.must_equal ["some url"]
+      external.must_be :json?
+      external.format.must_equal "NEWLINE_DELIMITED_JSON"
+    end
+  end
+
+  describe "Google Sheets" do
+    it "determines CSV from one URL" do
+      external = bigquery.external "https://docs.google.com/spreadsheets/d/1234567980"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines CSV from multiple URL" do
+      external = bigquery.external ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (:sheets)" do
+      external = bigquery.external "some url", format: :sheets
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (sheets)" do
+      external = bigquery.external "some url", format: "sheets"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (:SHEETS)" do
+      external = bigquery.external "some url", format: :SHEETS
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (SHEETS)" do
+      external = bigquery.external "some url", format: "SHEETS"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (:google_sheets)" do
+      external = bigquery.external "some url", format: :google_sheets
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (google_sheets)" do
+      external = bigquery.external "some url", format: "google_sheets"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (:GOOGLE_SHEETS)" do
+      external = bigquery.external "some url", format: :GOOGLE_SHEETS
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+
+    it "determines SHEETS from the format (GOOGLE_SHEETS)" do
+      external = bigquery.external "some url", format: "GOOGLE_SHEETS"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsTable
+      external.urls.must_equal ["some url"]
+      external.must_be :sheets?
+      external.format.must_equal "GOOGLE_SHEETS"
+    end
+  end
+
+  describe "AVRO" do
+    it "determines AVRO from one URL" do
+      external = bigquery.external "gs://my-bucket/path/to/file.avro"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["gs://my-bucket/path/to/file.avro"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from multiple URL" do
+      external = bigquery.external ["some url", "gs://my-bucket/path/to/file.avro"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.avro"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from the format (:avro)" do
+      external = bigquery.external "some url", format: :avro
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from the format (avro)" do
+      external = bigquery.external "some url", format: "avro"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from the format (:AVRO)" do
+      external = bigquery.external "some url", format: :AVRO
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+
+    it "determines AVRO from the format (AVRO)" do
+      external = bigquery.external "some url", format: "AVRO"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :avro?
+      external.format.must_equal "AVRO"
+    end
+  end
+
+  describe "Datastore Backup" do
+    it "determines BACKUP from one URL" do
+      external = bigquery.external "gs://my-bucket/path/to/file.backup_info"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["gs://my-bucket/path/to/file.backup_info"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from multiple URL" do
+      external = bigquery.external ["some url", "gs://my-bucket/path/to/file.backup_info"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.backup_info"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:backup)" do
+      external = bigquery.external "some url", format: :backup
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (backup)" do
+      external = bigquery.external "some url", format: "backup"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:BACKUP)" do
+      external = bigquery.external "some url", format: :BACKUP
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (BACKUP)" do
+      external = bigquery.external "some url", format: "BACKUP"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:datastore)" do
+      external = bigquery.external "some url", format: :datastore
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (datastore)" do
+      external = bigquery.external "some url", format: "datastore"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:DATASTORE)" do
+      external = bigquery.external "some url", format: :DATASTORE
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (DATASTORE)" do
+      external = bigquery.external "some url", format: "DATASTORE"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:datastore_backup)" do
+      external = bigquery.external "some url", format: :datastore_backup
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (datastore_backup)" do
+      external = bigquery.external "some url", format: "datastore_backup"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (:DATASTORE_BACKUP)" do
+      external = bigquery.external "some url", format: :DATASTORE_BACKUP
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+
+    it "determines BACKUP from the format (DATASTORE_BACKUP)" do
+      external = bigquery.external "some url", format: "DATASTORE_BACKUP"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::Table
+      external.urls.must_equal ["some url"]
+      external.must_be :backup?
+      external.format.must_equal "DATASTORE_BACKUP"
+    end
+  end
+
+  describe "BIGTABLE" do
+    it "determines BIGTABLE from one URL" do
+      external = bigquery.external "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from multiple URL" do
+      external = bigquery.external ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from the format (:bigtable)" do
+      external = bigquery.external "some url", format: :bigtable
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from the format (bigtable)" do
+      external = bigquery.external "some url", format: "bigtable"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from the format (:BIGTABLE)" do
+      external = bigquery.external "some url", format: :BIGTABLE
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+
+    it "determines BIGTABLE from the format (BIGTABLE)" do
+      external = bigquery.external "some url", format: "BIGTABLE"
+      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableTable
+      external.urls.must_equal ["some url"]
+      external.must_be :bigtable?
+      external.format.must_equal "BIGTABLE"
+    end
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
@@ -1,0 +1,72 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :query, :external, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM my_csv" }
+  let(:job_id) { "job_9876543210" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  it "queries with external data" do
+    job_gapi = query_job_gapi query
+    job_gapi.configuration.query.table_definitions = {
+      "my_csv" => Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+        source_uris: ["gs://my-bucket/path/to/file.csv"],
+        source_format: "CSV",
+        csv_options: Google::Apis::BigqueryV2::CsvOptions.new()
+      )
+    }
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+
+    external_csv = bigquery.external "gs://my-bucket/path/to/file.csv"
+    data = bigquery.query query, external: { my_csv: external_csv }
+    mock.verify
+
+    data.class.must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
+  def assert_valid_data data
+    data.count.must_equal 3
+    data[0].must_be_kind_of Hash
+    data[0][:name].must_equal "Heidi"
+    data[0][:age].must_equal 36
+    data[0][:score].must_equal 7.65
+    data[0][:active].must_equal true
+    data[1].must_be_kind_of Hash
+    data[1][:name].must_equal "Aaron"
+    data[1][:age].must_equal 42
+    data[1][:score].must_equal 8.15
+    data[1][:active].must_equal false
+    data[2].must_be_kind_of Hash
+    data[2][:name].must_equal "Sally"
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
@@ -1,0 +1,46 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Project, :query_job, :external, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM my_csv" }
+  let(:job_id) { "job_9876543210" }
+
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  it "queries with external data" do
+    job_gapi = query_job_gapi query
+    job_gapi.configuration.query.table_definitions = {
+      "my_csv" => Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+        source_uris: ["gs://my-bucket/path/to/file.csv"],
+        source_format: "CSV",
+        csv_options: Google::Apis::BigqueryV2::CsvOptions.new()
+      )
+    }
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+
+    external_csv = bigquery.external "gs://my-bucket/path/to/file.csv"
+    job = bigquery.query_job query, external: { my_csv: external_csv }
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -109,7 +109,6 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
       project_id: "some_random_project",
       dataset_id: "some_random_dataset"
     )
-    puts job_gapi.job_reference.job_id
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
     job = bigquery.query_job query, dataset: "some_random_dataset", project: "some_random_project"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -593,8 +593,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data[1][:active].must_equal false
     data[2].must_be_kind_of Hash
     data[2][:name].must_equal "Sally"
-    data[2][:age].must_equal nil
-    data[2][:score].must_equal nil
-    data[2][:active].must_equal nil
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -569,8 +569,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data[1][:active].must_equal false
     data[2].must_be_kind_of Hash
     data[2][:name].must_equal "Sally"
-    data[2][:age].must_equal nil
-    data[2][:score].must_equal nil
-    data[2][:active].must_equal nil
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
@@ -57,9 +57,9 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
     data[1][:active].must_equal false
     data[2].must_be_kind_of Hash
     data[2][:name].must_equal "Sally"
-    data[2][:age].must_equal nil
-    data[2][:score].must_equal nil
-    data[2][:active].must_equal nil
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
   end
 
   it "paginates the data" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
@@ -54,22 +54,22 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data[1][:age].must_equal 42
     data[1][:score].must_equal 8.15
     data[1][:active].must_equal false
-    data[1][:avatar].must_equal nil
-    data[1][:started_at].must_equal nil
+    data[1][:avatar].must_be :nil?
+    data[1][:started_at].must_be :nil?
     data[1][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
-    data[1][:target_end].must_equal nil
-    data[1][:birthday].must_equal nil
+    data[1][:target_end].must_be :nil?
+    data[1][:birthday].must_be :nil?
 
     data[2].must_be_kind_of Hash
     data[2][:name].must_equal "Sally"
-    data[2][:age].must_equal nil
-    data[2][:score].must_equal nil
-    data[2][:active].must_equal nil
-    data[2][:avatar].must_equal nil
-    data[2][:started_at].must_equal nil
-    data[2][:duration].must_equal nil
-    data[2][:target_end].must_equal nil
-    data[2][:birthday].must_equal nil
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
+    data[2][:avatar].must_be :nil?
+    data[2][:started_at].must_be :nil?
+    data[2][:duration].must_be :nil?
+    data[2][:target_end].must_be :nil?
+    data[2][:birthday].must_be :nil?
     end
 
   it "can retrieve query results when it already has destination_schema" do
@@ -104,22 +104,22 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data[1][:age].must_equal 42
     data[1][:score].must_equal 8.15
     data[1][:active].must_equal false
-    data[1][:avatar].must_equal nil
-    data[1][:started_at].must_equal nil
+    data[1][:avatar].must_be :nil?
+    data[1][:started_at].must_be :nil?
     data[1][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
-    data[1][:target_end].must_equal nil
-    data[1][:birthday].must_equal nil
+    data[1][:target_end].must_be :nil?
+    data[1][:birthday].must_be :nil?
 
     data[2].must_be_kind_of Hash
     data[2][:name].must_equal "Sally"
-    data[2][:age].must_equal nil
-    data[2][:score].must_equal nil
-    data[2][:active].must_equal nil
-    data[2][:avatar].must_equal nil
-    data[2][:started_at].must_equal nil
-    data[2][:duration].must_equal nil
-    data[2][:target_end].must_equal nil
-    data[2][:birthday].must_equal nil
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
+    data[2][:avatar].must_be :nil?
+    data[2][:started_at].must_be :nil?
+    data[2][:duration].must_be :nil?
+    data[2][:target_end].must_be :nil?
+    data[2][:birthday].must_be :nil?
   end
 
   it "paginates data" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -61,47 +61,47 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
 
     table.schema.fields[0].name.must_equal "name"
     table.schema.fields[0].type.must_equal "STRING"
-    table.schema.fields[0].description.must_equal nil
+    table.schema.fields[0].description.must_be :nil?
     table.schema.fields[0].mode.must_equal "REQUIRED"
 
     table.schema.fields[1].name.must_equal "age"
     table.schema.fields[1].type.must_equal "INTEGER"
-    table.schema.fields[1].description.must_equal nil
+    table.schema.fields[1].description.must_be :nil?
     table.schema.fields[1].mode.must_equal "NULLABLE"
 
     table.schema.fields[2].name.must_equal "score"
     table.schema.fields[2].type.must_equal "FLOAT"
-    table.schema.fields[2].description.must_equal nil
+    table.schema.fields[2].description.must_be :nil?
     table.schema.fields[2].mode.must_equal "NULLABLE"
 
     table.schema.fields[3].name.must_equal "active"
     table.schema.fields[3].type.must_equal "BOOLEAN"
-    table.schema.fields[3].description.must_equal nil
+    table.schema.fields[3].description.must_be :nil?
     table.schema.fields[3].mode.must_equal "NULLABLE"
 
     table.schema.fields[4].name.must_equal "avatar"
     table.schema.fields[4].type.must_equal "BYTES"
-    table.schema.fields[4].description.must_equal nil
+    table.schema.fields[4].description.must_be :nil?
     table.schema.fields[4].mode.must_equal "NULLABLE"
 
     table.schema.fields[5].name.must_equal "started_at"
     table.schema.fields[5].type.must_equal "TIMESTAMP"
-    table.schema.fields[5].description.must_equal nil
+    table.schema.fields[5].description.must_be :nil?
     table.schema.fields[5].mode.must_equal "NULLABLE"
 
     table.schema.fields[6].name.must_equal "duration"
     table.schema.fields[6].type.must_equal "TIME"
-    table.schema.fields[6].description.must_equal nil
+    table.schema.fields[6].description.must_be :nil?
     table.schema.fields[6].mode.must_equal "NULLABLE"
 
     table.schema.fields[7].name.must_equal "target_end"
     table.schema.fields[7].type.must_equal "DATETIME"
-    table.schema.fields[7].description.must_equal nil
+    table.schema.fields[7].description.must_be :nil?
     table.schema.fields[7].mode.must_equal "NULLABLE"
 
     table.schema.fields[8].name.must_equal "birthday"
     table.schema.fields[8].type.must_equal "DATE"
-    table.schema.fields[8].description.must_equal nil
+    table.schema.fields[8].description.must_be :nil?
     table.schema.fields[8].mode.must_equal "NULLABLE"
 
     table.fields.count.must_equal 9

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
@@ -70,9 +70,9 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
 
     data[2].must_be_kind_of Hash
     data[2][:name].must_equal "Sally"
-    data[2][:age].must_equal nil
-    data[2][:score].must_equal nil
-    data[2][:active].must_equal nil
+    data[2][:age].must_be :nil?
+    data[2][:score].must_be :nil?
+    data[2][:active].must_be :nil?
   end
 
   it "knows the data metadata" do
@@ -133,15 +133,15 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
     data.raw[1][1].must_equal data[1]["age"].to_s
     data.raw[1][2].must_equal data[1]["score"].to_s
     data.raw[1][3].must_equal data[1]["active"].to_s
-    data.raw[1][4].must_equal nil
-    data.raw[1][5].must_equal nil
+    data.raw[1][4].must_be :nil?
+    data.raw[1][5].must_be :nil?
 
     data.raw[2][0].must_equal data[2]["name"].to_s
-    data.raw[2][1].must_equal nil
-    data.raw[2][2].must_equal nil
-    data.raw[2][3].must_equal nil
-    data.raw[2][4].must_equal nil
-    data.raw[2][5].must_equal nil
+    data.raw[2][1].must_be :nil?
+    data.raw[2][2].must_be :nil?
+    data.raw[2][3].must_be :nil?
+    data.raw[2][4].must_be :nil?
+    data.raw[2][5].must_be :nil?
   end
 
   it "paginates data using next? and next" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -20,8 +20,8 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.bigquery" do
       gcloud = Google::Cloud.new
       stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
-        project.must_equal nil
-        keyfile.must_equal nil
+        project.must_be :nil?
+        keyfile.must_be :nil?
         scope.must_be :nil?
         retries.must_be :nil?
         timeout.must_be :nil?
@@ -88,14 +88,14 @@ describe Google::Cloud do
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
         keyfile.must_equal "path/to/keyfile.json"
-        scope.must_equal nil
+        scope.must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
         project.must_equal "project-id"
         credentials.must_equal "bigquery-credentials"
-        retries.must_equal nil
-        timeout.must_equal nil
+        retries.must_be :nil?
+        timeout.must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -139,14 +139,14 @@ describe Google::Cloud do
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
         keyfile.must_equal "path/to/keyfile.json"
-        scope.must_equal nil
+        scope.must_be :nil?
         "bigquery-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil) {
         project.must_equal "project-id"
         credentials.must_equal "bigquery-credentials"
-        retries.must_equal nil
-        timeout.must_equal nil
+        retries.must_be :nil?
+        timeout.must_be :nil?
         OpenStruct.new project: project
       }
 


### PR DESCRIPTION
This is an implementation of the external data sources.

```ruby
require "google/cloud/bigquery"

bigquery = Google::Cloud::Bigquery.new

pets_table = dataset.external "gs://my-bucket/pets.csv" do |t|
  t.skip_leading_rows = 1
  t.schema do |s|
    s.integer "id",    description: "id description",    mode: :required
    s.string  "name",  description: "name description",  mode: :required
    s.string  "breed", description: "breed description", mode: :required
  end
end

data = dataset.query "SELECT id, name, breed FROM pets", external: { pets: pets_table }

data.each do |row|
  puts row[:name]
end
```

[closes #1628]