### PR TITLE
Update stackdriver readmes

### DIFF
--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -48,7 +48,7 @@ frameworks, such as Ruby on Rails and Sinatra.
 ### With Ruby on Rails
 
 You can load the Railtie that comes with the library into your Ruby 
-on Rails application by explicitly require it in the application startup path:
+on Rails application by explicitly requiring it during the application startup:
 
 ```ruby
 # In config/application.rb

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -33,23 +33,32 @@ the `google-cloud-debugger` gem.
 
 ## Enable Stackdriver Debugger API
 
-The Stackdriver Debugger agent would need the [Stackdriver Debugger 
+The Stackdriver Debugger agent needs the [Stackdriver Debugger 
 API](https://console.cloud.google.com/apis/library/clouddebugger.googleapis.com) 
 to be enabled on your Google Cloud project. Make sure it's enabled if not 
 already.
 
 ## Enabling the Debugger agent
 
-If you're using Ruby on Rails and the `stackdriver` gem, they automatically 
-loads the library into your application when it starts.
+The Stackdriver Debugger library provides a Debugger agent that helps instrument
+breakpoints in your running applications. The library also comes with a Railtie
+and a Rack Middleware to help control the Debugger agent in popular Rack based
+frameworks, such as Ruby on Rails and Sinatra.
 
-Otherwise, you can load the Railtie that comes with the library into your Ruby 
+### With Ruby on Rails
+
+You can load the Railtie that comes with the library into your Ruby 
 on Rails application by explicitly require it in the application startup path:
 
 ```ruby
 # In config/application.rb
 require "google/cloud/debugger/rails"
 ```
+
+If you're using the `stackdriver` gem, it automatically loads the Railtie into 
+your application when it starts.
+
+### With other Rack-based frameworks
 
 Other Rack-based frameworks, such as Sinatra, can use the Rack Middleware 
 provided by the library:
@@ -58,6 +67,8 @@ provided by the library:
 require "google/cloud/debugger"
 use Google::Cloud::Debugger::Middleware
 ```
+
+### Without Rack-based framework
 
 Non-rack-based applications can start the agent explicitly at the entry point of
 your application:

--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -55,7 +55,7 @@ automatically reports exceptions captured from the application's Rack stack.
 ### With Ruby on Rails
 
 You can load the Railtie that comes with the library into your Ruby 
-on Rails application by explicitly require it in the application startup path:
+on Rails application by explicitly requiring it during the application startup:
 
 ```ruby
 # In config/application.rb

--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -40,7 +40,7 @@ the `google-cloud-error_reporting` gem.
 
 ## Enable Stackdriver Error Reporting API
 
-The Stackdriver Error Reporting library would need the [Stackdriver Error
+The Stackdriver Error Reporting library needs the [Stackdriver Error
 Reporting API](https://console.cloud.google.com/apis/library/clouderrorreporting.googleapis.com) 
 to be enabled on your Google Cloud project. Make sure it's enabled if not 
 already.
@@ -52,16 +52,20 @@ Stackdriver Error Reporting into popular Rack-based Ruby web frameworks such as
 Ruby on Rails and Sinatra. When the library integration is enabled, it 
 automatically reports exceptions captured from the application's Rack stack.
 
-If you're using Ruby on Rails and the `stackdriver` gem, they automatically 
-loads the library into your application when it starts.
+### With Ruby on Rails
 
-Otherwise, you can load the Railtie that comes with the library into your Ruby 
+You can load the Railtie that comes with the library into your Ruby 
 on Rails application by explicitly require it in the application startup path:
 
 ```ruby
 # In config/application.rb
 require "google/cloud/error_reporting/rails"
 ```
+
+If you're using the `stackdriver` gem, it automatically loads the Railtie into 
+your application when it starts.
+
+### With other Rack-based frameworks
 
 Other Rack-based frameworks, such as Sinatra, can use the Rack Middleware 
 provided by the library:
@@ -155,8 +159,8 @@ Rails.application.configure do |config|
 end
 ```
 
