### PR TITLE
GCS file signing crashes with symbols in query parameters

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
@@ -121,13 +121,13 @@ module Google
           end
 
           def generate_signed_url issuer, signed_string, expires, query
-            url = "#{ext_url}?GoogleAccessId=#{CGI.escape issuer}" \
+            url = "#{ext_url}?GoogleAccessId=#{url_escape issuer}" \
               "&Expires=#{expires}" \
-              "&Signature=#{CGI.escape signed_string}"
+              "&Signature=#{url_escape signed_string}"
 
             if query
               query.each do |name, value|
-                url << "&#{CGI.escape name}=#{CGI.escape value}"
+                url << "&#{url_escape name}=#{url_escape value}"
               end
             end
 
@@ -142,6 +142,10 @@ module Google
             end
             flatten.reject! { |h| h.start_with? "x-goog-encryption-key" }
             flatten.sort.join
+          end
+
+          def url_escape str
+            CGI.escape String str
           end
         end
       end

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_test.rb
@@ -161,6 +161,25 @@ describe Google::Cloud::Storage::Project, :signed_url, :mock_storage do
     end
   end
 
+  it "allows query params to be passed in as symbols" do
+    Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
+      signing_key_mock = Minitest::Mock.new
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/file.ext"]
+      credentials.issuer = "native_client_email"
+      credentials.signing_key = signing_key_mock
+
+      signed_url = storage.signed_url bucket_name, file_path,
+                                      query: { disposition: :inline }
+
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+      signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params["disposition"].must_equal ["inline"]
+
+      signing_key_mock.verify
+    end
+  end
+
   class PoisonSigningKey
     def sign kind, sig
       raise "The wrong signing_key was used"


### PR DESCRIPTION
Rails 5.2 ActiveStorage will, by default, pass
symbols as values for the query parameter, as shown
with this default `:inline` parameter:
https://github.com/rails/rails/blob/master/activestorage/app/models/active_storage/variant.rb#L64

```ruby
def service_url(expires_in: 5.minutes, disposition: :inline)
  ...
```

Before this commit, this would result in a crash. Now we coerce the query name, value pair to a string before escaping.

```
TypeError: no implicit conversion of Symbol into String
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/gems/google-cloud-storage-1.4.0/lib/google/cloud/storage/file/signer.rb:131:in `escape'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/gems/google-cloud-storage-1.4.0/lib/google/cloud/storage/file/signer.rb:131:in `block in generate_signed_url'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/gems/google-cloud-storage-1.4.0/lib/google/cloud/storage/file/signer.rb:130:in `each'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/gems/google-cloud-storage-1.4.0/lib/google/cloud/storage/file/signer.rb:130:in `generate_signed_url'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/gems/google-cloud-storage-1.4.0/lib/google/cloud/storage/file/signer.rb:112:in `signed_url'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/gems/google-cloud-storage-1.4.0/lib/google/cloud/storage/file.rb:859:in `signed_url'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/bundler/gems/rails-8b139444dd41/activestorage/lib/active_storage/service/gcs_service.rb:56:in `block in url'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/bundler/gems/rails-8b139444dd41/activesupport/lib/active_support/notifications.rb:168:in `block in instrument'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/bundler/gems/rails-8b139444dd41/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/bundler/gems/rails-8b139444dd41/activesupport/lib/active_support/notifications.rb:168:in `instrument'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/bundler/gems/rails-8b139444dd41/activestorage/lib/active_storage/service.rb:107:in `instrument'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/bundler/gems/rails-8b139444dd41/activestorage/lib/active_storage/service/gcs_service.rb:55:in `url'
/Users/dimroc/.rvm/gems/ruby-2.4.1@counting_company/bundler/gems/rails-8b139444dd41/activestorage/app/models/active_storage/variant.rb:65:in `service_url'
```