### PR TITLE
Add Datastore TransactionOptions

### DIFF
--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -601,7 +601,7 @@ describe "Datastore", :datastore do
         ancestor(book.key)
       entities = nil
 
-      tx = dataset.transaction read_only: true do |tx|
+      tx = dataset.read_only_transaction do |tx|
         fresh = tx.find book.key
         entities = dataset.run query
       end

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -596,6 +596,18 @@ describe "Datastore", :datastore do
       entities.count.must_equal 6
     end
 
+    it "should find and run query in a read-only transaction" do
+      query = dataset.query("Character").
+        ancestor(book.key)
+      entities = nil
+
+      tx = dataset.transaction read_only: true do |tx|
+        fresh = tx.find book.key
+        entities = dataset.run query
+      end
+      entities.count.must_equal 8
+    end
+
     after do
       dataset.delete *characters
     end

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -603,7 +603,7 @@ describe "Datastore", :datastore do
 
       tx = dataset.read_only_transaction do |tx|
         fresh = tx.find book.key
-        entities = dataset.run query
+        entities = tx.run query
       end
       entities.count.must_equal 8
     end
@@ -663,7 +663,7 @@ describe "Datastore", :datastore do
       dataset.save dataset.entity("Post", "#{prefix}_post5")
 
       tx = dataset.transaction do |tx|
-        in_tx_refresh = tx.find tx.key("Post", "#{prefix}_post5")
+        in_tx_refresh = tx.find dataset.key("Post", "#{prefix}_post5")
         tx.delete in_tx_refresh if in_tx_refresh
       end
 

--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -369,6 +369,30 @@ module Google
     # end
     # ```
     #
+    # A read-only transaction cannot modify entities; in return they do not
+    # contend with other read-write or read-only transactions. Using a read-only
+    # transaction for transactions that only read data will potentially improve
+    # throughput.
+    #
+    # ```ruby
+    # require "google/cloud/datastore"
+    #
+    # datastore = Google::Cloud::Datastore.new
+    #
+    # task_list_key = datastore.key "TaskList", "default"
+    # query = datastore.query("Task").
+    #   ancestor(task_list_key)
+    #
+    # tasks = nil
+    #
+    # datastore.transaction read_only: true do |tx|
+    #   task_list = tx.find task_list_key
+    #   if task_list
+    #     tasks = tx.run query
+    #   end
+    # end
+    # ```
+    #
     # See {Google::Cloud::Datastore::Transaction} and
     # {Google::Cloud::Datastore::Dataset#transaction}
     #

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -544,12 +544,19 @@ module Google
         end
 
         ##
-        # Creates a read-only Datastore transaction that only allows reads.
+        # Creates a read-only transaction that provides a consistent snapshot of
+        # Cloud Datastore. This can be useful when multiple reads are needed to
+        # render a page or export data that must be consistent.
         #
         # A read-only transaction cannot modify entities; in return they do not
         # contend with other read-write or read-only transactions. Using a
         # read-only transaction for transactions that only read data will
         # potentially improve throughput.
+        #
+        # Read-only single-group transactions never fail due to concurrent
+        # modifications, so you don't have to implement retries upon failure.
+        # However, multi-entity-group transactions can fail due to concurrent
+        # modifications, so these should have retries.
         #
         # @see https://cloud.google.com/datastore/docs/concepts/transactions
         #   Transactions
@@ -592,6 +599,7 @@ module Google
             raise TransactionError, "Transaction failed to commit."
           end
         end
+        alias_method :snapshot, :read_only_transaction
 
         ##
         # Create a new Query instance. This is a convenience method to make the

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -25,6 +25,7 @@ require "google/cloud/datastore/gql_query"
 require "google/cloud/datastore/cursor"
 require "google/cloud/datastore/dataset/lookup_results"
 require "google/cloud/datastore/dataset/query_results"
+require "google/cloud/datastore/transaction"
 
 module Google
   module Cloud
@@ -542,9 +543,9 @@ module Google
         #   Transactions
         #
         # @yield [tx] a block yielding a new transaction
-        # @yieldparam [Transaction] tx the transaction object
+        # @yieldparam [ReadOnlyTransaction] tx the transaction object
         #
