### PR TITLE
Update View attributes

### DIFF
--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -612,6 +612,15 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::View#set_query" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
+      mock.expect :patch_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::View#query_id" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -306,10 +306,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       ),
       view: Google::Apis::BigqueryV2::ViewDefinition.new(
         query: query,
-        use_legacy_sql: false
+        use_legacy_sql: false,
+        user_defined_function_resources: []
       )
     )
-    return_view = create_view_gapi view_id, query
+    return_view = create_view_gapi view_id, insert_view.view
     mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
     dataset.service.mocked_service = mock
 
@@ -317,9 +318,12 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
+    table.must_be_kind_of Google::Cloud::Bigquery::View
     table.table_id.must_equal view_id
     table.query.must_equal query
-    table.must_be_kind_of Google::Cloud::Bigquery::View
+    table.must_be :query_standard_sql?
+    table.wont_be :query_legacy_sql?
+    table.query_udfs.must_be :empty?
     table.must_be :view?
     table.wont_be :table?
   end
@@ -333,10 +337,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       description: view_description,
       view: Google::Apis::BigqueryV2::ViewDefinition.new(
         query: query,
-        use_legacy_sql: false
+        use_legacy_sql: false,
+        user_defined_function_resources: []
       )
     )
-    return_view = create_view_gapi view_id, query, view_name, view_description
+    return_view = create_view_gapi view_id, insert_view.view, view_name, view_description
     mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
     dataset.service.mocked_service = mock
 
@@ -352,6 +357,168 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     table.query.must_equal query
     table.name.must_equal view_name
     table.description.must_equal view_description
+    table.must_be :query_standard_sql?
+    table.wont_be :query_legacy_sql?
+    table.query_udfs.must_be :empty?
+    table.must_be :view?
+    table.wont_be :table?
+  end
+
+  it "can create a view with standard_sql" do
+    mock = Minitest::Mock.new
+    insert_view = Google::Apis::BigqueryV2::Table.new(
+      table_reference: Google::Apis::BigqueryV2::TableReference.new(
+        project_id: project, dataset_id: dataset_id, table_id: view_id),
+      view: Google::Apis::BigqueryV2::ViewDefinition.new(
+        query: query,
+        use_legacy_sql: false,
+        user_defined_function_resources: []
+      )
+    )
+    return_view = create_view_gapi view_id, insert_view.view, view_name, view_description
+    mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
+    dataset.service.mocked_service = mock
+
+    table = dataset.create_view view_id, query, standard_sql: true
+
+    mock.verify
+
+
+    table.must_be_kind_of Google::Cloud::Bigquery::View
+    table.table_id.must_equal view_id
+    table.query.must_equal query
+    table.must_be :query_standard_sql?
+    table.wont_be :query_legacy_sql?
+    table.query_udfs.must_be :empty?
+    table.must_be :view?
+    table.wont_be :table?
+  end
+
+  it "can create a view with legacy_sql" do
+    mock = Minitest::Mock.new
+    insert_view = Google::Apis::BigqueryV2::Table.new(
+      table_reference: Google::Apis::BigqueryV2::TableReference.new(
+        project_id: project, dataset_id: dataset_id, table_id: view_id),
+      view: Google::Apis::BigqueryV2::ViewDefinition.new(
+        query: query,
+        use_legacy_sql: true,
+        user_defined_function_resources: []
+      )
+    )
+    return_view = create_view_gapi view_id, insert_view.view, view_name, view_description
+    mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
+    dataset.service.mocked_service = mock
+
+    table = dataset.create_view view_id, query, legacy_sql: true
+
+    mock.verify
+
+
+    table.must_be_kind_of Google::Cloud::Bigquery::View
+    table.table_id.must_equal view_id
+    table.query.must_equal query
+    table.wont_be :query_standard_sql?
+    table.must_be :query_legacy_sql?
+    table.query_udfs.must_be :empty?
+    table.name.must_equal view_name
+    table.description.must_equal view_description
+    table.must_be :view?
+    table.wont_be :table?
+  end
+
+  it "can create a view with udfs (array)" do
+    mock = Minitest::Mock.new
+    insert_view = Google::Apis::BigqueryV2::Table.new(
+      table_reference: Google::Apis::BigqueryV2::TableReference.new(
+        project_id: project, dataset_id: dataset_id, table_id: view_id),
+      view: Google::Apis::BigqueryV2::ViewDefinition.new(
+        query: query,
+        use_legacy_sql: false,
+        user_defined_function_resources: [
+          Google::Apis::BigqueryV2::UserDefinedFunctionResource.new(inline_code: "return x+1;"),
+          Google::Apis::BigqueryV2::UserDefinedFunctionResource.new(resource_uri: "gs://my-bucket/my-lib.js")
+        ]
+      )
+    )
+    return_view = create_view_gapi view_id, insert_view.view, view_name, view_description
+    mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
+    dataset.service.mocked_service = mock
+
+    table = dataset.create_view view_id, query, udfs: ["return x+1;", "gs://my-bucket/my-lib.js"]
+
+    mock.verify
+
+
+    table.must_be_kind_of Google::Cloud::Bigquery::View
+    table.table_id.must_equal view_id
+    table.query.must_equal query
+    table.must_be :query_standard_sql?
+    table.wont_be :query_legacy_sql?
+    table.query_udfs.must_equal ["return x+1;", "gs://my-bucket/my-lib.js"]
+    table.must_be :view?
+    table.wont_be :table?
+  end
+
+  it "can create a view with udfs (inline)" do
+    mock = Minitest::Mock.new
+    insert_view = Google::Apis::BigqueryV2::Table.new(
+      table_reference: Google::Apis::BigqueryV2::TableReference.new(
+        project_id: project, dataset_id: dataset_id, table_id: view_id),
+      view: Google::Apis::BigqueryV2::ViewDefinition.new(
+        query: query,
+        use_legacy_sql: false,
+        user_defined_function_resources: [
+          Google::Apis::BigqueryV2::UserDefinedFunctionResource.new(inline_code: "return x+1;")
+        ]
+      )
+    )
+    return_view = create_view_gapi view_id, insert_view.view, view_name, view_description
+    mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
+    dataset.service.mocked_service = mock
+
+    table = dataset.create_view view_id, query, udfs: "return x+1;"
+
+    mock.verify
+
+
+    table.must_be_kind_of Google::Cloud::Bigquery::View
+    table.table_id.must_equal view_id
+    table.query.must_equal query
+    table.must_be :query_standard_sql?
+    table.wont_be :query_legacy_sql?
+    table.query_udfs.must_equal ["return x+1;"]
+    table.must_be :view?
+    table.wont_be :table?
+  end
+
+  it "can create a view with udfs (url)" do
+    mock = Minitest::Mock.new
+    insert_view = Google::Apis::BigqueryV2::Table.new(
+      table_reference: Google::Apis::BigqueryV2::TableReference.new(
+        project_id: project, dataset_id: dataset_id, table_id: view_id),
+      view: Google::Apis::BigqueryV2::ViewDefinition.new(
+        query: query,
+        use_legacy_sql: false,
+        user_defined_function_resources: [
+          Google::Apis::BigqueryV2::UserDefinedFunctionResource.new(resource_uri: "gs://my-bucket/my-lib.js")
+        ]
+      )
+    )
+    return_view = create_view_gapi view_id, insert_view.view, view_name, view_description
+    mock.expect :insert_table, return_view, [project, dataset_id, insert_view]
+    dataset.service.mocked_service = mock
+
+    table = dataset.create_view view_id, query, udfs: "gs://my-bucket/my-lib.js"
+
+    mock.verify
+
+
+    table.must_be_kind_of Google::Cloud::Bigquery::View
+    table.table_id.must_equal view_id
+    table.query.must_equal query
+    table.must_be :query_standard_sql?
+    table.wont_be :query_legacy_sql?
+    table.query_udfs.must_equal ["gs://my-bucket/my-lib.js"]
     table.must_be :view?
     table.wont_be :table?
   end
