### PR TITLE
Expose Error Additional Values

### DIFF
--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
@@ -133,7 +133,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
       end
 
       err.message.must_equal "notfound"
-      err.cause.body.must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"},{\"reason\":\"other\"}]}}" if err.respond_to? :cause
+      err.cause.body.must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"},{\"reason\":\"other\"}]}}"
     end
 
     mock.verify
@@ -211,7 +211,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
       end
 
       err.message.must_equal "invalid"
-      err.cause.body.must_be :nil? if err.respond_to? :cause
+      err.cause.body.must_be :nil?
     end
 
     mock.verify
@@ -241,7 +241,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
       end
 
       err.message.must_equal "invalid"
-      err.cause.body.must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"}]}}" if err.respond_to? :cause
+      err.cause.body.must_equal "{\"error\":{\"errors\":[{\"reason\":\"backendError\"}]}}"
     end
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
@@ -77,20 +77,18 @@ describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
 
     err = expect { dataset.query query }.must_raise Google::Cloud::PermissionDeniedError
     err.message.must_equal "string"
-    if err.respond_to? :cause
-      err.cause.body.must_equal({
+    err.cause.body.must_equal({
+      "debugInfo"=>"string",
+      "location"=>"string",
+      "message"=>"string",
+      "reason"=>"accessDenied",
+      "errors"=>[{
         "debugInfo"=>"string",
         "location"=>"string",
         "message"=>"string",
-        "reason"=>"accessDenied",
-        "errors"=>[{
-          "debugInfo"=>"string",
-          "location"=>"string",
-          "message"=>"string",
-          "reason"=>"accessDenied"
-        }]
-      })
-    end
+        "reason"=>"accessDenied"
+      }]
+    })
 
     mock.verify
   end
@@ -105,20 +103,18 @@ describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
 
     err = expect { dataset.query query }.must_raise Google::Cloud::InternalError
     err.message.must_equal "string"
-    if err.respond_to? :cause
-      err.cause.body.must_equal({
+    err.cause.body.must_equal({
+      "debugInfo"=>"string",
+      "location"=>"string",
+      "message"=>"string",
+      "reason"=>"backendError",
+      "errors"=>[{
         "debugInfo"=>"string",
         "location"=>"string",
         "message"=>"string",
-        "reason"=>"backendError",
-        "errors"=>[{
-          "debugInfo"=>"string",
-          "location"=>"string",
-          "message"=>"string",
-          "reason"=>"backendError"
-        }]
-      })
-    end
+        "reason"=>"backendError"
+      }]
+    })
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
@@ -186,20 +186,18 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
 
     err = expect { bigquery.query query }.must_raise Google::Cloud::PermissionDeniedError
     err.message.must_equal "string"
-    if err.respond_to? :cause
-      err.cause.body.must_equal({
+    err.cause.body.must_equal({
+      "debugInfo"=>"string",
+      "location"=>"string",
+      "message"=>"string",
+      "reason"=>"accessDenied",
+      "errors"=>[{
         "debugInfo"=>"string",
         "location"=>"string",
         "message"=>"string",
-        "reason"=>"accessDenied",
-        "errors"=>[{
-          "debugInfo"=>"string",
-          "location"=>"string",
-          "message"=>"string",
-          "reason"=>"accessDenied"
-        }]
-      })
-    end
+        "reason"=>"accessDenied"
+      }]
+    })
 
     mock.verify
   end
@@ -213,20 +211,18 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
 
     err = expect { bigquery.query query }.must_raise Google::Cloud::InternalError
     err.message.must_equal "string"
-    if err.respond_to? :cause
-      err.cause.body.must_equal({
+    err.cause.body.must_equal({
+      "debugInfo"=>"string",
+      "location"=>"string",
+      "message"=>"string",
+      "reason"=>"backendError",
+      "errors"=>[{
         "debugInfo"=>"string",
         "location"=>"string",
         "message"=>"string",
-        "reason"=>"backendError",
-        "errors"=>[{
-          "debugInfo"=>"string",
-          "location"=>"string",
-          "message"=>"string",
-          "reason"=>"backendError"
-        }]
-      })
-    end
+        "reason"=>"backendError"
+      }]
+    })
 
     mock.verify
   end

