### PR TITLE
Bigquery docs

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
@@ -22,15 +22,31 @@ module Google
       # A {Job} subclass representing a copy operation that may be performed on
       # a {Table}. A CopyJob instance is created when you call {Table#copy_job}.
       #
-      # @see https://cloud.google.com/bigquery/docs/tables#copyingtable Copying
+      # @see https://cloud.google.com/bigquery/docs/tables#copy-table Copying
       #   an Existing Table
       # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
       #   reference
       #
+      # @example
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #   dataset = bigquery.dataset "my_dataset"
+      #   table = dataset.table "my_table"
+      #   destination_table = dataset.table "my_destination_table"
+      #
+      #   copy_job = table.copy_job destination_table
+      #
+      #   copy_job.wait_until_done!
+      #   copy_job.done? #=> true
+      #
       class CopyJob < Job
         ##
         # The table from which data is copied. This is the table on
-        # which {Table#copy_job} was called. Returns a {Table} instance.
+        # which {Table#copy_job} was called.
+        #
+        # @return [Table] A table instance.
+        #
         def source
           table = @gapi.configuration.copy.source_table
           return nil unless table
@@ -40,7 +56,10 @@ module Google
         end
 
         ##
-        # The table to which data is copied. Returns a {Table} instance.
+        # The table to which data is copied.
+        #
+        # @return [Table] A table instance.
+        #
         def destination
           table = @gapi.configuration.copy.destination_table
           return nil unless table
@@ -52,7 +71,11 @@ module Google
         ##
         # Checks if the create disposition for the job is `CREATE_IF_NEEDED`,
         # which provides the following behavior: If the table does not exist,
-        # the copy operation creates the table. This is the default.
+        # the copy operation creates the table. This is the default create
+        # disposition for copy jobs.
+        #
+        # @return [Boolean] `true` when `CREATE_IF_NEEDED`, `false` otherwise.
+        #
         def create_if_needed?
           disp = @gapi.configuration.copy.create_disposition
           disp == "CREATE_IF_NEEDED"
@@ -62,6 +85,9 @@ module Google
         # Checks if the create disposition for the job is `CREATE_NEVER`, which
         # provides the following behavior: The table must already exist; if it
         # does not, an error is returned in the job result.
+        #
+        # @return [Boolean] `true` when `CREATE_NEVER`, `false` otherwise.
+        #
         def create_never?
           disp = @gapi.configuration.copy.create_disposition
           disp == "CREATE_NEVER"
@@ -71,6 +97,9 @@ module Google
         # Checks if the write disposition for the job is `WRITE_TRUNCATE`, which
         # provides the following behavior: If the table already exists, the copy
         # operation overwrites the table data.
+        #
+        # @return [Boolean] `true` when `WRITE_TRUNCATE`, `false` otherwise.
+        #
         def write_truncate?
           disp = @gapi.configuration.copy.write_disposition
           disp == "WRITE_TRUNCATE"
@@ -80,6 +109,9 @@ module Google
         # Checks if the write disposition for the job is `WRITE_APPEND`, which
         # provides the following behavior: If the table already exists, the copy
         # operation appends the data to the table.
+        #
+        # @return [Boolean] `true` when `WRITE_APPEND`, `false` otherwise.
+        #
         def write_append?
           disp = @gapi.configuration.copy.write_disposition
           disp == "WRITE_APPEND"
@@ -88,7 +120,11 @@ module Google
         ##
         # Checks if the write disposition for the job is `WRITE_EMPTY`, which
         # provides the following behavior: If the table already exists and
-        # contains data, the job will have an error. This is the default.
+        # contains data, the job will have an error. This is the default write
+        # disposition for copy jobs.
+        #
+        # @return [Boolean] `true` when `WRITE_EMPTY`, `false` otherwise.
+        #
         def write_empty?
           disp = @gapi.configuration.copy.write_disposition
           disp == "WRITE_EMPTY"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -22,8 +22,23 @@ module Google
       ##
       # # Data
       #
-      # Represents {Table} Data as a list of name/value pairs.
-      # Also contains metadata such as `etag` and `total`.
+      # Represents {Table} Data as a list of name/value pairs (hashes.)
+      # Also contains metadata such as `etag` and `total`, and provides access
+      # to the schema of the table from which the data was read.
+      #
+      # @example
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #   dataset = bigquery.dataset "my_dataset"
+      #   table = dataset.table "my_table"
+      #
+      #   data = table.data
+      #   puts "#{data.count} of #{data.total}"
+      #   if data.next?
+      #     next_data = data.next
+      #   end
+      #
       class Data < DelegateClass(::Array)
         ##
         # @private The Service object.
@@ -47,23 +62,50 @@ module Google
 
         ##
         # The resource type of the API response.
+        #
+        # @return [String] The resource type.
+        #
         def kind
           @gapi.kind
         end
 
         ##
-        # The etag.
+        # An ETag hash for the page of results represented by the data instance.
+        #
+        # @return [String] The ETag hash.
+        #
         def etag
           @gapi.etag
         end
 
         ##
-        # A token used for paging results.
+        # A token used for paging results. Used by the data instance to retrieve
+        # subsequent pages. See {#next}.
+        #
+        # @return [String] The pagination token.
+        #
         def token
           @gapi.page_token
         end
 
+        ##
         # The total number of rows in the complete table.
+        #
+        # @return [Integer] The number of rows.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   data = table.data
+        #   puts "#{data.count} of #{data.total}"
+        #   if data.next?
+        #     next_data = data.next
+        #   end
+        #
         def total
           Integer @gapi.total_rows
         rescue
@@ -71,19 +113,72 @@ module Google
         end
 
         ##
-        # The schema of the data.
+        # The schema of the table from which the data was read.
+        #
+        # The returned object is frozen and changes are not allowed. Use
+        # {Table#schema} to update the schema.
+        #
+        # @return [Schema] A schema object.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   data = table.data
+        #
+        #   schema = data.schema
+        #   field = schema.field "name"
+        #   field.required? #=> true
+        #
         def schema
           Schema.from_gapi(@table_gapi.schema).freeze
         end
 
         ##
-        # The fields of the data.
+        # The fields of the data, obtained from the schema of the table from
+        # which the data was read.
+        #
+        # @return [Array<Schema::Field>] An array of field objects.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   data = table.data
+        #
+        #   data.fields.each do |field|
+        #     puts field.name
+        #   end
+        #
         def fields
           schema.fields
         end
 
         ##
-        # The name of the columns in the data.
+        # The name of the columns in the data, obtained from the schema of the
+        # table from which the data was read.
+        #
+        # @return [Array<Symbol>] An array of column names.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   data = table.data
+        #
+        #   data.headers.each do |header|
+        #     puts header
+        #   end
+        #
         def headers
           schema.headers
         end
@@ -91,7 +186,7 @@ module Google
         ##
         # Whether there is a next page of data.
         #
-        # @return [Boolean]
+        # @return [Boolean] `true` when there is a next page, `false` otherwise.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -110,9 +205,9 @@ module Google
         end
 
         ##
-        # Retrieve the next page of data.
+        # Retrieves the next page of data.
         #
-        # @return [Data]
+        # @return [Data] A new instance providing the next page of data.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -141,7 +236,7 @@ module Google
         # returns `false`. Calls the given block once for each row, which is
         # passed as the parameter.
         #
-        # An Enumerator is returned if no block is given.
+        # An enumerator is returned if no block is given.
         #
         # This method may make several API calls until all rows are retrieved.
         # Be sure to use as narrow a search criteria as possible. Please use
@@ -152,7 +247,8 @@ module Google
         # @yield [row] The block for accessing each row of data.
         # @yieldparam [Hash] row The row object.
         #
-        # @return [Enumerator]
+        # @return [Enumerator] An enumerator providing access to all of the
+        #   data.
         #
         # @example Iterating each rows by passing a block:
         #   require "google/cloud/bigquery"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -73,7 +73,7 @@ module Google
         ##
         # The schema of the data.
         def schema
-          Schema.from_gapi @table_gapi.schema
+          Schema.from_gapi(@table_gapi.schema).freeze
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -161,7 +161,7 @@ module Google
         end
 
         ##
-        # The name of the columns in the data, obtained from the schema of the
+        # The names of the columns in the data, obtained from the schema of the
         # table from which the data was read.
         #
         # @return [Array<Symbol>] An array of column names.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -60,8 +60,9 @@ module Google
 
         ##
         # A unique ID for this dataset, without the project name.
-        # The ID must contain only letters (a-z, A-Z), numbers (0-9),
-        # or underscores (_). The maximum length is 1,024 characters.
+        #
+        # @return [String] The ID must contain only letters (a-z, A-Z), numbers
+        #   (0-9), or underscores (_). The maximum length is 1,024 characters.
         #
         # @!group Attributes
         #
@@ -71,6 +72,8 @@ module Google
 
         ##
         # The ID of the project containing this dataset.
+        #
+        # @return [String] The project ID.
         #
         # @!group Attributes
         #
@@ -91,6 +94,8 @@ module Google
         ##
         # A descriptive name for the dataset.
         #
+        # @return [String] The friendly name.
+        #
         # @!group Attributes
         #
         def name
@@ -100,6 +105,8 @@ module Google
         ##
         # Updates the descriptive name for the dataset.
         #
+        # @param [String] new_name The new friendly name.
+        #
         # @!group Attributes
         #
         def name= new_name
@@ -108,7 +115,9 @@ module Google
         end
 
         ##
