### PR TITLE
Update BigQuery insert_id

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -37,7 +37,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     t = dataset.table table_with_schema_id
     if t.nil?
       t = dataset.create_table table_with_schema_id do |schema|
-        schema.integer  "id",     description: "id description",    mode: :required
+        schema.integer   "id",    description: "id description",    mode: :required
         schema.string    "breed", description: "breed description", mode: :required
         schema.string    "name",  description: "name description",  mode: :required
         schema.timestamp "dob",   description: "dob description",   mode: :required
@@ -161,7 +161,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   it "imports data from a local file and creates a new table with specified schema in a block with load_job" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     job = dataset.load_job "local_file_table", local_file, job_id: job_id do |schema|
-      schema.integer  "id",     description: "id description",    mode: :required
+      schema.integer   "id",    description: "id description",    mode: :required
       schema.string    "breed", description: "breed description", mode: :required
       schema.string    "name",  description: "name description",  mode: :required
       schema.timestamp "dob",   description: "dob description",   mode: :required
@@ -194,7 +194,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
 
   it "imports data from a local file and creates a new table with specified schema in a block with load" do
     result = dataset.load "local_file_table", local_file do |schema|
-      schema.integer  "id",     description: "id description",    mode: :required
+      schema.integer   "id",    description: "id description",    mode: :required
       schema.string    "breed", description: "breed description", mode: :required
       schema.string    "name",  description: "name description",  mode: :required
       schema.timestamp "dob",   description: "dob description",   mode: :required
@@ -250,12 +250,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     insert_response.insert_errors.first.class.must_equal Google::Cloud::Bigquery::InsertResponse::InsertError
     insert_response.insert_errors.first.index.must_equal 1
 
-    # In the context of this test, the original row cannot be compared with InsertResponse row because
-    # rows are converted to "BigQuery JSON rows" early in table.insert: key symbols are turned into strings and
-    # dates/times are formated as timestamp strings with milliseconds.
-    # To be able to test InsertResponse#{insert_error_for, errrors_for, index_for} we need a "BigQuery JSON row"
-    # instead of using insert_response.insert_error.first we make one by converting our orginal "invalid_row"
-    bigquery_row = Google::Cloud::Bigquery::Convert.to_json_row(invalid_rows[insert_response.insert_errors.first.index])
+    bigquery_row = invalid_rows[insert_response.insert_errors.first.index]
     insert_response.insert_errors.first.row.must_equal bigquery_row
 
     insert_response.error_rows.wont_be :empty?
@@ -270,7 +265,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   it "inserts rows with autocreate option" do
     # schema block is not needed in this test since table exists, but provide anyway
     insert_response = dataset.insert table_with_schema.table_id, rows, autocreate: true do |t|
-      t.schema.integer  "id",     description: "id description",    mode: :required
+      t.schema.integer   "id",    description: "id description",    mode: :required
       t.schema.string    "breed", description: "breed description", mode: :required
       t.schema.string    "name",  description: "name description",  mode: :required
       t.schema.timestamp "dob",   description: "dob description",   mode: :required
@@ -302,7 +297,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     new_table_id = "new_dataset_table_id_#{rand(1000)}"
 
     insert_response = dataset.insert new_table_id, rows, autocreate: true do |t|
-      t.schema.integer  "id",     description: "id description",    mode: :required
+      t.schema.integer   "id",    description: "id description",    mode: :required
       t.schema.string    "breed", description: "breed description", mode: :required
       t.schema.string    "name",  description: "name description",  mode: :required
       t.schema.timestamp "dob",   description: "dob description",   mode: :required

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     t = dataset.table table_id
     if t.nil?
       t = dataset.create_table table_id do |schema|
-        schema.integer  "id",     description: "id description",    mode: :required
+        schema.integer   "id",    description: "id description",    mode: :required
         schema.string    "breed", description: "breed description", mode: :required
         schema.string    "name",  description: "name description",  mode: :required
         schema.timestamp "dob",   description: "dob description",   mode: :required
@@ -144,7 +144,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   it "create dataset returns valid etag equal to get dataset" do
     fresh_table_id = "#{rand 100}_kittens"
     fresh = dataset.create_table fresh_table_id do |schema|
-      schema.integer  "id",     description: "id description",    mode: :required
+      schema.integer   "id",    description: "id description",    mode: :required
       schema.string    "breed", description: "breed description", mode: :required
       schema.string    "name",  description: "name description",  mode: :required
       schema.timestamp "dob",   description: "dob description",   mode: :required
@@ -303,12 +303,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     insert_response.insert_errors.first.class.must_equal Google::Cloud::Bigquery::InsertResponse::InsertError
     insert_response.insert_errors.first.index.must_equal 1
 
-    # In the context of this test, the original row cannot be compared with InsertResponse row because
-    # rows are converted to "BigQuery JSON rows" early in table.insert: key symbols are turned into strings and
-    # dates/times are formated as timestamp strings with milliseconds.
-    # To be able to test InsertResponse#{insert_error_for, errrors_for, index_for} we need a "BigQuery JSON row"
-    # instead of using insert_response.insert_error.first we make one by converting our orginal "invalid_row"
-    bigquery_row = Google::Cloud::Bigquery::Convert.to_json_row(invalid_rows[insert_response.insert_errors.first.index])
+    bigquery_row = invalid_rows[insert_response.insert_errors.first.index]
     insert_response.insert_errors.first.row.must_equal bigquery_row
 
     insert_response.error_rows.wont_be :empty?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1611,7 +1611,6 @@ module Google
         def insert_data table_id, rows, skip_invalid: nil, ignore_unknown: nil
           rows = [rows] if rows.is_a? Hash
           fail ArgumentError, "No rows provided" if rows.empty?