--- a/google-cloud-bigtable/google-cloud-bigtable.gemspec
+++ b/google-cloud-bigtable/google-cloud-bigtable.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rubocop", "<= 0.35.1"

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem "rake", "~> 11.0"
 gem "google-api-client", "~> 0.17.0"
-gem "google-gax", "~> 0.9.2"
+gem "google-gax", "~> 0.10.1"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",

--- a/google-cloud-core/lib/google/cloud/errors.rb
+++ b/google-cloud-core/lib/google/cloud/errors.rb
@@ -18,6 +18,22 @@ module Google
     ##
     # Base google-cloud exception class.
     class Error < StandardError
+      def initialize msg = nil
+        super
+        @cause = $!
+      end
+
+      # Add Error#cause (introduced in 2.1) to Ruby 2.0.
+      unless respond_to?(:cause)
+        ##
+        # The previous exception at the time this exception was raised. This is
+        # useful for wrapping exceptions and retaining the original exception
+        # information.
+        define_method(:cause) do
+          @cause
+        end
+      end
+
       # @private Create a new error object from a client error
       def self.from_error error
         klass = if error.respond_to? :code

--- a/google-cloud-core/lib/google/cloud/errors.rb
+++ b/google-cloud-core/lib/google/cloud/errors.rb
@@ -13,14 +13,19 @@
 # limitations under the License.
 
 
+require "English"
+
 module Google
   module Cloud
     ##
     # Base google-cloud exception class.
     class Error < StandardError
+      ##
+      # Construct a new Google::Cloud::Error object, optionally passing in a
+      # message.
       def initialize msg = nil
         super
-        @cause = $!
+        @cause = $ERROR_INFO
       end
 
       # Add Error#cause (introduced in 2.1) to Ruby 2.0.
@@ -32,6 +37,97 @@ module Google
         define_method(:cause) do
           @cause
         end
+      end
+
+      ##
+      # Returns the value of `status_code` from the underlying cause error
+      # object, if both are present. Otherwise returns `nil`.
+      #
+      # This is typically present on errors originating from calls to an API
+      # over HTTP/REST.
+      #
+      # @returns [Object, nil]
+      def status_code
+        return nil unless cause && cause.respond_to?(:status_code)
+        cause.status_code
+      end
+
+      ##
+      # Returns the value of `body` from the underlying cause error
+      # object, if both are present. Otherwise returns `nil`.
+      #
+      # This is typically present on errors originating from calls to an API
+      # over HTTP/REST.
+      #
+      # @returns [Object, nil]
+      def body
+        return nil unless cause && cause.respond_to?(:body)
+        cause.body
+      end
+
+      ##
+      # Returns the value of `header` from the underlying cause error
+      # object, if both are present. Otherwise returns `nil`.
+      #
+      # This is typically present on errors originating from calls to an API
+      # over HTTP/REST.
+      #
+      # @returns [Object, nil]
+      def header
+        return nil unless cause && cause.respond_to?(:header)
+        cause.header
+      end
+
+      ##
+      # Returns the value of `code` from the underlying cause error
+      # object, if both are present. Otherwise returns `nil`.
+      #
+      # This is typically present on errors originating from calls to an API
+      # over gRPC.
+      #
+      # @returns [Object, nil]
+      def code
+        return nil unless cause && cause.respond_to?(:code)
+        cause.code
+      end
+
+      ##
+      # Returns the value of `details` from the underlying cause error
+      # object, if both are present. Otherwise returns `nil`.
+      #
+      # This is typically present on errors originating from calls to an API
+      # over gRPC.
+      #
+      # @returns [Object, nil]
+      def details
+        return nil unless cause && cause.respond_to?(:details)
+        cause.details
+      end
+
+      ##
+      # Returns the value of `metadata` from the underlying cause error
+      # object, if both are present. Otherwise returns `nil`.
+      #
+      # This is typically present on errors originating from calls to an API
+      # over gRPC.
+      #
+      # @returns [Object, nil]
+      def metadata
+        return nil unless cause && cause.respond_to?(:metadata)
+        cause.metadata
+      end
+
+      ##
+      # Returns the value of `status_details` from the underlying cause error
+      # object, if both are present. Otherwise returns `nil`.
+      #
+      # This is typically present on errors originating from calls to an API
+      # over gRPC.
+      #
+      # @returns [Object, nil]
+      def status_details
+        return nil unless cause && cause.respond_to?(:status_details)
+        cause.status_details
       end
 
       # @private Create a new error object from a client error