-        # A string hash of the dataset.
+        # The ETag hash of the dataset.
+        #
+        # @return [String] The ETag hash.
         #
         # @!group Attributes
         #
@@ -120,6 +129,8 @@ module Google
         ##
         # A URL that can be used to access the dataset using the REST API.
         #
+        # @return [String] A REST URL for the resource.
+        #
         # @!group Attributes
         #
         def api_url
@@ -129,6 +140,8 @@ module Google
 
         ##
         # A user-friendly description of the dataset.
+        #
+        # @return [String] The description.
         #
         # @!group Attributes
         #
@@ -140,6 +153,8 @@ module Google
         ##
         # Updates the user-friendly description of the dataset.
         #
+        # @param [String] new_description The new description for the dataset.
+        #
         # @!group Attributes
         #
         def description= new_description
@@ -149,6 +164,8 @@ module Google
 
         ##
         # The default lifetime of all tables in the dataset, in milliseconds.
+        #
+        # @return [Integer] The default table expiration in milliseconds.
         #
         # @!group Attributes
         #
@@ -165,6 +182,9 @@ module Google
         # Updates the default lifetime of all tables in the dataset, in
         # milliseconds.
         #
+        # @param [Integer] new_default_expiration The new default table
+        #   expiration in milliseconds.
+        #
         # @!group Attributes
         #
         def default_expiration= new_default_expiration
@@ -174,6 +194,8 @@ module Google
 
         ##
         # The time when this dataset was created.
+        #
+        # @return [Time, nil] The creation time.
         #
         # @!group Attributes
         #
@@ -189,6 +211,8 @@ module Google
         ##
         # The date when this dataset or any of its tables was last modified.
         #
+        # @return [Time, nil] The last modified time.
+        #
         # @!group Attributes
         #
         def modified_at
@@ -202,7 +226,9 @@ module Google
 
         ##
         # The geographic location where the dataset should reside. Possible
-        # values include EU and US. The default value is US.
+        # values include `EU` and `US`. The default value is `US`.
+        #
+        # @return [String] The location code.
         #
         # @!group Attributes
         #
@@ -213,11 +239,22 @@ module Google
 
         ##
         # A hash of user-provided labels associated with this dataset. Labels
-        # are used to organize and group datasets. See [Labeling
-        # Datasets](https://cloud.google.com/bigquery/docs/labeling-datasets).
+        # are used to organize and group datasets. See [Using
+        # Labels](https://cloud.google.com/bigquery/docs/labels).
         #
         # The returned hash is frozen and changes are not allowed. Use
         # {#labels=} to replace the entire hash.
+        #
+        # @return [Hash<String, String>] A hash containing key/value pairs.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #
+        #   labels = dataset.labels
+        #   labels["department"] #=> "shipping"
         #
         # @!group Attributes
         #
@@ -229,8 +266,26 @@ module Google
 
         ##
         # Updates the hash of user-provided labels associated with this dataset.
-        # Labels are used to organize and group datasets. See [Labeling
-        # Datasets](https://cloud.google.com/bigquery/docs/labeling-datasets).
+        # Labels are used to organize and group datasets. See [Using
+        # Labels](https://cloud.google.com/bigquery/docs/labels).
+        #
+        # @param [Hash<String, String>] labels A hash containing key/value
+        #   pairs.
+        #
+        #   * Label keys and values can be no longer than 63 characters.
+        #   * Label keys and values can contain only lowercase letters, numbers,
+        #     underscores, hyphens, and international characters.
+        #   * Label keys and values cannot exceed 128 bytes in size.
+        #   * Label keys must begin with a letter.
+        #   * Label keys must be unique within a dataset.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #
+        #   dataset.labels = { "department" => "shipping" }
         #
         # @!group Attributes
         #
@@ -250,7 +305,7 @@ module Google
         # @yield [access] a block for setting rules
         # @yieldparam [Dataset::Access] access the object accepting rules
         #
-        # @return [Google::Cloud::Bigquery::Dataset::Access]
+        # @return [Google::Cloud::Bigquery::Dataset::Access] The access object.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -328,7 +383,7 @@ module Google
         # @yield [table] a block for setting the table
         # @yieldparam [Table] table the table object to be updated
         #
-        # @return [Google::Cloud::Bigquery::Table]
+        # @return [Google::Cloud::Bigquery::Table] A new table object.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -425,7 +480,7 @@ module Google
         #   containing the same code. See [User-Defined
         #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
         #
-        # @return [Google::Cloud::Bigquery::View]
+        # @return [Google::Cloud::Bigquery::View] A new view object.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -505,8 +560,8 @@ module Google
         # @param [Integer] max Maximum number of tables to return.
         #
         # @return [Array<Google::Cloud::Bigquery::Table>,
-        #   Array<Google::Cloud::Bigquery::View>] (See
-        #   {Google::Cloud::Bigquery::Table::List})
+        #   Array<Google::Cloud::Bigquery::View>] An array of tables and/or
+        #   views(See {Google::Cloud::Bigquery::Table::List})
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -670,7 +725,7 @@ module Google
         #   containing the same code. See [User-Defined
         #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
         #
-        # @return [Google::Cloud::Bigquery::QueryJob]
+        # @return [Google::Cloud::Bigquery::QueryJob] A new query job object.
         #
         # @example Query using standard SQL:
         #   require "google/cloud/bigquery"
@@ -856,7 +911,7 @@ module Google
         #   ignored; the query will be run as if `large_results` is true and
         #   `flatten` is false. Optional. The default value is false.
         #
-        # @return [Google::Cloud::Bigquery::Data]
+        # @return [Google::Cloud::Bigquery::Data] A new data object.
         #
         # @example Query using standard SQL:
         #   require "google/cloud/bigquery"
@@ -1147,7 +1202,7 @@ module Google
         #   instance provided using the `schema` option, or a new, empty schema
         #   instance
         #
-        # @return [Google::Cloud::Bigquery::LoadJob]
+        # @return [Google::Cloud::Bigquery::LoadJob] A new load job object.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -1357,7 +1412,7 @@ module Google
         #   instance provided using the `schema` option, or a new, empty schema
         #   instance
         #
-        # @return [Google::Cloud::Bigquery::LoadJob]
+        # @return [Boolean] Returns `true` if the load job was successful.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -1482,7 +1537,8 @@ module Google
         #   a new table with the given `table_id`, if no table is found for
         #   `table_id`. The default value is false.
         #
-        # @return [Google::Cloud::Bigquery::InsertResponse]
+        # @return [Google::Cloud::Bigquery::InsertResponse] An insert response
+        #   object.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -1564,7 +1620,7 @@ module Google
         # @yieldparam [InsertResponse] response the result of the asynchonous
         #   insert
         #
-        # @return [Table::AsyncInserter] Returns inserter object.
+        # @return [Table::AsyncInserter] Returns an inserter object.
         #
         # @example
         #   require "google/cloud/bigquery"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -258,14 +258,8 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   dataset.access # [{"role"=>"OWNER",
-        #                  #   "specialGroup"=>"projectOwners"},
-        #                  #  {"role"=>"WRITER",
-        #                  #   "specialGroup"=>"projectWriters"},
-        #                  #  {"role"=>"READER",
-        #                  #   "specialGroup"=>"projectReaders"},
-        #                  #  {"role"=>"OWNER",
-        #                  #   "userByEmail"=>"123456789-...com"}]
+        #   access = dataset.access
+        #   access.writer_user? "reader@example.com" #=> false
         #
         # @example Manage the access rules by passing a block:
         #   require "google/cloud/bigquery"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
@@ -20,10 +20,10 @@ module Google
         ##
         # # Dataset Access Control
         #
-        # Represents the Access rules for a {Dataset}.
+        # Represents the access control rules for a {Dataset}.
         #
-        # @see https://cloud.google.com/bigquery/access-control BigQuery Access
-        #   Control
+        # @see https://cloud.google.com/bigquery/docs/access-control BigQuery
+        #   Access Control
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -106,258 +106,764 @@ module Google
 
           ##
           # Add reader access to a user.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_reader_user "entity@example.com"
+          #   end
+          #
           def add_reader_user email
             add_access_role_scope_value :reader, :user, email
           end
 
           ##
           # Add reader access to a group.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_reader_group "entity@example.com"
+          #   end
+          #
           def add_reader_group email
             add_access_role_scope_value :reader, :group, email
           end
 
           ##
           # Add reader access to a domain.
+          #
+          # @param [String] domain A [Cloud Identity
+          #   domain](https://cloud.google.com/iam/docs/overview#cloudid_name_domain).
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_reader_domain "example.com"
+          #   end
+          #
           def add_reader_domain domain
             add_access_role_scope_value :reader, :domain, domain
           end
 
           ##
           # Add reader access to a special group.
-          # Accepted values are `owners`, `writers`, `readers`, and `all`.
+          #
+          # @param [String] group Accepted values are `owners`, `writers`,
+          #   `readers`, and `all`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_reader_special :all
+          #   end
+          #
           def add_reader_special group
             add_access_role_scope_value :reader, :special, group
           end
 
           ##
           # Add reader access to a view.