-        # @example Use a read-only transaction when only performing reads:
+        # @example
         #   require "google/cloud/datastore"
         #
         #   datastore = Google::Cloud::Datastore.new
@@ -563,7 +564,7 @@ module Google
         #   end
         #
         def read_only_transaction
-          tx = Transaction.new service, read_only: true
+          tx = ReadOnlyTransaction.new service
           return tx unless block_given?
 
           begin

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -466,6 +466,15 @@ module Google
         ##
         # Creates a Datastore Transaction.
         #
+        # @see https://cloud.google.com/datastore/docs/concepts/transactions
+        #   Transactions
+        #
+        # @param [Boolean] read_only Whether the transaction should only allow
+        #   reads. A read-only transaction cannot modify entities; in return
+        #   they do not contend with other read-write or read-only transactions.
+        #   Using a read-only transaction for transactions that only read data
+        #   will potentially improve throughput. Optional. The default is `nil`.
+        #
         # @yield [tx] a block yielding a new transaction
         # @yieldparam [Transaction] tx the transaction object
         #
@@ -509,8 +518,26 @@ module Google
         #     tx.rollback
         #   end
         #
-        def transaction
-          tx = Transaction.new service
+        # @example Use a read-only transaction when only performing reads:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task_list_key = datastore.key "TaskList", "default"
+        #   query = datastore.query("Task").
+        #     ancestor(task_list_key)
+        #
+        #   tasks = nil
+        #
+        #   datastore.transaction read_only: true do |tx|
+        #     task_list = tx.find task_list_key
+        #     if task_list
+        #       tasks = tx.run query
+        #     end
+        #   end
+        #
+        def transaction read_only: nil
+          tx = Transaction.new service, read_only: read_only
           return tx unless block_given?
 
           begin

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -471,6 +471,16 @@ module Google
         # @see https://cloud.google.com/datastore/docs/concepts/transactions
         #   Transactions
         #
+        # @param [String] previous_transaction The transaction identifier of a
+        #   transaction that is being retried. Read-write transactions may fail
+        #   due to contention. A read-write transaction can be retried by
+        #   specifying `previous_transaction` when creating the new transaction.
+        #
+        #   Specifying `previous_transaction` provides information that can be
+        #   used to improve throughput. In particular, if transactional
+        #   operations A and B conflict, specifying the `previous_transaction`
+        #   can help to prevent livelock. (See {Transaction#id})
+        #
         # @yield [tx] a block yielding a new transaction
         # @yieldparam [Transaction] tx the transaction object
         #
@@ -514,8 +524,9 @@ module Google
         #     tx.rollback
         #   end
         #
-        def transaction
-          tx = Transaction.new service
+        def transaction previous_transaction: nil
+          tx = Transaction.new service,
+                               previous_transaction: previous_transaction
           return tx unless block_given?
 
           begin

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -26,6 +26,7 @@ require "google/cloud/datastore/cursor"
 require "google/cloud/datastore/dataset/lookup_results"
 require "google/cloud/datastore/dataset/query_results"
 require "google/cloud/datastore/transaction"
+require "google/cloud/datastore/read_only_transaction"
 
 module Google
   module Cloud

