### PR TITLE
bigquery: make queries faster

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -56,7 +56,7 @@ module Google
         ##
         # @private
         def self.format_row row, fields
-          row_pairs = fields.zip(row["f"]).map do |f, v|
+          row_pairs = fields.zip(row[:f]).map do |f, v|
             [f.name.to_sym, format_value(v, f)]
           end
           Hash[row_pairs]
@@ -67,36 +67,36 @@ module Google
             nil
           elsif value.empty?
             nil
-          elsif value["v"].nil?
+          elsif value[:v].nil?
             nil
-          elsif Array === value["v"]
-            value["v"].map { |v| format_value v, field }
-          elsif Hash === value["v"]
-            if value["v"].empty?
+          elsif Array === value[:v]
+            value[:v].map { |v| format_value v, field }
+          elsif Hash === value[:v]
+            if value[:v].empty?
               nil
             else
-              format_row value["v"], field.fields
+              format_row value[:v], field.fields
             end
           elsif field.type == "STRING"
-            String value["v"]
+            String value[:v]
           elsif field.type == "INTEGER"
-            Integer value["v"]
+            Integer value[:v]
           elsif field.type == "FLOAT"
-            Float value["v"]
+            Float value[:v]
           elsif field.type == "BOOLEAN"
-            (value["v"] == "true" ? true : (value["v"] == "false" ? false : nil))
+            (value[:v] == "true" ? true : (value[:v] == "false" ? false : nil))
           elsif field.type == "BYTES"
-            StringIO.new Base64.decode64 value["v"]
+            StringIO.new Base64.decode64 value[:v]
           elsif field.type == "TIMESTAMP"
-            ::Time.at Float(value["v"])
+            ::Time.at Float(value[:v])
           elsif field.type == "TIME"
-            Bigquery::Time.new value["v"]
+            Bigquery::Time.new value[:v]
           elsif field.type == "DATETIME"
-            ::Time.parse("#{value["v"]} UTC").to_datetime
+            ::Time.parse("#{value[:v]} UTC").to_datetime
           elsif field.type == "DATE"
-            Date.parse value["v"]
+            Date.parse value[:v]
           else
-            value["v"]
+            value[:v]
           end
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -56,7 +56,7 @@ module Google
         ##
         # @private
         def self.format_row row, fields
-          row_pairs = fields.zip(row[:f]).map do |f, v|
+          row_pairs = fields.zip(row["f"]).map do |f, v|
             [f.name.to_sym, format_value(v, f)]
           end
           Hash[row_pairs]
@@ -67,36 +67,36 @@ module Google
             nil
           elsif value.empty?
             nil
-          elsif value[:v].nil?
+          elsif value["v"].nil?
             nil
-          elsif Array === value[:v]
-            value[:v].map { |v| format_value v, field }
-          elsif Hash === value[:v]
-            if value[:v].empty?
+          elsif Array === value["v"]
+            value["v"].map { |v| format_value v, field }
+          elsif Hash === value["v"]
+            if value["v"].empty?
               nil
             else
-              format_row value[:v], field.fields
+              format_row value["v"], field.fields
             end
           elsif field.type == "STRING"
-            String value[:v]
+            String value["v"]
           elsif field.type == "INTEGER"
-            Integer value[:v]
+            Integer value["v"]
           elsif field.type == "FLOAT"
-            Float value[:v]
+            Float value["v"]
           elsif field.type == "BOOLEAN"
-            (value[:v] == "true" ? true : (value[:v] == "false" ? false : nil))
+            (value["v"] == "true" ? true : (value["v"] == "false" ? false : nil))
           elsif field.type == "BYTES"
-            StringIO.new Base64.decode64 value[:v]
+            StringIO.new Base64.decode64 value["v"]
           elsif field.type == "TIMESTAMP"
-            ::Time.at Float(value[:v])
+            ::Time.at Float(value["v"])
           elsif field.type == "TIME"
-            Bigquery::Time.new value[:v]
+            Bigquery::Time.new value["v"]
           elsif field.type == "DATETIME"
-            ::Time.parse("#{value[:v]} UTC").to_datetime
+            ::Time.parse("#{value["v"]} UTC").to_datetime
           elsif field.type == "DATE"
-            Date.parse value[:v]
+            Date.parse value["v"]
           else
-            value[:v]
+            value["v"]
           end
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -66,7 +66,7 @@ module Google
         # @return [String] The resource type.
         #
         def kind
-          @gapi_json["kind"]
+          @gapi_json[:kind]
         end
 
         ##
