### PR TITLE
Fix verification for gzipped files

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -275,12 +275,12 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   it "should upload, download, and verify gzip content_type" do
-    gz = StringIO.new("")
-    z = Zlib::GzipWriter.new(gz)
+    gz = StringIO.new ""
+    z = Zlib::GzipWriter.new gz
     z.write "Hello world!"
     z.close # write the gzip footer
-
     gzipped = StringIO.new gz.string
+
     uploaded = bucket.create_file gzipped, "uploaded/with/gzip-type.txt", content_type: "application/gzip"
     uploaded.name.must_equal "uploaded/with/gzip-type.txt"
     uploaded.content_type.must_equal "application/gzip"
@@ -296,20 +296,20 @@ describe Google::Cloud::Storage::File, :storage do
 
     data = downloaded.read
     data.must_equal gzipped.read
-    gzr = Zlib::GzipReader.new(StringIO.new(data))
+    gzr = Zlib::GzipReader.new StringIO.new(data)
     gzr.read.must_equal "Hello world!"
 
     uploaded.delete
   end
 
   it "should upload, download, verify, and decompress when Content-Encoding gzip response header" do
-    gz = StringIO.new("")
-    z = Zlib::GzipWriter.new(gz)
+    gz = StringIO.new ""
+    z = Zlib::GzipWriter.new gz
     data = "Hello world!"
     z.write data
     z.close # write the gzip footer
-
     gzipped = StringIO.new gz.string
+
     uploaded = bucket.create_file gzipped, "uploaded/with/gzip-encoding.txt", content_type: "text/plain", content_encoding: "gzip"
     uploaded.name.must_equal "uploaded/with/gzip-encoding.txt"
     uploaded.content_type.must_equal "text/plain"
@@ -336,7 +336,7 @@ describe Google::Cloud::Storage::File, :storage do
       downloaded = file.download tmpfile, skip_decompress: true
 
       data = File.read(downloaded.path, mode: "rb")
-      gzr = Zlib::GzipReader.new(StringIO.new(data))
+      gzr = Zlib::GzipReader.new StringIO.new(data)
       gzr.read.must_equal "hello world"
     end
   end

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -236,7 +236,6 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   it "should upload and download a file using IO" do
-    #skip "The download verification sometimes fails on CI. Not sure why."
     inmemory = StringIO.new(File.read(files[:logo][:path], mode: "rb"))
 
     uploaded = bucket.create_file inmemory, "uploaded/with/inmemory.png"
@@ -246,8 +245,6 @@ describe Google::Cloud::Storage::File, :storage do
     downloaded.must_be_kind_of StringIO
 
     inmemory.rewind
-    downloaded.rewind
-
     downloaded.size.must_equal inmemory.size
     downloaded.size.must_equal uploaded.size
 
@@ -268,8 +265,6 @@ describe Google::Cloud::Storage::File, :storage do
     downloaded.must_equal downloadio # The object returned is the object provided
 
     inmemory.rewind
-    downloaded.rewind
-
     downloaded.size.must_equal inmemory.size
     downloaded.size.must_equal uploaded.size
 
@@ -295,7 +290,6 @@ describe Google::Cloud::Storage::File, :storage do
     downloaded.must_be_kind_of StringIO
     downloaded.must_equal downloadio # The object returned is the object provided
     gzipped.rewind
-    downloaded.rewind
 
     downloaded.size.must_equal gzipped.size
     downloaded.size.must_equal uploaded.size
@@ -325,7 +319,6 @@ describe Google::Cloud::Storage::File, :storage do
     downloaded = uploaded.download downloadio
     downloaded.must_be_kind_of StringIO
     downloaded.wont_equal downloadio # The object returned is NOT the object provided
-    downloaded.rewind
 
     downloaded_data = downloaded.read
     downloaded_data.must_equal data

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -14,6 +14,7 @@
 
 require "storage_helper"
 require "net/http"
+require "zlib"
 
 describe Google::Cloud::Storage::File, :storage do
   let :bucket do
@@ -235,7 +236,7 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   it "should upload and download a file using IO" do
-    skip "The download verification sometimes fails on CI. Not sure why."
+    #skip "The download verification sometimes fails on CI. Not sure why."
     inmemory = StringIO.new(File.read(files[:logo][:path], mode: "rb"))
 
     uploaded = bucket.create_file inmemory, "uploaded/with/inmemory.png"