--- a/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
@@ -1,0 +1,212 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Datastore
+      ##
+      # # ReadOnlyTransaction
+      #
+      # Special Connection instance for running transactions.
+      #
+      # See {Google::Cloud::Datastore::Dataset#transaction}
+      #
+      # @see https://cloud.google.com/datastore/docs/concepts/transactions
+      #   Transactions
+      #
+      # @example Transactional read:
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new
+      #
+      #   task_list_key = datastore.key "TaskList", "default"
+      #   datastore.transaction do |tx|
+      #     task_list = tx.find task_list_key
+      #     query = tx.query("Task").ancestor(task_list)
+      #     tasks_in_list = tx.run query
+      #   end
+      #
+      class ReadOnlyTransaction < Dataset
+        attr_reader :id
+
+        ##
+        # @private Creates a new ReadOnlyTransaction instance.
+        # Takes a Service instead of project and Credentials.
+        #
+        def initialize service
+          @service = service
+          reset!
+          start
+        end
+
+        ##
+        # Retrieve an entity by providing key information. The lookup is run
+        # within the transaction.
+        #
+        # @param [Key, String] key_or_kind A Key object or `kind` string value.
+        #
+        # @return [Google::Cloud::Datastore::Entity, nil]
+        #
+        # @example Finding an entity with a key:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task_key = datastore.key "Task", "sampleTask"
+        #   task = datastore.find task_key
+        #
+        # @example Finding an entity with a `kind` and `id`/`name`:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.find "Task", "sampleTask"
+        #
+        def find key_or_kind, id_or_name = nil
+          key = key_or_kind
+          unless key.is_a? Google::Cloud::Datastore::Key
+            key = Key.new key_or_kind, id_or_name
+          end
+          find_all(key).first
+        end
+        alias_method :get, :find
+
+        ##
+        # Retrieve the entities for the provided keys. The lookup is run within
+        # the transaction.
+        #
+        # @param [Key] keys One or more Key objects to find records for.
+        #
+        # @return [Google::Cloud::Datastore::Dataset::LookupResults]
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task_key1 = datastore.key "Task", 123456
+        #   task_key2 = datastore.key "Task", 987654
+        #   tasks = datastore.find_all task_key1, task_key2
+        #
+        def find_all *keys
+          ensure_service!
+          lookup_res = service.lookup(*Array(keys).flatten.map(&:to_grpc),
+                                      transaction: @id)
+          LookupResults.from_grpc lookup_res, service, nil, @id
+        end
+        alias_method :lookup, :find_all
+
+        ##
+        # Retrieve entities specified by a Query. The query is run within the
+        # transaction.
+        #
+        # @param [Query] query The Query object with the search criteria.
+        # @param [String] namespace The namespace the query is to run within.
+        #
+        # @return [Google::Cloud::Datastore::Dataset::QueryResults]
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   query = datastore.query("Task").
+        #     where("done", "=", false)
+        #   datastore.transaction do |tx|
+        #     tasks = tx.run query
+        #   end
+        #
+        def run query, namespace: nil
+          ensure_service!
+          unless query.is_a?(Query) || query.is_a?(GqlQuery)
+            fail ArgumentError, "Cannot run a #{query.class} object."
+          end
+          query_res = service.run_query query.to_grpc, namespace,
+                                        transaction: @id
+          QueryResults.from_grpc query_res, service, namespace,
+                                 query.to_grpc.dup
+        end
+        alias_method :run_query, :run
+
+        ##
+        # Begins a transaction.
+        # This method is run when a new ReadOnlyTransaction is created.
+        #
+        def start
+          fail TransactionError, "Transaction already opened." unless @id.nil?
+
+          ensure_service!
+          tx_res = service.begin_transaction read_only: true
+          @id = tx_res.transaction
+        end
+        alias_method :begin_transaction, :start
+
+        ##
+        # Commits the transaction.
+        #
+        def commit
+          fail TransactionError,
+               "Cannot commit when not in a transaction." if @id.nil?
+
+          ensure_service!
+
+          service.commit [], transaction: @id
+          true
+        end
+
+        ##
+        # Rolls back the transaction.
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.entity "Task" do |t|
+        #     t["type"] = "Personal"
+        #     t["done"] = false
+        #     t["priority"] = 4
+        #     t["description"] = "Learn Cloud Datastore"
+        #   end
+        #
+        #   tx = datastore.transaction
+        #   begin
+        #     if tx.find(task.key).nil?
+        #       tx.save task
+        #     end
+        #     tx.commit
+        #   rescue
+        #     tx.rollback
+        #   end
+        def rollback
+          if @id.nil?
+            fail TransactionError, "Cannot rollback when not in a transaction."
+          end
+
+          ensure_service!
+          service.rollback @id
+          true
+        end
+
+        ##
+        # Reset the transaction.
+        # {ReadOnlyTransaction#start} must be called afterwards.
+        def reset!
+          @id = nil
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -110,8 +110,14 @@ module Google
 
         ##
         # Begin a new transaction.
-        def begin_transaction
-          execute { service.begin_transaction project }
+        def begin_transaction read_only: nil
+          transaction_options = Google::Datastore::V1::TransactionOptions.new(
+            read_only: Google::Datastore::V1::TransactionOptions::ReadOnly.new
+          ) if read_only
+          execute do
+            service.begin_transaction project,
+                                      transaction_options: transaction_options
+          end
         end
 
         ##