@@ -75,7 +75,7 @@ module Google
         # @return [String] The ETag hash.
         #
         def etag
-          @gapi_json["etag"]
+          @gapi_json[:etag]
         end
 
         ##
@@ -85,7 +85,7 @@ module Google
         # @return [String] The pagination token.
         #
         def token
-          @gapi_json["pageToken"]
+          @gapi_json[:pageToken]
         end
 
         ##
@@ -107,7 +107,7 @@ module Google
         #   end
         #
         def total
-          Integer @gapi_json["totalRows"]
+          Integer @gapi_json[:totalRows]
         rescue
           nil
         end
@@ -224,11 +224,11 @@ module Google
         def next
           return nil unless next?
           ensure_service!
-          data_json = service.list_tabledata_raw_json \
+          data_json = service.list_tabledata \
             @table_gapi.table_reference.dataset_id,
             @table_gapi.table_reference.table_id,
             token: token
-          self.class.from_json data_json, @table_gapi, @service
+          self.class.from_gapi_json data_json, @table_gapi, @service
         end
 
         ##
@@ -302,8 +302,8 @@ module Google
 
         ##
         # @private New Data from a response object.
-        def self.from_json gapi_json, table_gapi, service
-          formatted_rows = Convert.format_rows(gapi_json["rows"],
+        def self.from_gapi_json gapi_json, table_gapi, service
+          formatted_rows = Convert.format_rows(gapi_json[:rows],
                                                table_gapi.schema.fields)
 
           data = new formatted_rows

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -49,14 +49,14 @@ module Google
         attr_accessor :table_gapi
 
         ##
-        # @private The Google API Client object.
-        attr_accessor :gapi
+        # @private The Google API Client object in JSON Hash.
+        attr_accessor :gapi_json
 
         # @private
         def initialize arr = []
           @service = nil
           @table_gapi = nil
-          @gapi = nil
+          @gapi_json = nil
           super arr
         end
 
@@ -66,7 +66,7 @@ module Google
         # @return [String] The resource type.
         #
         def kind
-          @gapi.kind
+          @gapi_json["kind"]
         end
 
         ##
@@ -75,7 +75,7 @@ module Google
         # @return [String] The ETag hash.
         #
         def etag
-          @gapi.etag
+          @gapi_json["etag"]
         end
 
         ##
@@ -85,7 +85,7 @@ module Google
         # @return [String] The pagination token.
         #
         def token
-          @gapi.page_token
+          @gapi_json["pageToken"]
         end
 
         ##
@@ -107,7 +107,7 @@ module Google
         #   end
         #
         def total
-          Integer @gapi.total_rows
+          Integer @gapi_json["totalRows"]
         rescue
           nil
         end
@@ -224,11 +224,11 @@ module Google
         def next
           return nil unless next?
           ensure_service!
-          data_gapi = service.list_tabledata \
+          data_json = service.list_tabledata_raw_json \
             @table_gapi.table_reference.dataset_id,
             @table_gapi.table_reference.table_id,
             token: token
-          self.class.from_gapi data_gapi, @table_gapi, @service
+          self.class.from_json data_json, @table_gapi, @service
         end
 
         ##
@@ -302,13 +302,13 @@ module Google
 
         ##
         # @private New Data from a response object.
-        def self.from_gapi gapi, table_gapi, service
-          formatted_rows = Convert.format_rows(gapi.rows,
+        def self.from_json gapi_json, table_gapi, service
+          formatted_rows = Convert.format_rows(gapi_json["rows"],
                                                table_gapi.schema.fields)
 
           data = new formatted_rows
           data.table_gapi = table_gapi
-          data.gapi = gapi
+          data.gapi_json = gapi_json
           data.service = service
           data
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -305,11 +305,11 @@ module Google
           ensure_schema!
 
           options = { token: token, max: max, start: start }
-          data_hash = service.list_tabledata_raw_json \
+          data_hash = service.list_tabledata \
             destination_table_dataset_id,
             destination_table_table_id,
             options
-          Data.from_json data_hash, destination_table_gapi, service
+          Data.from_gapi_json data_hash, destination_table_gapi, service
         end
         alias_method :query_results, :data
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -305,9 +305,11 @@ module Google
           ensure_schema!
 
           options = { token: token, max: max, start: start }
-          data_gapi = service.list_tabledata destination_table_dataset_id,
-                                             destination_table_table_id, options
-          Data.from_gapi data_gapi, destination_table_gapi, service
+          data_hash = service.list_tabledata_raw_json \
+            destination_table_dataset_id,
+            destination_table_table_id,
+            options
+          Data.from_json data_hash, destination_table_gapi, service
         end
         alias_method :query_results, :data
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -188,13 +188,16 @@ module Google
 
         ##
         # Retrieves data from the table.
-        def list_tabledata dataset_id, table_id, options = {}
+        def list_tabledata_raw_json dataset_id, table_id, options = {}
           # The list operation is considered idempotent
           execute backoff: true do
-            service.list_table_data @project, dataset_id, table_id,
-                                    max_results: options.delete(:max),
-                                    page_token: options.delete(:token),
-                                    start_index: options.delete(:start)
+            json_txt = service.list_table_data \
+              @project, dataset_id, table_id,
+              max_results: options.delete(:max),
+              page_token: options.delete(:token),
+              start_index: options.delete(:start),
+              options: { skip_deserialization: true }
+            JSON.parse(json_txt)
           end
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -188,7 +188,7 @@ module Google
 
         ##
         # Retrieves data from the table.
-        def list_tabledata_raw_json dataset_id, table_id, options = {}
+        def list_tabledata dataset_id, table_id, options = {}
           # The list operation is considered idempotent
           execute backoff: true do
             json_txt = service.list_table_data \
@@ -197,7 +197,7 @@ module Google
               page_token: options.delete(:token),
               start_index: options.delete(:start),
               options: { skip_deserialization: true }
-            JSON.parse(json_txt)
+            JSON.parse json_txt, symbolize_names: true
           end
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -766,8 +766,9 @@ module Google
         def data token: nil, max: nil, start: nil
           ensure_service!
           options = { token: token, max: max, start: start }
-          data_gapi = service.list_tabledata dataset_id, table_id, options
-          Data.from_gapi data_gapi, gapi, service
+          data_json = service.list_tabledata_raw_json \
+            dataset_id, table_id, options
+          Data.from_json data_json, gapi, service
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -766,9 +766,9 @@ module Google
         def data token: nil, max: nil, start: nil
           ensure_service!
           options = { token: token, max: max, start: start }
-          data_json = service.list_tabledata_raw_json \
+          data_json = service.list_tabledata \
             dataset_id, table_id, options
-          Data.from_json data_json, gapi, service
+          Data.from_gapi_json data_json, gapi, service
         end
 
         ##

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -74,7 +74,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi, ["my-project-id", "my-dataset-id", "my_table", Hash]
+      mock.expect :list_table_data, table_data_gapi.to_json, ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -82,7 +82,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi, ["my-project-id", "my-dataset-id", "my_table", Hash]
+      mock.expect :list_table_data, table_data_gapi.to_json, ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -90,7 +90,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi, ["my-project-id", "my-dataset-id", "my_table", Hash]
+      mock.expect :list_table_data, table_data_gapi.to_json, ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -103,7 +103,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my_table", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -159,7 +159,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -172,7 +172,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job, query_job_gapi, ["my-project-id", "1234567890"]
       mock.expect :get_job_query_results, query_data_gapi, ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -308,7 +308,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi, ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -346,7 +346,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi, ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -409,7 +409,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -421,7 +421,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -433,7 +433,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job, query_job_gapi, ["my-project-id", "1234567890"]
       mock.expect :get_job_query_results, query_data_gapi, ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -462,7 +462,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -504,7 +504,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project-id", "my-dataset-id", Google::Apis::BigqueryV2::Table]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my_table", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "my-dataset-id", "my_table", Hash]
       mock.expect :insert_all_table_data,
                   Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(insert_errors: []),
                   ["my-project-id", "my-dataset-id", "my_table", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
@@ -536,7 +536,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "my-dataset-id", "my_table", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "my-dataset-id", "my_table", Hash]
     end
   end
 
@@ -621,7 +621,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_table, table_full_gapi, ["my-project-id", "my-dataset-id", "my_table"]
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -666,7 +666,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -693,7 +693,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -729,7 +729,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_table, view_full_gapi, ["my-project-id", "my-dataset-id", "my_view"]
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -737,7 +737,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -746,7 +746,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project-id", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 
@@ -754,7 +754,7 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project-id", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project-id", "1234567890", Hash]
-      mock.expect :list_table_data, table_data_gapi(token: nil), ["my-project-id", "target_dataset_id", "target_table_id", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project-id", "target_dataset_id", "target_table_id", Hash]
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -27,8 +27,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data
     mock.verify
@@ -74,8 +74,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data
     mock.verify
@@ -91,8 +91,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data
     mock.verify
@@ -107,8 +107,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                nil_table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                nil_table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     nil_data = table.data
     mock.verify
@@ -147,8 +147,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                nested_table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                nested_table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     nested_data = nested_table.data
     mock.verify
@@ -192,8 +192,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                nested_table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                nested_table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     nested_data = nested_table.data
     mock.verify
@@ -208,11 +208,11 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options: {skip_deserialization: true} }]
 
     data1 = table.data
 