-Other Rack-based applications that are loading the Rack Middleware directly can use
-the configration interface:
+Other Rack-based applications that are loading the Rack Middleware directly or
+using the manually reporting interface can leverage the configration interface:
  
 ```ruby
 require "google/cloud/error_reporting"

--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -13,63 +13,166 @@ new errors.
 - [google-cloud-error_reporting on RubyGems](https://rubygems.org/gems/google-cloud-error_reporting)
 - [Stackdriver ErrorReporting documentation](https://cloud.google.com/error-reporting/docs/)
 
-google-cloud-error_reporting provides an instrumentation API that makes it easy 
-to report exceptions to the Stackdriver Error Reporting service. It also 
-contains a full API client library for the 
-[Stackdriver Error Reporting API](https://developers.google.com/apis-explorer/#p/clouderrorreporting/v1beta1/) 
-(v1beta1).
-
 ## Quick Start
+
+Install the gem directly:
+
 ```sh
 $ gem install google-cloud-error_reporting
 ```
+
+Or install through Bundler:
+
+1. Add the `google-cloud-error_reporting` gem to your Gemfile:
+
+```ruby
+gem "google-cloud-error_reporting"
+```
+
+2. Use Bundler to install the gem:
+
+```sh
+$ bundle install
+```
+
+Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes 
+the `google-cloud-error_reporting` gem.
+
+## Enable Stackdriver Error Reporting API
+
+The Stackdriver Error Reporting library would need the [Stackdriver Error
+Reporting API](https://console.cloud.google.com/apis/library/clouderrorreporting.googleapis.com) 
+to be enabled on your Google Cloud project. Make sure it's enabled if not 
+already.
+
+## Reporting errors in Rack-based frameworks
+
+The Stackdriver Error Reporting library for Ruby makes it easy to integrate 
+Stackdriver Error Reporting into popular Rack-based Ruby web frameworks such as 
+Ruby on Rails and Sinatra. When the library integration is enabled, it 
+automatically reports exceptions captured from the application's Rack stack.
+
+If you're using Ruby on Rails and the `stackdriver` gem, they automatically 
+loads the library into your application when it starts.
+
+Otherwise, you can load the Railtie that comes with the library into your Ruby 
+on Rails application by explicitly require it in the application startup path:
+
+```ruby
+# In config/application.rb
+require "google/cloud/error_reporting/rails"
+```
+
+Other Rack-based frameworks, such as Sinatra, can use the Rack Middleware 
+provided by the library:
+
+```ruby
+require "google/cloud/error_reporting"
+use Google::Cloud::ErrorReporting::Middleware
+```
+
+## Reporting errors manually
+
+Manually reporting an error is as easy as calling the report method:
+
+```ruby
+require "google/cloud/error_reporting"
+begin
+  fail "boom!"
+rescue => exception
+  Google::Cloud::ErrorReporting.report exception
+end
+```
+
+## Configuring the library
+
+You can customize the behavior of the Stackdriver Error Reporting library for 
+Ruby. See the [configuration guide](../stackdriver/configuration.md) for a list 
+of possible configuration options.
+
+## Running on Google Cloud Platform
+
+The Stackdriver Error Reporting library for Ruby should work without you 
+manually providing authentication credentials for instances running on Google 
+Cloud Platform, as long as the Stackdriver Error Reporting API access scope is 
+enabled on that instance.
+
+### App Engine
+
+On Google App Engine, the Stackdriver Error Reporting API access scope is 
+enabled by default, and the Stackdriver Error Reporting library for Ruby can 
+be used without providing credentials or a project ID.
+
+### Container Engine
+
+On Google Container Engine, you must explicitly add the `cloud-platform` OAuth 
+scope when creating the cluster:
+
+```sh
+$ gcloud container clusters create example-cluster-name --scopes https://www.googleapis.com/auth/cloud-platform
+```
+
+You may also do this through the Google Cloud Platform Console. Select 
+**Enabled** in the **Cloud Platform** section of **Create a container cluster**.
+
+### Compute Engine
+
+For Google Compute Engine instances, you must explicitly enable the 
+`cloud-platform` access scope for each instance. When you create a new instance 
+through the Google Cloud Platform Console, you can do this under Identity and 
+API access: Use the Compute Engine default service account and select "Allow 
+full access to all Cloud APIs" under Access scopes.
+
+## Running locally and elsewhere
+
+To run the Stackdriver Error Reporting outside of Google Cloud Platform, you 
+must supply your GCP project ID and appropriate service account credentials 
+directly to the Stackdriver Error Reporting. This applies to running the 
+library on your own workstation, on your datacenter's computers, or on the VM 
+instances of another cloud provider. See the [Authentication 
+section](#authentication) for instructions on how to do so.
 
 ## Authentication
 
 The Instrumentation client and API use Service Account credentials to connect 
 to Google Cloud services. When running on Google Cloud Platform environments, 
 the credentials will be discovered automatically. When running on other 
-environments the Service Account credentials can be specified by providing the 
-path to the JSON file, or the JSON itself, in environment variables or 
-configuration code.
+environments the Service Account credentials can be specified by providing in 
+several ways.
 
-Instructions and configuration options are covered in the 
-[Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-error_reporting/guides/authentication).
+The best way to provide authentication information if you're using Ruby on Rails
+is through the Rails configuration interface:
 
-## Instrumentation Example
+```ruby
+# in config/environments/*.rb
+Rails.application.configure do |config|
+  # Shared parameters
+  config.google_cloud.project_id = "your-project-id"
+  config.google_cloud.keyfile = "/path/to/key.json"
+  # Or Stackdriver Error Reporting specific parameters
+  config.google_cloud.error_reporting.project_id = "your-project-id"
+  config.google_cloud.error_reporting.keyfile = "/path/to/key.json"
+end
+```
+
+Other Rack-based applications that are loading the Rack Middleware directly can use
+the configration interface:
+ 
 ```ruby
 require "google/cloud/error_reporting"