@@ -543,12 +710,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     Google::Apis::BigqueryV2::Table.from_json random_table_hash(dataset_id, id, name, description).to_json
   end
 
-  def create_view_gapi id, query, name = nil, description = nil
+  def create_view_gapi id, view, name = nil, description = nil
     hash = random_table_hash dataset_id, id, name, description
-    hash["view"] = {"query" => query}
     hash["type"] = "VIEW"
 
-    Google::Apis::BigqueryV2::Table.from_json hash.to_json
+    Google::Apis::BigqueryV2::Table.from_json(hash.to_json).tap do |v|
+      v.view = view
+    end
   end
 
   def find_table_gapi id, name = nil, description = nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -35,6 +35,10 @@ describe Google::Cloud::Bigquery::View, :mock_bigquery do
     view.description.must_equal description
     view.etag.must_equal etag
     view.api_url.must_equal api_url
+    view.query.must_equal "SELECT name, age, score, active FROM `external.publicdata.users`"
+    view.wont_be :query_standard_sql?
+    view.must_be :query_legacy_sql?
+    view.query_udfs.must_be :empty?
     view.view?.must_equal true
     view.table?.must_equal false
     view.location.must_equal location_code

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -311,7 +311,7 @@ class MockBigquery < Minitest::Spec
       "lastModifiedTime" => time_millis,
       "type" => "VIEW",
       "view" => {
-        "query" => "SELECT name, age, score, active FROM `external:publicdata.users`"
+        "query" => "SELECT name, age, score, active FROM `external.publicdata.users`"
       },
       "location" => "US"
     }


### PR DESCRIPTION
Allow users to specify if the view query is using standard vs. legacy SQL.
Also allow users to provide user-defined function resourcesfor the query.
These can be set when creating a view, or updating an existing view.

[closes #1741]