@@ -228,11 +228,11 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi(token: nil),
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi(token: nil).to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options: {skip_deserialization: true} }]
 
     data1 = table.data
 
@@ -250,11 +250,11 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi(token: nil),
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi(token: nil).to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data.all.to_a
 
@@ -267,11 +267,11 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi(token: nil),
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi(token: nil).to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data
 
@@ -283,11 +283,11 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data.all.take(5)
 
@@ -300,11 +300,11 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data.all(request_limit: 1).to_a
 
@@ -317,8 +317,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: 3, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: 3, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data max: 3
     data.class.must_equal Google::Cloud::Bigquery::Data
@@ -328,8 +328,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: 25 }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: 25, options: {skip_deserialization: true} }]
 
     data = table.data start: 25
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
@@ -41,8 +41,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :external, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     external_csv = dataset.external "gs://my-bucket/path/to/file.csv"
     data = dataset.query query, external: { my_csv: external_csv }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -45,8 +45,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
@@ -77,8 +77,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
@@ -109,8 +109,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
@@ -141,8 +141,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE active = @active", params: { active: true }
     mock.verify
@@ -173,8 +173,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE active = @active", params: { active: false }
     mock.verify
@@ -207,8 +207,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
@@ -241,8 +241,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true}}]
 
     data = dataset.query "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