-          # The view can be a Google::Cloud::Bigquery::View object,
-          # or a string identifier as specified by the
-          # [Query
-          # Reference](https://cloud.google.com/bigquery/query-reference#from):
-          # +project_name:datasetId.tableId+.
+          #
+          # @param [Google::Cloud::Bigquery::View, String] view A view object or
+          #   a string identifier as specified by the [Query
+          #   Reference](https://cloud.google.com/bigquery/query-reference#from):
+          #   `project_name:datasetId.tableId`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   other_dataset = bigquery.dataset "my_other_dataset"
+          #
+          #   view = other_dataset.table "my_view"
+          #
+          #   dataset.access do |access|
+          #     access.add_reader_view view
+          #   end
+          #
           def add_reader_view view
             add_access_view view
           end
 
           ##
           # Add writer access to a user.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_writer_user "entity@example.com"
+          #   end
+          #
           def add_writer_user email
             add_access_role_scope_value :writer, :user, email
           end
 
           ##
           # Add writer access to a group.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_writer_group "entity@example.com"
+          #   end
+          #
           def add_writer_group email
             add_access_role_scope_value :writer, :group, email
           end
 
           ##
           # Add writer access to a domain.
+          #
+          # @param [String] domain A [Cloud Identity
+          #   domain](https://cloud.google.com/iam/docs/overview#cloudid_name_domain).
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_writer_domain "example.com"
+          #   end
+          #
           def add_writer_domain domain
             add_access_role_scope_value :writer, :domain, domain
           end
 
           ##
           # Add writer access to a special group.
-          # Accepted values are `owners`, `writers`, `readers`, and `all`.
+          #
+          # @param [String] group Accepted values are `owners`, `writers`,
+          #   `readers`, and `all`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_writer_special :all
+          #   end
+          #
           def add_writer_special group
             add_access_role_scope_value :writer, :special, group
           end
 
           ##
           # Add owner access to a user.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_owner_user "entity@example.com"
+          #   end
+          #
           def add_owner_user email
             add_access_role_scope_value :owner, :user, email
           end
 
           ##
           # Add owner access to a group.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_owner_group "entity@example.com"
+          #   end
+          #
           def add_owner_group email
             add_access_role_scope_value :owner, :group, email
           end
 
           ##
           # Add owner access to a domain.
+          #
+          # @param [String] domain A [Cloud Identity
+          #   domain](https://cloud.google.com/iam/docs/overview#cloudid_name_domain).
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_owner_domain "example.com"
+          #   end
+          #
           def add_owner_domain domain
             add_access_role_scope_value :owner, :domain, domain
           end
 
           ##
           # Add owner access to a special group.
-          # Accepted values are `owners`, `writers`, `readers`, and `all`.
+          #
+          # @param [String] group Accepted values are `owners`, `writers`,
+          #   `readers`, and `all`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.add_owner_special :all
+          #   end
+          #
           def add_owner_special group
             add_access_role_scope_value :owner, :special, group
           end
 
           ##
           # Remove reader access from a user.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_reader_user "entity@example.com"
+          #   end
+          #
           def remove_reader_user email
             remove_access_role_scope_value :reader, :user, email
           end
 
           ##
           # Remove reader access from a group.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_reader_group "entity@example.com"
+          #   end
+          #
           def remove_reader_group email
             remove_access_role_scope_value :reader, :group, email
           end
 
           ##
           # Remove reader access from a domain.
+          #
+          # @param [String] domain A [Cloud Identity
+          #   domain](https://cloud.google.com/iam/docs/overview#cloudid_name_domain).
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_reader_domain "example.com"
+          #   end
+          #
           def remove_reader_domain domain
             remove_access_role_scope_value :reader, :domain, domain
           end
 
           ##
           # Remove reader access from a special group.
-          # Accepted values are `owners`, `writers`, `readers`, and `all`.
+          #
+          # @param [String] group Accepted values are `owners`, `writers`,
+          #   `readers`, and `all`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_reader_special :all
+          #   end
+          #
           def remove_reader_special group
             remove_access_role_scope_value :reader, :special, group
           end
 
           ##
           # Remove reader access from a view.
-          # The view can be a Google::Cloud::Bigquery::View object,
-          # or a string identifier as specified by the
-          # [Query
-          # Reference](https://cloud.google.com/bigquery/query-reference#from):
-          # +project_name:datasetId.tableId+.
+          #
+          # @param [Google::Cloud::Bigquery::View, String] view A view object or
+          #   a string identifier as specified by the [Query
+          #   Reference](https://cloud.google.com/bigquery/query-reference#from):
+          #   `project_name:datasetId.tableId`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   other_dataset = bigquery.dataset "my_other_dataset"
+          #
+          #   view = other_dataset.table "my_view"
+          #
+          #   dataset.access do |access|
+          #     access.remove_reader_view view
+          #   end
+          #
           def remove_reader_view view
             remove_access_view view
           end
 
           ##
           # Remove writer access from a user.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_writer_user "entity@example.com"
+          #   end
+          #
           def remove_writer_user email
             remove_access_role_scope_value :writer, :user, email
           end
 
           ##
           # Remove writer access from a group.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_writer_group "entity@example.com"
+          #   end
+          #
           def remove_writer_group email
             remove_access_role_scope_value :writer, :group, email
           end
 
           ##
           # Remove writer access from a domain.
+          #
+          # @param [String] domain A [Cloud Identity
+          #   domain](https://cloud.google.com/iam/docs/overview#cloudid_name_domain).
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_writer_domain "example.com"
+          #   end
+          #
           def remove_writer_domain domain
             remove_access_role_scope_value :writer, :domain, domain
           end
 
           ##
           # Remove writer access from a special group.
-          # Accepted values are `owners`, `writers`, `readers`, and `all`.
+          #
+          # @param [String] group Accepted values are `owners`, `writers`,
+          #   `readers`, and `all`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_writer_special :all
+          #   end
+          #
           def remove_writer_special group
             remove_access_role_scope_value :writer, :special, group
           end
 
           ##
           # Remove owner access from a user.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_owner_user "entity@example.com"
+          #   end
+          #
           def remove_owner_user email
             remove_access_role_scope_value :owner, :user, email
           end
 
           ##
           # Remove owner access from a group.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_owner_group "entity@example.com"
+          #   end
+          #
           def remove_owner_group email
             remove_access_role_scope_value :owner, :group, email
           end
 
           ##
           # Remove owner access from a domain.
+          #
+          # @param [String] domain A [Cloud Identity
+          #   domain](https://cloud.google.com/iam/docs/overview#cloudid_name_domain).
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_owner_domain "example.com"
+          #   end
+          #
           def remove_owner_domain domain
             remove_access_role_scope_value :owner, :domain, domain
           end
 
           ##
           # Remove owner access from a special group.
-          # Accepted values are `owners`, `writers`, `readers`, and `all`.
+          #
+          # @param [String] group Accepted values are `owners`, `writers`,
+          #   `readers`, and `all`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   dataset.access do |access|
+          #     access.remove_owner_special :all
+          #   end
+          #
           def remove_owner_special group
             remove_access_role_scope_value :owner, :special, group
           end
 
           ##
           # Checks reader access for a user.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.reader_user? "entity@example.com" #=> false
+          #
           def reader_user? email
             lookup_access_role_scope_value :reader, :user, email
           end
 
           ##
           # Checks reader access for a group.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.reader_group? "entity@example.com" #=> false
+          #
           def reader_group? email
             lookup_access_role_scope_value :reader, :group, email
           end
 
           ##
           # Checks reader access for a domain.
+          #
+          # @param [String] domain A [Cloud Identity
+          #   domain](https://cloud.google.com/iam/docs/overview#cloudid_name_domain).
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.reader_domain? "example.com" #=> false
+          #
           def reader_domain? domain
             lookup_access_role_scope_value :reader, :domain, domain
           end
 
           ##
           # Checks reader access for a special group.
-          # Accepted values are `owners`, `writers`, `readers`, and `all`.
+          #
+          # @param [String] group Accepted values are `owners`, `writers`,
+          #   `readers`, and `all`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.reader_special? :all #=> false
+          #
           def reader_special? group
             lookup_access_role_scope_value :reader, :special, group
           end
 
           ##
           # Checks reader access for a view.
-          # The view can be a Google::Cloud::Bigquery::View object,
-          # or a string identifier as specified by the
-          # [Query
-          # Reference](https://cloud.google.com/bigquery/query-reference#from):
-          # +project_name:datasetId.tableId+.
+          #
+          # @param [Google::Cloud::Bigquery::View, String] view A view object or
+          #   a string identifier as specified by the [Query
+          #   Reference](https://cloud.google.com/bigquery/query-reference#from):
+          #   `project_name:datasetId.tableId`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   other_dataset = bigquery.dataset "my_other_dataset"
+          #
+          #   view = other_dataset.table "my_view"
+          #
+          #   access = dataset.access
+          #   access.reader_view? view #=> false
+          #
           def reader_view? view
             lookup_access_view view
           end
 
           ##
           # Checks writer access for a user.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.writer_user? "entity@example.com" #=> false
+          #
           def writer_user? email
             lookup_access_role_scope_value :writer, :user, email
           end
 
           ##
           # Checks writer access for a group.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.writer_group? "entity@example.com" #=> false
+          #
           def writer_group? email
             lookup_access_role_scope_value :writer, :group, email
           end
 
           ##
           # Checks writer access for a domain.
+          #
+          # @param [String] domain A [Cloud Identity
+          #   domain](https://cloud.google.com/iam/docs/overview#cloudid_name_domain).
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.writer_domain? "example.com" #=> false
+          #
           def writer_domain? domain
             lookup_access_role_scope_value :writer, :domain, domain
           end
 
           ##
           # Checks writer access for a special group.
