### PR TITLE
Add Bucket#compose

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -735,9 +735,6 @@ module Google
         #   of source file names or objects that will be concatenated into a
         #   single file.
         # @param [String] destination The name of the new file.
-        # @param [String] content_type The
-        #   [Content-Type](https://tools.ietf.org/html/rfc2616#section-14.17)
-        #   response header to be returned when the file is downloaded.
         # @param [String] acl A predefined set of access controls to apply to
         #   this file.
         #
@@ -804,7 +801,7 @@ module Google
         #
         #   new_file = bucket.compose [file_1, file_2], "path/to/new-file.ext"
         #
-        def compose sources, destination, content_type: nil, acl: nil
+        def compose sources, destination, acl: nil
           ensure_service!
           sources = Array sources
           if sources.size < 2
@@ -812,11 +809,10 @@ module Google
           end
 
           options = { acl: File::Acl.predefined_rule_for(acl),
-                      content_type: content_type, user_project: user_project }
+                      user_project: user_project }
           destination_gapi = nil
           if block_given?
-            destination_gapi = Google::Apis::StorageV1::Object.new \
-              content_type: content_type
+            destination_gapi = Google::Apis::StorageV1::Object.new
             updater = File::Updater.new destination_gapi
             yield updater
             updater.check_for_changed_metadata!

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -350,14 +350,10 @@ module Google
         ## Copy a file from source bucket/object to a
         # destination bucket/object.
         def compose_file bucket_name, source_files, destination_path,
-                         destination_gapi, content_type: nil, acl: nil,
-                         key: nil, user_project: nil
+                         destination_gapi, acl: nil, key: nil, user_project: nil
           key_options = rewrite_key_options key, key
-          content_type ||= destination_gapi.content_type if destination_gapi
-          content_type ||= mime_type_for destination_path
 
           compose_req = Google::Apis::StorageV1::ComposeRequest.new \
-            content_type: content_type,
             source_objects: compose_file_source_objects(source_files),
             destination: destination_gapi
 

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -351,7 +351,6 @@ module Google
         # destination bucket/object.
         def compose_file bucket_name, source_files, destination_path,
                          destination_gapi, acl: nil, key: nil, user_project: nil
-          key_options = rewrite_key_options key, key
 
           compose_req = Google::Apis::StorageV1::ComposeRequest.new \
             source_objects: compose_file_source_objects(source_files),
@@ -363,7 +362,7 @@ module Google
               compose_req,
               destination_predefined_acl: acl,
               user_project: user_project(user_project),
-              options: key_options
+              options: key_options(key)
           end
         end
 

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -143,6 +143,8 @@ YARD::Doctest.configure do |doctest|
   # Skip all aliases, since tests would be exact duplicates
   doctest.skip "Google::Cloud::Storage::Bucket#new_file"
   doctest.skip "Google::Cloud::Storage::Bucket#find_files"
+  doctest.skip "Google::Cloud::Storage::Bucket#combine"
+  doctest.skip "Google::Cloud::Storage::Bucket#compose_file"
   doctest.skip "Google::Cloud::Storage::Bucket#new_notification"
   doctest.skip "Google::Cloud::Storage::Bucket#find_notification"
   doctest.skip "Google::Cloud::Storage::Bucket#find_notifications"