@@ -258,8 +259,8 @@ describe Google::Cloud::Storage::File, :storage do
 
   it "should upload and download text using IO" do
     inmemory = StringIO.new "Hello world!"
-    uploaded = bucket.create_file inmemory, "uploaded/with/inmemory.png"
-    uploaded.name.must_equal "uploaded/with/inmemory.png"
+    uploaded = bucket.create_file inmemory, "uploaded/with/inmemory.txt"
+    uploaded.name.must_equal "uploaded/with/inmemory.txt"
 
     downloadio = StringIO.new()
     downloaded = uploaded.download downloadio
@@ -276,6 +277,88 @@ describe Google::Cloud::Storage::File, :storage do
     downloaded.read.encoding.must_equal inmemory.read.encoding
 
     uploaded.delete
+  end
+
+  it "should upload, download, and verify gzip content_type" do
+    gz = StringIO.new("")
+    z = Zlib::GzipWriter.new(gz)
+    z.write "Hello world!"
+    z.close # write the gzip footer
+
+    gzipped = StringIO.new gz.string
+    uploaded = bucket.create_file gzipped, "uploaded/with/gzip-type.txt", content_type: "application/gzip"
+    uploaded.name.must_equal "uploaded/with/gzip-type.txt"
+    uploaded.content_type.must_equal "application/gzip"
+    uploaded.content_encoding.must_be_nil
+    puts uploaded.md5.inspect
+    downloadio = StringIO.new()
+    downloaded = uploaded.download downloadio
+    downloaded.must_be_kind_of StringIO
+    downloaded.must_equal downloadio # The object returned is the object provided
+    gzipped.rewind
+    downloaded.rewind
+
+    downloaded.size.must_equal gzipped.size
+    downloaded.size.must_equal uploaded.size
+
+    data = downloaded.read
+    data.must_equal gzipped.read
+    #data.encoding.must_equal gzipped.read.encoding # Fails: Expected: #<Encoding:ASCII-8BIT> Actual: #<Encoding:UTF-8>
+    gzr = Zlib::GzipReader.new(StringIO.new(data))
+    gzr.read.must_equal "Hello world!"
+
+    uploaded.delete
+  end
+
+  it "should upload, download, verify, and decompress when Content-Encoding gzip response header" do
+    gz = StringIO.new("")
+    z = Zlib::GzipWriter.new(gz)
+    data = "Hello world!"
+    z.write data
+    z.close # write the gzip footer
+
+    gzipped = StringIO.new gz.string
+    uploaded = bucket.create_file gzipped, "uploaded/with/gzip-encoding.txt", content_type: "text/plain", content_encoding: "gzip"
+    uploaded.name.must_equal "uploaded/with/gzip-encoding.txt"
+    uploaded.content_type.must_equal "text/plain"
+    uploaded.content_encoding.must_equal "gzip"
+
+    downloadio = StringIO.new()
+    downloaded = uploaded.download downloadio
+    downloaded.must_be_kind_of StringIO
+    downloaded.wont_equal downloadio # The object returned is NOT the object provided
+    downloaded.rewind
+
+    downloaded_data = downloaded.read
+    downloaded_data.must_equal data
+    downloaded_data.encoding.must_equal data.encoding
+
+    uploaded.delete
+  end
+
+  it "should download, verify, and decompress when Content-Encoding gzip response header with skip_lookup" do
+    bucket = storage.bucket bucket_public_test_name, skip_lookup: true
+    file = bucket.file file_public_test_gzip_name, skip_lookup: true
+    file.content_encoding.must_be_nil # metadata not loaded
+    file.content_type.must_be_nil # metadata not loaded
+    Tempfile.open ["hello_world", ".txt"] do |tmpfile|
+      tmpfile.binmode
+      downloaded = file.download tmpfile
+
+      File.read(downloaded.path, mode: "rb").must_equal "hello world" # FAIL
+    end
+  end
+
+  it "should download, verify, and decompress when Content-Encoding gzip response header with crc32c verification" do
+    lazy_bucket = storage.bucket bucket_public_test_name
+    lazy_file = lazy_bucket.file file_public_test_gzip_name
+
+    Tempfile.open ["hello_world", ".txt"] do |tmpfile|
+      tmpfile.binmode
+      downloaded = lazy_file.download tmpfile,  verify: :crc32c
+
+      File.read(downloaded.path, mode: "rb").must_equal "hello world" # decompressed file data
+    end
   end
 
   it "should upload and download a file with customer-supplied encryption key" do
@@ -317,34 +400,6 @@ describe Google::Cloud::Storage::File, :storage do
     end
 
     uploaded.delete
