### PR TITLE
Add Table::AsyncInserter::Result

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -317,20 +317,21 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
   it "inserts rows asynchonously and gets its data" do
     # data = table.data
-    insert_response = nil
+    insert_result = nil
 
-    inserter = table.insert_async do |response|
-      insert_response = response
+    inserter = table.insert_async do |result|
+      insert_result = result
     end
     inserter.insert rows
 
     inserter.flush
     inserter.stop.wait!
 
-    insert_response.must_be :success?
-    insert_response.insert_count.must_equal 3
-    insert_response.insert_errors.must_be :empty?
-    insert_response.error_rows.must_be :empty?
+    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    insert_result.must_be :success?
+    insert_result.insert_count.must_equal 3
+    insert_result.insert_errors.must_be :empty?
+    insert_result.error_rows.must_be :empty?
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1598,7 +1598,7 @@ module Google
         end
 
         ##
-        # Create an asynchonous inserter object used to insert rows in batches.
+        # Create an asynchronous inserter object used to insert rows in batches.
         #
         # @param [String] table_id The ID of the table to insert rows into.
         # @param [Boolean] skip_invalid Insert all valid rows of a request, even
@@ -1617,8 +1617,8 @@ module Google
         # @attr_reader [Numeric] threads The number of threads used to insert
         #   batches of rows. Default is 4.
         # @yield [response] the callback for when a batch of rows is inserted
-        # @yieldparam [InsertResponse] response the result of the asynchonous
-        #   insert
+        # @yieldparam [Table::AsyncInserter::Result] result the result of the
+        #   asynchronous insert
         #
         # @return [Table::AsyncInserter] Returns an inserter object.
         #
@@ -1628,9 +1628,13 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
-        #   inserter = table.insert_async do |response|
-        #     log_insert "inserted #{response.insert_count} rows " \
-        #       "with #{response.error_count} errors"
+        #   inserter = table.insert_async do |result|
+        #     if result.error?
+        #       log_error result.error
+        #     else
+        #       log_insert "inserted #{result.insert_count} rows " \
+        #         "with #{result.error_count} errors"
+        #     end
         #   end
         #
         #   rows = [

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1452,7 +1452,7 @@ module Google
         end
 
         ##
-        # Create an asynchonous inserter object used to insert rows in batches.
+        # Create an asynchronous inserter object used to insert rows in batches.
         #
         # @param [Boolean] skip_invalid Insert all valid rows of a request, even
         #   if invalid rows exist. The default value is `false`, which causes
@@ -1470,8 +1470,8 @@ module Google
         # @attr_reader [Numeric] threads The number of threads used to insert
         #   batches of rows. Default is 4.
         # @yield [response] the callback for when a batch of rows is inserted
-        # @yieldparam [InsertResponse] response the result of the asynchonous
-        #   insert
+        # @yieldparam [Table::AsyncInserter::Result] result the result of the
+        #   asynchronous insert
         #
         # @return [Table::AsyncInserter] Returns inserter object.
         #
@@ -1481,9 +1481,13 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
-        #   inserter = table.insert_async do |response|
-        #     log_insert "inserted #{response.insert_count} rows " \
-        #       "with #{response.error_count} errors"
+        #   inserter = table.insert_async do |result|
+        #     if result.error?
+        #       log_error result.error
+        #     else
+        #       log_insert "inserted #{result.insert_count} rows " \
+        #         "with #{result.error_count} errors"
+        #     end
         #   end
         #
         #   rows = [


### PR DESCRIPTION
Include operation-level API error in type passed to #insert_async callback.

[closes #1787]