### PR TITLE
BigQuery Error Retry and Backoff

### DIFF
--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -39,7 +39,7 @@ module Google
     #
     #   * `https://www.googleapis.com/auth/bigquery`
     # @param [Integer] retries Number of times to retry requests on server
-    #   error. The default value is `3`. Optional.
+    #   error. The default value is `5`. Optional.
     # @param [Integer] timeout Default request timeout in seconds. Optional.
     #
     # @return [Google::Cloud::Bigquery::Project]
@@ -88,7 +88,7 @@ module Google
     #
     #   * `https://www.googleapis.com/auth/bigquery`
     # @param [Integer] retries Number of times to retry requests on server
-    #   error. The default value is `3`. Optional.
+    #   error. The default value is `5`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     #
     # @return [Google::Cloud::Bigquery::Project]

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -468,7 +468,7 @@ module Google
       #
       #   * `https://www.googleapis.com/auth/bigquery`
       # @param [Integer] retries Number of times to retry requests on server
-      #   error. The default value is `3`. Optional.
+      #   error. The default value is `5`. Optional.
       # @param [Integer] timeout Default timeout to use in requests. Optional.
       #
       # @return [Google::Cloud::Bigquery::Project]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_delay_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_delay_test.rb
@@ -1,0 +1,115 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Service::Backoff, :delay do
+  class BackoffVerifier
+    def initialize
+      @mock = Minitest::Mock.new
+    end
+
+    def expect meth, ret, args
+      @mock.expect meth, ret, args
+    end
+
+    def verify
+      @mock.verify
+    end
+
+    def sleep num
+      @mock.sleep num
+    end
+
+    # Use the lambda, but give it a new binding context that will use the sleep mock.
+    define_method :backoff, &Google::Cloud::Bigquery::Service::Backoff.backoff
+  end
+
+  it "has a lambda that calls sleep with the delay given 0" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [1]
+    b.backoff 0
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 1" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [2]
+    b.backoff 1
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 2" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [4]
+    b.backoff 2
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 3" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [8]
+    b.backoff 3
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 4" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [16]
+    b.backoff 4
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 5" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [32]
+    b.backoff 5
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 6" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [32]
+    b.backoff 6
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 7" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [32]
+    b.backoff 7
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 8" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [32]
+    b.backoff 8
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 9" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [32]
+    b.backoff 9
+    b.verify
+  end
+
+  it "has a lambda that calls sleep with the delay given 10" do
+    b = BackoffVerifier.new
+    b.expect :sleep, nil, [32]
+    b.backoff 10
+    b.verify
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
@@ -1,0 +1,233 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+
+describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
+  let(:dataset_id) { "my_dataset" }
+
+  it "finds a dataset without any retry or backoff" do
+    mock = Minitest::Mock.new
+    mock.expect :get_dataset, find_dataset_gapi(dataset_id),
+      [project, dataset_id]
+    bigquery.service.mocked_service = mock
+
+    dataset = bigquery.dataset dataset_id
+
+    mock.verify
+
+    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.dataset_id.must_equal dataset_id
+  end
+
+  it "handles a single 404 error (retriable) and retries with backoff" do
+    mock = Minitest::Mock.new
+    mock.expect :retry, nil, [0]
+
+    mocked_backoff = lambda { |i| mock.retry i }
+
+    stub = Object.new
+    def stub.get_dataset *args
+      @tries ||= 0
+      @tries += 1
+      if @tries == 1
+        # raise Google::Apis::Error.new "notfound", status_code: 400, body: backenderror_body
+        raise Google::Apis::Error.new "notfound",
+          status_code: 400,
+          body: { "error" => { "errors" => [{ "reason" => "backendError" }] } }.to_json
+      end
+
+      random_dataset_hash = {
+        "kind" => "bigquery#dataset",
+        "etag" => "etag123456789",
+        "id" => "id",
+        "datasetReference" => {
+          "datasetId" => "my_dataset",
+          "projectId" => "test"
+        },
+        "friendlyName" => "My Dataset",
+      }
+      Google::Apis::BigqueryV2::Dataset.from_json random_dataset_hash.to_json
+    end
+    bigquery.service.mocked_service = stub
+
+    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+      dataset = bigquery.dataset dataset_id
+
+      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      dataset.dataset_id.must_equal dataset_id
+    end
+
+    mock.verify
+  end
+
+  it "handles a multiple 500 errors (retriable) and retries with backoff" do
+    mock = Minitest::Mock.new
+    mock.expect :retry, nil, [0]
+    mock.expect :retry, nil, [1]
+    mock.expect :retry, nil, [2]
+    mock.expect :retry, nil, [3]
+
+    mocked_backoff = lambda { |i| mock.retry i }
+
+    stub = Object.new
+    def stub.get_dataset *args
+      @tries ||= 0
+      @tries += 1
+      if @tries < 5
+        raise Google::Apis::Error.new "internal",
+          status_code: 500,
+          body: { "error" => { "errors" => [{ "reason" => "backendError" }] } }.to_json
+      end
+
+      random_dataset_hash = {
+        "kind" => "bigquery#dataset",
+        "etag" => "etag123456789",
+        "id" => "id",
+        "datasetReference" => {
+          "datasetId" => "my_dataset",
+          "projectId" => "test"
+        },
+        "friendlyName" => "My Dataset",
+      }
+      Google::Apis::BigqueryV2::Dataset.from_json random_dataset_hash.to_json
+    end
+    bigquery.service.mocked_service = stub
+
+    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+      dataset = bigquery.dataset dataset_id
+
+      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      dataset.dataset_id.must_equal dataset_id
+    end
+
+    mock.verify
+  end
+
+  it "handles a multiple 500 errors (retriable) and then a 400 error (non-retriable)" do
+    mock = Minitest::Mock.new
+    mock.expect :retry, nil, [0]
+    mock.expect :retry, nil, [1]
+    mock.expect :retry, nil, [2]
+    mock.expect :retry, nil, [3]
+
+    mocked_backoff = lambda { |i| mock.retry i }
+
+    stub = Object.new
+    def stub.get_dataset *args
+      @tries ||= 0
+      @tries += 1
+      if @tries < 5
+        raise Google::Apis::Error.new "internal",
+          status_code: 500,
+          body: { "error" => { "errors" => [{ "reason" => "backendError" }] } }.to_json
+      end
+
+      raise Google::Apis::Error.new "invalid", status_code: 400
+    end
+    bigquery.service.mocked_service = stub
+
+    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+      err = assert_raises Google::Cloud::InvalidArgumentError do
+        bigquery.dataset dataset_id
+      end
+
+      err.message.must_equal "invalid"
+      err.cause.body.must_be :nil? if err.respond_to? :cause
+    end
+
+    mock.verify
+  end
+
+  it "handles a multiple 400 errors (retriable) until retries limit is reached" do
+    mock = Minitest::Mock.new
+    mock.expect :retry, nil, [0]
+    mock.expect :retry, nil, [1]
+    mock.expect :retry, nil, [2]
+    mock.expect :retry, nil, [3]
+    mock.expect :retry, nil, [4]
+
+    mocked_backoff = lambda { |i| mock.retry i }
+
+    stub = Object.new
+    def stub.get_dataset *args
+      raise Google::Apis::Error.new "invalid",
+        status_code: 400,
+        body: { "error" => { "errors" => [{ "reason" => "backendError" }] } }.to_json
+    end
+    bigquery.service.mocked_service = stub
+
+    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+      err = assert_raises Google::Cloud::InvalidArgumentError do
+        bigquery.dataset dataset_id
+      end
+
+      err.message.must_equal "invalid"
+      err.cause.body.must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"}]}}" if err.respond_to? :cause
+    end
+
+    mock.verify
+  end
+
+  it "does not handle a single 404 error (non-retriable)" do
+    stub = Object.new
+    def stub.get_dataset *args
+      raise Google::Apis::Error.new "invalid", status_code: 400
+    end
+    bigquery.service.mocked_service = stub
+
+    err = assert_raises StandardError do
+      bigquery.dataset dataset_id
+    end
+
+    err.message.must_equal "invalid"
+  end
+
+  it "does not handle a single 404 error with reason (non-retriable)" do
+    stub = Object.new
+    def stub.get_dataset *args
+      raise Google::Apis::Error.new "invalid", status_code: 400,
+        body: { "error" => { "errors" => [{ "reason" => "other" }] } }.to_json
+    end
+    bigquery.service.mocked_service = stub
+
+    err = assert_raises StandardError do
+      bigquery.dataset dataset_id
+    end
+
+    err.message.must_equal "invalid"
+  end
+
+  it "re-raises non-retriable errors" do
+    error_proc = -> { raise "nope" }
+
+    stub = Object.new
+    def stub.get_dataset *args
+      tries ||= 0
+      fail "nope"
+    end
+    bigquery.service.mocked_service = stub
+
+    err = assert_raises StandardError do
+      bigquery.dataset dataset_id
+    end
+
+    err.message.must_equal "nope"
+  end
+
+  def find_dataset_gapi id
+    Google::Apis::BigqueryV2::Dataset.from_json random_dataset_hash(id).to_json
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
@@ -67,6 +67,7 @@ describe Google::Cloud::Bigquery::CopyJob, :mock_bigquery do
     bigquery.service.mocked_service = mock
 
     rerun_job_gapi = Google::Apis::BigqueryV2::Job.new(
+      job_reference: job_reference_gapi(project, "job_9876543210"),
       configuration: Google::Apis::BigqueryV2::JobConfiguration.from_json(job.configuration.to_json)
     )
     mock.expect :insert_job, copy_job_gapi(job.job_id + "-rerun"), [project, rerun_job_gapi]


### PR DESCRIPTION
Disable the Google API Client error retry and handle error retry ourselves.
The rules for the retry are from the Google BigQuery SLA:

    After the first error, there is a minimum back-off interval of 1 second
    and for each consecutive error, the back-off interval increases
    exponentially up to 32 seconds.

https://cloud.google.com/bigquery/sla

[closes #1715]