-  end
-
-  it "should download, verify, and decompress a gzipped file with default md5 verification" do
-    skip "Not working. See https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1835"
-
-    lazy_bucket = storage.bucket bucket_public_test_name
-    lazy_file = lazy_bucket.file file_public_test_gzip_name
-
-    Tempfile.open ["hello_world", ".txt"] do |tmpfile|
-      tmpfile.binmode
-      downloaded = lazy_file.download tmpfile
-
-      File.read(downloaded.path, mode: "rb").must_equal "hello world" # decompressed file data
-    end
-  end
-
-  it "should download, verify, and decompress a gzipped file with crc32c verification" do
-    skip "Not working. See https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1835"
-
-    lazy_bucket = storage.bucket bucket_public_test_name
-    lazy_file = lazy_bucket.file file_public_test_gzip_name
-
-    Tempfile.open ["hello_world", ".txt"] do |tmpfile|
-      tmpfile.binmode
-      downloaded = lazy_file.download tmpfile,  verify: :crc32c
-
-      File.read(downloaded.path, mode: "rb").must_equal "hello world" # decompressed file data
-    end
   end
 
   it "should write metadata" do

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -83,16 +83,16 @@ module Acceptance
       end
     end
 
-    # def self.run_one_method klass, method_name, reporter
-    #   result = nil
-    #   reporter.prerecord klass, method_name
-    #   (1..3).each do |try|
-    #     result = Minitest.run_one_method(klass, method_name)
-    #     break if (result.passed? || result.skipped?)
-    #     puts "Retrying #{klass}##{method_name} (#{try})"
-    #   end
-    #   reporter.record result
-    # end
+    def self.run_one_method klass, method_name, reporter
+      result = nil
+      reporter.prerecord klass, method_name
+      (1..3).each do |try|
+        result = Minitest.run_one_method(klass, method_name)
+        break if (result.passed? || result.skipped?)
+        puts "Retrying #{klass}##{method_name} (#{try})"
+      end
+      reporter.record result
+    end
   end
 end
 

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -83,16 +83,16 @@ module Acceptance
       end
     end
 
-    def self.run_one_method klass, method_name, reporter
-      result = nil
-      reporter.prerecord klass, method_name
-      (1..3).each do |try|
-        result = Minitest.run_one_method(klass, method_name)
-        break if (result.passed? || result.skipped?)
-        puts "Retrying #{klass}##{method_name} (#{try})"
-      end
-      reporter.record result
-    end
+    # def self.run_one_method klass, method_name, reporter
+    #   result = nil
+    #   reporter.prerecord klass, method_name
+    #   (1..3).each do |try|
+    #     result = Minitest.run_one_method(klass, method_name)
+    #     break if (result.passed? || result.skipped?)
+    #     puts "Retrying #{klass}##{method_name} (#{try})"
+    #   end
+    #   reporter.record result
+    # end
   end
 end
 

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.1"
-  gem.add_dependency "google-api-client", "~> 0.17.0"
+  gem.add_dependency "google-api-client", "~> 0.17.4"
   gem.add_dependency "googleauth", "~> 0.6.2"
   gem.add_dependency "digest-crc", "~> 0.4"
 

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -334,6 +334,44 @@ module Google
     # downloaded.read #=> "Hello world!"
     # ```
     #
+    # ## Creating and downloading gzip-encoded files
+    #
+    # When uploading a gzip-compressed file, you should pass
+    # `content_encoding: "gzip"` if you want the file to be eligible for
+    # [decompressive transcoding](https://cloud.google.com/storage/docs/transcoding)
+    # when it is later downloaded. In addition, giving the gzip-compressed file
+    # a name containing the original file extension (for example, `.txt`) will
+    # ensure that the file's `Content-Type` metadata is set correctly. (You can
+    # also set the file's `Content-Type` metadata explicitly with the
+    # `content_type` option.)
+    #
+    # ```ruby
+    # require "zlib"
+    # require "google/cloud/storage"
+    #
+    # storage = Google::Cloud::Storage.new
+    #
+    # gz = StringIO.new ""
+    # z = Zlib::GzipWriter.new gz
+    # z.write "Hello world!"
+    # z.close
+    # data = StringIO.new gz.string
+    #
+    # bucket = storage.bucket "my-bucket"
+    #
+    # bucket.create_file data, "path/to/gzipped.txt",
+    #                    content_encoding: "gzip"
+    #
+    # file = bucket.file "path/to/gzipped.txt"
+    #
+    # # The downloaded data is decompressed by default.
+    # file.download "path/to/downloaded/hello.txt"
+    #
+    # # The downloaded data remains compressed with skip_decompress.
+    # file.download "path/to/downloaded/gzipped.txt",
+    #               skip_decompress: true
+    # ```
+    #
     # ## Using Signed URLs
     #
     # Access without authentication can be granted to a file for a specified

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -608,7 +608,12 @@ module Google
         #   response header to be returned when the file is downloaded.
         # @param [String] content_encoding The [Content-Encoding
         #   ](https://tools.ietf.org/html/rfc7231#section-3.1.2.2) response
