### PR TITLE
Asynchronous Insert

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -268,7 +268,6 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     step.substeps.must_be_kind_of Array
     step.substeps.wont_be :empty?
 
-
     data = table.data max: 1
     data.class.must_equal Google::Cloud::Bigquery::Data
     data.kind.wont_be :nil?
@@ -320,6 +319,109 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     insert_response.insert_error_for(invalid_rows[1]).index.must_equal insert_response.insert_errors.first.index
     insert_response.errors_for(invalid_rows[1]).wont_be :empty?
     insert_response.index_for(invalid_rows[1]).must_equal 1
+  end
+
+  it "inserts rows asynchonously and gets its data" do
+    # data = table.data
+    insert_response = nil
+
+    inserter = table.insert_async do |response|
+      insert_response = response
+    end
+    inserter.insert rows
+
+    inserter.flush
+    inserter.stop.wait!
+
+    insert_response.must_be :success?
+    insert_response.insert_count.must_equal 3
+    insert_response.insert_errors.must_be :empty?
+    insert_response.error_rows.must_be :empty?
+
+
+    job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
+    query_job = dataset.query_job query, job_id: job_id
+    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    query_job.job_id.must_equal job_id
+    query_job.wait_until_done!
+
+    # Job methods
+    query_job.done?.must_equal true
+    query_job.running?.must_equal false
+    query_job.pending?.must_equal false
+    query_job.created_at.must_be_kind_of Time
+    query_job.started_at.must_be_kind_of Time
+    query_job.ended_at.must_be_kind_of Time
+    query_job.configuration.wont_be :nil?
+    query_job.statistics.wont_be :nil?
+    query_job.status.wont_be :nil?
+    query_job.errors.must_be :empty?
+    query_job.rerun!
+    query_job.wait_until_done!
+
+    query_job.batch?.must_equal false
+    query_job.interactive?.must_equal true
+    query_job.large_results?.must_equal false
+    query_job.cache?.must_equal true
+    query_job.flatten?.must_equal true
+    query_job.cache_hit?.must_equal false
+    query_job.bytes_processed.wont_be :nil?
+    query_job.destination.wont_be :nil?
+    query_job.data.class.must_equal Google::Cloud::Bigquery::Data
+    query_job.data.total.wont_be :nil?
+
+    # Query Job - Statistics Query Plan
+    query_job.query_plan.wont_be_nil
+    query_job.query_plan.must_be_kind_of Array
+    query_job.query_plan.wont_be :empty?
+    stage = query_job.query_plan.first
+    stage.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
+    stage.compute_ratio_avg.must_be_kind_of Float
+    stage.compute_ratio_max.must_be_kind_of Float
+    stage.id.must_be_kind_of Integer
+    stage.name.must_be_kind_of String
+    stage.read_ratio_avg.must_be_kind_of Float
+    stage.read_ratio_max.must_be_kind_of Float
+    stage.records_read.must_be_kind_of Integer
+    stage.records_written.must_be_kind_of Integer
+    stage.status.must_be_kind_of String
+    stage.wait_ratio_avg.must_be_kind_of Float
+    stage.wait_ratio_max.must_be_kind_of Float
+    stage.write_ratio_avg.must_be_kind_of Float
+    stage.write_ratio_max.must_be_kind_of Float
+    stage.steps.wont_be_nil
+    stage.steps.must_be_kind_of Array
+    stage.steps.wont_be :empty?
+    step = stage.steps.first
+    step.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
+    step.kind.must_be_kind_of String
+    step.substeps.wont_be_nil
+    step.substeps.must_be_kind_of Array
+    step.substeps.wont_be :empty?
+
+    data = table.data max: 1
+    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.kind.wont_be :nil?
+    data.etag.wont_be :nil?
+    [nil, 0].must_include data.total
+    data.count.wont_be :nil?
+    data.all(request_limit: 2).each do |row|
+      row.must_be_kind_of Hash
+      [:id, :breed, :name, :dob].each { |k| row.keys.must_include k }
+    end
+    more_data = data.next
+    more_data.wont_be :nil?
+
+    data = dataset.query query
+    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.total.wont_be(:nil?)
+    data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    data.fields.count.must_equal 4
+    [:id, :breed, :name, :dob].each { |k| data.headers.must_include k }
+    data.all.each do |row|
+      row.must_be_kind_of Hash
+    end
+    data.next.must_be :nil?
   end
 
   it "imports data from a local file with load_job" do

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "google-api-client", "~> 0.13.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1539,6 +1539,65 @@ module Google
           end
         end
 
