### PR TITLE
Add Pub/Sub Notifications to Storage

### DIFF
--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "rake", "~> 11.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
+gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"

--- a/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
@@ -1,0 +1,70 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "storage_helper"
+
+describe Google::Cloud::Storage::Bucket, :notification, :storage do
+  let(:project_email) { "serviceAccount:#{storage.project}@gs-project-accounts.iam.gserviceaccount.com" }
+  let(:bucket_name) { $bucket_names.first }
+  let :bucket do
+    storage.bucket(bucket_name) ||
+    storage.create_bucket(bucket_name)
+  end
+  let(:topic_name) { "#{prefix}_bucket_notification_topic" }
+  let(:topic_name_full_path) { "//pubsub.googleapis.com/projects/#{storage.project}/topics/#{topic_name}" }
+  let(:custom_attrs) { { "foo" => "bar" } }
+  let(:event_types) { ["OBJECT_FINALIZE"] }
+  let(:filename_prefix) { "my-prefix" }
+  let(:payload) { "NONE" }
+
+  it "creates a Pub/Sub subscription notification" do
+    begin
+      topic = Google::Cloud.pubsub.create_topic topic_name
+      topic.policy do |p|
+        p.add "roles/pubsub.publisher", project_email
+      end
+
+      notification = bucket.create_notification topic.name, custom_attrs: custom_attrs,
+                                                            event_types: event_types,
+                                                            prefix: filename_prefix,
+                                                            payload: payload
+
+      notification.wont_be_nil
+      notification.id.wont_be_nil
+      notification.custom_attrs.must_equal custom_attrs
+      notification.event_types.must_equal event_types
+      notification.prefix.must_equal filename_prefix
+      notification.payload.must_equal payload
+      notification.topic.must_equal topic_name_full_path
+
+      bucket.notifications.wont_be :empty?
+
+      fresh_notification = bucket.notification notification.id
+      fresh_notification.wont_be_nil
+      fresh_notification.id.wont_be_nil
+      fresh_notification.custom_attrs.must_equal custom_attrs
+      fresh_notification.event_types.must_equal event_types
+      fresh_notification.prefix.must_equal filename_prefix
+      fresh_notification.payload.must_equal payload
+      fresh_notification.topic.must_equal topic_name_full_path
+
+
+      fresh_notification.delete
+    ensure
+      bucket.notifications.map(&:delete)
+      post_topic = Google::Cloud.pubsub.topic "#{prefix}_bucket_notification_topic"
+      post_topic.delete if post_topic # Assume no subscriptions to clean up.
+    end
+  end
+end

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -17,6 +17,7 @@ require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"
 require "google/cloud/storage"
+require "google/cloud/pubsub"
 
 # Create shared storage object so we don't create new for each test
 $storage = Google::Cloud.new.storage retries: 10
@@ -36,13 +37,16 @@ module Acceptance
   #   end
   class StorageTest < Minitest::Test
     attr_accessor :storage
+    attr_accessor :prefix
 
     ##
     # Setup project based on available ENV variables
     def setup
       @storage = $storage
+      @prefix = $prefix
 
       refute_nil @storage, "You do not have an active storage to run the tests."
+      refute_nil @prefix, "You do not have a prefix to name the pubsub topics with."
 
       super
     end
@@ -87,6 +91,7 @@ require "time"
 require "securerandom"
 t = Time.now.utc.iso8601.gsub ":", "-"
 $bucket_names = 4.times.map { "gcloud-ruby-acceptance-#{t}-#{SecureRandom.hex(4)}".downcase }
+$prefix = "gcloud_ruby_acceptance_#{t}_#{SecureRandom.hex(4)}".downcase.gsub "-", "_"
 
 def clean_up_storage_buckets
   puts "Cleaning up storage buckets after tests."

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -488,6 +488,38 @@ module Google
     # files = bucket.files # Billed to "my-other-project"
     # ```
     #