-        #   header to be returned when the file is downloaded.
+        #   header to be returned when the file is downloaded. For example,
+        #   `content_encoding: "gzip"` can indicate to clients that the uploaded
+        #   data is gzip-compressed. However, there is no check to guarantee the
+        #   specified `Content-Encoding` has actually been applied to the file
+        #   data, and incorrectly specifying the file's encoding could lead
+        #   to unintended behavior on subsequent download requests.
         # @param [String] content_language The
         #   [Content-Language](http://tools.ietf.org/html/bcp47) response
         #   header to be returned when the file is downloaded.
@@ -681,6 +686,32 @@ module Google
         #   # Store your key and hash securely for later use.
         #   file = bucket.file "destination/path/file.ext",
         #                      encryption_key: key
+        #
+        # @example Create a file with gzip-encoded data.
+        #   require "zlib"
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   gz = StringIO.new ""
+        #   z = Zlib::GzipWriter.new gz
+        #   z.write "Hello world!"
+        #   z.close
+        #   data = StringIO.new gz.string
+        #
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   bucket.create_file data, "path/to/gzipped.txt",
+        #                      content_encoding: "gzip"
+        #
+        #   file = bucket.file "path/to/gzipped.txt"
+        #
+        #   # The downloaded data is decompressed by default.
+        #   file.download "path/to/downloaded/hello.txt"
+        #
+        #   # The downloaded data remains compressed with skip_decompress.
+        #   file.download "path/to/downloaded/gzipped.txt",
+        #                 skip_decompress: true
         #
         def create_file file, path = nil, acl: nil, cache_control: nil,
                         content_disposition: nil, content_encoding: nil,

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -505,7 +505,7 @@ module Google
         #   downloaded.rewind
         #   downloaded.read #=> "Hello world!"
         #
-        # @example Download a public file with an unauthenticated client:
+        # @example Download a public file with an unauthenticated client.
         #   require "google/cloud/storage"
         #
         #   storage = Google::Cloud::Storage.anonymous
@@ -516,6 +516,32 @@ module Google
         #   downloaded = file.download
         #   downloaded.rewind
         #   downloaded.read #=> "Hello world!"
+        #
+        # @example Upload and download gzip-encoded file data.
+        #   require "zlib"
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   gz = StringIO.new ""
+        #   z = Zlib::GzipWriter.new gz
+        #   z.write "Hello world!"
+        #   z.close
+        #   data = StringIO.new gz.string
+        #
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   bucket.create_file data, "path/to/gzipped.txt",
+        #                      content_encoding: "gzip"
+        #
+        #   file = bucket.file "path/to/gzipped.txt"
+        #
+        #   # The downloaded data is decompressed by default.
+        #   file.download "path/to/downloaded/hello.txt"
+        #
+        #   # The downloaded data remains compressed with skip_decompress.
+        #   file.download "path/to/downloaded/gzipped.txt",
+        #                 skip_decompress: true
         #
         def download path = nil, verify: :md5, encryption_key: nil,
                      skip_decompress: nil

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -439,6 +439,13 @@ module Google
         # @param [String] encryption_key Optional. The customer-supplied,
         #   AES-256 encryption key used to encrypt the file, if one was provided
         #   to {Bucket#create_file}.
+        # @param [Boolean] skip_decompress Optional. If `true`, the data for a
+        #   Storage object returning a `Content-Encoding: gzip` response header
+        #   will *not* be automatically decompressed by this client library. The
+        #   default is `nil`. Note that all requests by this client library send
+        #   the `Accept-Encoding: gzip` header, so decompressive transcoding is
+        #   not performed in the Storage service. (See [Transcoding of
+        #   gzip-compressed files](https://cloud.google.com/storage/docs/transcoding))
         #
         # @return [IO] Returns an IO object representing the file data. This
         #   will ordinarily be a `::File` object referencing the local file