-          rows = Convert.to_json_rows rows
           ensure_service!
           options = { skip_invalid: skip_invalid,
                       ignore_unknown: ignore_unknown }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
@@ -54,8 +54,7 @@ module Google
         end
 
         def insert_error_for row
-          json_row = Convert.to_json_row(row)
-          insert_errors.detect { |e| e.row == json_row }
+          insert_errors.detect { |e| e.row == row }
         end
 
         def errors_for row

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -18,7 +18,7 @@ require "google/cloud/bigquery/convert"
 require "google/cloud/errors"
 require "google/apis/bigquery_v2"
 require "pathname"
-require "digest/md5"
+require "securerandom"
 require "mime/types"
 require "date"
 
@@ -201,8 +201,8 @@ module Google
         def insert_tabledata dataset_id, table_id, rows, options = {}
           insert_rows = Array(rows).map do |row|
             Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
-              insert_id: Digest::MD5.base64digest(row.to_json),
-              json: row
+              insert_id: SecureRandom.uuid,
+              json: Convert.to_json_row(row)
             )
           end
           insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1326,7 +1326,6 @@ module Google
         def insert rows, skip_invalid: nil, ignore_unknown: nil
           rows = [rows] if rows.is_a? Hash
           fail ArgumentError, "No rows provided" if rows.empty?
-          rows = Convert.to_json_rows rows
           ensure_service!
           options = { skip_invalid: skip_invalid,
                       ignore_unknown: ignore_unknown }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -62,8 +62,6 @@ module Google
 
             synchronize do
               rows.each do |row|
-                row = Convert.to_json_row row
-
                 if @batch.nil?
                   @batch = Batch.new max_bytes: @max_bytes, max_rows: @max_rows
                   @batch.insert row
@@ -197,7 +195,7 @@ module Google
 
             def current_bytes
               # TODO: add to a counter instead of calling #to_json each time
-              rows.to_json.bytes.size
+              Convert.to_json_rows(rows).to_json.bytes.size
             end
           end
         end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
@@ -49,7 +49,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
     inserter = dataset.insert_async table_id
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows.first
 
       inserter.batch.rows.must_equal [rows.first]
@@ -81,7 +81,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
     inserter = dataset.insert_async table_id
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
       inserter.batch.rows.must_equal rows
@@ -113,7 +113,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
     inserter = dataset.insert_async table_id
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       rows.each do |row|
         inserter.insert row
       end
@@ -152,7 +152,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
       callback_called = true
     end
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
       inserter.batch.rows.must_equal rows
@@ -191,7 +191,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
       callbacks += 1
     end
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
       inserter.batch.rows.must_equal [rows.last]
@@ -230,7 +230,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
       callbacks += 1
     end
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
       inserter.batch.rows.must_equal [rows.last]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
@@ -49,7 +49,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = dataset.insert table_id, rows.first
     end
 
@@ -69,7 +69,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = dataset.insert table_id, rows
     end
 
@@ -89,7 +89,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = dataset.insert table_id, rows
     end
 
@@ -146,7 +146,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = dataset.insert table_id, rows, skip_invalid: true
     end
 
@@ -166,7 +166,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = dataset.insert table_id, rows, ignore_unknown: true
     end
 
@@ -213,7 +213,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = dataset.insert table_id, [inserting_row]
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
@@ -45,7 +45,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
     inserter = table.insert_async
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows.first
 
       inserter.batch.rows.must_equal [rows.first]
@@ -76,7 +76,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
     inserter = table.insert_async
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
       inserter.batch.rows.must_equal rows
@@ -107,7 +107,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
     inserter = table.insert_async
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       rows.each do |row|
         inserter.insert row
       end
@@ -145,7 +145,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
       callback_called = true
     end
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
       inserter.batch.rows.must_equal rows
@@ -183,7 +183,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
       callbacks += 1
     end
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
       inserter.batch.rows.must_equal [rows.last]
@@ -221,7 +221,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
       callbacks += 1
     end
 
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
 
       inserter.batch.rows.must_equal [rows.last]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = table.insert rows.first
     end
 
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = table.insert rows
     end
 
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = table.insert rows
     end
 
@@ -140,7 +140,7 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = table.insert rows, skip_invalid: true
     end
 
@@ -160,7 +160,7 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = table.insert rows, ignore_unknown: true
     end
 
@@ -207,7 +207,7 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = nil
-    Digest::MD5.stub :base64digest, insert_id do
+    SecureRandom.stub :uuid, insert_id do
       result = table.insert [inserting_row]
     end
 


### PR DESCRIPTION
Per the BigQuery team:

> The insert ID in tabledata.insertAll should not be a hash of the row's contents. We should support customers intentionally including multiple rows in the same value.

This PR changes the value used for insert_id to `Object#object_id` from an MD5 hash. [`Object#object_id` is guaranteed to be unique on active objects.](https://ruby-doc.org/core-2.4.2/Object.html#method-i-object_id)