### PR TITLE
Update Build Commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
 - 2.1.9
 - 2.0.0-p648
 script:
+- gem install bundler
 - bundle exec rake travis:build
 notifications:
   slack:

--- a/Rakefile
+++ b/Rakefile
@@ -546,6 +546,7 @@ namespace :travis do
     valid_gems.each do |gem|
       Dir.chdir gem do
         Bundler.with_clean_env do
+          sh "gem install bundler"
           sh "bundle update"
 
           if run_acceptance

--- a/build/post_test.rb
+++ b/build/post_test.rb
@@ -2,7 +2,7 @@ require "pty"
 
 commands = [
   "rvm-exec 2.4.0 bundle exec rake circleci:post",
-  "rvm-exec 2.4.0 bundle exec rake test:coveralls"
+  "rvm-exec 2.3.1 bundle exec rake test:coveralls"
 ]
 
 node_index = Integer ENV["CIRCLE_NODE_INDEX"]

--- a/build/test.rb
+++ b/build/test.rb
@@ -1,29 +1,42 @@
 require "pty"
 
-commands = [
-  "rvm-exec 2.4.0 bundle exec rake circleci:build",
-  "rvm-exec 2.3.1 bundle exec rake circleci:build",
-  "rvm-exec 2.2.5 bundle exec rake circleci:build",
-  "rvm rubygems current; bundle exec rake circleci:build",
-  "rvm-exec 2.0.0-p648 bundle exec rake circleci:build"
+command_groups = [
+  ["rvm-exec 2.4.0 gem install bundler",
+   "rvm-exec 2.4.0 bundle update",
+   "rvm-exec 2.4.0 bundle exec rake circleci:build"],
+  ["rvm-exec 2.3.1 gem install bundler",
+   "rvm-exec 2.3.1 bundle update",
+   "rvm-exec 2.3.1 bundle exec rake circleci:build"],
+  ["rvm-exec 2.2.5 gem install bundler",
+   "rvm-exec 2.2.5 bundle update",
+   "rvm-exec 2.2.5 bundle exec rake circleci:build"],
+  ["rvm rubygems current",
+   "gem install bundler",
+   "bundle update",
+   "bundle exec rake circleci:build"],
+  ["rvm-exec 2.0.0-p648 gem install bundler",
+   "rvm-exec 2.0.0-p648 bundle update",
+   "rvm-exec 2.0.0-p648 bundle exec rake circleci:build"]
 ]
 
 node_index = Integer ENV["CIRCLE_NODE_INDEX"]
 node_total = Integer ENV["CIRCLE_NODE_TOTAL"]
 
-commands.each_with_index do |command, index|
+command_groups.each_with_index do |commands, index|
   # only run the commands that are for the current node
   if node_index == index % node_total
     begin
-      PTY.spawn(command) do |stdout, _stdin, pid|
-        begin
-          stdout.each_char { |c| print c }
-        rescue Errno::EIO
+      commands.each do |command|
+        PTY.spawn(command) do |stdout, _stdin, pid|
+          begin
+            stdout.each_char { |c| print c }
+          rescue Errno::EIO
+          end
+          Process.wait(pid)
         end
-        Process.wait(pid)
+        status = $?.exitstatus
+        exit status if status && status != 0
       end
-      status = $?.exitstatus
-      exit status if status && status != 0
     rescue PTY::ChildExited
       puts "The test process exited."
     end

--- a/circle.yml
+++ b/circle.yml
@@ -28,20 +28,6 @@ dependencies:
     - rvm-exec 2.2.5 gem update --system
     - rvm install 2.0.0-p648
     - rvm-exec 2.0.0-p648 gem update --system
-    # get the latest versions of bundler
-    - gem install bundler
-    - rvm-exec 2.4.0 gem install bundler
-    - rvm-exec 2.3.1 gem install bundler
-    - rvm-exec 2.2.5 gem install bundler
-    - rvm-exec 2.0.0-p648 gem install bundler
-
-  override:
-    # The following command installs dependencies for 2.1.9
-    - bundle update
-    - rvm-exec 2.4.0 bundle update
-    - rvm-exec 2.3.1 bundle update
-    - rvm-exec 2.2.5 bundle update
-    - rvm-exec 2.0.0-p648 bundle update
 
 test:
   override:

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -9,6 +9,13 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
+  # WORKAROUND: builds on Travis-CI are resolving a version that cannot run on
+  # Ruby 2.0. We think this is because of a bug in Bundler 1.6. Specify a viable
+  # version to allow the build to succeed.
+  gem "jwt", "~> 1.5"
+end
+
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"


### PR DESCRIPTION
The build has had issues since the release of Bundler 1.6. We think this might be due to an issue where a previous ruby version is cached somewhere in Bundler's metadata. Install the bundler gem immediately before the build to see if this helps.