### PR TITLE
Update google-gax dependency

### DIFF
--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "stackdriver-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 0.8.0"
+  gem.add_dependency "google-gax", "~> 0.8.11"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"


### PR DESCRIPTION
The latest partial success support requires some changes that were added in google-gax 0.8.11.