### PR TITLE
Update BigQuery Retry Logic

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -720,10 +720,12 @@ module Google
 
           def retry_error_reason? err_body
             err_hash = JSON.parse err_body
-            Array(err_hash["error"]["errors"]).each do |error|
-              return true if @reasons.include? error["reason"]
+            json_errors = Array err_hash["error"]["errors"]
+            return false if json_errors.empty?
+            json_errors.each do |json_error|
+              return false unless @reasons.include? json_error["reason"]
             end
-            false
+            true
           rescue
             false
           end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
@@ -73,6 +73,72 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     mock.verify
   end
 
+  it "handles a single 404 error with multiple reasons (all retriable) and retries with backoff" do
+    mock = Minitest::Mock.new
+    mock.expect :retry, nil, [0]
+
+    mocked_backoff = lambda { |i| mock.retry i }
+
+    stub = Object.new
+    def stub.get_dataset *args
+      @tries ||= 0
+      @tries += 1
+      if @tries == 1
+        # raise Google::Apis::Error.new "notfound", status_code: 400, body: backenderror_body
+        raise Google::Apis::Error.new "notfound",
+          status_code: 400,
+          body: { "error" => { "errors" => [{ "reason" => "backendError" }, { "reason" => "rateLimitExceeded" }] } }.to_json
+      end
+
+      random_dataset_hash = {
+        "kind" => "bigquery#dataset",
+        "etag" => "etag123456789",
+        "id" => "id",
+        "datasetReference" => {
+          "datasetId" => "my_dataset",
+          "projectId" => "test"
+        },
+        "friendlyName" => "My Dataset",
+      }
+      Google::Apis::BigqueryV2::Dataset.from_json random_dataset_hash.to_json
+    end
+    bigquery.service.mocked_service = stub
+
+    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+      dataset = bigquery.dataset dataset_id
+
+      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      dataset.dataset_id.must_equal dataset_id
+    end
+
+    mock.verify
+  end
+
+  it "handles a single 404 error with multiple reasons (not all retriable) and does not retry with backoff" do
+    mock = Minitest::Mock.new
+
+    mocked_backoff = lambda { |i| mock.retry i }
+
+    stub = Object.new
+    def stub.get_dataset *args
+      raise Google::Apis::Error.new "notfound",
+        status_code: 400,
+        body: { "error" => { "errors" => [{ "reason" => "backendError" }, { "reason" => "other" }] } }.to_json
+    end
+    bigquery.service.mocked_service = stub
+
+    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+      err = assert_raises Google::Cloud::InvalidArgumentError do
+        bigquery.dataset dataset_id
+      end
+
+      err.message.must_equal "notfound"
+      err.cause.body.must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"},{\"reason\":\"other\"}]}}" if err.respond_to? :cause
+    end
+
+    mock.verify
+  end
+
   it "handles a multiple 500 errors (retriable) and retries with backoff" do
     mock = Minitest::Mock.new
     mock.expect :retry, nil, [0]


### PR DESCRIPTION
Per the BigQuery team, retry if _all_ error reasons are retriable, not if _any_ if the error reasons are retriable.