+        ##
+        # Create an asynchonous inserter object used to insert rows in batches.
+        #
+        # @param [String] table_id The ID of the table to insert rows into.
+        # @param [Boolean] skip_invalid Insert all valid rows of a request, even
+        #   if invalid rows exist. The default value is `false`, which causes
+        #   the entire request to fail if any invalid rows exist.
+        # @param [Boolean] ignore_unknown Accept rows that contain values that
+        #   do not match the schema. The unknown values are ignored. Default is
+        #   false, which treats unknown values as errors.
+        # @attr_reader [Integer] max_bytes The maximum size of rows to be
+        #   collected before the batch is published. Default is 10,000,000
+        #   (10MB).
+        # @param [Integer] max_rows The maximum number of rows to be collected
+        #   before the batch is published. Default is 500.
+        # @attr_reader [Numeric] interval The number of seconds to collect
+        #   messages before the batch is published. Default is 10.
+        # @attr_reader [Numeric] threads The number of threads used to insert
+        #   batches of rows. Default is 4.
+        # @yield [response] the callback for when a batch of rows is inserted
+        # @yieldparam [InsertResponse] response the result of the asynchonous
+        #   insert
+        #
+        # @return [Table::AsyncInserter] Returns inserter object.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #   inserter = table.insert_async do |response|
+        #     log_insert "inserted #{response.insert_count} rows " \
+        #       "with #{response.error_count} errors"
+        #   end
+        #
+        #   rows = [
+        #     { "first_name" => "Alice", "age" => 21 },
+        #     { "first_name" => "Bob", "age" => 22 }
+        #   ]
+        #   inserter.insert rows
+        #
+        #   inserter.stop.wait!
+        #
+        def insert_async table_id, skip_invalid: nil, ignore_unknown: nil,
+                         max_bytes: 10000000, max_rows: 500, interval: 10,
+                         threads: 4, &block
+          ensure_service!
+
+          # Get table, don't use Dataset#table which handles NotFoundError
+          gapi = service.get_table dataset_id, table_id
+          table = Table.from_gapi gapi, service
+          # Get the AsyncInserter from the table
+          table.insert_async skip_invalid: skip_invalid,
+                             ignore_unknown: ignore_unknown,
+                             max_bytes: max_bytes, max_rows: max_rows,
+                             interval: interval, threads: threads, &block
+        end
+
         protected
 
         def insert_data table_id, rows, skip_invalid: nil, ignore_unknown: nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -21,6 +21,7 @@ require "google/cloud/bigquery/table/list"
 require "google/cloud/bigquery/schema"
 require "google/cloud/bigquery/external"
 require "google/cloud/bigquery/insert_response"
+require "google/cloud/bigquery/table/async_inserter"
 require "google/apis/bigquery_v2"
 
 module Google
@@ -1330,6 +1331,60 @@ module Google
                       ignore_unknown: ignore_unknown }
           gapi = service.insert_tabledata dataset_id, table_id, rows, options
           InsertResponse.from_gapi rows, gapi