@@ -510,7 +517,8 @@ module Google
         #   downloaded.rewind
         #   downloaded.read #=> "Hello world!"
         #
-        def download path = nil, verify: :md5, encryption_key: nil
+        def download path = nil, verify: :md5, encryption_key: nil,
+                     skip_decompress: nil
           ensure_service!
           if path.nil?
             path = StringIO.new
@@ -521,7 +529,8 @@ module Google
           # FIX: downloading with encryption key will return nil
           file ||= ::File.new(path)
           verify_file! file, verify
-          if Array(resp.header["Content-Encoding"]).include?("gzip")
+          if !skip_decompress &&
+             Array(resp.header["Content-Encoding"]).include?("gzip")
             file = gzip_decompress file
           end
           file

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -58,7 +58,9 @@ module Google
               end
             else # StringIO
               local_file.rewind
-              ::Digest::MD5.base64digest local_file.read
+              md5 = ::Digest::MD5.base64digest local_file.read
+              local_file.rewind
+              md5
             end
           end
 
@@ -69,7 +71,9 @@ module Google
               end
             else # StringIO
               local_file.rewind
-              ::Digest::CRC32c.base64digest local_file.read
+              crc32c = ::Digest::CRC32c.base64digest local_file.read
+              local_file.rewind
+              crc32c
             end
           end
         end

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -62,7 +62,7 @@ module Google
         end
       end
       class File
-        def download path = nil, verify: :md5, encryption_key: nil
+        def download path = nil, verify: :md5, encryption_key: nil, skip_decompress: nil
           # no-op stub, but ensures that calls match this copied signature
           return StringIO.new("Hello world!") if path.nil?
         end
@@ -148,6 +148,7 @@ YARD::Doctest.configure do |doctest|
 
   # Skip all aliases, since tests would be exact duplicates
   doctest.skip "Google::Cloud::Storage::Bucket#new_file"
+  doctest.skip "Google::Cloud::Storage::Bucket#upload_file"
   doctest.skip "Google::Cloud::Storage::Bucket#find_files"
   doctest.skip "Google::Cloud::Storage::Bucket#combine"
   doctest.skip "Google::Cloud::Storage::Bucket#compose_file"
@@ -239,6 +240,15 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::Bucket#create_file@Create a file with gzip-encoded data." do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :insert_object, file_gapi, ["my-bucket", Google::Apis::StorageV1::Object, Hash]
+      # Following expectation is only used in last example
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/gzipped.txt", Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Storage::Bucket#create_notification" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :create_topic, topic_gapi, ["projects/my-project/topics/my-topic", Hash]
@@ -248,15 +258,6 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
       mock.expect :insert_notification, notification_gapi, ["my-bucket", Google::Apis::StorageV1::Notification, Hash]
-    end
-  end
-
-  doctest.before "Google::Cloud::Storage::Bucket#upload_file" do
-    mock_storage do |mock|
-      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
-      mock.expect :insert_object, file_gapi, ["my-bucket", Google::Apis::StorageV1::Object, Hash]
-      # Following expectation is only used in last example
-      mock.expect :get_object, file_gapi, ["my-bucket", "destination/path/file.ext", Hash]
     end
   end
 
@@ -655,6 +656,14 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
       mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::File#download@Upload and download gzip-encoded file data." do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :insert_object, file_gapi, ["my-bucket", Google::Apis::StorageV1::Object, Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/gzipped.txt", Hash]
     end
   end
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -192,7 +192,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       tmpfile.write "yay!"
 
       mock = Minitest::Mock.new
