### PR TITLE
Datastore Transaction Automatic Retry

### DIFF
--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -32,7 +32,7 @@ Metrics/PerceivedComplexity:
 Metrics/AbcSize:
   Max: 25
 Metrics/MethodLength:
-  Max: 20
+  Max: 25
 Metrics/ParameterLists:
   Enabled: false
 Style/RescueModifier:

--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -561,8 +561,6 @@ module Google
     # ```
     #
     module Datastore
-      # rubocop:disable MethodLength
-
       ##
       # Creates a new object for connecting to the Datastore service.
       # Each call creates a new connection.
@@ -638,8 +636,6 @@ module Google
             project_id, credentials,
             timeout: timeout, client_config: client_config))
       end
-
-      # rubocop:enable MethodLength
     end
   end
 end


### PR DESCRIPTION
Update Datastore to auto retry errors setting previous_transaction.
This brings Datastore to parity with Spanner and Firestore.