- 
-# Configure Stackdriver ErrorReporting instrumentation
-Google::Cloud::ErrorReporting.configure do |config|
-  config.project_id = "my-project"
-  config.keyfile = "/path/to/keyfile.json"
-end
- 
-# Insert a Rack Middleware to report unhanded exceptions 
-use Google::Cloud::ErrorReporting::Middleware
- 
-# Or explicitly submit exceptions
-begin
-  fail "Boom!"
-rescue => exception
-  Google::Cloud::ErrorReporting.report exception
+Google::Cloud.configure do |config|
+  # Shared parameters
+  config.project_id = "your-project-id"
+  config.keyfile = "/path/to/key.json"
+  # Or Stackdriver Error Reporting specific parameters
+  config.error_reporting.project_id = "your-project-id"
+  config.error_reporting.keyfile = "/path/to/key.json"
 end
 ```
 
-## Rails and Rack Integration
-
-This library also provides a built-in Railtie for Ruby on Rails integration. To
- do this, simply add this line to config/application.rb:
-```ruby
-require "google/cloud/error_reporting/rails"
-```
-
-Alternatively, check out the [stackdriver](../stackdriver) gem, which includes 
-this library and enables the Railtie by default.
-
-For Rack integration and more examples, see the
-[Instrumentation Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-error_reporting/guides/instrumentation).
+This library also supports the other authentication methods provided by the 
+`google-cloud-ruby` suite. Instructions and configuration options are covered 
+in the [Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-debugger/guides/authentication).
 
 ## Supported Ruby Versions
 

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -8,17 +8,32 @@
 
 ## Quick Start
 
+Install the gem directly:
+
 ```sh
 $ gem install google-cloud-logging
 ```
 
-## Authentication
+Or install through Bundler:
 
-This library uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables.
+1. Add the `google-cloud-logging` gem to your Gemfile:
 
-Instructions and configuration options are covered in the [Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/guides/authentication).
+```ruby
+gem "google-cloud-logging"
+```
 
-## Example
+2. Use Bundler to install the gem:
+
+```sh
+$ bundle install
+```
+
+Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes 
+the `google-cloud-logging` gem.
+
+## Logging using client library
+
+You can directly read or write log entries through the client library:
 
 ```ruby
 require "google/cloud/logging"
@@ -44,48 +59,82 @@ entry.resource.labels[:version_id] = "20150925t173233"
 logging.write_entries entry
 ```
 
-## Rails Integration
+## Logging in Rack-based frameworks
 
-This library also provides a built in Railtie for Ruby on Rails integration. When enabled, it sets an instance of Google::Cloud::Logging::Logger as the default Rails logger. Then all consequent log entries will be submitted to the Stackdriver Logging service.
+The `google-cloud-logging` library provides framework integration for popular 
+Rack-based frameworks, such as Ruby on Rails and Sinatra, which sets the default 
+Rack logger to an instance of Stackdriver Logging logger.
 
-To do this, simply add this line to config/application.rb:
-```ruby
-require "google/cloud/logging/rails"
-```
-Then the library can be configured through this set of Rails parameters in config/environments/*.rb:
-```ruby
-# Sharing authentication parameters
-config.google_cloud.project_id = "gcp-project-id"
-config.google_cloud.keyfile = "/path/to/gcp/secret.json"
-# Or more specificly for Logging
-config.google_cloud.logging.project_id = "gcp-project-id"
-config.google_cloud.logging.keyfile = "/path/to/gcp/sercret.json"
+If you're using Ruby on Rails and the `stackdriver` gem, bundler automatically 
+loads the library into your application when it starts.
 