--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -110,10 +110,20 @@ module Google
 
         ##
         # Begin a new transaction.
-        def begin_transaction read_only: nil
-          transaction_options = Google::Datastore::V1::TransactionOptions.new(
-            read_only: Google::Datastore::V1::TransactionOptions::ReadOnly.new
-          ) if read_only
+        def begin_transaction read_only: nil, previous_transaction: nil
+          if read_only
+            transaction_options = Google::Datastore::V1::TransactionOptions.new
+            transaction_options.read_only = \
+              Google::Datastore::V1::TransactionOptions::ReadOnly.new
+          end
+          if previous_transaction
+            transaction_options ||= \
+              Google::Datastore::V1::TransactionOptions.new
+            rw = Google::Datastore::V1::TransactionOptions::ReadWrite.new(
+              previous_transaction: previous_transaction.encode("ASCII-8BIT")
+            )
+            transaction_options.read_write = rw
+          end
           execute do
             service.begin_transaction project,
                                       transaction_options: transaction_options

--- a/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
@@ -26,6 +26,8 @@ module Google
       # @see https://cloud.google.com/datastore/docs/concepts/transactions
       #   Transactions
       #
+      # @attr_reader [String] id The identifier of the transaction.
+      #
       # @example Transactional update:
       #   require "google/cloud/datastore"
       #
@@ -47,8 +49,9 @@ module Google
         ##
         # @private Creates a new Transaction instance.
         # Takes a Service instead of project and Credentials.
-        def initialize service
+        def initialize service, previous_transaction: nil
           @service = service
+          @previous_transaction = previous_transaction
           reset!
           start
         end
@@ -267,7 +270,8 @@ module Google
           fail TransactionError, "Transaction already opened." unless @id.nil?
 
           ensure_service!
-          tx_res = service.begin_transaction
+          tx_res = service.begin_transaction \
+            previous_transaction: @previous_transaction
           @id = tx_res.transaction
         end
         alias_method :begin_transaction, :start

--- a/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-require "google/cloud/datastore/read_only_transaction"
-
 module Google
   module Cloud
     module Datastore
@@ -43,19 +41,9 @@ module Google
       #     end
       #   end
       #
-      # @example Transactional read:
-      #   require "google/cloud/datastore"
-      #
-      #   datastore = Google::Cloud::Datastore.new
-      #
-      #   task_list_key = datastore.key "TaskList", "default"
-      #   datastore.transaction do |tx|
-      #     task_list = tx.find task_list_key
-      #     query = tx.query("Task").ancestor(task_list)
-      #     tasks_in_list = tx.run query
-      #   end
-      #
-      class Transaction < ReadOnlyTransaction
+      class Transaction < Dataset
+        attr_reader :id
+
         ##
         # @private Creates a new Transaction instance.
         # Takes a Service instead of project and Credentials.
@@ -174,6 +162,105 @@ module Google
         end
 
         ##