-          # Accepted values are `owners`, `writers`, `readers`, and `all`.
+          #
+          # @param [String] group Accepted values are `owners`, `writers`,
+          #   `readers`, and `all`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.writer_special? :all #=> false
+          #
           def writer_special? group
             lookup_access_role_scope_value :writer, :special, group
           end
 
           ##
           # Checks owner access for a user.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.owner_user? "entity@example.com" #=> false
+          #
           def owner_user? email
             lookup_access_role_scope_value :owner, :user, email
           end
 
           ##
           # Checks owner access for a group.
+          #
+          # @param [String] email The email address for the entity.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.owner_group? "entity@example.com" #=> false
+          #
           def owner_group? email
             lookup_access_role_scope_value :owner, :group, email
           end
 
           ##
           # Checks owner access for a domain.
+          #
+          # @param [String] domain A [Cloud Identity
+          #   domain](https://cloud.google.com/iam/docs/overview#cloudid_name_domain).
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.owner_domain? "example.com" #=> false
+          #
           def owner_domain? domain
             lookup_access_role_scope_value :owner, :domain, domain
           end
 
           ##
           # Checks owner access for a special group.
-          # Accepted values are `owners`, `writers`, `readers`, and `all`.
+          #
+          # @param [String] group Accepted values are `owners`, `writers`,
+          #   `readers`, and `all`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #
+          #   access = dataset.access
+          #   access.owner_special? :all #=> false
+          #
           def owner_special? group
             lookup_access_role_scope_value :owner, :special, group
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
@@ -23,10 +23,22 @@ module Google
       # on a {Table}. A ExtractJob instance is created when you call
       # {Table#extract_job}.
       #
-      # @see https://cloud.google.com/bigquery/exporting-data-from-bigquery
+      # @see https://cloud.google.com/bigquery/docs/exporting-data
       #   Exporting Data From BigQuery
       # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
       #   reference
+      #
+      # @example
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #   dataset = bigquery.dataset "my_dataset"
+      #   table = dataset.table "my_table"
+      #
+      #   extract_job = table.extract_job "gs://my-bucket/file-name.json",
+      #                                   format: "json"
+      #   extract_job.wait_until_done!
+      #   extract_job.done? #=> true
       #
       class ExtractJob < Job
         ##
@@ -38,7 +50,10 @@ module Google
 
         ##
         # The table from which the data is exported. This is the table upon
-        # which {Table#extract_job} was called. Returns a {Table} instance.
+        # which {Table#extract_job} was called.
+        #
+        # @return [Table] A table instance.
+        #
         def source
           table = @gapi.configuration.extract.source_table
           return nil unless table
@@ -50,6 +65,9 @@ module Google
         ##
         # Checks if the export operation compresses the data using gzip. The
         # default is `false`.
+        #
+        # @return [Boolean] `true` when `GZIP`, `false` otherwise.
+        #
         def compression?
           val = @gapi.configuration.extract.compression
           val == "GZIP"
@@ -58,6 +76,10 @@ module Google
         ##
         # Checks if the destination format for the data is [newline-delimited
         # JSON](http://jsonlines.org/). The default is `false`.
+        #
+        # @return [Boolean] `true` when `NEWLINE_DELIMITED_JSON`, `false`
+        #   otherwise.
+        #
         def json?
           val = @gapi.configuration.extract.destination_format
           val == "NEWLINE_DELIMITED_JSON"
@@ -67,6 +89,9 @@ module Google
         # Checks if the destination format for the data is CSV. Tables with
         # nested or repeated fields cannot be exported as CSV. The default is
         # `true`.
+        #
+        # @return [Boolean] `true` when `CSV`, `false` otherwise.
+        #
         def csv?
           val = @gapi.configuration.extract.destination_format
           return true if val.nil?
@@ -76,14 +101,20 @@ module Google
         ##
         # Checks if the destination format for the data is
         # [Avro](http://avro.apache.org/). The default is `false`.
+        #
+        # @return [Boolean] `true` when `AVRO`, `false` otherwise.
+        #
         def avro?
           val = @gapi.configuration.extract.destination_format
           val == "AVRO"
         end
 
         ##
-        # The symbol the operation uses to delimit fields in the exported data.
-        # The default is a comma (,).
+        # The character or symbol the operation uses to delimit fields in the
+        # exported data. The default is a comma (,).
+        #
+        # @return [String] A string containing the character, such as `","`.
+        #
         def delimiter
           val = @gapi.configuration.extract.field_delimiter
           val = "," if val.nil?
@@ -93,6 +124,10 @@ module Google
         ##
         # Checks if the exported data contains a header row. The default is
         # `true`.
+        #
+        # @return [Boolean] `true` when the print header configuration is
+        #   present or `nil`, `false` otherwise.
+        #
         def print_header?
           val = @gapi.configuration.extract.print_header
           val = true if val.nil?
@@ -100,17 +135,23 @@ module Google
         end
 
         ##
-        # The count of files per destination URI or URI pattern specified in
-        # {#destinations}. Returns an Array of values in the same order as the
-        # URI patterns.
+        # The number of files per destination URI or URI pattern specified in
+        # {#destinations}.
+        #
+        # @return [Array<Integer>] An array of values in the same order as the
+        #   URI patterns.
+        #
         def destinations_file_counts
           Array @gapi.statistics.extract.destination_uri_file_counts
         end
 
         ##
-        # The count of files per destination URI or URI pattern specified in
-        # {#destinations}. Returns a Hash with the URI patterns as keys and the
-        # counts as values.
+        # A hash containing the URI or URI pattern specified in
+        # {#destinations} mapped to the counts of files per destination.
+        #
+        # @return [Hash<String, Integer>] A Hash with the URI patterns as keys
+        #   and the counts as values.
+        #
         def destinations_counts
           Hash[destinations.zip destinations_file_counts]
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
@@ -20,6 +20,28 @@ module Google
     module Bigquery
       ##
       # InsertResponse
+      #
+      # Represents the response from BigQuery when data is inserted into a table
+      # for near-immediate querying, without the need to complete a load
+      # operation before the data can appear in query results. See
+      # {Dataset#insert} and {Table#insert}.
+      #
+      # @see https://cloud.google.com/bigquery/streaming-data-into-bigquery
+      #   Streaming Data Into BigQuery
+      #
+      # @example
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #   dataset = bigquery.dataset "my_dataset"
+      #
+      #   rows = [
+      #     { "first_name" => "Alice", "age" => 21 },
+      #     { "first_name" => "Bob", "age" => 22 }
+      #   ]
+      #
+      #   insert_response = dataset.insert "my_table", rows
+      #
       class InsertResponse
         # @private
         def initialize rows, gapi
@@ -27,18 +49,43 @@ module Google
           @gapi = gapi
         end
 
+        ##
+        # Checks if the error count is zero, meaning that all of the rows were
+        # inserted. Use {#insert_errors} to access the errors.
+        #
+        # @return [Boolean] `true` when the error count is zero, `false`
+        #   otherwise.
+        #
         def success?
           error_count.zero?
         end
 
+
+        ##
+        # The count of rows in the response, minus the count of errors for rows
+        # that were not inserted.
+        #
+        # @return [Integer] The number of rows inserted.
+        #
         def insert_count
           @rows.count - error_count
         end
 
+
+        ##
+        # The count of errors for rows that were not inserted.
+        #
+        # @return [Integer] The number of errors.
+        #
         def error_count
           Array(@gapi.insert_errors).count
         end
 
+        ##
+        # The error objects for rows that were not inserted.
+        #
+        # @return [Array<InsertError>] An array containing error objects.
+        #
         def insert_errors
           Array(@gapi.insert_errors).map do |ie|
             row = @rows[ie.index]
@@ -47,23 +94,55 @@ module Google
           end
         end
 
+        ##
+        # The rows that were not inserted.
+        #
+        # @return [Array<Hash>] An array of hash objects containing the row
+        #   data.
+        #
         def error_rows
           Array(@gapi.insert_errors).map do |ie|
             @rows[ie.index]
           end
         end
 
+        ##
+        # Returns the error object for a row that was not inserted.
+        #
+        # @param [Hash] row A hash containing the data for a row.
+        #
+        # @return [InsertError, nil] An error object, or `nil` if no error is
+        #   found in the response for the row.
+        #
         def insert_error_for row
           json_row = Convert.to_json_row(row)
           insert_errors.detect { |e| e.row == json_row }
         end
 
+        ##
+        # Returns the error hashes for a row that was not inserted. Each error
+        # hash contains the following keys: `reason`, `location`, `debugInfo`,
+        # and `message`.
+        #
+        # @param [Hash] row A hash containing the data for a row.
+        #
+        # @return [Array<Hash>, nil] An array of error hashes, or `nil` if no
+        #   errors are found in the response for the row.
+        #
         def errors_for row
           ie = insert_error_for row
           return ie.errors if ie
           []
         end
 
+        ##
+        # Returns the index for a row that was not inserted.
+        #
+        # @param [Hash] row A hash containing the data for a row.
+        #
+        # @return [Integer, nil] An error object, or `nil` if no error is
+        #   found in the response for the row.
+        #
         def index_for row
           ie = insert_error_for row
           return ie.index if ie
@@ -78,6 +157,16 @@ module Google
 
         ##
         # InsertError
+        #
+        # Represents the errors for a row that was not inserted.
+        #
+        # @attr_reader [Integer] index The index of the row that error applies
+        #   to.
+        # @attr_reader [Hash] row The row that error applies to.
+        # @attr_reader [Hash] errors Error information for the row indicated by
+        #   the index property, with the following keys: `reason`, `location`,
+        #   `debugInfo`, and `message`.
+        #
         class InsertError
           attr_reader :index
           attr_reader :row

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -153,6 +153,9 @@ module Google
 
         ##
         # The time when the job was created.