@@ -275,8 +275,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
@@ -309,8 +309,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
@@ -343,8 +343,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
@@ -377,8 +377,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
@@ -463,8 +463,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE name = @name" +
                                   " AND age > @age" +
@@ -515,8 +515,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
@@ -566,8 +566,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -17,10 +17,10 @@ require "helper"
 describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
   let(:job_id) { "job_9876543210" }
-  
+
   let(:dataset_id) { "my_dataset" }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
-  
+
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
 
   it "queries the data with a string parameter" do
@@ -44,8 +44,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
 
     data = dataset.query "#{query} WHERE name = ?", params: ["Testy McTesterson"]
@@ -76,8 +76,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE age > ?", params: [35]
     mock.verify
@@ -107,8 +107,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE score > ?", params: [90.0]
     mock.verify
@@ -138,8 +138,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE active = ?", params: [true]
     mock.verify
@@ -169,8 +169,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE active = ?", params: [false]
     mock.verify
@@ -202,8 +202,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE create_date = ?", params: [today]
     mock.verify
@@ -235,8 +235,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
@@ -268,8 +268,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
@@ -301,8 +301,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
@@ -334,8 +334,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                   query_data_gapi,
                   [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
       mock.expect :list_table_data,
-                  table_data_gapi,
-                  [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                  table_data_gapi.to_json,
+                  [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
       data = dataset.query "#{query} WHERE avatar = ?", params: [file]
       mock.verify
@@ -367,8 +367,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                   query_data_gapi,
                   [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
       mock.expect :list_table_data,
-                  table_data_gapi,
-                  [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                  table_data_gapi.to_json,
+                  [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
       data = dataset.query "#{query} WHERE avatar = ?", params: [file]
       mock.verify
@@ -446,8 +446,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE name = ?" +
                                   " AND age > ?" +
@@ -492,8 +492,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
     mock.verify
@@ -542,8 +542,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
@@ -34,8 +34,8 @@ describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query query
     data.class.must_equal Google::Cloud::Bigquery::Data

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
@@ -40,8 +40,8 @@ describe Google::Cloud::Bigquery::Project, :query, :external, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     external_csv = bigquery.external "gs://my-bucket/path/to/file.csv"
     data = bigquery.query query, external: { my_csv: external_csv }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -48,8 +48,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
@@ -80,8 +80,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
@@ -112,8 +112,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
@@ -144,8 +144,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE active = @active", params: { active: true }
     mock.verify
@@ -176,8 +176,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE active = @active", params: { active: false }
     mock.verify
@@ -210,8 +210,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
@@ -244,8 +244,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
@@ -278,8 +278,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
@@ -312,8 +312,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", { max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true}}]
 
     data = bigquery.query "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
@@ -346,8 +346,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
@@ -380,8 +380,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
@@ -466,8 +466,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE name = @name" +
                                   " AND age > @age" +
@@ -518,8 +518,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
@@ -569,8 +569,8 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -48,8 +48,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE name = ?", params: ["Testy McTesterson"]
     mock.verify
@@ -79,8 +79,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE age > ?", params: [35]
     mock.verify
@@ -110,8 +110,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE score > ?", params: [90.0]
     mock.verify
@@ -141,8 +141,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE active = ?", params: [true]
     mock.verify
@@ -172,8 +172,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE active = ?", params: [false]
     mock.verify
@@ -205,8 +205,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE create_date = ?", params: [today]
     mock.verify
@@ -238,8 +238,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
@@ -271,8 +271,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
@@ -304,8 +304,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
@@ -337,8 +337,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE avatar = ?", params: [file]
     mock.verify
@@ -370,8 +370,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE avatar = ?", params: [file]
     mock.verify
@@ -449,8 +449,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE name = ?" +
                                   " AND age > ?" +
@@ -495,8 +495,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
     mock.verify
@@ -545,8 +545,8 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
@@ -37,8 +37,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query
     mock.verify
@@ -72,11 +72,11 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: "token1234567890", start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query
     # data.must_be_kind_of Google::Cloud::Bigquery::Data
@@ -101,8 +101,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: 42, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: 42, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query, max: 42
     data.class.must_equal Google::Cloud::Bigquery::Data
@@ -123,8 +123,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query, dataset: "some_random_dataset"
     data.class.must_equal Google::Cloud::Bigquery::Data
@@ -145,8 +145,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query, dataset: "some_random_dataset",
                                  project: "some_random_project"
@@ -167,8 +167,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
 
     data = bigquery.query query, cache: false

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
@@ -28,8 +28,8 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job.job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
 
     job.must_be :done?
     data = job.data
@@ -76,8 +76,8 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
 
     job.instance_variable_set :@destination_schema_gapi, query_data_gapi.schema
 
@@ -129,11 +129,11 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job.job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options:{skip_deserialization: true} }]
 
     data1 = job.data
 
@@ -152,11 +152,11 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job.job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi(token: nil),
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi(token: nil).to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options:{skip_deserialization: true} }]
 
     data1 = job.data
 
@@ -177,11 +177,11 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job.job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi(token: nil),
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi(token: nil).to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options:{skip_deserialization: true} }]
 
     data = job.data.all.to_a
 