+    # ## Configuring Pub/Sub notification subscriptions
+    #
+    # You can configure notifications to send Google Cloud Pub/Sub messages
+    # about changes to files in your buckets. For example, you can track files
+    # that are created and deleted in your bucket. Each notification contains
+    # information describing both the event that triggered it and the file that
+    # changed.
+    #
+    # You can send notifications to any Cloud Pub/Sub topic in any project for
+    # which your service account has sufficient permissions. As shown below, you
+    # need to explicitly grant permission to your service account to enable
+    # Google Cloud Storage to publish on behalf of your account. (Even if your
+    # current project created and owns the topic.)
+    #
+    # ```ruby
+    # require "google/cloud/pubsub"
+    # require "google/cloud/storage"
+    #
+    # pubsub = Google::Cloud::Pubsub.new
+    # topic = pubsub.create_topic "my-topic"
+    # topic.policy do |p|
+    #   p.add "roles/pubsub.publisher",
+    #         "serviceAccount:my-project" \
+    #         "@gs-project-accounts.iam.gserviceaccount.com"
+    # end
+    #
+    # storage = Google::Cloud::Storage.new
+    # bucket = storage.bucket "my-bucket"
+    #
+    # notification = bucket.create_notification topic.name
+    # ```
+    #
     # ## Configuring retries and timeout
     #
     # You can configure how many times API requests may be automatically

