### PR TITLE
bigquery: add simple benchmark

### DIFF
--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude:
     - "acceptance/**/*"
     - "support/**/*"
+    - "benchmark/**/*"
     - "google-cloud-bigquery.gemspec"
     - "Rakefile"
     - "test/**/*"

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -101,6 +101,14 @@ namespace :acceptance do
   end
 end
 
+desc "Run benchmark script."
+task :benchmark, :queries do |t, args|
+  queries = args[:queries]
+  queries ||= "benchmark/queries.json"
+
+  sh "bundle exec ruby benchmark/benchmark.rb #{queries}"
+end
+
 desc "Run yard-doctest example tests."
 task doctest: :yard do
   sh "bundle exec yard config -a autoload_plugins yard-doctest"

--- a/google-cloud-bigquery/benchmark/README.md
+++ b/google-cloud-bigquery/benchmark/README.md
@@ -2,7 +2,7 @@
 This directory contains benchmarks for BigQuery client.
 
 ## Usage
-`ruby benchmark/benchmark.rb -- <your project id> benchmark/queries.json`
+`BIGQUERY_PROJECT=<your project id> ruby benchmark/benchmark.rb benchmark/queries.json`
 
 BigQuery service caches requests so the benchmark should be run
 at least twice, disregarding the first result.

--- a/google-cloud-bigquery/benchmark/README.md
+++ b/google-cloud-bigquery/benchmark/README.md
@@ -1,0 +1,8 @@
+# BigQuery Benchmark
+This directory contains benchmarks for BigQuery client.
+
+## Usage
+`ruby benchmark/benchmark.rb -- <your project id> benchmark/queries.json`
+
+BigQuery service caches requests so the benchmark should be run
+at least twice, disregarding the first result.

--- a/google-cloud-bigquery/benchmark/benchmark.rb
+++ b/google-cloud-bigquery/benchmark/benchmark.rb
@@ -15,31 +15,31 @@
 require "google/cloud/bigquery"
 require "json"
 
-if ARGV.length < 1 || !ENV.has_key?('BIGQUERY_PROJECT')
+if ARGV.length < 1 || !ENV.key?("BIGQUERY_PROJECT")
   puts "usage: BIGQUERY_PROJECT=<project-id> ruby bench.rb <queries.json>"
   exit 1
 end
 
-bigquery = Google::Cloud::Bigquery.new(project: ENV['BIGQUERY_PROJECT']);
+bigquery = Google::Cloud::Bigquery.new(project: ENV["BIGQUERY_PROJECT"])
 queries = JSON.parse(File.open(ARGV[0]).read)
 
-for query in queries
+queries.each do |query|
   start = Time.now
-  numRows = 0
-  numCols = 0
-  timeToFirstByte = nil
+  num_rows = 0
+  num_cols = 0
+  time_to_first_byte = nil
 
   data = bigquery.query query
-  while 1
+  loop do
     data.each do |row|
-      if numRows == 0
-        numCols = row.length
-        timeToFirstByte = Time.now - start
-      elsif numCols != row.length
-        raise "expected #{numCols} cols, got #{row.length}"
+      if num_rows == 0
+        num_cols = row.length
+        time_to_first_byte = Time.now - start
+      elsif num_cols != row.length
+        fail "expected #{num_cols} cols, got #{row.length}"
       end
 
-      numRows += 1
+      num_rows += 1
     end
 
     if data.next?
@@ -49,5 +49,6 @@ for query in queries
     end
   end
 
-  puts "query #{query}: #{numRows} rows, #{numCols} cols, first byte #{timeToFirstByte} sec, total #{Time.now - start} sec"
+  puts "query #{query}: #{num_rows} rows, #{num_cols} cols, "\
+    "first byte #{time_to_first_byte} sec, total #{Time.now - start} sec"
 end