+        #
+        # @return [Time, nil] The creation time from the job statistics.
+        #
         def created_at
           ::Time.at(Integer(@gapi.statistics.creation_time) / 1000.0)
         rescue

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -106,6 +106,7 @@ module Google
         #
         # @return [String] The state code. The possible values are `PENDING`,
         #   `RUNNING`, and `DONE`.
+        #
         def state
           return nil if @gapi.status.nil?
           @gapi.status.state
@@ -113,6 +114,9 @@ module Google
 
         ##
         # Checks if the job's state is `RUNNING`.
+        #
+        # @return [Boolean] `true` when `RUNNING`, `false` otherwise.
+        #
         def running?
           return false if state.nil?
           "running".casecmp(state).zero?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -260,6 +260,9 @@ module Google
         # destination table already exists, or if you're loading data from
         # Google Cloud Datastore.
         #
+        # The returned object is frozen and changes are not allowed. Use
+        # {Table#schema} to update the schema.
+        #
         # @return [Schema, nil] A schema object, or `nil`.
         #
         def schema

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -46,6 +46,22 @@ module Google
       class Schema
         ##
         # The fields of the table schema.
+        #
+        # @return [Array<Field>] An array of field objects.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   schema = table.schema
+        #
+        #   schema.fields.each do |field|
+        #     puts field.name
+        #   end
+        #
         def fields
           if frozen?
             Array(@gapi.fields).map { |f| Field.from_gapi(f).freeze }.freeze
@@ -56,12 +72,41 @@ module Google
 
         ##
         # The names of the fields as symbols.
+        #
+        # @return [Array<Symbol>] An array of column names.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.create_table "my_table"
+        #
+        #   schema = table.schema
+        #
+        #   schema.headers.each do |header|
+        #     puts header
+        #   end
+        #
         def headers
           fields.map(&:name).map(&:to_sym)
         end
 
         ##
-        # Retreive a fields by name.
+        # Retrieve a field by name.
+        #
+        # @return [Field] A field object.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   field = table.schema.field "name"
+        #   field.required? #=> true
+        #
         def field name
           f = fields.find { |fld| fld.name == name.to_s }
           return nil if f.nil?
@@ -71,6 +116,9 @@ module Google
 
         ##
         # Whether the schema has no fields defined.
+        #
+        # @return [Boolean] `true` when there are no fields, `false` otherwise.
+        #
         def empty?
           fields.empty?
         end
@@ -86,6 +134,7 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        #
         def string name, description: nil, mode: :nullable
           add_field name, :string, description: description, mode: mode
         end
@@ -101,6 +150,7 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        #
         def integer name, description: nil, mode: :nullable
           add_field name, :integer, description: description, mode: mode
         end
@@ -116,6 +166,7 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        #
         def float name, description: nil, mode: :nullable
           add_field name, :float, description: description, mode: mode
         end
@@ -131,6 +182,7 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        #
         def boolean name, description: nil, mode: :nullable
           add_field name, :boolean, description: description, mode: mode
         end
@@ -146,6 +198,7 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        #
         def bytes name, description: nil, mode: :nullable
           add_field name, :bytes, description: description, mode: mode
         end
@@ -176,6 +229,7 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        #
         def time name, description: nil, mode: :nullable
           add_field name, :time, description: description, mode: mode
         end
@@ -191,6 +245,7 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        #
         def datetime name, description: nil, mode: :nullable
           add_field name, :datetime, description: description, mode: mode
         end
@@ -206,6 +261,7 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        #
         def date name, description: nil, mode: :nullable
           add_field name, :date, description: description, mode: mode
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -34,6 +34,7 @@ module Google
         #
         #   field = table.schema.field "name"
         #   field.required? #=> true
+        #
         class Field
           # @private
           MODES = %w( NULLABLE REQUIRED REPEATED )
@@ -45,6 +46,11 @@ module Google
           ##
           # The name of the field.
           #
+          # @return [String] The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          #
           def name
             @gapi.name
           end
@@ -52,19 +58,38 @@ module Google
           ##
           # Updates the name of the field.
           #
+          # @param [String] new_name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          #
           def name= new_name
             @gapi.update! name: String(new_name)
           end
 
           ##
-          # The type of the field.
+          # The data type of the field.
+          #
+          # @return [String] The field data type. Possible values include
+          #   `STRING`, `BYTES`, `INTEGER`, `INT64` (same as `INTEGER`),
+          #   `FLOAT`, `FLOAT64` (same as `FLOAT`), `BOOLEAN`, `BOOL` (same as
+          #   `BOOLEAN`), `TIMESTAMP`, `DATE`, `TIME`, `DATETIME`, `RECORD`
+          #   (where `RECORD` indicates that the field contains a nested schema)
+          #   or `STRUCT` (same as `RECORD`).
           #
           def type
             @gapi.type
           end
 
           ##
-          # Updates the type of the field.
+          # Updates the data type of the field.
+          #
+          # @param [String] new_type The data type. Possible values include
+          #   `STRING`, `BYTES`, `INTEGER`, `INT64` (same as `INTEGER`),
+          #   `FLOAT`, `FLOAT64` (same as `FLOAT`), `BOOLEAN`, `BOOL` (same as
+          #   `BOOLEAN`), `TIMESTAMP`, `DATE`, `TIME`, `DATETIME`, `RECORD`
+          #   (where `RECORD` indicates that the field contains a nested schema)
+          #   or `STRUCT` (same as `RECORD`).
           #
           def type= new_type
             @gapi.update! type: verify_type(new_type)
@@ -72,24 +97,36 @@ module Google
 
           ##
           # Checks if the type of the field is `NULLABLE`.
+          #
+          # @return [Boolean] `true` when `NULLABLE`, `false` otherwise.
+          #
           def nullable?
             mode == "NULLABLE"
           end
 
           ##
           # Checks if the type of the field is `REQUIRED`.
+          #
+          # @return [Boolean] `true` when `REQUIRED`, `false` otherwise.
+          #
           def required?
             mode == "REQUIRED"
           end
 
           ##
           # Checks if the type of the field is `REPEATED`.
+          #
+          # @return [Boolean] `true` when `REPEATED`, `false` otherwise.
+          #
           def repeated?
             mode == "REPEATED"
           end
 
           ##
           # The description of the field.
+          #
+          # @return [String] The field description. The maximum length is 1,024
+          #   characters.
           #
           def description
             @gapi.description
@@ -98,12 +135,18 @@ module Google
           ##
           # Updates the description of the field.
           #
+          # @param [String] new_description The field description. The maximum
+          #   length is 1,024 characters.
+          #
           def description= new_description
             @gapi.update! description: new_description
           end
 
           ##
           # The mode of the field.
+          #
+          # @return [String] The field mode. Possible values include `NULLABLE`,
+          #   `REQUIRED` and `REPEATED`. The default value is `NULLABLE`.
           #
           def mode
             @gapi.mode
@@ -112,66 +155,100 @@ module Google
           ##
           # Updates the mode of the field.
           #
+          # @param [String] new_mode The field mode. Possible values include
+          #   `NULLABLE`, `REQUIRED` and `REPEATED`. The default value is
+          #   `NULLABLE`.
+          #
           def mode= new_mode
             @gapi.update! mode: verify_mode(new_mode)
           end
 
           ##
           # Checks if the mode of the field is `STRING`.
+          #
+          # @return [Boolean] `true` when `STRING`, `false` otherwise.
+          #
           def string?
             mode == "STRING"
           end
 
           ##
           # Checks if the mode of the field is `INTEGER`.
+          #
+          # @return [Boolean] `true` when `INTEGER`, `false` otherwise.
+          #
           def integer?
             mode == "INTEGER"
           end
 
           ##
           # Checks if the mode of the field is `FLOAT`.
+          #
+          # @return [Boolean] `true` when `FLOAT`, `false` otherwise.
+          #
           def float?
             mode == "FLOAT"
           end
 
           ##
           # Checks if the mode of the field is `BOOLEAN`.
+          #
+          # @return [Boolean] `true` when `BOOLEAN`, `false` otherwise.
+          #
           def boolean?
             mode == "BOOLEAN"
           end
 
           ##
           # Checks if the mode of the field is `BYTES`.
+          #
+          # @return [Boolean] `true` when `BYTES`, `false` otherwise.
+          #
           def bytes?
             mode == "BYTES"
           end
 
           ##
           # Checks if the mode of the field is `TIMESTAMP`.
+          #
+          # @return [Boolean] `true` when `TIMESTAMP`, `false` otherwise.
+          #
           def timestamp?
             mode == "TIMESTAMP"
           end
 
           ##
           # Checks if the mode of the field is `TIME`.
+          #
+          # @return [Boolean] `true` when `TIME`, `false` otherwise.
+          #
           def time?
             mode == "TIME"
           end
 
           ##
           # Checks if the mode of the field is `DATETIME`.
+          #
+          # @return [Boolean] `true` when `DATETIME`, `false` otherwise.
+          #
           def datetime?
             mode == "DATETIME"
           end
 
           ##
           # Checks if the mode of the field is `DATE`.
+          #
+          # @return [Boolean] `true` when `DATE`, `false` otherwise.
+          #
           def date?
             mode == "DATE"
           end
 
           ##
           # Checks if the mode of the field is `RECORD`.