+        # Retrieve an entity by providing key information. The lookup is run
+        # within the transaction.
+        #
+        # @param [Key, String] key_or_kind A Key object or `kind` string value.
+        #
+        # @return [Google::Cloud::Datastore::Entity, nil]
+        #
+        # @example Finding an entity with a key:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task_key = datastore.key "Task", "sampleTask"
+        #   task = datastore.find task_key
+        #
+        # @example Finding an entity with a `kind` and `id`/`name`:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.find "Task", "sampleTask"
+        #
+        def find key_or_kind, id_or_name = nil
+          key = key_or_kind
+          unless key.is_a? Google::Cloud::Datastore::Key
+            key = Key.new key_or_kind, id_or_name
+          end
+          find_all(key).first
+        end
+        alias_method :get, :find
+
+        ##
+        # Retrieve the entities for the provided keys. The lookup is run within
+        # the transaction.
+        #
+        # @param [Key] keys One or more Key objects to find records for.
+        #
+        # @return [Google::Cloud::Datastore::Dataset::LookupResults]
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task_key1 = datastore.key "Task", 123456
+        #   task_key2 = datastore.key "Task", 987654
+        #   tasks = datastore.find_all task_key1, task_key2
+        #
+        def find_all *keys
+          ensure_service!
+          lookup_res = service.lookup(*Array(keys).flatten.map(&:to_grpc),
+                                      transaction: @id)
+          LookupResults.from_grpc lookup_res, service, nil, @id
+        end
+        alias_method :lookup, :find_all
+
+        ##
+        # Retrieve entities specified by a Query. The query is run within the
+        # transaction.
+        #
+        # @param [Query] query The Query object with the search criteria.
+        # @param [String] namespace The namespace the query is to run within.
+        #
+        # @return [Google::Cloud::Datastore::Dataset::QueryResults]
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   datastore.transaction do |tx|
+        #     query = datastore.query("Task")
+        #     tasks = tx.run query
+        #   end
+        #
+        # @example Run the query within a namespace with the `namespace` option:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   query = Google::Cloud::Datastore::Query.new.kind("Task").
+        #     where("done", "=", false)
+        #   datastore.transaction do |tx|
+        #     tasks = tx.run query, namespace: "example-ns"
+        #   end
+        #
+        def run query, namespace: nil
+          ensure_service!
+          unless query.is_a?(Query) || query.is_a?(GqlQuery)
+            fail ArgumentError, "Cannot run a #{query.class} object."
+          end
+          query_res = service.run_query query.to_grpc, namespace,
+                                        transaction: @id
+          QueryResults.from_grpc query_res, service, namespace,
+                                 query.to_grpc.dup
+        end
+        alias_method :run_query, :run
+
+        ##
         # Begins a transaction.
         # This method is run when a new Transaction is created.
         def start
@@ -245,6 +332,40 @@ module Google
           end
           # Make sure all entity keys are frozen so all show as persisted
           entities.each { |e| e.key.freeze unless e.persisted? }
+          true
+        end
+
+        ##
+        # Rolls a transaction back.
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task = datastore.entity "Task" do |t|
+        #     t["type"] = "Personal"
+        #     t["done"] = false
+        #     t["priority"] = 4
+        #     t["description"] = "Learn Cloud Datastore"
+        #   end
+        #
+        #   tx = datastore.transaction
+        #   begin
+        #     if tx.find(task.key).nil?
+        #       tx.save task
+        #     end
+        #     tx.commit
+        #   rescue
+        #     tx.rollback
+        #   end
+        def rollback
+          if @id.nil?
+            fail TransactionError, "Cannot rollback when not in a transaction."
+          end
+
+          ensure_service!
+          service.rollback @id
           true
         end
 

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -305,6 +305,39 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction") do
+    mock_datastore do |mock|
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
+      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
+    end
+  end
+
+  doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction@Transactional read:") do
+    mock_datastore do |mock|
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
+      mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
+      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
+    end
+  end
+
+  doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction#find") do
+    mock_datastore do |mock|
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
+      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
+    end
+  end
+
+  doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction#run") do
+    mock_datastore do |mock|
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
+      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
+    end
+  end
+
   doctest.before("Google::Cloud::Datastore::Transaction") do
     mock_datastore do |mock|
       mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
@@ -326,30 +359,6 @@ YARD::Doctest.configure do |doctest|
     mock_datastore do |mock|
       mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
-      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
-    end
-  end
-
-  doctest.before("Google::Cloud::Datastore::Transaction#find") do
-    mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
-      mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
-      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
-    end
-  end
-
-  doctest.before("Google::Cloud::Datastore::Transaction#run") do
-    mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
-      mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
-      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
-    end
-  end
-
-  doctest.before("Google::Cloud::Datastore::Transaction#run@Run the query within a namespace with the `namespace` option:") do
-    mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
-      mock.expect :run_query, run_query_res, ["my-todo-project", Google::Datastore::V1::PartitionId, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
   end

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -90,6 +90,7 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Datastore::Dataset#get"
   doctest.skip "Google::Cloud::Datastore::Dataset#lookup"
   doctest.skip "Google::Cloud::Datastore::Dataset#run_query"
+  doctest.skip "Google::Cloud::Datastore::Dataset#snapshot"
   doctest.skip "Google::Cloud::Datastore::Key#dataset_id"
   doctest.skip "Google::Cloud::Datastore::Query#filter"
   doctest.skip "Google::Cloud::Datastore::Query#cursor"

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -232,7 +232,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before("Google::Cloud::Datastore::Dataset#transaction@Use a read-only transaction when only performing reads:") do
+  doctest.before("Google::Cloud::Datastore::Dataset#read_only_transaction") do
     mock_datastore do |mock|
       mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", Hash]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -226,8 +226,17 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::Dataset#transaction") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project"]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
