### PR TITLE
Add high-level, synchronous version of extract

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -421,7 +421,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       Tempfile.open "empty_extract_file.json" do |tmp|
         bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
         extract_url = "gs://#{bucket.name}/kitten-test-data-backup.json"
-        extract_job = table.extract extract_url, labels: labels
+        extract_job = table.extract_job extract_url, labels: labels
 
         extract_job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
         extract_job.labels.must_equal labels
@@ -461,7 +461,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
         extract_file = bucket.create_file tmp, "kitten-test-data-backup.json"
         job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
 
-        extract_job = table.extract extract_file, job_id: job_id
+        extract_job = table.extract_job extract_file, job_id: job_id
         extract_job.job_id.must_equal job_id
         extract_job.wait_until_done!
         extract_job.wont_be :failed?

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -389,7 +389,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     load_job.wont_be :failed?
   end
 
-  it "extracts data to a url in your bucket" do
+  it "extracts data to a url in your bucket with extract_job" do
     begin
       # Make sure there is data to extract...
       load_job = table.load local_file
@@ -450,7 +450,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     end
   end
 
-  it "extracts data to a file in your bucket" do
+  it "extracts data to a file in your bucket with extract_job" do
     begin
       # Make sure there is data to extract...
       load_job = table.load local_file
@@ -465,6 +465,61 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
         extract_job.job_id.must_equal job_id
         extract_job.wait_until_done!
         extract_job.wont_be :failed?
+        # Refresh to get the latest file data
+        extract_file = bucket.file "kitten-test-data-backup.json"
+        downloaded_file = extract_file.download tmp.path
+        downloaded_file.size.must_be :>, 0
+      end
+    ensure
+      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
+      if post_bucket
+        post_bucket.files.map &:delete
+        post_bucket.delete
+      end
+    end
+  end
+
+  it "extracts data to a url in your bucket with extract" do
+    begin
+      # Make sure there is data to extract...
+      load_job = table.load local_file
+
+      load_job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      load_job.wait_until_done!
+
+      load_job.wont_be :failed?
+
+      Tempfile.open "empty_extract_file.json" do |tmp|
+        bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+        extract_url = "gs://#{bucket.name}/kitten-test-data-backup.json"
+        result = table.extract extract_url
+        result.must_equal true
+
+        extract_file = bucket.file "kitten-test-data-backup.json"
+        downloaded_file = extract_file.download tmp.path
+        downloaded_file.size.must_be :>, 0
+      end
+    ensure
+      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
+      if post_bucket
+        post_bucket.files.map &:delete
+        post_bucket.delete
+      end
+    end
+  end
+
+  it "extracts data to a file in your bucket with extract" do
+    begin
+      # Make sure there is data to extract...
+      load_job = table.load local_file
+      load_job.wait_until_done!
+      Tempfile.open "empty_extract_file.json" do |tmp|
+        tmp.size.must_equal 0
+        bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+        extract_file = bucket.create_file tmp, "kitten-test-data-backup.json"
+
+        result = table.extract extract_file
+        result.must_equal true
         # Refresh to get the latest file data
         extract_file = bucket.file "kitten-test-data-backup.json"
         downloaded_file = extract_file.download tmp.path

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -411,7 +411,7 @@ module Google
     #   bucket = storage.create_bucket bucket_id
     #   extract_url = "gs://#{bucket.id}/baby-names.csv"
     #
-    #   extract_job = result_table.extract extract_url
+    #   extract_job = result_table.extract_job extract_url
     #
     #   extract_job.wait_until_done!
     #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -411,9 +411,7 @@ module Google
     #   bucket = storage.create_bucket bucket_id
     #   extract_url = "gs://#{bucket.id}/baby-names.csv"
     #
-    #   extract_job = result_table.extract_job extract_url
-    #
-    #   extract_job.wait_until_done!
+    #   result_table.extract extract_url
     #
     #   # Download to local filesystem
     #   bucket.files.first.download "baby-names.csv"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
@@ -21,7 +21,7 @@ module Google
       #
       # A {Job} subclass representing an export operation that may be performed
       # on a {Table}. A ExtractJob instance is created when you call