+          #
+          # @return [Boolean] `true` when `RECORD`, `false` otherwise.
+          #
           def record?
             mode == "RECORD"
           end
@@ -179,6 +256,10 @@ module Google
           ##
           # The nested fields if the type property is set to `RECORD`. Will be
           # empty otherwise.
+          #
+          # @return [Array<Field>, nil] The nested schema fields if the type
+          #   is set to `RECORD`.
+          #
           def fields
             if frozen?
               Array(@gapi.fields).map { |f| Field.from_gapi(f).freeze }.freeze
@@ -190,13 +271,20 @@ module Google
           ##
           # The names of the nested fields as symbols if the type property is
           # set to `RECORD`. Will be empty otherwise.
+          #
+          # @return [Array<Symbol>, nil] The names of the nested schema fields
+          #   if the type is set to `RECORD`.
+          #
           def headers
             fields.map(&:name).map(&:to_sym)
           end
 
           ##
-          # Retreive a nested fields by name, if the type property is
+          # Retrieve a nested field by name, if the type property is
           # set to `RECORD`. Will return `nil` otherwise.
+          #
+          # @return [Field, nil] The nested schema field object, or `nil`.
+          #
           def field name
             f = fields.find { |fld| fld.name == name.to_s }
             return nil if f.nil?
@@ -205,7 +293,7 @@ module Google
           end
 
           ##
-          # Adds a string field to the schema.
+          # Adds a string field to the nested schema of a record field.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -217,6 +305,7 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          #
           def string name, description: nil, mode: :nullable
             record_check!
 
@@ -224,7 +313,7 @@ module Google
           end
 
           ##
-          # Adds an integer field to the schema.
+          # Adds an integer field to the nested schema of a record field.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -236,6 +325,7 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          #
           def integer name, description: nil, mode: :nullable
             record_check!
 
@@ -243,7 +333,8 @@ module Google
           end
 
           ##
-          # Adds a floating-point number field to the schema.
+          # Adds a floating-point number field to the nested schema of a record
+          # field.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -255,6 +346,7 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          #
           def float name, description: nil, mode: :nullable
             record_check!
 
@@ -262,7 +354,7 @@ module Google
           end
 
           ##
-          # Adds a boolean field to the schema.
+          # Adds a boolean field to the nested schema of a record field.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -274,6 +366,7 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          #
           def boolean name, description: nil, mode: :nullable
             record_check!
 
@@ -281,7 +374,7 @@ module Google
           end
 
           ##
-          # Adds a bytes field to the schema.
+          # Adds a bytes field to the nested schema of a record field.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -293,6 +386,7 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          #
           def bytes name, description: nil, mode: :nullable
             record_check!
 
@@ -300,7 +394,7 @@ module Google
           end
 
           ##
-          # Adds a timestamp field to the schema.
+          # Adds a timestamp field to the nested schema of a record field.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -312,6 +406,7 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          #
           def timestamp name, description: nil, mode: :nullable
             record_check!
 
@@ -319,7 +414,7 @@ module Google
           end
 
           ##
-          # Adds a time field to the schema.
+          # Adds a time field to the nested schema of a record field.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -331,6 +426,7 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          #
           def time name, description: nil, mode: :nullable
             record_check!
 
@@ -338,7 +434,7 @@ module Google
           end
 
           ##
-          # Adds a datetime field to the schema.
+          # Adds a datetime field to the nested schema of a record field.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -350,6 +446,7 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          #
           def datetime name, description: nil, mode: :nullable
             record_check!
 
@@ -357,7 +454,7 @@ module Google
           end
 
           ##
-          # Adds a date field to the schema.
+          # Adds a date field to the nested schema of a record field.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -369,6 +466,7 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          #
           def date name, description: nil, mode: :nullable
             record_check!
 
@@ -376,10 +474,10 @@ module Google
           end
 
           ##
-          # Adds a record field to the schema. A block must be passed describing
-          # the nested fields of the record. For more information about nested
-          # and repeated records, see [Preparing Data for BigQuery
-          # ](https://cloud.google.com/bigquery/preparing-data-for-bigquery).
+          # Adds a record field to the nested schema of a record field. A block
+          # must be passed describing the nested fields of the record. For more
+          # information about nested and repeated records, see [Preparing Data
+          # for BigQuery](https://cloud.google.com/bigquery/preparing-data-for-bigquery).
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -405,7 +503,10 @@ module Google
           #   table.schema do |schema|
           #     schema.string "first_name", mode: :required
           #     schema.record "cities_lived", mode: :repeated do |cities_lived|
-          #       cities_lived.string "place", mode: :required
+          #       cities_lived.record "city", mode: :required do |city|
+          #         city.string "name", mode: :required
+          #         city.string "country", mode: :required
+          #       end
           #       cities_lived.integer "number_of_years", mode: :required
           #     end
           #   end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -84,8 +84,9 @@ module Google
 
         ##
         # A unique ID for this table.
-        # The ID must contain only letters (a-z, A-Z), numbers (0-9),
-        # or underscores (_). The maximum length is 1,024 characters.
+        #
+        # @return [String] The ID must contain only letters (a-z, A-Z), numbers
+        #   (0-9), or underscores (_). The maximum length is 1,024 characters.
         #
         # @!group Attributes
         #
@@ -96,6 +97,9 @@ module Google
         ##
         # The ID of the `Dataset` containing this table.
         #
+        # @return [String] The ID must contain only letters (a-z, A-Z), numbers
+        #   (0-9), or underscores (_). The maximum length is 1,024 characters.
+        #
         # @!group Attributes
         #
         def dataset_id
@@ -104,6 +108,8 @@ module Google
 
         ##
         # The ID of the `Project` containing this table.
+        #
+        # @return [String] The project ID.
         #
         # @!group Attributes
         #
@@ -121,7 +127,11 @@ module Google
         end
 
         ###
-        # Is the table partitioned?
+        # Checks if the table is time-partitioned. See [Partitioned
+        # Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        #
+        # @return [Boolean] `true` when the table is time-partitioned, `false`
+        #   otherwise.
         #
         # @!group Attributes
         #
@@ -130,7 +140,11 @@ module Google
         end
 
         ###
-        # The period for which the table is partitioned, if any.
+        # The period for which the table is partitioned, if any. See
+        # [Partitioned Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        #
+        # @return [String, nil] The partition type. Currently the only supported
+        #   value is "DAY".
         #
         # @!group Attributes
         #
@@ -140,15 +154,15 @@ module Google
         end
 
         ##
-        # Sets the partitioning for the table. See [Partitioned Tables
-        # ](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        # Sets the partitioning for the table. See [Partitioned
+        # Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
         #
         # You can only set partitioning when creating a table as in
         # the example below. BigQuery does not allow you to change partitioning
         # on an existing table.
         #
         # @param [String] type The partition type. Currently the only
-        # supported value is "DAY".
+        #   supported value is "DAY".
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -170,7 +184,11 @@ module Google
 
 
         ###
-        # The expiration for the table partitions, if any, in seconds.
+        # The expiration for the table partitions, if any, in seconds. See
+        # [Partitioned Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        #
+        # @return [Integer, nil] The expiration time, in seconds, for data in
+        #   partitions.
         #
         # @!group Attributes
         #
@@ -182,14 +200,14 @@ module Google
         end
 
         ##
-        # Sets the partition expiration for the table. See [Partitioned Tables
-        # ](https://cloud.google.com/bigquery/docs/partitioned-tables). The
-        # table must also be partitioned.
+        # Sets the partition expiration for the table. See [Partitioned
+        # Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        # The table must also be partitioned.
         #
         # See {Table#time_partitioning_type=}.
         #
         # @param [Integer] expiration An expiration time, in seconds,
-        # for data in partitions.
+        #   for data in partitions.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -217,6 +235,8 @@ module Google
         # `project_name:datasetId.tableId`. To use this value in queries see
         # {#query_id}.
         #
+        # @return [String] The combined ID.
+        #
         # @!group Attributes
         #
         def id
@@ -237,6 +257,9 @@ module Google
         #   [legacy
         #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
         #   dialect. Optional. The default value is false.
+        #
+        # @return [String] The appropriate table ID for use in queries,
+        #   depending on SQL type.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -260,6 +283,8 @@ module Google
         ##
         # The name of the table.
         #
+        # @return [String] The friendly name.
+        #
         # @!group Attributes
         #
         def name
@@ -269,6 +294,8 @@ module Google
         ##
         # Updates the name of the table.
         #
+        # @param [String] new_name The new friendly name.
+        #
         # @!group Attributes
         #
         def name= new_name
@@ -277,7 +304,9 @@ module Google
         end
 
         ##
-        # A string hash of the dataset.
+        # The ETag hash of the table.
+        #
+        # @return [String] The ETag hash.
         #
         # @!group Attributes
         #
@@ -287,7 +316,9 @@ module Google
         end
 
         ##
-        # A URL that can be used to access the dataset using the REST API.
+        # A URL that can be used to access the table using the REST API.
+        #
+        # @return [String] A REST URL for the resource.
         #
         # @!group Attributes
         #
@@ -297,7 +328,9 @@ module Google
         end
 
         ##
-        # The description of the table.
+        # A user-friendly description of the table.
+        #
+        # @return [String] The description.
         #
         # @!group Attributes
         #
@@ -307,7 +340,9 @@ module Google
         end
 
         ##
-        # Updates the description of the table.
+        # Updates the user-friendly description of the table.
+        #
+        # @param [String] new_description The new user-friendly description.
         #
         # @!group Attributes
         #