+      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
+    end
+  end
+
+  doctest.before("Google::Cloud::Datastore::Dataset#transaction@Use a read-only transaction when only performing reads:") do
+    mock_datastore do |mock|
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", Hash]
+      mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
+      mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
   end
@@ -298,7 +307,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::Transaction") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project"]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
@@ -306,7 +315,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::Transaction@Transactional read:") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project"]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
       mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
@@ -315,7 +324,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::Transaction#delete") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project"]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
@@ -323,7 +332,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::Transaction#find") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project"]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
@@ -331,7 +340,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::Transaction#run") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project"]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
@@ -339,7 +348,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::Transaction#run@Run the query within a namespace with the `namespace` option:") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project"]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :run_query, run_query_res, ["my-todo-project", Google::Datastore::V1::PartitionId, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
@@ -347,7 +356,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::Transaction#commit") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project"]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -100,6 +100,11 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Datastore::Transaction#lookup"
   doctest.skip "Google::Cloud::Datastore::Transaction#run_query"
   doctest.skip "Google::Cloud::Datastore::Transaction#begin_transaction"
+  doctest.skip "Google::Cloud::Datastore::ReadOnlyTransaction#upsert"
+  doctest.skip "Google::Cloud::Datastore::ReadOnlyTransaction#get"
+  doctest.skip "Google::Cloud::Datastore::ReadOnlyTransaction#lookup"
+  doctest.skip "Google::Cloud::Datastore::ReadOnlyTransaction#run_query"
+  doctest.skip "Google::Cloud::Datastore::ReadOnlyTransaction#begin_transaction"
 
   ##
   # BEFORE (mocking)
@@ -307,15 +312,16 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", Hash]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
+      mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
   end
 
-  doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction@Transactional read:") do
+  doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction#commit") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", Hash]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
       mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
@@ -324,15 +330,24 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction#find") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", Hash]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
   end
 
+  doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction#rollback") do
+    mock_datastore do |mock|
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", Hash]
+      mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
+      mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
+      mock.expect :rollback, OpenStruct.new(mutation_results: []), ["my-todo-project", String, Hash]
+    end
+  end
+
   doctest.before("Google::Cloud::Datastore::ReadOnlyTransaction#run") do
     mock_datastore do |mock|
-      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", Hash]
       mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
@@ -359,6 +374,30 @@ YARD::Doctest.configure do |doctest|
     mock_datastore do |mock|
       mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
       mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
+      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
+    end
+  end
+
+  doctest.before("Google::Cloud::Datastore::Transaction#find") do
+    mock_datastore do |mock|
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :lookup, lookup_res, ["my-todo-project", Array, Hash]
+      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
+    end
+  end
+
+  doctest.before("Google::Cloud::Datastore::Transaction#run") do
+    mock_datastore do |mock|
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :run_query, run_query_res, ["my-todo-project", nil, Hash]
+      mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
+    end
+  end
+
+  doctest.before("Google::Cloud::Datastore::Transaction#run@Run the query within a namespace with the `namespace` option:") do
+    mock_datastore do |mock|
+      mock.expect :begin_transaction, begin_tx_res, ["my-todo-project", transaction_options: nil]
+      mock.expect :run_query, run_query_res, ["my-todo-project", Google::Datastore::V1::PartitionId, Hash]
       mock.expect :commit, OpenStruct.new(mutation_results: []), ["my-todo-project", :TRANSACTIONAL, Array, Hash]
     end
   end

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -1154,6 +1154,19 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     tx.must_be_kind_of Google::Cloud::Datastore::ReadOnlyTransaction
   end
 