-# Explicitly enable or disable Logging
-config.google_cloud.use_logging = true
+Other Rack-based applications can use the Rack Middleware to replace the Rack 
+logger with the Stackdriver Logging logger:
 
-# Set Stackdriver Logging log name
-config.google_cloud.logging.log_name = "my-app-log"
-
-# Override default monitored resource if needed. E.g. used on AWS
-config.google_cloud.logging.monitored_resource.type = "aws_ec2_instance"
-config.google_cloud.logging.monitored_resource.labels.instance_id = "ec2-instance-id"
-config.google_cloud.logging.monitored_resource.labels.aws_account = "AWS account number"
-```
-Alternatively, check out [stackdriver](../stackdriver) gem, which includes this Railtie by default.
-
-## Rack Integration
-
-Other Rack base framework can also directly leverage the built-in Middleware.
 ```ruby
 require "google/cloud/logging"
-
-logging = Google::Cloud::Logging.new
-resource = Google::Cloud::Logging::Middleware.build_monitored_resource
-logger = logging.logger "my-log-name",
-                        resource
-use Google::Cloud::Logging::Middleware, logger: logger
+use Google::Cloud::Logging::Middleware
 ```
+
+Once the Rack logger is set, some Rack-based frameworks, such as Ruby on Rails 
+and Sinatra, automatically initialize the default application logger to use the 
+Rack logger:
+
+```ruby
+logger.info "Hello World"
+logger.warn "Hola Mundo"
+logger.error "Bonjour Monde"
+```
+
+For other frameworks, consult the documentations on how to utilize the Rack 
+logger. 
+
+### Configuring the framework integration
+
+You can customize the behavior of the Stackdriver Logging framework integration 
+for Ruby. See the [configuration guide](../stackdriver/configuration.md) for a 
+list of possible configuration options.
+
+## Authentication
+
+This library uses Service Account credentials to connect to Google Cloud 
+services. When running on Compute Engine the credentials will be discovered 
+automatically. When running on other environments the Service Account 
+credentials can be specified by providing in several ways.
+
+If you're using Ruby on Rails and the library's Rails integration feature, you 
+can provide the authentication parameters through the Rails configuration 
+interface:
+ 
+```ruby
+# Add this to config/environments/*.rb
+Rails.application.configure do |config|
+  # Shared parameters
+  config.google_cloud.project_id = "your-project-id"
+  config.google_cloud.keyfile = "/path/to/key.json"
+  # Stackdriver Logging specific parameters
+  config.google_cloud.logging.project_id = "your-project-id"
+  config.google_cloud.logging.keyfile    = "/path/to/key.json"
+end
+```
+Other Rack-based applications that are loading the Rack Middleware directly can 
+use the configration interface:
+
+```ruby
+require "google/cloud/logging"
+Google::Cloud.configure do |config|
+  # Shared parameters
+  config.project_id = "your-project-id"
+  config.keyfile = "/path/to/key.json"
+  # Or Stackdriver logging specific parameters
+  config.logging.project_id = "your-project-id"
+  config.logging.keyfile = "/path/to/key.json"
+end
+```
+
+See the [Authentication 
+Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/guides/authentication).
+for more ways to authenticate the client library.
 
 ## Supported Ruby Versions
 

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -63,12 +63,12 @@ logging.write_entries entry
 
 The `google-cloud-logging` library provides framework integration for popular 
 Rack-based frameworks, such as Ruby on Rails and Sinatra, which sets the default 
-Rack logger to an instance of Stackdriver Logging logger.
+Rack logger to an instance of the Stackdriver Logging logger.
 
 ### With Ruby on Rails
 
 You can load the Railtie that comes with the library into your Ruby 
-on Rails application by explicitly require it in the application startup path:
+on Rails application by explicitly requiring it during the application startup:
 
 ```ruby
 # In config/application.rb

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -59,14 +59,34 @@ entry.resource.labels[:version_id] = "20150925t173233"
 logging.write_entries entry
 ```
 
-## Logging in Rack-based frameworks
+## Using Stackdriver Logging in frameworks
 
 The `google-cloud-logging` library provides framework integration for popular 
 Rack-based frameworks, such as Ruby on Rails and Sinatra, which sets the default 
 Rack logger to an instance of Stackdriver Logging logger.
 
-If you're using Ruby on Rails and the `stackdriver` gem, bundler automatically 
-loads the library into your application when it starts.
+### With Ruby on Rails
+
+You can load the Railtie that comes with the library into your Ruby 
+on Rails application by explicitly require it in the application startup path:
+
+```ruby
+# In config/application.rb
+require "google/cloud/logging/rails"
+```
+
+If you're using the `stackdriver` gem, it automatically loads the Railtie into 
+your application when it starts.
+
+You'll be able to use Stackdriver logger through the standard Rails logger:
+
+```ruby
+Rails.logger.info "Hello World"
+# Or just...
+logger.warn "Hola Mundo"
+```
+
+### With other Rack-based frameworks
 
 Other Rack-based applications can use the Rack Middleware to replace the Rack 
 logger with the Stackdriver Logging logger:
@@ -87,7 +107,7 @@ logger.error "Bonjour Monde"
 ```
 
 For other frameworks, consult the documentations on how to utilize the Rack 