@@ -318,6 +353,8 @@ module Google
 
         ##
         # The number of bytes in the table.
+        #
+        # @return [Integer] The count of bytes in the table.
         #
         # @!group Data
         #
@@ -333,6 +370,8 @@ module Google
         ##
         # The number of rows in the table.
         #
+        # @return [Integer] The count of rows in the table.
+        #
         # @!group Data
         #
         def rows_count
@@ -346,6 +385,8 @@ module Google
 
         ##
         # The time when this table was created.
+        #
+        # @return [Time, nil] The creation time.
         #
         # @!group Attributes
         #
@@ -363,6 +404,8 @@ module Google
         # If not present, the table will persist indefinitely.
         # Expired tables will be deleted and their storage reclaimed.
         #
+        # @return [Time, nil] The expiration time.
+        #
         # @!group Attributes
         #
         def expires_at
@@ -376,6 +419,8 @@ module Google
 
         ##
         # The date when this table was last modified.
+        #
+        # @return [Time, nil] The last modified time.
         #
         # @!group Attributes
         #
@@ -391,6 +436,8 @@ module Google
         ##
         # Checks if the table's type is "TABLE".
         #
+        # @return [Boolean] `true` when the type is `TABLE`, `false` otherwise.
+        #
         # @!group Attributes
         #
         def table?
@@ -399,6 +446,8 @@ module Google
 
         ##
         # Checks if the table's type is "VIEW".
+        #
+        # @return [Boolean] `true` when the type is `VIEW`, `false` otherwise.
         #
         # @!group Attributes
         #
@@ -409,6 +458,9 @@ module Google
         ##
         # Checks if the table's type is "EXTERNAL".
         #
+        # @return [Boolean] `true` when the type is `EXTERNAL`, `false`
+        #   otherwise.
+        #
         # @!group Attributes
         #
         def external?
@@ -417,7 +469,9 @@ module Google
 
         ##
         # The geographic location where the table should reside. Possible
-        # values include EU and US. The default value is US.
+        # values include `EU` and `US`. The default value is `US`.
+        #
+        # @return [String] The location code.
         #
         # @!group Attributes
         #
@@ -434,6 +488,18 @@ module Google
         # The returned hash is frozen and changes are not allowed. Use
         # {#labels=} to replace the entire hash.
         #
+        # @return [Hash<String, String>] A hash containing key/value pairs.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   labels = table.labels
+        #   labels["department"] #=> "shipping"
+        #
         # @!group Attributes
         #
         def labels
@@ -446,6 +512,25 @@ module Google
         # Updates the hash of user-provided labels associated with this table.
         # Labels are used to organize and group tables. See [Using
         # Labels](https://cloud.google.com/bigquery/docs/labels).
+        #
+        # @param [Hash<String, String>] labels A hash containing key/value
+        #   pairs.
+        #
+        #   * Label keys and values can be no longer than 63 characters.
+        #   * Label keys and values can contain only lowercase letters, numbers,
+        #     underscores, hyphens, and international characters.
+        #   * Label keys and values cannot exceed 128 bytes in size.
+        #   * Label keys must begin with a letter.
+        #   * Label keys must be unique within a table.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   table.labels = { "department" => "shipping" }
         #
         # @!group Attributes
         #
@@ -467,7 +552,7 @@ module Google
         # @yield [schema] a block for setting the schema
         # @yieldparam [Schema] schema the object accepting the schema
         #
-        # @return [Google::Cloud::Bigquery::Schema]
+        # @return [Google::Cloud::Bigquery::Schema] A frozen schema object.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -501,7 +586,20 @@ module Google
         end
 
         ##
-        # The fields of the table.
+        # The fields of the table, obtained from its schema.
+        #
+        # @return [Array<Schema::Field>] An array of field objects.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   table.fields.each do |field|
+        #     puts field.name
+        #   end
         #
         # @!group Attributes
         #
@@ -510,7 +608,20 @@ module Google
         end
 
         ##
-        # The names of the columns in the table.
+        # The names of the columns in the table, obtained from its schema.
+        #
+        # @return [Array<Symbol>] An array of column names.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   table.headers.each do |header|
+        #     puts header
+        #   end
         #
         # @!group Attributes
         #
@@ -531,7 +642,7 @@ module Google
         # @see https://cloud.google.com/bigquery/external-data-sources
         #   Querying External Data Sources
         #
-        # @return [External::DataSource]
+        # @return [External::DataSource] The external data source.
         #
         #   @!group Attributes
         #
@@ -553,7 +664,7 @@ module Google
         # @see https://cloud.google.com/bigquery/external-data-sources
         #   Querying External Data Sources
         #
-        # @return [External::DataSource] External data source.
+        # @param [External::DataSource] external An external data source.
         #
         # @!group Attributes
         #
@@ -568,6 +679,8 @@ module Google
         # if the table is not being streamed to or if there is no data in the
         # streaming buffer.
         #
+        # @return [Integer] The estimated number of bytes in the buffer.
+        #
         # @!group Attributes
         #
         def buffer_bytes
@@ -581,6 +694,8 @@ module Google
         # if the table is not being streamed to or if there is no data in the
         # streaming buffer.
         #
+        # @return [Integer] The estimated number of rows in the buffer.
+        #
         # @!group Attributes
         #
         def buffer_rows
@@ -592,6 +707,8 @@ module Google
         # The time of the oldest entry currently in this table's streaming
         # buffer, if one is present. This field will be absent if the table is
         # not being streamed to or if there is no data in the streaming buffer.
+        #
+        # @return [Time, nil] The oldest entry time.
         #
         # @!group Attributes
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -51,16 +51,17 @@ module Google
         attr_accessor :gapi
 
         ##
-        # @private Create an empty Table object.
+        # @private Create an empty View object.
         def initialize
           @service = nil
           @gapi = Google::Apis::BigqueryV2::Table.new
         end
 
         ##
-        # A unique ID for this table.
-        # The ID must contain only letters (a-z, A-Z), numbers (0-9),
-        # or underscores (_). The maximum length is 1,024 characters.
+        # A unique ID for this view.
+        #
+        # @return [String] The ID must contain only letters (a-z, A-Z), numbers
+        #   (0-9), or underscores (_). The maximum length is 1,024 characters.
         #
         # @!group Attributes
         #
@@ -69,7 +70,10 @@ module Google
         end
 
         ##
-        # The ID of the `Dataset` containing this table.
+        # The ID of the `Dataset` containing this view.
+        #
+        # @return [String] The ID must contain only letters (a-z, A-Z), numbers
+        #   (0-9), or underscores (_). The maximum length is 1,024 characters.
         #
         # @!group Attributes
         #
@@ -78,7 +82,9 @@ module Google
         end
 
         ##
-        # The ID of the `Project` containing this table.
+        # The ID of the `Project` containing this view.
+        #
+        # @return [String] The project ID.
         #
         # @!group Attributes
         #
@@ -96,7 +102,7 @@ module Google
         end
 
         ##
-        # The combined Project ID, Dataset ID, and Table ID for this table, in
+        # The combined Project ID, Dataset ID, and Table ID for this view, in
         # the format specified by the [Legacy SQL Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # `project_name:datasetId.tableId`. To use this value in queries see
@@ -143,7 +149,9 @@ module Google
         end
 
         ##
-        # The name of the table.
+        # The name of the view.
+        #
+        # @return [String] The friendly name.
         #
         # @!group Attributes
         #
@@ -152,7 +160,9 @@ module Google
         end
 
         ##
-        # Updates the name of the table.
+        # Updates the name of the view.
+        #
+        # @param [String] new_name The new friendly name.
         #
         # @!group Attributes
         #
@@ -162,7 +172,9 @@ module Google
         end
 
         ##
-        # A string hash of the dataset.
+        # The ETag hash of the view.
+        #
+        # @return [String] The ETag hash.
         #
         # @!group Attributes
         #
@@ -172,7 +184,9 @@ module Google
         end
 
         ##
-        # A URL that can be used to access the dataset using the REST API.
+        # A URL that can be used to access the view using the REST API.
+        #
+        # @return [String] A REST URL for the resource.
         #
         # @!group Attributes
         #
@@ -182,7 +196,9 @@ module Google
         end
 
         ##
-        # The description of the table.
+        # A user-friendly description of the view.
+        #
+        # @return [String] The description.
         #
         # @!group Attributes
         #
@@ -192,7 +208,9 @@ module Google
         end
 
         ##
-        # Updates the description of the table.
+        # Updates the user-friendly description of the view.
+        #
+        # @param [String] new_description The new user-friendly description.
         #
         # @!group Attributes
         #
@@ -202,7 +220,9 @@ module Google
         end
 
         ##
-        # The time when this table was created.
+        # The time when this view was created.
+        #
+        # @return [Time, nil] The creation time.
         #
         # @!group Attributes
         #
@@ -216,9 +236,11 @@ module Google
         end
 
         ##
-        # The time when this table expires.
-        # If not present, the table will persist indefinitely.
-        # Expired tables will be deleted and their storage reclaimed.
+        # The time when this view expires.
+        # If not present, the view will persist indefinitely.
+        # Expired views will be deleted and their storage reclaimed.
+        #
+        # @return [Time, nil] The expiration time.
         #
         # @!group Attributes
         #
@@ -232,7 +254,9 @@ module Google
         end
 
         ##
-        # The date when this table was last modified.
+        # The date when this view was last modified.
+        #
+        # @return [Time, nil] The last modified time.
         #
         # @!group Attributes
         #