+  it "snapshot will return a read-only Transaction" do
+    tx_id = "giterdone".encode("ASCII-8BIT")
+    tx_options = Google::Datastore::V1::TransactionOptions.new(
+      read_write: nil,
+      read_only: Google::Datastore::V1::TransactionOptions::ReadOnly.new
+    )
+    begin_tx_res = Google::Datastore::V1::BeginTransactionResponse.new(transaction: tx_id)
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: tx_options]
+
+    tx = dataset.snapshot
+    tx.must_be_kind_of Google::Cloud::Datastore::ReadOnlyTransaction
+  end
+
   it "transaction will commit with a block" do
     tx_id = "giterdone".encode("ASCII-8BIT")
     begin_tx_res = Google::Datastore::V1::BeginTransactionResponse.new(transaction: tx_id)

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -1136,7 +1136,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: tx_options]
 
     tx = dataset.read_only_transaction
-    tx.must_be_kind_of Google::Cloud::Datastore::Transaction
+    tx.must_be_kind_of Google::Cloud::Datastore::ReadOnlyTransaction
   end
 
   it "transaction will commit with a block" do

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -1124,8 +1124,6 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     tx = dataset.transaction
     tx.must_be_kind_of Google::Cloud::Datastore::Transaction
     tx.id.must_equal "giterdone"
-    tx.wont_be :read_only?
-    tx.must_be :read_write?
   end
 
   it "transaction will return a read-only Transaction" do
@@ -1137,10 +1135,8 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     begin_tx_res = Google::Datastore::V1::BeginTransactionResponse.new(transaction: tx_id)
     dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: tx_options]
 
-    tx = dataset.transaction read_only: true
+    tx = dataset.read_only_transaction
     tx.must_be_kind_of Google::Cloud::Datastore::Transaction
-    tx.must_be :read_only?
-    tx.wont_be :read_write?
   end
 
   it "transaction will commit with a block" do

--- a/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
@@ -134,7 +134,7 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
       #   key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc
       # )]
     )
-    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project]
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: nil]
     dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [], transaction: tx_id, options: default_options]
     read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
     dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, first_keys, read_options: read_options, options: default_options]
@@ -232,7 +232,7 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
       #   key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc
       # )]
     )
-    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project]
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: nil]
     dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [], transaction: tx_id, options: default_options]
     read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
     dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, first_keys, read_options: read_options, options: default_options]
@@ -296,7 +296,7 @@ describe Google::Cloud::Datastore::Dataset, :find_all, :mock_datastore do
       #   key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc
       # )]
     )
-    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project]
+    dataset.service.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: nil]
     dataset.service.mocked_service.expect :commit, commit_res, [project, :TRANSACTIONAL, [], transaction: tx_id, options: default_options]
     read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
     dataset.service.mocked_service.expect :lookup, first_lookup_res,  [project, first_keys, read_options: read_options, options: default_options]

