### PR TITLE
Increase timeout on error reporting acceptance tests

### DIFF
--- a/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
@@ -37,9 +37,9 @@ module Acceptance
                  "You do not have an active error stats vtk client to run the tests."
     end
 
-    def wait_until
+    def wait_until attempts=20
       delay = 2
-      while delay <= 11
+      while delay <= attempts
         sleep delay
         result = yield
         return result if result


### PR DESCRIPTION
Attempt to unstick acceptance tests for error reporting, by increasing the timeout by about 2.5 more minutes. In my local tests the call does eventually succeed, but for some reason it seems to be taking longer for the backend to register and index the data.