-      mock.expect :get_object, tmpfile,
+      mock.expect :get_object_with_response, [tmpfile, download_http_resp],
         [bucket_name, file_name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
@@ -215,7 +215,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       tmpfile.write "yay!"
 
       mock = Minitest::Mock.new
-      mock.expect :get_object, tmpfile,
+      mock.expect :get_object_with_response, [tmpfile, download_http_resp],
         [bucket_name, file_name, download_dest: tmpfile.path, generation: nil, user_project: nil, options: {}]
 
       bucket.service.mocked_service = mock
@@ -238,7 +238,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       tmpfile.write "yay!"
 
       mock = Minitest::Mock.new
-      mock.expect :get_object, tmpfile,
+      mock.expect :get_object_with_response, [tmpfile, download_http_resp],
         [bucket.name, file_user_project.name, download_dest: tmpfile, generation: nil, user_project: "test", options: {}]
 
       bucket.service.mocked_service = mock
@@ -257,7 +257,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     end
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, StringIO.new("yay!"),
+    mock.expect :get_object_with_response, [StringIO.new("yay!"), download_http_resp],
       [bucket_name, file_name, Hash] # Can't match StringIO in mock...
 
     bucket.service.mocked_service = mock
@@ -275,7 +275,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     end
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, StringIO.new("yay!"),
+    mock.expect :get_object_with_response, [StringIO.new("yay!"), download_http_resp],
       [bucket_name, file_name, Hash] # Can't match StringIO in mock...
 
     bucket.service.mocked_service = mock
@@ -299,7 +299,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
       tmpfile.write "yay!"
 
       mock = Minitest::Mock.new
-      mock.expect :get_object, nil, # using encryption keys seems to return nil
+      mock.expect :get_object_with_response, [nil, download_http_resp], # using encryption keys seems to return nil
         [bucket_name, file_name, download_dest: tmpfile, generation: nil, user_project: nil, options: key_options]
 
       bucket.service.mocked_service = mock
@@ -319,7 +319,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
-        mock.expect :get_object, tmpfile,
+        mock.expect :get_object_with_response, [tmpfile, download_http_resp],
           [bucket_name, file_name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
@@ -346,7 +346,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
-        mock.expect :get_object, tmpfile,
+        mock.expect :get_object_with_response, [tmpfile, download_http_resp],
           [bucket_name, file_name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
@@ -373,7 +373,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
-        mock.expect :get_object, tmpfile,
+        mock.expect :get_object_with_response, [tmpfile, download_http_resp],
           [bucket_name, file_name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
@@ -400,7 +400,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
-        mock.expect :get_object, tmpfile,
+        mock.expect :get_object_with_response, [tmpfile, download_http_resp],
           [bucket_name, file_name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
@@ -431,7 +431,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
-        mock.expect :get_object, tmpfile,
+        mock.expect :get_object_with_response, [tmpfile, download_http_resp],
           [bucket_name, file_name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock
@@ -456,7 +456,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
       Tempfile.open "google-cloud" do |tmpfile|
         mock = Minitest::Mock.new
-        mock.expect :get_object, tmpfile,
+        mock.expect :get_object_with_response, [tmpfile, download_http_resp],
           [bucket_name, file_name, download_dest: tmpfile.path, generation: nil, user_project: nil, options: {}]
 
         bucket.service.mocked_service = mock

--- a/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
@@ -108,7 +108,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
       mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name, {user_project: nil}]
       mock.expect :get_object, find_file_gapi(bucket_name, file_name),
         [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
-      mock.expect :get_object, tmpfile,
+      mock.expect :get_object_with_response, [tmpfile, download_http_resp],
         [bucket_name, file_name, download_dest: tmpfile, generation: nil, user_project: nil, options: {}]
 
       anonymous_storage.service.mocked_service = mock

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -138,4 +138,11 @@ class MockStorage < Minitest::Spec
     gapi.id = id if id
     gapi
   end
+
+  # Stub for the `http_res` that is returned in the Apis::Core::DownloadCommand monkey-patch in Service.
+  def download_http_resp gzip: nil
+    headers = {}
+    headers["Content-Encoding"] = ["gzip"] if gzip
+    OpenStruct.new(header: headers)
+  end
 end


### PR DESCRIPTION
This PR updates `File#download` and `Service#download_file` to download gzipped files from the GCS in their original state. (See [Transcoding of gzip-compressed files](https://cloud.google.com/storage/docs/transcoding) for background.) This allows the files to be verified against the `md5` and/or `crc32c` values in their metadata, which are computed from this compressed state.

Changes include:

* Update google-api-client dependency to `~> 0.17.4` in order to disable automatic gzip decompression. (See google/google-api-ruby-client#637.)
* Monkey-patch google-api-client `Apis::StorageV1::StorageService` and `Apis::Core::DownloadCommand` to expose the HTTP response to the download request.
* Add automatic decompression in this client library (after verification) for files returned with a `Content-Encoding: gzip` header. (Similar to the [google-cloud-node](https://github.com/googleapis/nodejs-storage/blob/05fa3f709e80b5c4228a47ca049838b13d413861/src/file.js#L509) implementation.)
* Add `skip_decompress` to `File#download` for users who want to disable the automatic decompression.
* Fix a bug in `File::Verifier`, to rewind `StringIO` objects before returning.

[closes #1835]