-      # {Table#extract}.
+      # {Table#extract_job}.
       #
       # @see https://cloud.google.com/bigquery/exporting-data-from-bigquery
       #   Exporting Data From BigQuery
@@ -38,7 +38,7 @@ module Google
 
         ##
         # The table from which the data is exported. This is the table upon
-        # which {Table#extract} was called. Returns a {Table} instance.
+        # which {Table#extract_job} was called. Returns a {Table} instance.
         def source
           table = @gapi.configuration.extract.source_table
           return nil unless table

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -260,7 +260,7 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   extract_job = table.extract_job "gs://my-bucket/file-name.json",
-        #                               format: "json"
+        #                                   format: "json"
         #   extract_job.wait_until_done!
         #   extract_job.done? #=> true
         def wait_until_done!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -30,8 +30,8 @@ module Google
       # {CopyJob}, {ExtractJob}, {LoadJob}, and {QueryJob}.
       #
       # A job instance is created when you call {Project#query_job},
-      # {Dataset#query_job}, {Table#copy_job}, {Table#extract}, {Table#load}, or
-      # {View#data}.
+      # {Dataset#query_job}, {Table#copy_job}, {Table#extract_job},
+      # {Table#load}, or {View#data}.
       #
       # @see https://cloud.google.com/bigquery/docs/managing_jobs_datasets_projects
       #   Managing Jobs, Datasets, and Projects
@@ -259,7 +259,7 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
-        #   extract_job = table.extract "gs://my-bucket/file-name.json",
+        #   extract_job = table.extract_job "gs://my-bucket/file-name.json",
         #                               format: "json"
         #   extract_job.wait_until_done!
         #   extract_job.done? #=> true

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -812,14 +812,14 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
-        #   extract_job = table.extract "gs://my-bucket/file-name.json",
+        #   extract_job = table.extract_job "gs://my-bucket/file-name.json",
         #                               format: "json"
         #
         # @!group Data
         #
-        def extract extract_url, format: nil, compression: nil, delimiter: nil,
-                    header: nil, dryrun: nil, job_id: nil, prefix: nil,
-                    labels: nil
+        def extract_job extract_url, format: nil, compression: nil,
+                        delimiter: nil, header: nil, dryrun: nil, job_id: nil,
+                        prefix: nil, labels: nil
           ensure_service!
           options = { format: format, compression: compression,
                       delimiter: delimiter, header: header, dryrun: dryrun,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
@@ -48,7 +48,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     bigquery.service.mocked_service = mock
     job_gapi = copy_job_gapi(source_table, target_table)
     job_resp_gapi = job_gapi.dup
-    job_resp_gapi.status = status_done
+    job_resp_gapi.status = status "done"
     mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
 
     result = source_table.copy target_table
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
 
     job_gapi = copy_job_gapi(source_table, target_table_other_proj)
     job_resp_gapi = job_gapi.dup
-    job_resp_gapi.status = status_done
+    job_resp_gapi.status = status "done"
     mock.expect :insert_job, job_resp_gapi, ["test-project", job_gapi]
 
     result = source_table.copy "target-project:target_dataset.target_table_id"
@@ -85,7 +85,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
 
     job_gapi = copy_job_gapi(source_table, new_target_table)
     job_resp_gapi = job_gapi.dup
-    job_resp_gapi.status = status_done
+    job_resp_gapi.status = status "done"
     mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
 
     result = source_table.copy "new_target_table_id"
@@ -101,7 +101,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     job_gapi = copy_job_gapi(source_table, target_table)
     job_gapi.configuration.copy.create_disposition = "CREATE_NEVER"
     job_resp_gapi = job_gapi.dup
-    job_resp_gapi.status = status_done
+    job_resp_gapi.status = status "done"
     mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
 
     result = source_table.copy target_table, create: "CREATE_NEVER"
@@ -117,7 +117,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     job_gapi = copy_job_gapi(source_table, target_table)
     job_gapi.configuration.copy.create_disposition = "CREATE_NEVER"
     job_resp_gapi = job_gapi.dup
-    job_resp_gapi.status = status_done
+    job_resp_gapi.status = status "done"
     mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
 
     result = source_table.copy target_table, create: :never
@@ -134,7 +134,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     job_gapi = copy_job_gapi(source_table, target_table)
     job_gapi.configuration.copy.write_disposition = "WRITE_TRUNCATE"
     job_resp_gapi = job_gapi.dup
-    job_resp_gapi.status = status_done
+    job_resp_gapi.status = status "done"
     mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
 
     result = source_table.copy target_table, write: "WRITE_TRUNCATE"
@@ -150,7 +150,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
     job_gapi = copy_job_gapi(source_table, target_table)
     job_gapi.configuration.copy.write_disposition = "WRITE_TRUNCATE"
     job_resp_gapi = job_gapi.dup
-    job_resp_gapi.status = status_done
+    job_resp_gapi.status = status "done"
     mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
 
     result = source_table.copy target_table, write: :truncate
@@ -187,9 +187,5 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
         "dryRun" => nil
       }
     }.to_json