-logger. 
+logger.
 
 ### Configuring the framework integration
 

--- a/google-cloud-trace/README.md
+++ b/google-cloud-trace/README.md
@@ -40,7 +40,7 @@ the `google-cloud-cloud` gem.
 
 ## Enable Stackdriver Trace API
 
-The Stackdriver Trace library would need the [Stackdriver Trace 
+The Stackdriver Trace library needs the [Stackdriver Trace 
 API](https://console.cloud.google.com/apis/library/cloudtrace.googleapis.com) 
 to be enabled on your Google Cloud project. Make sure it's enabled if not 
 already.
@@ -52,16 +52,20 @@ Trace into popular Rack-based Ruby web frameworks such as Ruby on Rails and
 Sinatra. When the library integration is enabled, it automatically traces 
 incoming requests in the application.
 
-If you're using Ruby on Rails and the `stackdriver` gem, they automatically 
-loads the library into your application when it starts.
+### With Ruby on Rails
 
-Otherwise, you can load the Railtie that comes with the library into your Ruby 
+You can load the Railtie that comes with the library into your Ruby 
 on Rails application by explicitly require it in the application startup path:
 
 ```ruby
 # In config/application.rb
 require "google/cloud/trace/rails"
 ```
+
+If you're using the `stackdriver` gem, it automatically loads the Railtie into 
+your application when it starts.
+
+### With other Rack-based frameworks
 
 Other Rack-based frameworks, such as Sinatra, can use the Rack Middleware 
 provided by the library:

--- a/google-cloud-trace/README.md
+++ b/google-cloud-trace/README.md
@@ -55,7 +55,7 @@ incoming requests in the application.
 ### With Ruby on Rails
 
 You can load the Railtie that comes with the library into your Ruby 
-on Rails application by explicitly require it in the application startup path:
+on Rails application by explicitly requiring it during the application startup:
 
 ```ruby
 # In config/application.rb
@@ -75,7 +75,7 @@ require "google/cloud/trace"
 use Google::Cloud::Trace::Middleware
 ```
 
-### Add Custom Trace Span
+### Adding Custom Trace Span
 
 The Stackdriver Trace Rack Middleware automatically creates a trace record for
 incoming requests. You can add additional custom trace spans within each 

--- a/google-cloud-trace/README.md
+++ b/google-cloud-trace/README.md
@@ -75,7 +75,7 @@ require "google/cloud/trace"
 use Google::Cloud::Trace::Middleware
 ```
 
-### Adding Custom Trace Span
+### Adding Custom Trace Spans
 
 The Stackdriver Trace Rack Middleware automatically creates a trace record for
 incoming requests. You can add additional custom trace spans within each 


### PR DESCRIPTION
Another round of updates to the READMEs for stackdriver gems. Add comprehensive instructions on enabling the API and authentication scope for running on GCP environments.

[closes #1694]