--- a/google-cloud-storage/lib/google/cloud/storage/notification.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/notification.rb
@@ -1,0 +1,212 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/errors"
+require "google/apis/storage_v1"
+
+module Google
+  module Cloud
+    module Storage
+      ##
+      # # Notification
+      #
+      # Represents a Pub/Sub notification subscription for a Cloud Storage
+      # bucket.
+      #
+      # @see https://cloud.google.com/storage/docs/pubsub-notifications Cloud
+      #   Pub/Sub Notifications for Google Cloud
+      #
+      # @attr [String] bucket The name of the {Bucket} to which this
+      #   notification belongs.
+      #
+      # @example
+      #   require "google/cloud/pubsub"
+      #   require "google/cloud/storage"
+      #
+      #   pubsub = Google::Cloud::Pubsub.new
+      #   topic = pubsub.create_topic "my-topic"
+      #   topic.policy do |p|
+      #     p.add "roles/pubsub.publisher",
+      #           "serviceAccount:my-project" \
+      #           "@gs-project-accounts.iam.gserviceaccount.com"
+      #   end
+      #
+      #   storage = Google::Cloud::Storage.new
+      #   bucket = storage.bucket "my-bucket"
+      #
+      #   notification = bucket.create_notification topic.name
+      #
+      class Notification
+        ##
+        # @private The Connection object.
+        attr_accessor :service
+
+        ##
+        # @private The Google API Client object.
+        attr_accessor :gapi
+
+        ##
+        # @private The project ID string for a requester pays bucket.
+        attr_accessor :user_project
+
+        attr_reader :bucket
+
+        ##
+        # @private Creates a Notification object.
+        def initialize
+          @bucket = nil
+          @service = nil
+          @gapi = nil
+          @user_project = nil
+        end
+
+        ##
+        # The kind of item this is.
+        # For notifications, this is always storage#notification.
+        def kind
+          @gapi.kind
+        end
+
+        ##
+        # The ID of the notification.
+        def id
+          @gapi.id
+        end
+
+        ##
+        # A URL that can be used to access the notification using the REST API.
+        def api_url
+          @gapi.self_link
+        end
+
+        ##
+        # The custom attributes of this notification. An optional list of
+        # additional attributes to attach to each Cloud Pub/Sub message
+        # published for this notification subscription.
+        def custom_attrs
+          @gapi.custom_attributes
+        end
+
+        ##
+        # The event types of this notification. If present, only send
+        # notifications about listed event types. If empty, sent notifications
+        # for all event types.
+        #
+        # The following is a list of event types currently supported by Cloud
+        # Storage:
+        #
+        # * `OBJECT_FINALIZE` - Sent when a new object (or a new generation of
+        #   an existing object) is successfully created in the bucket. This
+        #   includes copying or rewriting an existing object. A failed upload
+        #   does not trigger this event.
+        # * `OBJECT_METADATA_UPDATE` - Sent when the metadata of an existing
+        #   object changes.
+        # * `OBJECT_DELETE` - Sent when an object has been permanently deleted.
+        #   This includes objects that are overwritten or are deleted as part of
+        #   the bucket's lifecycle configuration. For buckets with object
+        #   versioning enabled, this is not sent when an object is archived (see
+        #   `OBJECT_ARCHIVE`), even if archival occurs via the {File#delete}
+        #   method.
+        # * `OBJECT_ARCHIVE` - Only sent when a bucket has enabled object
+        #   versioning. This event indicates that the live version of an object
+        #   has become an archived version, either because it was archived or
+        #   because it was overwritten by the upload of an object of the same
+        #   name.
+        #
+        # Important: Additional event types may be released later. Client code
+        # should either safely ignore unrecognized event types, or else
+        # explicitly specify in their notification configuration which event
+        # types they are prepared to accept.
+        #
+        def event_types
+          @gapi.event_types
+        end
+
+        ##
+        # The file name prefix of this notification. If present, only apply
+        # this notification configuration to file names that begin with this
+        # prefix.
+        #
+        def prefix
+          @gapi.object_name_prefix
+        end
+
+        ##
+        # The desired content of the Pub/Sub message payload. Acceptable values
+        # are:
+        #
+        # * `JSON_API_V1` - The payload will be a UTF-8 string containing the
+        #   [resource
+        #   representation](https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations)
+        #   of the file's metadata.
+        # * `NONE` - No payload is included with the notification.
+        #
+        def payload
+          @gapi.payload_format
+        end
+
+        ##
+        # The Cloud Pub/Sub topic to which this subscription publishes.
+        # Formatted as:
+        # `//pubsub.googleapis.com/projects/{project-id}/topics/{my-topic}`
+        def topic
+          @gapi.topic
+        end
+
+        ##
+        # Permanently deletes the notification.
+        #
+        # The API call to delete the notification may be retried under certain
+        # conditions. See {Google::Cloud#storage} to control this behavior.
+        #
+        # @return [Boolean] Returns `true` if the notification was deleted.
+        #
+        # @example
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "my-bucket"
+        #   notification = bucket.notification "1"
+        #   notification.delete
+        #
+        def delete
+          ensure_service!
+          @service.delete_notification bucket, id, user_project: @user_project
+          true
+        end
+
+        ##
+        # @private New Notification from a
+        # Google::Apis::StorageV1::Notification object.
+        def self.from_gapi bucket_name, gapi, service, user_project: nil
+          new.tap do |f|
+            f.instance_variable_set :@bucket, bucket_name
+            f.gapi = gapi
+            f.service = service
+            f.user_project = user_project
+          end
+        end
+
+        protected
+
+        ##
+        # Raise an error unless an active service is available.
+        def ensure_service!
+          fail "Must have active connection" unless service
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
@@ -1,0 +1,231 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
+  let(:bucket_name) { "found-bucket" }
+  let(:bucket_hash) { random_bucket_hash bucket_name }
+  let(:bucket_json) { bucket_hash.to_json }
+  let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json bucket_json }
+  let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
+  let(:bucket_user_project) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_project: true }
+
+  let(:topic_name) { "my-topic" }
+  let(:topic_name_full_path) { "//pubsub.googleapis.com/projects/#{storage.project}/topics/#{topic_name}" }
+  let(:custom_attrs) { { "foo" => "bar" } }
+  let(:notification_id) { "1" }
+  let(:event_types) { ["OBJECT_FINALIZE"] }
+  let(:filename_prefix) { "my-prefix" }
+  let(:payload) { "NONE" }
+
+  it "creates a notification" do
+    mock = Minitest::Mock.new
+    mock.expect :insert_notification, random_notification_gapi(id: notification_id, topic: topic_name_full_path),
+                [bucket.name, random_notification_gapi(id: nil, topic: topic_name_full_path), { user_project: nil }]
+
+    bucket.service.mocked_service = mock
+
+    notification = bucket.create_notification topic_name, custom_attrs: custom_attrs,
+                                                          event_types: event_types,
+                                                          prefix: filename_prefix,
+                                                          payload: payload
+
+    mock.verify
+
+    notification.wont_be_nil
+    notification.id.must_equal notification_id
+    notification.custom_attrs.must_equal custom_attrs
+    notification.event_types.must_equal event_types
+    notification.prefix.must_equal filename_prefix
+    notification.payload.must_equal payload
+    notification.topic.must_equal topic_name_full_path
+    notification.user_project.must_be :nil?
+  end
+
+  it "creates a notification with a boolean payload" do
+    mock = Minitest::Mock.new
+    mock.expect :insert_notification, random_notification_gapi(id: notification_id, payload: "JSON_API_V1"),
+                [bucket.name, random_notification_gapi(id: nil, payload: "JSON_API_V1"), { user_project: nil }]
+
+    bucket.service.mocked_service = mock
+
+    notification = bucket.create_notification topic_name, custom_attrs: custom_attrs,
+                                                          event_types: event_types,
+                                                          prefix: filename_prefix,
+                                                          payload: true
+
+    mock.verify
+
+    notification.payload.must_equal "JSON_API_V1"
+  end
+
+  it "creates a notification with a symbol event type" do
+    mock = Minitest::Mock.new
+    mock.expect :insert_notification, random_notification_gapi(id: notification_id),
+                [bucket.name, random_notification_gapi(id: nil), { user_project: nil }]
+
+    bucket.service.mocked_service = mock
+
+    notification = bucket.create_notification topic_name, custom_attrs: custom_attrs,
+                                                          event_types: [:finalize],
+                                                          prefix: filename_prefix,
+                                                          payload: payload
+
+    mock.verify
+
+    notification.event_types.must_equal event_types
+  end
+
+  it "creates a notification with new_notification alias" do
+    mock = Minitest::Mock.new
+    mock.expect :insert_notification, minimal_notification_gapi,
+                [bucket.name, minimal_notification_gapi, { user_project: nil }]
+
+    bucket.service.mocked_service = mock
+
+    bucket.new_notification topic_name
+
+    mock.verify
+  end
+
+  it "creates a notification with user_project set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :insert_notification, minimal_notification_gapi,
+                [bucket_user_project.name, minimal_notification_gapi, { user_project: "test" }]
+
+    bucket_user_project.service.mocked_service = mock
+
+    notification = bucket_user_project.create_notification topic_name
+
+    mock.verify
+
+    notification.user_project.must_equal true
+  end
+
+  it "lists notifications" do
+    num_notifications = 3
+
+    mock = Minitest::Mock.new
+    mock.expect :list_notifications, list_notifications_gapi(num_notifications),
+                [bucket.name, user_project: nil]
+
+    bucket.service.mocked_service = mock
+
+    notifications = bucket.notifications
+
+    mock.verify
+
+    notifications.size.must_equal num_notifications
+    notifications.each do |notification|
+      notification.must_be_kind_of Google::Cloud::Storage::Notification
+      notification.user_project.must_be :nil?
+    end
+  end
+
+  it "lists notifications with find_notifications alias" do
+    mock = Minitest::Mock.new
+    mock.expect :list_notifications, list_notifications_gapi, [bucket.name, { user_project: nil }]
+
+    bucket.service.mocked_service = mock
+
+    bucket.find_notifications
+
+    mock.verify
+  end
+
+  it "lists notifications with user_project set to true" do
+    num_notifications = 3
+
+    mock = Minitest::Mock.new
+    mock.expect :list_notifications, list_notifications_gapi(num_notifications),
+                [bucket_user_project.name, { user_project: "test" }]
+
+    bucket_user_project.service.mocked_service = mock
+
+    notifications = bucket_user_project.notifications
+
+    mock.verify
+
+    notifications.size.must_equal num_notifications
+    notifications.each do |notification|
+      notification.must_be_kind_of Google::Cloud::Storage::Notification
+      notification.user_project.must_equal true
+    end
+  end
+
+  it "finds a notification" do
+    notification_id = "1"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_notification, random_notification_gapi(id: notification_id),
+      [bucket.name, notification_id, { user_project: nil }]
+
+    bucket.service.mocked_service = mock
+
+    notification = bucket.notification notification_id
+
+    mock.verify
+
+    notification.id.must_equal notification_id
+    notification.custom_attrs.must_equal custom_attrs
+    notification.event_types.must_equal event_types
+    notification.prefix.must_equal filename_prefix
+    notification.payload.must_equal payload
+    notification.topic.must_equal topic_name_full_path
+    notification.user_project.must_be :nil?
+  end
+
+  it "finds a notification with find_notification alias" do
+    notification_id = "1"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_notification, random_notification_gapi(id: notification_id),
+      [bucket.name, notification_id, { user_project: nil }]
+
+    bucket.service.mocked_service = mock
+
+    bucket.find_notification notification_id
+
+    mock.verify
+  end
+
+  it "finds a notification with user_project set to true" do
+    notification_id = "1"
+
+    mock = Minitest::Mock.new
+    mock.expect :get_notification, random_notification_gapi(id: notification_id),
+      [bucket_user_project.name, notification_id, { user_project: "test" }]
+
+    bucket_user_project.service.mocked_service = mock
+
+    notification = bucket_user_project.notification notification_id
+
+    mock.verify
+
+    notification.user_project.must_equal true
+  end
+
+  def minimal_notification_gapi
+    Google::Apis::StorageV1::Notification.new(
+      payload_format: "JSON_API_V1",
+      topic: "//pubsub.googleapis.com/projects/test/topics/my-topic"
+    )
+  end
+
+  def list_notifications_gapi count = 2
+    notifications = count.times.map { minimal_notification_gapi }
+    Google::Apis::StorageV1::Notifications.new kind: "storage#notifications", items: notifications
+  end
+end

