### PR TITLE
Update Debugger README to use project

### DIFF
--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -176,7 +176,7 @@ Or provide the parameters to the Stackdriver Debugger agent when it starts:
 
 ```ruby
 require "google/cloud/debugger"
-Google::Cloud::Debugger.new(project_id: "your-project-id",
+Google::Cloud::Debugger.new(project: "your-project-id",
                             keyfile: "/path/to/key.json").start
 ```
 


### PR DESCRIPTION
This is the only item left for issue #1797. I reviewed the code for `project_id` and Debugger.new uses `project` instead of `project_id`.