--- a/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
@@ -1,0 +1,55 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0  the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "google/cloud/errors"
+
+describe Google::Cloud::Error, :cause do
+  def wrapped_std_error msg
+    begin
+      raise msg
+    rescue => std_err
+      raise Google::Cloud::Error.from_error std_err
+    end
+  rescue => gcoud_err
+    return gcoud_err
+  end
+
+  # These tests show Google::Cloud::Error#cause is available, even on ruby 2.0
+
+  it "always has a cause" do
+    error = wrapped_std_error "yo"
+
+    error.must_be_kind_of Google::Cloud::Error
+    error.message.must_equal "yo"
+
+    error.cause.wont_be :nil?
+    error.cause.must_be_kind_of StandardError
+    error.cause.message.must_equal "yo"
+
+    error.instance_variable_get(:@cause).must_be_kind_of StandardError
+    error.instance_variable_get(:@cause).message.must_equal "yo"
+  end
+
+  it "can have a nil cause" do
+    error = Google::Cloud::Error.new "sup"
+
+    error.must_be_kind_of Google::Cloud::Error
+    error.message.must_equal "sup"
+
+    error.cause.must_be :nil?
+
+    error.instance_variable_get(:@cause).must_be :nil?
+  end
+end

--- a/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
@@ -34,6 +34,14 @@ describe Google::Cloud::Error, :cause do
     error.must_be_kind_of Google::Cloud::Error
     error.message.must_equal "yo"
 
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+
     error.cause.wont_be :nil?
     error.cause.must_be_kind_of StandardError
     error.cause.message.must_equal "yo"
@@ -47,6 +55,14 @@ describe Google::Cloud::Error, :cause do
 
     error.must_be_kind_of Google::Cloud::Error
     error.message.must_equal "sup"
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
 
     error.cause.must_be :nil?
 

--- a/google-cloud-core/test/google/cloud/errors/grpc_errors_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/grpc_errors_test.rb
@@ -78,7 +78,7 @@ describe Google::Cloud::Error, :grpc do
   end
 
   it "identifies InternalError" do
-    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(13, "InternalError")
+    mapped_error = Google::Cloud::Error.from_error GRPC::BadStatus.new(13, "internal")
     mapped_error.must_be_kind_of Google::Cloud::InternalError
   end
 

