### PR TITLE
Add high-level, synchronous version of copy

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -65,6 +65,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   end
   let(:local_file) { "acceptance/data/kitten-test-data.json" }
   let(:target_table_id) { "kittens_copy" }
+  let(:target_table_2_id) { "kittens_copy_2" }
   let(:labels) { { "foo" => "bar" } }
 
   it "has the attributes of a table" do
@@ -350,9 +351,9 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     end
   end
 
-  it "copies itself to another table" do
+  it "copies itself to another table with copy_job" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
-    copy_job = table.copy target_table_id, create: :needed, write: :empty, job_id: job_id, labels: labels
+    copy_job = table.copy_job target_table_id, create: :needed, write: :empty, job_id: job_id, labels: labels
 
     copy_job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
     copy_job.job_id.must_equal job_id
@@ -367,6 +368,11 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     copy_job.write_truncate?.must_equal false
     copy_job.write_append?.must_equal false
     copy_job.write_empty?.must_equal true
+  end
+
+  it "copies itself to another table with copy" do
+    result = table.copy target_table_2_id, create: :needed, write: :empty
+    result.must_equal true
   end
 
   it "creates and cancels jobs" do

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
@@ -20,7 +20,7 @@ module Google
       # # CopyJob
       #
       # A {Job} subclass representing a copy operation that may be performed on
-      # a {Table}. A CopyJob instance is created when you call {Table#copy}.
+      # a {Table}. A CopyJob instance is created when you call {Table#copy_job}.
       #
       # @see https://cloud.google.com/bigquery/docs/tables#copyingtable Copying
       #   an Existing Table
@@ -30,7 +30,7 @@ module Google
       class CopyJob < Job
         ##
         # The table from which data is copied. This is the table on
-        # which {Table#copy} was called. Returns a {Table} instance.
+        # which {Table#copy_job} was called. Returns a {Table} instance.
         def source
           table = @gapi.configuration.copy.source_table
           return nil unless table

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -30,7 +30,7 @@ module Google
       # {CopyJob}, {ExtractJob}, {LoadJob}, and {QueryJob}.
       #
       # A job instance is created when you call {Project#query_job},
-      # {Dataset#query_job}, {Table#copy}, {Table#extract}, {Table#load}, or
+      # {Dataset#query_job}, {Table#copy_job}, {Table#extract}, {Table#load}, or
       # {View#data}.
       #
       # @see https://cloud.google.com/bigquery/docs/managing_jobs_datasets_projects

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -411,8 +411,17 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Table#copy@Passing a string identifier for the destination table:
   doctest.before "Google::Cloud::Bigquery::Table#copy" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_destination_table"]
+      mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
+    end
+  end
+
+  # Google::Cloud::Bigquery::Table#copy_job@Passing a string identifier for the destination table:
+  doctest.before "Google::Cloud::Bigquery::Table#copy_job" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]


### PR DESCRIPTION
* Rename `Table#copy` to `Table#copy_job`.
* Add high-level, synchronous version as `Table#copy`.

[refs #1720]