### PR TITLE
Remove Emulator warnings

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -54,7 +54,6 @@ module Google
         def service
           return mocked_service if mocked_service
           @service ||= V1::DatastoreClient.new(
-            service_path: host,
             credentials: channel,
             timeout: timeout,
             client_config: client_config,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -35,7 +35,7 @@ module Google
                        client_config: nil
           @project = project
           @credentials = credentials
-          @host = host || "pubsub.googleapis.com"
+          @host = host || V1::PublisherClient::SERVICE_ADDRESS
           @timeout = timeout
           @client_config = client_config || {}
         end
@@ -62,7 +62,6 @@ module Google
           return mocked_subscriber if mocked_subscriber
           @subscriber ||= begin
             V1::SubscriberClient.new(
-              service_path: host,
               credentials: channel,
               timeout: timeout,
               client_config: client_config,
@@ -76,7 +75,6 @@ module Google
           return mocked_publisher if mocked_publisher
           @publisher ||= begin
             V1::PublisherClient.new(
-              service_path: host,
               credentials: channel,
               timeout: timeout,
               lib_name: "gccl",


### PR DESCRIPTION
A warning is being raised when connecting to a Datastore or Pub/Sub emulator that users are unable to avoid. This is due to the usage of the `service_path` argument while creating the GAPIC client. To avoid this, remove usage of the `service_path` argument and only specify the host on the GRPC::Core::Channel object passed as the GAPIC client's `credentials` argument.

We don't use emulators in acceptance tests, so I have manually verified the warnings being raised when using emulators with the previous code, and the lack of warnings with this PR's changes.

[fixes #1844]