--- a/google-cloud-core/test/google/cloud/errors/wrapped_gapi_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/wrapped_gapi_test.rb
@@ -1,0 +1,332 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0  the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "google/cloud/errors"
+require "google/apis/errors"
+
+describe Google::Cloud::Error, :wrapped_gapi do
+  def wrapped_error msg, status, body = nil, header = nil
+    err = gapi_error msg, status, body, header
+    begin
+      begin
+        raise err
+      rescue => inner_err
+        raise Google::Cloud::Error.from_error inner_err
+      end
+    rescue => e
+      return e
+    end
+  end
+
+  def gapi_error msg, status, body = nil, header = nil
+    Google::Apis::Error.new msg, status_code: status, body: body, header: header
+  end
+
+  it "wraps InvalidArgumentError" do
+    error = wrapped_error "invalid", 400, "invalid body", ["invalid headers"]
+    error.must_be_kind_of Google::Cloud::InvalidArgumentError
+
+    error.message.must_equal "invalid"
+    error.status_code.must_equal 400
+    error.body.must_equal "invalid body"
+    error.header.must_equal ["invalid headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps FailedPreconditionError" do
+    skip "don't know how we differentiate this error yet"
+
+    error = wrapped_error "precondition", 400, "precondition body", ["precondition headers"]
+    error.must_be_kind_of Google::Cloud::FailedPreconditionError
+
+    error.message.must_equal "precondition"
+    error.status_code.must_equal 400
+    error.body.must_equal "precondition body"
+    error.header.must_equal ["precondition headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps OutOfRangeError" do
+    skip "don't know how we differentiate this error yet"
+
+    error = wrapped_error "out of range", 400, "out of range body", ["out of range headers"]
+    error.must_be_kind_of Google::Cloud::OutOfRangeError
+
+    error.message.must_equal "out of range"
+    error.status_code.must_equal 400
+    error.body.must_equal "out of range body"
+    error.header.must_equal ["out of range headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps UnauthenticatedError" do
+    error = wrapped_error "unauthenticated", 401, "unauthenticated body", ["unauthenticated headers"]
+    error.must_be_kind_of Google::Cloud::UnauthenticatedError
+
+    error.message.must_equal "unauthenticated"
+    error.status_code.must_equal 401
+    error.body.must_equal "unauthenticated body"
+    error.header.must_equal ["unauthenticated headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps PermissionDeniedError" do
+    error = wrapped_error "denied", 403, "denied body", ["denied headers"]
+    error.must_be_kind_of Google::Cloud::PermissionDeniedError
+
+    error.message.must_equal "denied"
+    error.status_code.must_equal 403
+    error.body.must_equal "denied body"
+    error.header.must_equal ["denied headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps NotFoundError" do
+    error = wrapped_error "notfound", 404, "notfound body", ["notfound headers"]
+    error.must_be_kind_of Google::Cloud::NotFoundError
+
+    error.message.must_equal "notfound"
+    error.status_code.must_equal 404
+    error.body.must_equal "notfound body"
+    error.header.must_equal ["notfound headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps AlreadyExistsError" do
+    error = wrapped_error "exists", 409, "exists body", ["exists headers"]
+    error.must_be_kind_of Google::Cloud::AlreadyExistsError
+
+    error.message.must_equal "exists"
+    error.status_code.must_equal 409
+    error.body.must_equal "exists body"
+    error.header.must_equal ["exists headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps AbortedError" do
+    skip "don't know how we differentiate this error yet"
+
+    error = wrapped_error "aborted", 409, "aborted body", ["aborted headers"]
+    error.must_be_kind_of Google::Cloud::AbortedError
+
+    error.message.must_equal "aborted"
+    error.status_code.must_equal 409
+    error.body.must_equal "aborted body"
+    error.header.must_equal ["aborted headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps invalid (411) error" do
+    # We don't know what to map this error case to
+    error = wrapped_error "invalid", 411, "invalid body", ["invalid headers"]
+    error.must_be_kind_of Google::Cloud::Error
+
+    error.message.must_equal "invalid"
+    error.status_code.must_equal 411
+    error.body.must_equal "invalid body"
+    error.header.must_equal ["invalid headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps FailedPreconditionError" do
+    error = wrapped_error "conditionNotMet", 412, "conditionNotMet body", ["conditionNotMet headers"]
+    error.must_be_kind_of Google::Cloud::FailedPreconditionError
+
+    error.message.must_equal "conditionNotMet"
+    error.status_code.must_equal 412
+    error.body.must_equal "conditionNotMet body"
+    error.header.must_equal ["conditionNotMet headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps ResourceExhaustedError" do
+    error = wrapped_error "exhausted", 429, "exhausted body", ["exhausted headers"]
+    error.must_be_kind_of Google::Cloud::ResourceExhaustedError
+
+    error.message.must_equal "exhausted"
+    error.status_code.must_equal 429
+    error.body.must_equal "exhausted body"
+    error.header.must_equal ["exhausted headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps CanceledError" do
+    error = wrapped_error "canceled", 499, "canceled body", ["canceled headers"]
+    error.must_be_kind_of Google::Cloud::CanceledError
+
+    error.message.must_equal "canceled"
+    error.status_code.must_equal 499
+    error.body.must_equal "canceled body"
+    error.header.must_equal ["canceled headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps InternalError" do
+    error = wrapped_error "internal", 500, "internal body", ["internal headers"]
+    error.must_be_kind_of Google::Cloud::InternalError
+
+    error.message.must_equal "internal"
+    error.status_code.must_equal 500
+    error.body.must_equal "internal body"
+    error.header.must_equal ["internal headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps UnknownError" do
+    skip "don't know how we differentiate this error yet"
+
+    error = wrapped_error "unknown", 500, "unknown body", ["unknown headers"]
+    error.must_be_kind_of Google::Cloud::UnknownError
+
+    error.message.must_equal "invalid"
+    error.status_code.must_equal 500
+    error.body.must_equal "invalid body"
+    error.header.must_equal ["invalid headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps DataLossError" do
+    skip "don't know how we differentiate this error yet"
+
+    error = wrapped_error "data loss", 500, "data loss body", ["data loss headers"]
+    error.must_be_kind_of Google::Cloud::DataLossError
+
+    error.message.must_equal "data loss"
+    error.status_code.must_equal 500
+    error.body.must_equal "data loss body"
+    error.header.must_equal ["data loss headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps UnimplementedError" do
+    error = wrapped_error "unimplemented", 501, "unimplemented body", ["unimplemented headers"]
+    error.must_be_kind_of Google::Cloud::UnimplementedError
+
+    error.message.must_equal "unimplemented"
+    error.status_code.must_equal 501
+    error.body.must_equal "unimplemented body"
+    error.header.must_equal ["unimplemented headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps UnavailableError" do
+    error = wrapped_error "unavailable", 503, "unavailable body", ["unavailable headers"]
+    error.must_be_kind_of Google::Cloud::UnavailableError
+
+    error.message.must_equal "unavailable"
+    error.status_code.must_equal 503
+    error.body.must_equal "unavailable body"
+    error.header.must_equal ["unavailable headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps DeadlineExceededError" do
+    error = wrapped_error "exceeded", 504, "exceeded body", ["exceeded headers"]
+    error.must_be_kind_of Google::Cloud::DeadlineExceededError
+
+    error.message.must_equal "exceeded"
+    error.status_code.must_equal 504
+    error.body.must_equal "exceeded body"
+    error.header.must_equal ["exceeded headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+
+  it "wraps unknown error" do
+    error = wrapped_error "unknown", 999, "unknown body", ["unknown headers"]
+    error.must_be_kind_of Google::Cloud::Error
+
+    error.message.must_equal "unknown"
+    error.status_code.must_equal 999
+    error.body.must_equal "unknown body"
+    error.header.must_equal ["unknown headers"]
+
+    error.code.must_be :nil?
+    error.details.must_be :nil?
+    error.metadata.must_be :nil?
+    error.status_details.must_be :nil?
+  end
+end

--- a/google-cloud-core/test/google/cloud/errors/wrapped_gax_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/wrapped_gax_test.rb
@@ -1,0 +1,324 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0  the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "google/cloud/errors"
+require "grpc/errors"
+require "google/gax/errors"
+
+describe Google::Cloud::Error, :wrapped_gax do
+  def debug_info
+    Google::Rpc::DebugInfo.new detail: "lolz"
+  end
+  def encoded_protobuf
+    any = Google::Protobuf::Any.new
+    any.pack debug_info
+
+    status = Google::Rpc::Status.new details: [any]
+
+    Google::Rpc::Status.encode status
+  end
+
+  def wrapped_error status, msg, metadata = {}
+    err = grpc_error status, msg, metadata
+    begin
+      begin
+        begin
+          raise err
+        rescue => inner_err
+          raise Google::Gax::GaxError.new(inner_err.message)
+        end
+      rescue => gax_err
+        raise Google::Cloud::Error.from_error gax_err.cause
+      end
+    rescue => e
+      return e
+    end
+  end
+
+  def grpc_error status, msg, metadata = {}
+    GRPC::BadStatus.new status, msg, metadata
+  end
+
+  it "wraps CanceledError" do
+    error = wrapped_error 1, "cancelled", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::CanceledError
+
+    error.message.must_equal "1:cancelled"
+    error.code.must_equal 1
+    error.details.must_equal "cancelled"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps UnknownError" do
+    error = wrapped_error 2, "unknown", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::UnknownError
+
+    error.message.must_equal "2:unknown"
+    error.code.must_equal 2
+    error.details.must_equal "unknown"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps InvalidArgumentError" do
+    error = wrapped_error 3, "invalid", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::InvalidArgumentError
+
+    error.message.must_equal "3:invalid"
+    error.code.must_equal 3
+    error.details.must_equal "invalid"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps DeadlineExceededError" do
+    error = wrapped_error 4, "exceeded", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::DeadlineExceededError
+
+    error.message.must_equal "4:exceeded"
+    error.code.must_equal 4
+    error.details.must_equal "exceeded"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps NotFoundError" do
+    error = wrapped_error 5, "not found", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::NotFoundError
+
+    error.message.must_equal "5:not found"
+    error.code.must_equal 5
+    error.details.must_equal "not found"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps AlreadyExistsError" do
+    error = wrapped_error 6, "exists", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::AlreadyExistsError
+
+    error.message.must_equal "6:exists"
+    error.code.must_equal 6
+    error.details.must_equal "exists"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps PermissionDeniedError" do
+    error = wrapped_error 7, "denied", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::PermissionDeniedError
+
+    error.message.must_equal "7:denied"
+    error.code.must_equal 7
+    error.details.must_equal "denied"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps ResourceExhaustedError" do
+    error = wrapped_error 8, "exhausted", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::ResourceExhaustedError
+
+    error.message.must_equal "8:exhausted"
+    error.code.must_equal 8
+    error.details.must_equal "exhausted"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps FailedPreconditionError" do
+    error = wrapped_error 9, "precondition", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::FailedPreconditionError
+
+    error.message.must_equal "9:precondition"
+    error.code.must_equal 9
+    error.details.must_equal "precondition"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps AbortedError" do
+    error = wrapped_error 10, "aborted", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::AbortedError
+
+    error.message.must_equal "10:aborted"
+    error.code.must_equal 10
+    error.details.must_equal "aborted"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps OutOfRangeError" do
+    error = wrapped_error 11, "out of range", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::OutOfRangeError
+
+    error.message.must_equal "11:out of range"
+    error.code.must_equal 11
+    error.details.must_equal "out of range"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps UnimplementedError" do
+    error = wrapped_error 12, "unimplemented", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::UnimplementedError
+
+    error.message.must_equal "12:unimplemented"
+    error.code.must_equal 12
+    error.details.must_equal "unimplemented"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps InternalError" do
+    error = wrapped_error 13, "internal", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::InternalError
+
+    error.message.must_equal "13:internal"
+    error.code.must_equal 13
+    error.details.must_equal "internal"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps UnavailableError" do
+    error = wrapped_error 14, "unavailable", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::UnavailableError
+
+    error.message.must_equal "14:unavailable"
+    error.code.must_equal 14
+    error.details.must_equal "unavailable"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps DataLossError" do
+    error = wrapped_error 15, "data loss", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::DataLossError
+
+    error.message.must_equal "15:data loss"
+    error.code.must_equal 15
+    error.details.must_equal "data loss"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps UnauthenticatedError" do
+    error = wrapped_error 16, "unauthenticated", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::UnauthenticatedError
+
+    error.message.must_equal "16:unauthenticated"
+    error.code.must_equal 16
+    error.details.must_equal "unauthenticated"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps unknown error (0)" do
+    # We don't know what to map this error case to
+    error = wrapped_error 0, "unknown", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::Error
+
+    error.message.must_equal "0:unknown"
+    error.code.must_equal 0
+    error.details.must_equal "unknown"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps unknown error (17)" do
+    error = wrapped_error 17, "unknown", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf }
+    error.must_be_kind_of Google::Cloud::Error
+
+    error.message.must_equal "17:unknown"
+    error.code.must_equal 17
+    error.details.must_equal "unknown"
+    error.metadata["foo"].must_equal "bar"
+    error.status_details.must_equal [debug_info]
+
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+end

--- a/google-cloud-core/test/google/cloud/errors/wrapped_grpc_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/wrapped_grpc_test.rb
@@ -1,0 +1,307 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0  the "License";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "google/cloud/errors"
+require "grpc/errors"
+
+describe Google::Cloud::Error, :wrapped_grpc do
+  def wrapped_error status, msg, metadata = {}
+    err = grpc_error status, msg, metadata
+    begin
+      begin
+        raise err
+      rescue => inner_err
+        raise Google::Cloud::Error.from_error inner_err
+      end
+    rescue => e
+      return e
+    end
+  end
+
+  def grpc_error status, msg, metadata = {}
+    GRPC::BadStatus.new status, msg, metadata
+  end
+
+  it "wraps CanceledError" do
+    error = wrapped_error 1, "cancelled", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::CanceledError
+
+    error.message.must_equal "1:cancelled"
+    error.code.must_equal 1
+    error.details.must_equal "cancelled"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps UnknownError" do
+    error = wrapped_error 2, "unknown", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::UnknownError
+
+    error.message.must_equal "2:unknown"
+    error.code.must_equal 2
+    error.details.must_equal "unknown"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps InvalidArgumentError" do
+    error = wrapped_error 3, "invalid", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::InvalidArgumentError
+
+    error.message.must_equal "3:invalid"
+    error.code.must_equal 3
+    error.details.must_equal "invalid"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps DeadlineExceededError" do
+    error = wrapped_error 4, "exceeded", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::DeadlineExceededError
+
+    error.message.must_equal "4:exceeded"
+    error.code.must_equal 4
+    error.details.must_equal "exceeded"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps NotFoundError" do
+    error = wrapped_error 5, "not found", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::NotFoundError
+
+    error.message.must_equal "5:not found"
+    error.code.must_equal 5
+    error.details.must_equal "not found"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps AlreadyExistsError" do
+    error = wrapped_error 6, "exists", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::AlreadyExistsError
+
+    error.message.must_equal "6:exists"
+    error.code.must_equal 6
+    error.details.must_equal "exists"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps PermissionDeniedError" do
+    error = wrapped_error 7, "denied", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::PermissionDeniedError
+
+    error.message.must_equal "7:denied"
+    error.code.must_equal 7
+    error.details.must_equal "denied"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps ResourceExhaustedError" do
+    error = wrapped_error 8, "exhausted", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::ResourceExhaustedError
+
+    error.message.must_equal "8:exhausted"
+    error.code.must_equal 8
+    error.details.must_equal "exhausted"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps FailedPreconditionError" do
+    error = wrapped_error 9, "precondition", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::FailedPreconditionError
+
+    error.message.must_equal "9:precondition"
+    error.code.must_equal 9
+    error.details.must_equal "precondition"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps AbortedError" do
+    error = wrapped_error 10, "aborted", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::AbortedError
+
+    error.message.must_equal "10:aborted"
+    error.code.must_equal 10
+    error.details.must_equal "aborted"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps OutOfRangeError" do
+    error = wrapped_error 11, "out of range", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::OutOfRangeError
+
+    error.message.must_equal "11:out of range"
+    error.code.must_equal 11
+    error.details.must_equal "out of range"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps UnimplementedError" do
+    error = wrapped_error 12, "unimplemented", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::UnimplementedError
+
+    error.message.must_equal "12:unimplemented"
+    error.code.must_equal 12
+    error.details.must_equal "unimplemented"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps InternalError" do
+    error = wrapped_error 13, "internal", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::InternalError
+
+    error.message.must_equal "13:internal"
+    error.code.must_equal 13
+    error.details.must_equal "internal"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps UnavailableError" do
+    error = wrapped_error 14, "unavailable", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::UnavailableError
+
+    error.message.must_equal "14:unavailable"
+    error.code.must_equal 14
+    error.details.must_equal "unavailable"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps DataLossError" do
+    error = wrapped_error 15, "data loss", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::DataLossError
+
+    error.message.must_equal "15:data loss"
+    error.code.must_equal 15
+    error.details.must_equal "data loss"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps UnauthenticatedError" do
+    error = wrapped_error 16, "unauthenticated", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::UnauthenticatedError
+
+    error.message.must_equal "16:unauthenticated"
+    error.code.must_equal 16
+    error.details.must_equal "unauthenticated"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps unknown error (0)" do
+    # We don't know what to map this error case to
+    error = wrapped_error 0, "unknown", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::Error
+
+    error.message.must_equal "0:unknown"
+    error.code.must_equal 0
+    error.details.must_equal "unknown"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+
+  it "wraps unknown error (17)" do
+    error = wrapped_error 17, "unknown", { "foo" => "bar" }
+    error.must_be_kind_of Google::Cloud::Error
+
+    error.message.must_equal "17:unknown"
+    error.code.must_equal 17
+    error.details.must_equal "unknown"
+    error.metadata.must_equal({ "foo" => "bar" })
+
+    error.status_details.must_be :nil?
+    error.status_code.must_be :nil?
+    error.body.must_be :nil?
+    error.header.must_be :nil?
+  end
+end

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
   gem.add_dependency "google-protobuf", "~> 3.3"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -1166,10 +1166,8 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
 
     error.wont_be :nil?
     error.message.must_equal "Transaction failed to commit."
-    if error.respond_to? :cause
-      error.cause.wont_be :nil?
-      error.cause.message.must_equal "This error should be wrapped by TransactionError."
-    end
+    error.cause.wont_be :nil?
+    error.cause.message.must_equal "This error should be wrapped by TransactionError."
   end
 
   it "transaction will wrap errors for both commit and rollback" do
@@ -1206,12 +1204,10 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
 
       error.wont_be :nil?
       error.message.must_equal "Transaction failed to commit and rollback."
-      if error.respond_to? :cause # ruby 2.0 doesn't have cause
-        error.cause.wont_be :nil?
-        error.cause.message.must_equal "rollback error"
-        error.cause.cause.wont_be :nil?
-        error.cause.cause.message.must_equal "commit error"
-      end
+      error.cause.wont_be :nil?
+      error.cause.message.must_equal "rollback error"
+      error.cause.cause.wont_be :nil?
+      error.cause.cause.message.must_equal "commit error"
     ensure
       # Reset mocked service so the call to verify works.
       dataset.service = mocked_service

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -1203,11 +1203,15 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
       end
 
       error.wont_be :nil?
+      error.must_be_kind_of Google::Cloud::Datastore::TransactionError
       error.message.must_equal "Transaction failed to commit and rollback."
       error.cause.wont_be :nil?
+      error.cause.must_be_kind_of RuntimeError
       error.cause.message.must_equal "rollback error"
-      error.cause.cause.wont_be :nil?
-      error.cause.cause.message.must_equal "commit error"
+      if error.cause.respond_to? :cause # RuntimeError#cause not on Ruby 2.0
+        error.cause.cause.must_be_kind_of RuntimeError
+        error.cause.cause.message.must_equal "commit error"
+      end
     ensure
       # Reset mocked service so the call to verify works.
       dataset.service = mocked_service

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "binding_of_caller", "~> 0.7"
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "google-cloud-logging", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
   gem.add_dependency "stackdriver-core", "~> 1.2"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "stackdriver-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
   gem.add_dependency "googleapis-common-protos", "~> 1.3.1"
   gem.add_dependency "googleauth", "~> 0.6.1"
 

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "stackdriver-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rubocop", "<= 0.35.1"

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -119,8 +119,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   end
 
   it "retries aborted transactions with retry metadata seconds" do
-    skip "Can't get trailing metadata on Ruby 2.0" unless Exception.instance_methods.include? :cause
-
     mutations = [
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
@@ -175,8 +173,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   end
 
   it "retries aborted transactions with retry metadata seconds and nanos" do
-    skip "Can't get trailing metadata on Ruby 2.0" unless Exception.instance_methods.include? :cause
-
     mutations = [
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
@@ -231,8 +227,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   end
 
   it "retries multiple aborted transactions" do
-    skip "Can't get trailing metadata on Ruby 2.0" unless Exception.instance_methods.include? :cause
-
     mutations = [
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
@@ -297,8 +291,6 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   end
 
   it "retries with incremental backoff until deadline has passed" do
-    skip "Can't get trailing metadata on Ruby 2.0" unless Exception.instance_methods.include? :cause
-
     mutations = [
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
   gem.add_dependency "stackdriver-core", "~> 1.2"
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
+++ b/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rubocop", "<= 0.35.1"

--- a/google-cloud-vision/google-cloud-vision.gemspec
+++ b/google-cloud-vision/google-cloud-vision.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.0"
-  gem.add_dependency "google-gax", "~> 0.9.2"
+  gem.add_dependency "google-gax", "~> 0.10.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"


### PR DESCRIPTION
Add helper methods to access wrapped error methods. This includes `GaxError#status_details` used by Logging's `partial_success` feature that returns additional information through GRPC's trailing metadata.

[closes #1791]