--- a/google-cloud-storage/test/google/cloud/storage/notification_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/notification_test.rb
@@ -1,0 +1,60 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe Google::Cloud::Storage::Notification, :mock_storage do
+  let(:bucket_name) { "my-bucket" }
+  let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash(bucket_name).to_json }
+  let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
+
+  let(:topic_name) { "my-topic" }
+  let(:notification_gapi) { random_notification_gapi }
+  let(:notification) { Google::Cloud::Storage::Notification.from_gapi bucket_name, notification_gapi, storage.service }
+  let(:notification_user_project) { Google::Cloud::Storage::Notification.from_gapi  bucket_name, notification_gapi, storage.service, user_project: true }
+
+
+  it "knows its attributes" do
+    notification.id.must_equal "1"
+    notification.custom_attrs.must_equal({ "foo" => "bar" })
+    notification.event_types.must_equal ["OBJECT_FINALIZE"]
+    notification.prefix.must_equal "my-prefix"
+    notification.payload.must_equal "NONE"
+    notification.topic.must_equal "//pubsub.googleapis.com/projects/#{project}/topics/#{topic_name}"
+  end
+
+  it "can delete itself" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_notification, nil, [bucket.name, notification.id, { user_project: nil }]
+
+    notification.service.mocked_service = mock
+
+    notification.delete
+
+    mock.verify
+  end
+
+  it "can delete itself with user_project set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :delete_notification, nil, [bucket.name, notification_user_project.id, { user_project: "test" }]
+
+    notification_user_project.service.mocked_service = mock
+
+    notification_user_project.delete
+
+    mock.verify
+  end
+end

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -126,4 +126,16 @@ class MockStorage < Minitest::Spec
   def undone_rewrite token
     Google::Apis::StorageV1::RewriteResponse.new done: false, rewrite_token: token
   end
+
+  def random_notification_gapi id: "1", topic: "//pubsub.googleapis.com/projects/test/topics/my-topic", payload: "NONE"
+    gapi = Google::Apis::StorageV1::Notification.new(
+      custom_attributes: { "foo" => "bar" },
+      event_types: ["OBJECT_FINALIZE"],
+      object_name_prefix: "my-prefix",
+      payload_format: payload,
+      topic: topic
+    )
+    gapi.id = id if id
+    gapi
+  end
 end


### PR DESCRIPTION
Add google-cloud-pubsub dependency to `Gemfile` for tests and docs.

[closes #1739]