--- a/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
@@ -1,0 +1,147 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
+  let(:service) do
+    s = dataset.service
+    s.mocked_service = Minitest::Mock.new
+    s.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: Google::Datastore::V1::TransactionOptions.new(read_write: nil, read_only: Google::Datastore::V1::TransactionOptions::ReadOnly.new)]
+    s
+  end
+  let(:transaction) { Google::Cloud::Datastore::ReadOnlyTransaction.new service }
+  let(:commit_res) do
+    Google::Datastore::V1::CommitResponse.new(
+      mutation_results: [Google::Datastore::V1::MutationResult.new]
+    )
+  end
+  let(:lookup_res) do
+    Google::Datastore::V1::LookupResponse.new(
+      found: 2.times.map do
+        Google::Datastore::V1::EntityResult.new(
+          entity: Google::Datastore::V1::Entity.new(
+            key: Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc,
+            properties: { "name" => Google::Cloud::Datastore::Convert.to_value("thingamajig") }
+          )
+        )
+      end
+    )
+  end
+  let(:run_query_res) do
+    run_query_res_entities = 2.times.map do
+      Google::Datastore::V1::EntityResult.new(
+        entity: Google::Cloud::Datastore::Entity.new.tap do |e|
+          e.key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
+          e["name"] = "thingamajig"
+        end.to_grpc
+      )
+    end
+    Google::Datastore::V1::RunQueryResponse.new(
+      batch: Google::Datastore::V1::QueryResultBatch.new(
+        entity_results: run_query_res_entities,
+        end_cursor: Google::Cloud::Datastore::Convert.decode_bytes(query_cursor)
+      )
+    )
+  end
+  let(:query_cursor) { Google::Cloud::Datastore::Cursor.new "c3VwZXJhd2Vzb21lIQ==" }
+  let(:begin_tx_res) do
+    Google::Datastore::V1::BeginTransactionResponse.new(transaction: tx_id)
+  end
+  let(:tx_id) { "giterdone".encode("ASCII-8BIT") }
+
+  after do
+    transaction.service.mocked_service.verify
+  end
+
+  it "find can take a key" do
+    keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie").to_grpc]
+    read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
+    transaction.service.mocked_service.expect :lookup, lookup_res, [project, keys, read_options: read_options, options: default_options]
+
+    key = Google::Cloud::Datastore::Key.new "ds-test", "thingie"
+    entity = transaction.find key
+    entity.must_be_kind_of Google::Cloud::Datastore::Entity
+  end
+
+  it "find_all takes several keys" do
+    keys = [Google::Cloud::Datastore::Key.new("ds-test", "thingie1").to_grpc,
+             Google::Cloud::Datastore::Key.new("ds-test", "thingie2").to_grpc]
+    read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
+    transaction.service.mocked_service.expect :lookup, lookup_res, [project, keys, read_options: read_options, options: default_options]
+
+    key1 = Google::Cloud::Datastore::Key.new "ds-test", "thingie1"
+    key2 = Google::Cloud::Datastore::Key.new "ds-test", "thingie2"
+    entities = transaction.find_all key1, key2
+    entities.count.must_equal 2
+    entities.deferred.count.must_equal 0
+    entities.missing.count.must_equal 0
+    entities.each do |entity|
+      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    end
+  end
+
+  it "run will fulfill a query" do
+    query_grpc = Google::Cloud::Datastore::Query.new.kind("User").to_grpc
+    read_options = Google::Datastore::V1::ReadOptions.new(transaction: tx_id)
+    transaction.service.mocked_service.expect :run_query, run_query_res, [project, nil, read_options: read_options, query: query_grpc, gql_query: nil, options: default_options]
+
+    query = Google::Cloud::Datastore::Query.new.kind("User")
+    entities = transaction.run query
+    entities.count.must_equal 2
+    entities.each do |entity|
+      entity.must_be_kind_of Google::Cloud::Datastore::Entity
+    end
+    entities.cursor.must_equal query_cursor
+    entities.end_cursor.must_equal query_cursor
+    entities.more_results.must_equal :MORE_RESULTS_TYPE_UNSPECIFIED
+    refute entities.not_finished?
+    refute entities.more_after_limit?
+    refute entities.more_after_cursor?
+    refute entities.no_more?
+  end
+
+  describe "error handling" do
+    it "start will raise if transaction is already open" do
+      transaction.id.wont_be :nil?
+      error = assert_raises Google::Cloud::Datastore::TransactionError do
+        transaction.start
+      end
+      error.wont_be :nil?
+      error.message.must_equal "Transaction already opened."
+    end
+
+    it "commit will raise if transaction is not open" do
+      transaction.id.wont_be :nil?
+      transaction.reset!
+      transaction.id.must_be :nil?
+      error = assert_raises Google::Cloud::Datastore::TransactionError do
+        transaction.commit
+      end
+      error.wont_be :nil?
+      error.message.must_equal "Cannot commit when not in a transaction."
+    end
+
+    it "transaction will raise if transaction is not open" do
+      transaction.id.wont_be :nil?
+      transaction.reset!
+      transaction.id.must_be :nil?
+      error = assert_raises Google::Cloud::Datastore::TransactionError do
+        transaction.rollback
+      end
+      error.wont_be :nil?
+      error.message.must_equal "Cannot rollback when not in a transaction."
+    end
+  end
+end

--- a/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::Datastore::Transaction, :mock_datastore do
   let(:service) do
     s = dataset.service
     s.mocked_service = Minitest::Mock.new
-    s.mocked_service.expect :begin_transaction, begin_tx_res, [project]
+    s.mocked_service.expect :begin_transaction, begin_tx_res, [project, transaction_options: nil]
     s
   end
   let(:transaction) { Google::Cloud::Datastore::Transaction.new service }


### PR DESCRIPTION
* Add support for read-only transactions: Add `read_only` option to Dataset#transaction, and `Transaction#read_only?` and `#read_write?`.
* Add support for `previous_transaction` (pending)

[closes #1807]