@@ -197,11 +197,11 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job.job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi(token: nil),
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi(token: nil).to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options:{skip_deserialization: true} }]
 
     data = job.data
 
@@ -216,11 +216,11 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job.job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options:{skip_deserialization: true} }]
 
     data = job.data.all.take(5)
 
@@ -236,11 +236,11 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job.job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: "token1234567890", start_index: nil, options:{skip_deserialization: true} }]
 
     data = job.data.all(request_limit: 1).to_a
 
@@ -256,8 +256,8 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job.job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: 3, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: 3, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
 
     data = job.data max: 3
     data.class.must_equal Google::Cloud::Bigquery::Data
@@ -270,8 +270,8 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job.job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: 25 }]
+                table_data_gapi.to_json,
+                [project, dataset_id, table_id, {  max_results: nil, page_token: nil, start_index: 25, options:{skip_deserialization: true} }]
 
     data = job.data start: 25
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_data_test.rb
@@ -48,8 +48,10 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {
+                  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true}
+                }]
 
     data = view.data
     mock.verify
@@ -87,8 +89,10 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {
+                  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true}
+                }]
 
     data = view.data
     mock.verify
@@ -112,8 +116,10 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {
+                  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true}
+                }]
 
     data = view.data
     mock.verify
@@ -156,11 +162,15 @@ describe Google::Cloud::Bigquery::View, :data, :mock_bigquery do
                 query_data_gapi,
                 [project, job_id, {max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {
+                  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true}
+                }]
     mock.expect :list_table_data,
-                table_data_gapi,
-                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: "token1234567890", start_index: nil }]
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {
+                  max_results: nil, page_token: "token1234567890", start_index: nil, options: {skip_deserialization: true}
+                }]
 
     data1 = view.data
     data1.class.must_equal Google::Cloud::Bigquery::Data


### PR DESCRIPTION
Simple benchmarks introduced by
https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/1775
showed that Ruby was much slower than other languages.
Investigations showed that we spent disproportionate amount of time
deserializing JSON into TableData, just to later convert it into
Data.

This commit circumvents this work by deserializing JSON into a hash
instead using JSON.parse, and later convert the hash into Data.
On my machine, this made the benchmarks run about 4x as fast.