### PR TITLE
Fix Logging HttpRequest#method

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
@@ -43,7 +43,7 @@ module Google
           #   `"POST"`. (String)
           def method *args
             # Call Object#method when args are present.
-            return super if args.any?
+            return super unless args.empty?
 
             request_method
           end

--- a/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
@@ -31,9 +31,20 @@ module Google
           end
 
           ##
+          # @overload method()
+          #   The request method. Examples: `"GET"`, `"HEAD"`, `"PUT"`,
+          #   `"POST"`. (String)
+          def method *args
+            # Call Object#method when args are present.
+            return super if args.any?
+
+            @method
+          end
+
+          ##
           # The request method. Examples: `"GET"`, `"HEAD"`, `"PUT"`, `"POST"`.
           # (String)
-          attr_accessor :method
+          attr_writer :method
 
           ##
           # The URL. The scheme (http, https), the host name, the path and the

--- a/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
@@ -31,20 +31,32 @@ module Google
           end
 
           ##
+          # The request method. Examples: `"GET"`, `"HEAD"`, `"PUT"`, `"POST"`.
+          # (String)
+          attr_accessor :request_method
+
+          ##
           # @overload method()
+          #   Deprecated. Use {#request_method} instead.
+          #
           #   The request method. Examples: `"GET"`, `"HEAD"`, `"PUT"`,
           #   `"POST"`. (String)
           def method *args
             # Call Object#method when args are present.
             return super if args.any?
 
-            @method
+            request_method
           end
 
           ##
-          # The request method. Examples: `"GET"`, `"HEAD"`, `"PUT"`, `"POST"`.
-          # (String)
-          attr_writer :method
+          # @overload method()
+          #   Deprecated. Use {#request_method=} instead.
+          #
+          #   The request method. Examples: `"GET"`, `"HEAD"`, `"PUT"`,
+          #   `"POST"`. (String)
+          def method= new_request_method
+            self.request_method = new_request_method
+          end
 
           ##
           # The URL. The scheme (http, https), the host name, the path and the
@@ -118,7 +130,7 @@ module Google
           def to_grpc
             return nil if empty?
             Google::Logging::Type::HttpRequest.new(
-              request_method:                     method.to_s,
+              request_method:                     request_method.to_s,
               request_url:                        url.to_s,
               request_size:                       size.to_i,
               status:                             status.to_i,
@@ -137,16 +149,16 @@ module Google
           def self.from_grpc grpc
             return new if grpc.nil?
             new.tap do |h|
-              h.method        = grpc.request_method
-              h.url           = grpc.request_url
-              h.size          = grpc.request_size
-              h.status        = grpc.status
-              h.response_size = grpc.response_size
-              h.user_agent    = grpc.user_agent
-              h.remote_ip     = grpc.remote_ip
-              h.referer       = grpc.referer
-              h.cache_hit     = grpc.cache_hit
-              h.validated     = grpc.cache_validated_with_origin_server
+              h.request_method = grpc.request_method
+              h.url            = grpc.request_url
+              h.size           = grpc.request_size
+              h.status         = grpc.status
+              h.response_size  = grpc.response_size
+              h.user_agent     = grpc.user_agent
+              h.remote_ip      = grpc.remote_ip
+              h.referer        = grpc.referer
+              h.cache_hit      = grpc.cache_hit
+              h.validated      = grpc.cache_validated_with_origin_server
             end
           end
         end

--- a/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
@@ -52,4 +52,14 @@ describe Google::Cloud::Logging::Entry::HttpRequest, :mock_logging do
     actual_method.to_proc.call true
     http_request.validated.must_equal true
   end
+
+  it "method alias being passed nil calls Object#method" do
+    http_request.request_method.must_equal "GET"
+    http_request.method.must_equal http_request.request_method
+
+    err = expect do
+      http_request.method nil
+    end.must_raise TypeError
+    err.message.must_include "nil is not a symbol"
+  end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
@@ -31,4 +31,15 @@ describe Google::Cloud::Logging::Entry::HttpRequest, :mock_logging do
     http_request.cache_hit.must_equal false
     http_request.validated.must_equal false
   end
+
+  it "doesn't stomp on Object#method" do
+    actual_method = http_request.method :validated=
+    actual_method.must_be_kind_of Method
+    actual_method.name.must_equal :validated=
+
+    # This is the real method object, which can be used.
+    http_request.validated.must_equal false
+    actual_method.to_proc.call true
+    http_request.validated.must_equal true
+  end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Logging::Entry::HttpRequest, :mock_logging do
   let(:http_request) { Google::Cloud::Logging::Entry::HttpRequest.from_grpc http_request_grpc }
 
   it "has attributes" do
-    http_request.method.must_equal "GET"
+    http_request.request_method.must_equal "GET"
     http_request.url.must_equal "http://test.local/foo?bar=baz"
     http_request.size.must_equal 123
     http_request.status.must_equal 200
@@ -32,7 +32,17 @@ describe Google::Cloud::Logging::Entry::HttpRequest, :mock_logging do
     http_request.validated.must_equal false
   end
 
-  it "doesn't stomp on Object#method" do
+  it "method alias (deprecated)" do
+    http_request.request_method.must_equal "GET"
+    http_request.method.must_equal http_request.request_method
+
+    http_request.method = "POST"
+
+    http_request.request_method.must_equal "POST"
+    http_request.method.must_equal http_request.request_method
+  end
+
+  it "method alias doesn't stomp on Object#method" do
     actual_method = http_request.method :validated=
     actual_method.must_be_kind_of Method
     actual_method.name.must_equal :validated=

--- a/google-cloud-logging/test/google/cloud/logging/entry_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry_test.rb
@@ -96,7 +96,7 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
   end
 
   it "has the correct http_request attributes" do
-    entry.http_request.method.must_equal "GET"
+    entry.http_request.request_method.must_equal "GET"
     entry.http_request.url.must_equal "http://test.local/foo?bar=baz"
     entry.http_request.size.must_equal 123
     entry.http_request.status.must_equal 200
@@ -113,7 +113,7 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
 
     entry.http_request.wont_be :nil?
     entry.http_request.must_be_kind_of Google::Cloud::Logging::Entry::HttpRequest
-    entry.http_request.method.must_be :nil?
+    entry.http_request.request_method.must_be :nil?
     entry.http_request.url.must_be :nil?
     entry.http_request.size.must_be :nil?
     entry.http_request.status.must_be :nil?


### PR DESCRIPTION
`HttpRequest#method` is stomping on `Object#method` and this is preventing calls to `Object#method` to be made. This fix is to maintain both behaviors by checking whether an argument was passed to `#method`. The `HttpRequest#method` behavior is used when called with no arguments, and the `Object#method`, behavior is used when called with arguments.

```ruby
require "google/cloud/logging"

logging = Google::Cloud::Logging.new

entry = logging.entry
entry.http_request.method = :GET

# call with HttpRequest#method behavior
entry.http_request.method #=>:GET

# call with Object#method behavior
entry.http_request.method(:validated)
#=> #<Method: Google::Cloud::Logging::Entry::HttpRequest#validated>
```

[fixes #1798]