+        end
+
+        ##
+        # Create an asynchonous inserter object used to insert rows in batches.
+        #
+        # @param [Boolean] skip_invalid Insert all valid rows of a request, even
+        #   if invalid rows exist. The default value is `false`, which causes
+        #   the entire request to fail if any invalid rows exist.
+        # @param [Boolean] ignore_unknown Accept rows that contain values that
+        #   do not match the schema. The unknown values are ignored. Default is
+        #   false, which treats unknown values as errors.
+        # @attr_reader [Integer] max_bytes The maximum size of rows to be
+        #   collected before the batch is published. Default is 10,000,000
+        #   (10MB).
+        # @param [Integer] max_rows The maximum number of rows to be collected
+        #   before the batch is published. Default is 500.
+        # @attr_reader [Numeric] interval The number of seconds to collect
+        #   messages before the batch is published. Default is 10.
+        # @attr_reader [Numeric] threads The number of threads used to insert
+        #   batches of rows. Default is 4.
+        # @yield [response] the callback for when a batch of rows is inserted
+        # @yieldparam [InsertResponse] response the result of the asynchonous
+        #   insert
+        #
+        # @return [Table::AsyncInserter] Returns inserter object.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #   inserter = table.insert_async do |response|
+        #     log_insert "inserted #{response.insert_count} rows " \
+        #       "with #{response.error_count} errors"
+        #   end
+        #
+        #   rows = [
+        #     { "first_name" => "Alice", "age" => 21 },
+        #     { "first_name" => "Bob", "age" => 22 }
+        #   ]
+        #   inserter.insert rows
+        #
+        #   inserter.stop.wait!
+        #
+        def insert_async skip_invalid: nil, ignore_unknown: nil,
+                         max_bytes: 10000000, max_rows: 500, interval: 10,
+                         threads: 4, &block
+          ensure_service!
+
+          AsyncInserter.new self, skip_invalid: skip_invalid,
+                                  ignore_unknown: ignore_unknown,
+                                  max_bytes: max_bytes, max_rows: max_rows,
+                                  interval: interval, threads: threads, &block
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -1,0 +1,207 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/bigquery/convert"
+require "monitor"
+require "concurrent"
+
+module Google
+  module Cloud
+    module Bigquery
+      class Table
+        ##
+        # # AsyncInserter
+        #
+        class AsyncInserter
+          include MonitorMixin
+
+          attr_reader :table, :batch
+          attr_reader :max_bytes, :max_rows, :interval, :threads
+
+          ##
+          # @private
+          def initialize table, skip_invalid: nil, ignore_unknown: nil,
+                         max_bytes: 10000000, max_rows: 500, interval: 10,
+                         threads: 4, &block
+            @table = table
+            @skip_invalid = skip_invalid
+            @ignore_unknown = ignore_unknown
+
+            @max_bytes = max_bytes
+            @max_rows = max_rows
+            @interval = interval
+            @threads = threads
+            @callback = block
+
+            @batch = nil
+
+            @thread_pool = Concurrent::FixedThreadPool.new @threads
+
+            @cond = new_cond
+
+            # init MonitorMixin
+            super()
+          end
+
+          def insert rows
+            return nil if rows.nil?
+            return nil if rows.is_a?(Array) && rows.empty?
+            rows = [rows] if rows.is_a? Hash
+
+            synchronize do
+              rows.each do |row|
+                row = Convert.to_json_row row
+
+                if @batch.nil?
+                  @batch = Batch.new max_bytes: @max_bytes, max_rows: @max_rows
+                  @batch.insert row
+                else
+                  unless @batch.try_insert row
+                    push_batch_request!
+
+                    @batch = Batch.new max_bytes: @max_bytes,
+                                       max_rows: @max_rows
+                    @batch.insert row
+                  end
+                end
+
+                @batch_created_at ||= ::Time.now
+                @background_thread ||= Thread.new { run_background }
+
+                push_batch_request! if @batch.ready?
+              end
+
+              @cond.signal
+            end
+
+            true
+          end
+
+          def stop
+            synchronize do
+              break if @stopped
+
+              @stopped = true
+              push_batch_request!
+              @cond.signal
+            end
+
+            self
+          end
+
+          def wait! timeout = nil
+            synchronize do
+              @thread_pool.shutdown
+              @thread_pool.wait_for_termination timeout
+            end
+
+            self
+          end
+
+          def flush
+            synchronize do
+              push_batch_request!
+              @cond.signal
+            end
+
+            self
+          end
+
+          def started?
+            !stopped?
+          end
+
+          def stopped?
+            synchronize { @stopped }
+          end
+
+          protected
+
+          def run_background
+            synchronize do
+              until @stopped
+                if @batch.nil?
+                  @cond.wait
+                  next
+                end
+
+                time_since_first_publish = ::Time.now - @batch_created_at
+                if time_since_first_publish < @interval
+                  # still waiting for the interval to publish the batch...
+                  @cond.wait(@interval - time_since_first_publish)
+                else
+                  # interval met, publish the batch...
+                  push_batch_request!
+                  @cond.wait
+                end
+              end
+            end
+          end
+
+          def push_batch_request!
+            return unless @batch
+
+            batch_rows = @batch.rows
+            Concurrent::Future.new(executor: @thread_pool) do
+              begin
+                response = @table.insert batch_rows,
+                                         skip_invalid:   @skip_invalid,
+                                         ignore_unknown: @ignore_unknown
+                @callback.call response if @callback
+              rescue => e
+                raise e.inspect
+              end
+            end.execute
+
+            @batch = nil
+            @batch_created_at = nil
+          end
+
+          class Batch
+            attr_reader :max_bytes, :max_rows, :rows
+
+            def initialize max_bytes: 10000000, max_rows: 500
+              @max_bytes = max_bytes
+              @max_rows = max_rows
+              @rows = []
+            end
+
+            def insert row
+              @rows << row
+            end
+
+            def try_insert row
+              addl_bytes = row.to_json.bytes.size + 1
+              return false if current_bytes + addl_bytes >= @max_bytes
+              return false if @rows.count + 1 >= @max_rows
+
+              insert row
+              true
+            end
+
+            def ready?
+              current_bytes >= @max_bytes || rows.count >= @max_rows
+            end
+
+            def current_bytes
+              # TODO: add to a counter instead of calling #to_json each time
+              rows.to_json.bytes.size
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
@@ -1,0 +1,265 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+Thread.abort_on_exception = true
+
+describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset_hash) { random_dataset_hash dataset_id }
+  let(:dataset_gapi) { Google::Apis::BigqueryV2::Dataset.from_json dataset_hash.to_json }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+
+  let(:table_id) { "my_table" }
+  let(:table_hash) { random_table_hash dataset_id, table_id }
+  let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
+
+  let(:rows) { [{"name"=>"Heidi", "age"=>"36", "score"=>"7.65", "active"=>"true"},
+                {"name"=>"Aaron", "age"=>"42", "score"=>"8.15", "active"=>"false"},
+                {"name"=>"Sally", "age"=>nil, "score"=>nil, "active"=>nil}] }
+  let(:insert_id) { "abc123" }
+  let(:insert_rows) { rows.map do |row|
+                        Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
+                          insert_id: insert_id,
+                          json: row
+                        )
+                      end }
+  let(:success_table_insert_gapi) { Google::Apis::BigqueryV2::InsertAllTableDataResponse.new insert_errors: [] }
+
+  it "inserts one row" do
+    mock = Minitest::Mock.new
+    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+      rows: [insert_rows.first], ignore_unknown_values: nil, skip_invalid_rows: nil)
+    mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [project, dataset_id, table_id, insert_req]
+    dataset.service.mocked_service = mock
+
+    inserter = dataset.insert_async table_id
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows.first
+
+      inserter.batch.rows.must_equal [rows.first]
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts three rows at the same time" do
+    mock = Minitest::Mock.new
+    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [project, dataset_id, table_id, insert_req]
+    dataset.service.mocked_service = mock
+
+    inserter = dataset.insert_async table_id
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows
+
+      inserter.batch.rows.must_equal rows
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts three rows one at a time" do
+    mock = Minitest::Mock.new
+    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [project, dataset_id, table_id, insert_req]
+    dataset.service.mocked_service = mock
+
+    inserter = dataset.insert_async table_id
+
+    Digest::MD5.stub :base64digest, insert_id do
+      rows.each do |row|
+        inserter.insert row
+      end
+
+      inserter.batch.rows.must_equal rows
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts rows with a callback" do
+    mock = Minitest::Mock.new
+    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [project, dataset_id, table_id, insert_req]
+    dataset.service.mocked_service = mock
+
+    callback_called = false
+
+    inserter = dataset.insert_async table_id do |response|
+      assert_kind_of Google::Cloud::Bigquery::InsertResponse, response
+      callback_called = true
+    end
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows
+
+      inserter.batch.rows.must_equal rows
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      wait_until { callback_called == true }
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts multiple batches when row byte size limit is reached" do
+    mock = Minitest::Mock.new
+    mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
+    # It makes two requests, but we can't control what order they occur.
+    # So only specify that two InsertAllTableDataRequests are made.
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [project, dataset_id, table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [project, dataset_id, table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    dataset.service.mocked_service = mock
+
+    callbacks = 0
+
+    inserter = dataset.insert_async table_id, max_bytes: 150 do |response|
+      callbacks += 1
+    end
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows
+
+      inserter.batch.rows.must_equal [rows.last]
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      wait_until { callbacks == 2 }
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts multiple batches when row count limit is reached" do
+    mock = Minitest::Mock.new
+    mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
+    # It makes two requests, but we can't control what order they occur.
+    # So only specify that two InsertAllTableDataRequests are made.
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [project, dataset_id, table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [project, dataset_id, table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    dataset.service.mocked_service = mock
+
+    callbacks = 0
+
+    inserter = dataset.insert_async table_id, max_rows: 2 do |response|
+      callbacks += 1
+    end
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows
+
+      inserter.batch.rows.must_equal [rows.last]
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      wait_until { callbacks == 2 }
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  def wait_until delay: 0.01, max: 100, output: nil, msg: "criteria not met", &block
+    attempts = 0
+    while !block.call
+      return if attempts >= max
+      # fail msg if attempts >= max
+      attempts += 1
+      puts "Retrying #{attempts} out of #{max}." if output
+      sleep delay
+    end
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
@@ -1,0 +1,256 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+Thread.abort_on_exception = true
+
+describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
+  let(:dataset_id) { "my_dataset" }
+  let(:table_id) { "my_table" }
+  let(:table_hash) { random_table_hash dataset_id, table_id }
+  let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+
+  let(:rows) { [{"name"=>"Heidi", "age"=>"36", "score"=>"7.65", "active"=>"true"},
+                {"name"=>"Aaron", "age"=>"42", "score"=>"8.15", "active"=>"false"},
+                {"name"=>"Sally", "age"=>nil, "score"=>nil, "active"=>nil}] }
+  let(:insert_id) { "abc123" }
+  let(:insert_rows) { rows.map do |row|
+                        Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
+                          insert_id: insert_id,
+                          json: row
+                        )
+                      end }
+  let(:success_table_insert_gapi) { Google::Apis::BigqueryV2::InsertAllTableDataResponse.new insert_errors: [] }
+
+  it "inserts one row" do
+    mock = Minitest::Mock.new
+    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+      rows: [insert_rows.first], ignore_unknown_values: nil, skip_invalid_rows: nil)
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [table.project_id, table.dataset_id, table.table_id, insert_req]
+    table.service.mocked_service = mock
+
+    inserter = table.insert_async
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows.first
+
+      inserter.batch.rows.must_equal [rows.first]
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts three rows at the same time" do
+    mock = Minitest::Mock.new
+    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [table.project_id, table.dataset_id, table.table_id, insert_req]
+    table.service.mocked_service = mock
+
+    inserter = table.insert_async
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows
+
+      inserter.batch.rows.must_equal rows
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts three rows one at a time" do
+    mock = Minitest::Mock.new
+    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [table.project_id, table.dataset_id, table.table_id, insert_req]
+    table.service.mocked_service = mock
+
+    inserter = table.insert_async
+
+    Digest::MD5.stub :base64digest, insert_id do
+      rows.each do |row|
+        inserter.insert row
+      end
+
+      inserter.batch.rows.must_equal rows
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts rows with a callback" do
+    mock = Minitest::Mock.new
+    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [table.project_id, table.dataset_id, table.table_id, insert_req]
+    table.service.mocked_service = mock
+
+    callback_called = false
+
+    inserter = table.insert_async do |response|
+      assert_kind_of Google::Cloud::Bigquery::InsertResponse, response
+      callback_called = true
+    end
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows
+
+      inserter.batch.rows.must_equal rows
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      wait_until { callback_called == true }
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts multiple batches when row byte size limit is reached" do
+    mock = Minitest::Mock.new
+    # It makes two requests, but we can't control what order they occur.
+    # So only specify that two InsertAllTableDataRequests are made.
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [table.project_id, table.dataset_id, table.table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [table.project_id, table.dataset_id, table.table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    table.service.mocked_service = mock
+
+    callbacks = 0
+
+    inserter = table.insert_async max_bytes: 150 do |response|
+      callbacks += 1
+    end
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows
+
+      inserter.batch.rows.must_equal [rows.last]
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      wait_until { callbacks == 2 }
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  it "inserts multiple batches when row count limit is reached" do
+    mock = Minitest::Mock.new
+    # It makes two requests, but we can't control what order they occur.
+    # So only specify that two InsertAllTableDataRequests are made.
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [table.project_id, table.dataset_id, table.table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+      [table.project_id, table.dataset_id, table.table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    table.service.mocked_service = mock
+
+    callbacks = 0
+
+    inserter = table.insert_async max_rows: 2 do |response|
+      callbacks += 1
+    end
+
+    Digest::MD5.stub :base64digest, insert_id do
+      inserter.insert rows
+
+      inserter.batch.rows.must_equal [rows.last]
+
+      inserter.must_be :started?
+      inserter.wont_be :stopped?
+
+      # force the queued rows to be inserted
+      inserter.flush
+      wait_until { callbacks == 2 }
+      inserter.stop.wait!
+
+      inserter.wont_be :started?
+      inserter.must_be :stopped?
+
+      inserter.batch.must_be :nil?
+    end
+
+    mock.verify
+  end
+
+  def wait_until delay: 0.01, max: 100, output: nil, msg: "criteria not met", &block
+    attempts = 0
+    while !block.call
+      return if attempts >= max
+      # fail msg if attempts >= max
+      attempts += 1
+      puts "Retrying #{attempts} out of #{max}." if output
+      sleep delay
+    end
+  end
+end


### PR DESCRIPTION
AsyncInserter is a new class that will create objects that will collect rows to insert in batches.

```ruby
require "google/cloud/bigquery"

bigquery = Google::Cloud::Bigquery.new
dataset = bigquery.dataset "my_dataset"
table = dataset.table "my_table"

inserter = table.insert_async do |response|
  # this is called every time a batch is inserted
  log_insert "inserted #{response.insert_count} rows " \
    "with #{response.error_count} errors"
end

# insert multiple rows one at a time
inserter.insert row1
inserter.insert row2
inserter.insert row3
inserter.insert row4

inserter.flush # publish what was given so far

# insert multiple rows at once
inserter.insert [row5, row6, row7, row8]

# stop the inserter, wait for all threads to end
inserter.stop.wait!
```