@@ -246,7 +270,9 @@ module Google
         end
 
         ##
-        # Checks if the table's type is "TABLE".
+        # Checks if the view's type is "TABLE".
+        #
+        # @return [Boolean] `true` when the type is `TABLE`, `false` otherwise.
         #
         # @!group Attributes
         #
@@ -255,7 +281,9 @@ module Google
         end
 
         ##
-        # Checks if the table's type is "VIEW".
+        # Checks if the view's type is "VIEW".
+        #
+        # @return [Boolean] `true` when the type is `VIEW`, `false` otherwise.
         #
         # @!group Attributes
         #
@@ -264,7 +292,10 @@ module Google
         end
 
         ##
-        # Checks if the table's type is "EXTERNAL".
+        # Checks if the view's type is "EXTERNAL".
+        #
+        # @return [Boolean] `true` when the type is `EXTERNAL`, `false`
+        #   otherwise.
         #
         # @!group Attributes
         #
@@ -273,8 +304,10 @@ module Google
         end
 
         ##
-        # The geographic location where the table should reside. Possible
-        # values include EU and US. The default value is US.
+        # The geographic location where the view should reside. Possible
+        # values include `EU` and `US`. The default value is `US`.
+        #
+        # @return [String] The location code.
         #
         # @!group Attributes
         #
@@ -286,6 +319,21 @@ module Google
         ##
         # The schema of the view.
         #
+        # The returned object is frozen and changes are not allowed.
+        #
+        # @return [Schema] A schema object.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   view = dataset.table "my_view"
+        #
+        #   schema = view.schema
+        #   field = schema.field "name"
+        #   field.required? #=> true
+        #
         # @!group Attributes
         #
         def schema
@@ -294,7 +342,20 @@ module Google
         end
 
         ##
-        # The fields of the view.
+        # The fields of the view, obtained from its schema.
+        #
+        # @return [Array<Schema::Field>] An array of field objects.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   view = dataset.table "my_view"
+        #
+        #   view.fields.each do |field|
+        #     puts field.name
+        #   end
         #
         # @!group Attributes
         #
@@ -303,7 +364,20 @@ module Google
         end
 
         ##
-        # The names of the columns in the view.
+        # The names of the columns in the view, obtained from its schema.
+        #
+        # @return [Array<Symbol>] An array of column names.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   view = dataset.table "my_view"
+        #
+        #   view.headers.each do |header|
+        #     puts header
+        #   end
         #
         # @!group Attributes
         #
@@ -313,6 +387,8 @@ module Google
 
         ##
         # The query that executes each time the view is loaded.
+        #
+        # @return [String] The query that defines the view.
         #
         # @!group Attributes
         #
@@ -397,6 +473,8 @@ module Google
         ##
         # Checks if the view's query is using legacy sql.
         #
+        # @return [Boolean] `true` when legacy sql is used, `false` otherwise.
+        #
         # @!group Attributes
         #
         def query_legacy_sql?
@@ -407,6 +485,8 @@ module Google
 
         ##
         # Checks if the view's query is using standard sql.
+        #
+        # @return [Boolean] `true` when standard sql is used, `false` otherwise.
         #
         # @!group Attributes
         #
@@ -422,6 +502,9 @@ module Google
         # equivalent to providing a URI for a file containing the same code. See
         # [User-Defined
         # Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
+        #
+        # @return [Array<String>] An array containing Google Cloud Storage URIs
+        #   and/or inline source code.
         #
         # @!group Attributes
         #
@@ -489,9 +572,9 @@ module Google
         end
 
         ##
-        # Permanently deletes the table.
+        # Permanently deletes the view.
         #
-        # @return [Boolean] Returns `true` if the table was deleted.
+        # @return [Boolean] Returns `true` if the view was deleted.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -511,7 +594,7 @@ module Google
         end
 
         ##
-        # Reloads the table with current data from the BigQuery service.
+        # Reloads the view with current data from the BigQuery service.
         #
         # @!group Lifecycle
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/view.rb
@@ -317,6 +317,65 @@ module Google
         end
 
         ##
+        # A hash of user-provided labels associated with this view. Labels
+        # are used to organize and group views and views. See [Using
+        # Labels](https://cloud.google.com/bigquery/docs/labels).
+        #
+        # The returned hash is frozen and changes are not allowed. Use
+        # {#labels=} to replace the entire hash.
+        #
+        # @return [Hash<String, String>] A hash containing key/value pairs.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   view = dataset.table "my_view"
+        #
+        #   labels = view.labels
+        #   labels["department"] #=> "shipping"
+        #
+        # @!group Attributes
+        #
+        def labels
+          m = @gapi.labels
+          m = m.to_h if m.respond_to? :to_h
+          m.dup.freeze
+        end
+
+        ##
+        # Updates the hash of user-provided labels associated with this view.
+        # Labels are used to organize and group tables and views. See [Using
+        # Labels](https://cloud.google.com/bigquery/docs/labels).
+        #
+        # @param [Hash<String, String>] labels A hash containing key/value
+        #   pairs.
+        #
+        #   * Label keys and values can be no longer than 63 characters.
+        #   * Label keys and values can contain only lowercase letters, numbers,
+        #     underscores, hyphens, and international characters.
+        #   * Label keys and values cannot exceed 128 bytes in size.
+        #   * Label keys must begin with a letter.
+        #   * Label keys must be unique within a view.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   view = dataset.table "my_view"
+        #
+        #   view.labels = { "department" => "shipping" }
+        #
+        # @!group Attributes
+        #
+        def labels= labels
+          @gapi.labels = labels
+          patch_gapi! :labels
+        end
+
+        ##
         # The schema of the view.
         #
         # The returned object is frozen and changes are not allowed.

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -247,6 +247,8 @@ YARD::Doctest.configure do |doctest|
       end
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project-id", Google::Apis::BigqueryV2::Dataset]
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_other_dataset"] # for view methods
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_view"] # for view methods
       mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset, Hash]
     end
   end

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -678,6 +678,15 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::View#labels=" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
+      mock.expect :patch_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::View#data" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -74,7 +74,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Hash]
+      mock.expect :list_table_data, table_data_gapi, ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -82,7 +82,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Hash]
+      mock.expect :list_table_data, table_data_gapi, ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -90,7 +90,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Hash]
+      mock.expect :list_table_data, table_data_gapi, ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -103,7 +103,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my-table-id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -471,8 +471,8 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
+      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
     end
   end
 
@@ -494,8 +494,8 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
+      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
     end
   end
 
@@ -503,11 +503,11 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my-table-id", Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
+      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my_table", Hash]
       mock.expect :insert_all_table_data,
                   Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(insert_errors: []),
-                  ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+                  ["my-project-id", "my-dataset-id", "my_table", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
     end
   end
 
@@ -536,7 +536,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my-table-id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -544,7 +544,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :delete_table, nil, ["my-project-id", "my-dataset-id", "my-table-id"]
+      mock.expect :delete_table, nil, ["my-project-id", "my-dataset-id", "my_table"]
     end
   end
 
@@ -562,7 +562,16 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
       mock.expect :insert_all_table_data,
                   Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(insert_errors: []),
-                  ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+                  ["my-project-id", "my-dataset-id", "my_table", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::Table#labels=" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
+      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
     end
   end
 
@@ -620,8 +629,8 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
-      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id", Google::Apis::BigqueryV2::Table, Hash]
-      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my-table-id"]
+      mock.expect :patch_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
     end
   end
 
@@ -800,7 +809,7 @@ def table_full_gapi
 end
 
 def table_full_hash project = "my-project-id", dataset = "my-dataset-id", id = nil, name = nil, description = nil
-  id ||= "my-table-id"
+  id ||= "my_table"
   name ||= "Table Name"
 
   {
@@ -843,7 +852,8 @@ def table_full_hash project = "my-project-id", dataset = "my-dataset-id", id = n
     "expirationTime" => time_millis,
     "lastModifiedTime" => time_millis,
     "type" => "TABLE",
-    "location" => "US"
+    "location" => "US",
+    "labels" => { "department" => "shipping" }
   }
 end
 

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -476,12 +476,20 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Schema#field" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::Schema::Field" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
     end
   end
+
   doctest.before "Google::Cloud::Bigquery::Schema::Field#record" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -191,6 +191,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Dataset#labels" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
+      mock.expect :patch_dataset, dataset_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Dataset, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::Dataset#load" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
@@ -742,7 +750,8 @@ def random_dataset_hash project = "my-project-id", id = nil, name = nil, descrip
     "access" => [],
     "creationTime" => time_millis,
     "lastModifiedTime" => time_millis,
-    "location" => location
+    "location" => location,
+    "labels" => { "department" => "shipping" }
   }
 end
 

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -290,6 +290,16 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::InsertResponse" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
+      mock.expect :insert_all_table_data,
+                  Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(insert_errors: []),
+                  ["my-project-id", "my-dataset-id", "my_table", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+    end
+  end
+
   # Google::Cloud::Bigquery::Job
   # Google::Cloud::Bigquery::Job#wait_until_done!
   doctest.before "Google::Cloud::Bigquery::Job" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -98,6 +98,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock.verify
 
     data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    data.schema.must_be :frozen?
     data.fields.must_equal data.schema.fields
     data.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]
   end


### PR DESCRIPTION
This PR updates docs and adds examples across BigQuery where they are missing or not conforming with the YARD format.

[refs #1691]

It also adds labels support to `View`.

[refs #1716]

And it freezes the `Schema` object returned by `Data`, similar to `View` and `LoadJob`.