### PR TITLE
Raise if job is not successful

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/database_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/database_test.rb
@@ -28,6 +28,7 @@ describe "Spanner Databases", :spanner do
     job.wait_until_done!
 
     job.must_be :done?
+    raise Google::Cloud::Error.from_error(job.error) if job.error?
     database = job.database
     database.wont_be :nil?
     database.must_be_kind_of Google::Cloud::Spanner::Database

--- a/google-cloud-spanner/acceptance/spanner/instance_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/instance_test.rb
@@ -29,6 +29,7 @@ describe "Spanner Instances", :spanner do
     job.wait_until_done!
 
     job.must_be :done?
+    raise Google::Cloud::Error.from_error(job.error) if job.error?
     instance = job.instance
     instance.wont_be :nil?
     instance.must_be_kind_of Google::Cloud::Spanner::Instance


### PR DESCRIPTION
We have seen these tests fail occasionally. Raise to indicate what the problem was.