### PR TITLE
Add gRPC keepalive

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -47,7 +47,8 @@ module Google
 
         def chan_args
           { "grpc.max_send_message_length"    => -1,
-            "grpc.max_receive_message_length" => -1 }
+            "grpc.max_receive_message_length" => -1,
+            "grpc.keepalive_time_ms"          => 300000 }
         end
 
         def chan_creds


### PR DESCRIPTION
Set the keepalive to 5 minutes. I created separate publisher and subscriber sessions and left them open for more than 5 minutes. Messages were published to a topic and pulled from a subscriber with no issues.