-  end
-
-  def status_done
-    Google::Apis::BigqueryV2::JobStatus.new state: "done"
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
+describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
   let(:extract_bucket_gapi) {  Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
@@ -44,7 +44,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_file
+    job = table.extract_job extract_file
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -57,7 +57,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_url
+    job = table.extract_job extract_url
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -71,7 +71,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_url, dryrun: true
+    job = table.extract_job extract_url, dryrun: true
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -86,7 +86,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract "#{extract_url}.csv"
+    job = table.extract_job "#{extract_url}.csv"
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -100,7 +100,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_url, format: :csv
+    job = table.extract_job extract_url, format: :csv
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -117,7 +117,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
+    job = table.extract_job extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -132,7 +132,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract "#{extract_url}.json"
+    job = table.extract_job "#{extract_url}.json"
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -146,7 +146,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_url, format: :json
+    job = table.extract_job extract_url, format: :json
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -161,7 +161,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract "#{extract_url}.avro"
+    job = table.extract_job "#{extract_url}.avro"
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -175,7 +175,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_url, format: :avro
+    job = table.extract_job extract_url, format: :avro
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -189,7 +189,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_url, job_id: job_id
+    job = table.extract_job extract_url, job_id: job_id
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -207,7 +207,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_url, prefix: prefix
+    job = table.extract_job extract_url, prefix: prefix
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -222,7 +222,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_url, job_id: job_id, prefix: "IGNORED"
+    job = table.extract_job extract_url, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
@@ -237,7 +237,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
-    job = table.extract extract_file, labels: labels
+    job = table.extract_job extract_file, labels: labels
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
@@ -1,0 +1,259 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
+  let(:credentials) { OpenStruct.new }
+  let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
+  let(:extract_bucket_gapi) {  Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
+  let(:extract_bucket) { Google::Cloud::Storage::Bucket.from_gapi extract_bucket_gapi,
+                                                           storage.service }
+  let(:extract_file_gapi) { Google::Apis::StorageV1::Object.from_json random_file_hash(extract_bucket.name).to_json }
+  let(:extract_file) { Google::Cloud::Storage::File.from_gapi extract_file_gapi,
+                                                       storage.service }
+  let(:extract_url) { extract_file.to_gs_url }
+
+  let(:dataset) { "dataset" }
+  let(:table_id) { "table_id" }
+  let(:table_name) { "Target Table" }
+  let(:description) { "This is the target table" }
+  let(:table_gapi) { random_table_gapi dataset,
+                                       table_id,
+                                       table_name,
+                                       description }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+                                                  bigquery.service }
+
+  it "can extract itself to a storage file" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = table.extract extract_file
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract itself to a storage url" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = table.extract extract_url
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract itself and determine the csv format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "CSV"
+    job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".csv"]
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = table.extract "#{extract_url}.csv"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract itself and specify the csv format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "CSV"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = table.extract extract_url, format: :csv
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract itself and specify the csv format and options" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "CSV"
+    job_gapi.configuration.extract.compression = "GZIP"
+    job_gapi.configuration.extract.field_delimiter = "\t"
+    job_gapi.configuration.extract.print_header = false
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = table.extract extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract itself and determine the json format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "NEWLINE_DELIMITED_JSON"
+    job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".json"]
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = table.extract "#{extract_url}.json"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract itself and specify the json format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "NEWLINE_DELIMITED_JSON"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = table.extract extract_url, format: :json
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract itself and determine the avro format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "AVRO"
+    job_gapi.configuration.extract.destination_uris = [job_gapi.configuration.extract.destination_uris.first + ".avro"]
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = table.extract "#{extract_url}.avro"
+    mock.verify
+
+    result.must_equal true
+  end
+
+  it "can extract itself and specify the avro format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "AVRO"
+    job_resp_gapi = job_gapi.dup
+    job_resp_gapi.status = status "done"
+
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    result = table.extract extract_url, format: :avro
+    mock.verify
+
+    result.must_equal true
+  end
+
+  def extract_job_gapi table, extract_file, job_id: "job_9876543210"
+    Google::Apis::BigqueryV2::Job.from_json extract_job_json(table, extract_file, job_id)
+  end
+
+  def extract_job_json table, extract_file, job_id
+    {
+      "jobReference" => {
+        "projectId" => project,
+        "jobId" => job_id
+      },
+      "configuration" => {
+        "extract" => {
+          "destinationUris" => [extract_file.to_gs_url],
+          "sourceTable" => {
+            "projectId" => table.project_id,
+            "datasetId" => table.dataset_id,
+            "tableId" => table.table_id
+          },
+          "printHeader" => nil,
+          "compression" => nil,
+          "fieldDelimiter" => nil,
+          "destinationFormat" => nil
+        },
+        "dryRun" => nil
+      }
+    }.to_json
+  end
+
+  # Borrowed from MockStorage, extract to a common module?
+
+  def random_bucket_hash name=random_bucket_name
+    {"kind"=>"storage#bucket",
+     "id"=>name,
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{name}",
+     "projectNumber"=>"1234567890",
+     "name"=>name,
+     "timeCreated"=>::Time.now,
+     "metageneration"=>"1",
+     "owner"=>{"entity"=>"project-owners-1234567890"},
+     "location"=>"US",
+     "storageClass"=>"STANDARD",
+     "etag"=>"CAE=" }
+  end
+
+  def random_file_hash bucket=random_bucket_name, name=random_file_path
+    {"kind"=>"storage#object",
+     "id"=>"#{bucket}/#{name}/1234567890",
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{bucket}/o/#{name}",
+     "name"=>"#{name}",
+     "bucket"=>"#{bucket}",
+     "generation"=>"1234567890",
+     "metageneration"=>"1",
+     "contentType"=>"text/plain",
+     "updated"=>::Time.now,
+     "storageClass"=>"STANDARD",
+     "size"=>rand(10_000),
+     "md5Hash"=>"HXB937GQDFxDFqUGi//weQ==",
+     "mediaLink"=>"https://www.googleapis.com/download/storage/v1/b/#{bucket}/o/#{name}?generation=1234567890&alt=media",
+     "owner"=>{"entity"=>"user-1234567890", "entityId"=>"abc123"},
+     "crc32c"=>"Lm1F3g==",
+     "etag"=>"CKih16GjycICEAE="}
+  end
+
+  def random_bucket_name
+    (0...50).map { ("a".."z").to_a[rand(26)] }.join
+  end
+
+  def random_file_path
+    [(0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join + ".txt"].join "/"
+  end
+end

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -628,6 +628,10 @@ class MockBigquery < Minitest::Spec
     Google::Apis::BigqueryV2::Job.from_json hash.to_json
   end
 
+  def status state = "running"
+    Google::Apis::BigqueryV2::JobStatus.new state: state
+  end
+
   def temp_csv
     Tempfile.open ["import", ".csv"] do |tmpfile|
       tmpfile.puts "id,name"


### PR DESCRIPTION
* Rename `Table#extract` to `Table#extract_job`
* Add high-level, synchronous version as `Table#extract`

[refs #1720]

