### PR TITLE
Fix Spanner timeout configuration based on upstream changes

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client_config.json
@@ -28,7 +28,7 @@
           "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
           "max_rpc_timeout_millis": 3600000,
-          "total_timeout_millis": 36000000
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {


### PR DESCRIPTION
Previous update had an off-by-factor-of-ten error

Upstream change:
https://github.com/googleapis/googleapis/pull/438