--- a/google-cloud-bigquery/benchmark/benchmark.rb
+++ b/google-cloud-bigquery/benchmark/benchmark.rb
@@ -1,0 +1,53 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/bigquery"
+require "json"
+
+if ARGV.length < 2
+  puts "usage: ruby bench.rb <project-id> <queries.json>"
+  exit 1
+end
+
+bigquery = Google::Cloud::Bigquery.new(project: ARGV[0]);
+queries = JSON.parse(File.open(ARGV[1]).read)
+
+for query in queries
+  start = Time.now
+  numRows = 0
+  numCols = 0
+  timeToFirstByte = nil
+
+  data = bigquery.query query
+  while 1
+    data.each do |row|
+      if numRows == 0
+        numCols = row.length
+        timeToFirstByte = Time.now - start
+      elsif numCols != row.length
+        raise "expected #{numCols} cols, got #{row.length}"
+      end
+
+      numRows += 1
+    end
+
+    if data.next?
+      data = data.next
+    else
+      break
+    end
+  end
+
+  puts "query #{query}: #{numRows} rows, #{numCols} cols, first byte #{timeToFirstByte} sec, total #{Time.now - start} sec"
+end

--- a/google-cloud-bigquery/benchmark/benchmark.rb
+++ b/google-cloud-bigquery/benchmark/benchmark.rb
@@ -15,13 +15,13 @@
 require "google/cloud/bigquery"
 require "json"
 
-if ARGV.length < 2
-  puts "usage: ruby bench.rb <project-id> <queries.json>"
+if ARGV.length < 1 || !ENV.has_key?('BIGQUERY_PROJECT')
+  puts "usage: BIGQUERY_PROJECT=<project-id> ruby bench.rb <queries.json>"
   exit 1
 end
 
-bigquery = Google::Cloud::Bigquery.new(project: ARGV[0]);
-queries = JSON.parse(File.open(ARGV[1]).read)
+bigquery = Google::Cloud::Bigquery.new(project: ENV['BIGQUERY_PROJECT']);
+queries = JSON.parse(File.open(ARGV[0]).read)
 
 for query in queries
   start = Time.now

--- a/google-cloud-bigquery/benchmark/benchmark.rb
+++ b/google-cloud-bigquery/benchmark/benchmark.rb
@@ -20,8 +20,8 @@ if ARGV.length < 1
   exit 1
 end
 
-bigquery = Google::Cloud::Bigquery.new(project: ENV["BIGQUERY_PROJECT"])
-queries = JSON.parse(File.open(ARGV[0]).read)
+bigquery = Google::Cloud::Bigquery.new
+queries = JSON.parse(File.read(ARGV[0]))
 
 queries.each do |query|
   start = Time.now

--- a/google-cloud-bigquery/benchmark/benchmark.rb
+++ b/google-cloud-bigquery/benchmark/benchmark.rb
@@ -15,8 +15,8 @@
 require "google/cloud/bigquery"
 require "json"
 
-if ARGV.length < 1 || !ENV.key?("BIGQUERY_PROJECT")
-  puts "usage: BIGQUERY_PROJECT=<project-id> ruby bench.rb <queries.json>"
+if ARGV.length < 1
+  puts "usage: BIGQUERY_PROJECT=<project-id> ruby benchmark/benchmark.rb <queries.json>"
   exit 1
 end
 

--- a/google-cloud-bigquery/benchmark/queries.json
+++ b/google-cloud-bigquery/benchmark/queries.json
@@ -1,0 +1,10 @@
+[
+  "SELECT * FROM `nyc-tlc.yellow.trips` LIMIT 10000",
+  "SELECT * FROM `nyc-tlc.yellow.trips` LIMIT 100000",
+  "SELECT * FROM `nyc-tlc.yellow.trips` LIMIT 1000000",
+  "SELECT title FROM `bigquery-public-data.samples.wikipedia` ORDER BY title LIMIT 1000",
+  "SELECT title, id, timestamp, contributor_ip FROM `bigquery-public-data.samples.wikipedia` WHERE title like 'Blo%' ORDER BY id",
+  "SELECT * FROM `bigquery-public-data.baseball.games_post_wide` ORDER BY gameId",
+  "SELECT * FROM `bigquery-public-data.samples.github_nested` WHERE repository.has_downloads ORDER BY repository.created_at LIMIT 10000",
+  "SELECT repo_name, path FROM `bigquery-public-data.github_repos.files` WHERE path LIKE '%.java' ORDER BY id LIMIT 1000000"
+]


### PR DESCRIPTION
The benchmark runs queries and reports
1. how long we wait until first row
2. how long we take to iterate all rows