@@ -189,6 +191,13 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
       mock.expect :patch_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Google::Apis::StorageV1::Bucket, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::Bucket#compose" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :compose_object, file_gapi, ["my-bucket", "path/to/new-file.ext", Google::Apis::StorageV1::ComposeRequest, Hash]
     end
   end
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_compose_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_compose_test.rb
@@ -1,0 +1,243 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe Google::Cloud::Storage::Bucket, :compose, :mock_storage do
+  let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash("bucket").to_json }
+  let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
+  let(:bucket_user_project) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_project: true }
+
+  let(:file_name) { "file.ext" }
+  let(:file_hash) { random_file_hash bucket.name, file_name }
+  let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
+  let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
+  let(:file_user_project) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_project: true }
+
+  let(:file_2_name) { "file-2.ext" }
+  let(:file_2_hash) { random_file_hash bucket.name, file_2_name }
+  let(:file_2_gapi) { Google::Apis::StorageV1::Object.from_json file_2_hash.to_json }
+  let(:file_2) { Google::Cloud::Storage::File.from_gapi file_2_gapi, storage.service }
+  let(:file_2_user_project) { Google::Cloud::Storage::File.from_gapi file_2_gapi, storage.service, user_project: true }
+
+  let(:file_3_name) { "file-3.ext" }
+  let(:file_3_hash) { random_file_hash bucket.name, file_3_name }
+  let(:file_3_gapi) { Google::Apis::StorageV1::Object.from_json file_3_hash.to_json }
+  let(:file_3) { Google::Cloud::Storage::File.from_gapi file_3_gapi, storage.service }
+  let(:file_3_user_project) { Google::Cloud::Storage::File.from_gapi file_3_gapi, storage.service, user_project: true }
+
+  let(:encryption_key) { "y\x03\"\x0E\xB6\xD3\x9B\x0E\xAB*\x19\xFAv\xDEY\xBEI\xF8ftA|[z\x1A\xFBE\xDE\x97&\xBC\xC7" }
+  let(:encryption_key_sha256) { "5\x04_\xDF\x1D\x8A_d\xFEK\e6p[XZz\x13s]E\xF6\xBB\x10aQH\xF6o\x14f\xF9" }
+  let(:source_encryption_key) { "T\x80\xC2}\x91R\xD2\x05\fTo\xD4\xB3+\xAE\xBCbd\xD1\x81|\xCD\x06%\xC8|\xA2\x17\xF6\xB4^\xD0" }
+  let(:source_encryption_key_sha256) { "\x03(M#\x1D(BF\x12$T\xD4\xDCP\xE6\x98\a\xEB'\x8A\xB9\x89\xEEM)\x94\xFD\xE3VR*\x86" }
+  let(:key_headers) do {
+      "x-goog-encryption-algorithm"  => "AES256",
+      "x-goog-encryption-key"        => Base64.strict_encode64(encryption_key),
+      "x-goog-encryption-key-sha256" => Base64.strict_encode64(encryption_key_sha256)
+    }
+  end
+  let(:source_key_headers) do {
+      "x-goog-copy-source-encryption-algorithm"  => "AES256",
+      "x-goog-copy-source-encryption-key"        => Base64.strict_encode64(source_encryption_key),
+      "x-goog-copy-source-encryption-key-sha256" => Base64.strict_encode64(source_encryption_key_sha256)
+    }
+  end
+  let(:both_key_headers) do {
+      "x-goog-copy-source-encryption-algorithm"  => "AES256",
+      "x-goog-copy-source-encryption-key"        => Base64.strict_encode64(encryption_key),
+      "x-goog-copy-source-encryption-key-sha256" => Base64.strict_encode64(encryption_key_sha256),
+      "x-goog-encryption-algorithm"  => "AES256",
+      "x-goog-encryption-key"        => Base64.strict_encode64(encryption_key),
+      "x-goog-encryption-key-sha256" => Base64.strict_encode64(encryption_key_sha256)
+    }
+  end
+  let(:key_options) { { header: key_headers } }
+  let(:source_key_options) { { header: source_key_headers } }
+  let(:both_key_options) { { header: both_key_headers } }
+
+  it "can compose a new file with string sources" do
+    mock = Minitest::Mock.new
+    mock.expect :compose_object, file_3_gapi,
+      [bucket.name, file_3_name, compose_request([file_name, file_2_name]), destination_predefined_acl: nil, user_project: nil, options: {}]
+
+    bucket.service.mocked_service = mock
+
+    new_file = bucket.compose [file_name, file_2_name], file_3_name
+    new_file.must_be_kind_of Google::Cloud::Storage::File
+    new_file.name.must_equal file_3_name
+
+    mock.verify
+  end
+
+  it "can compose a new file with File sources" do
+    mock = Minitest::Mock.new
+    mock.expect :compose_object, file_3_gapi,
+      [bucket.name, file_3_name, compose_request([file_gapi, file_2_gapi]), destination_predefined_acl: nil, user_project: nil, options: {}]
+
+    bucket.service.mocked_service = mock
+
+    new_file = bucket.compose [file, file_2], file_3_name
+    new_file.must_be_kind_of Google::Cloud::Storage::File
+    new_file.name.must_equal file_3_name
+
+    mock.verify
+  end
+
+  it "can compose a new file with File sources that have generations" do
+    file_gapi.generation = "123"
+    file_2_gapi.generation = "456"
+
+    mock = Minitest::Mock.new
+    mock.expect :compose_object, file_3_gapi,
+      [bucket.name, file_3_name, compose_request([file_gapi, file_2_gapi]), destination_predefined_acl: nil, user_project: nil, options: {}]
+
+    bucket.service.mocked_service = mock
+    puts file.gapi
+
+    new_file = bucket.compose [file, file_2], file_3_name
+    new_file.must_be_kind_of Google::Cloud::Storage::File
+    new_file.name.must_equal file_3_name
+
+    mock.verify
+  end
+
+  it "can compose a new file with predefined ACL" do
+    mock = Minitest::Mock.new
+    mock.expect :compose_object, file_3_gapi,
+      [bucket.name, file_3_name, compose_request([file_gapi, file_2_gapi]), destination_predefined_acl: "private", user_project: nil, options: {}]
+
+    bucket.service.mocked_service = mock
+
+    new_file = bucket.compose [file, file_2], file_3_name, acl: "private"
+    new_file.must_be_kind_of Google::Cloud::Storage::File
+    new_file.name.must_equal file_3_name
+
+    mock.verify
+  end
+
+  it "can compose a new file with ACL alias" do
+    mock = Minitest::Mock.new
+    mock.expect :compose_object, file_3_gapi,
+      [bucket.name, file_3_name, compose_request([file_gapi, file_2_gapi]), destination_predefined_acl: "publicRead", user_project: nil, options: {}]
+
+    bucket.service.mocked_service = mock
+
+    new_file = bucket.compose [file, file_2], file_3_name, acl: :public
+    new_file.must_be_kind_of Google::Cloud::Storage::File
+    new_file.name.must_equal file_3_name
+
+    mock.verify
+  end
+
+  it "can compose a new file with user_project set to true" do
+    mock = Minitest::Mock.new
+    mock.expect :compose_object, file_3_gapi,
+      [bucket.name, file_3_name, compose_request([file_gapi, file_2_gapi]), destination_predefined_acl: nil, user_project: "test", options: {}]
+
+    file.service.mocked_service = mock
+
+    new_file = bucket_user_project.compose [file, file_2], file_3_name
+    new_file.must_be_kind_of Google::Cloud::Storage::File
+    new_file.name.must_equal file_3_name
+
+    mock.verify
+  end
+
+  it "can compose a new file and set file attributes" do
+    mock = Minitest::Mock.new
+    update_file_gapi = Google::Apis::StorageV1::Object.new(
+      cache_control: "private, max-age=0, no-cache",
+      content_disposition: "inline; filename=filename.ext",
+      content_encoding: "deflate",
+      content_language: "de",
+      content_type: "application/json",
+      metadata: { "player" => "Bob", "score" => "10" },
+      storage_class: "NEARLINE"
+    )
+    compose_req = compose_request([file_gapi, file_2_gapi], update_file_gapi)
+    mock.expect :compose_object, file_3_gapi,
+      [bucket.name, file_3_name, compose_req, destination_predefined_acl: nil, user_project: nil, options: {}]
+
+    bucket.service.mocked_service = mock
+
+    new_file = bucket.compose [file, file_2], file_3_name do |f|
+      f.cache_control = "private, max-age=0, no-cache"
+      f.content_disposition = "inline; filename=filename.ext"
+      f.content_encoding = "deflate"
+      f.content_language = "de"
+      f.content_type = "application/json"
+      f.metadata["player"] = "Bob"
+      f.metadata["score"] = "10"
+      f.storage_class = :nearline
+    end
+
+    new_file.must_be_kind_of Google::Cloud::Storage::File
+    new_file.name.must_equal file_3_name
+
+    mock.verify
+  end
+
+  it "can compose a new file and set file attributes with user_project set to true" do
+    mock = Minitest::Mock.new
+    update_file_gapi = Google::Apis::StorageV1::Object.new(
+      cache_control: "private, max-age=0, no-cache",
+      content_disposition: "inline; filename=filename.ext",
+      content_encoding: "deflate",
+      content_language: "de",
+      content_type: "application/json",
+      metadata: { "player" => "Bob", "score" => "10" },
+      storage_class: "NEARLINE"
+    )
+    compose_req = compose_request([file_gapi, file_2_gapi], update_file_gapi)
+    mock.expect :compose_object, file_3_gapi,
+      [bucket.name, file_3_name, compose_req, destination_predefined_acl: nil, user_project: "test", options: {}]
+
+    bucket.service.mocked_service = mock
+
+    new_file = bucket_user_project.compose [file, file_2], file_3_name do |f|
+      f.cache_control = "private, max-age=0, no-cache"
+      f.content_disposition = "inline; filename=filename.ext"
+      f.content_encoding = "deflate"
+      f.content_language = "de"
+      f.content_type = "application/json"
+      f.metadata["player"] = "Bob"
+      f.metadata["score"] = "10"
+      f.storage_class = :nearline
+    end
+
+    new_file.must_be_kind_of Google::Cloud::Storage::File
+    new_file.name.must_equal file_3_name
+
+    mock.verify
+  end
+
+  def compose_request source_files, destination = nil
+    source_objects = source_files.map do |file|
+      if file.is_a? String
+        Google::Apis::StorageV1::ComposeRequest::SourceObject.new \
+          name: file
+      else
+        Google::Apis::StorageV1::ComposeRequest::SourceObject.new \
+          name: file.name,
+          generation: file.generation
+      end
+    end
+    Google::Apis::StorageV1::ComposeRequest.new(
+      destination: destination,
+      source_objects: source_objects
+    )
+  end
+end


### PR DESCRIPTION
This PR add `Bucket#compose`, with support for setting the properties of the destination file and for encryption keys.

[closes #94]