### PR TITLE
Update Copyright Format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/LICENSE
+++ b/gcloud/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud.rb
+++ b/gcloud/lib/gcloud.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud.rb
+++ b/gcloud/lib/gcloud.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/bigquery.rb
+++ b/gcloud/lib/gcloud/bigquery.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/bigquery.rb
+++ b/gcloud/lib/gcloud/bigquery.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/datastore.rb
+++ b/gcloud/lib/gcloud/datastore.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/datastore.rb
+++ b/gcloud/lib/gcloud/datastore.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/dns.rb
+++ b/gcloud/lib/gcloud/dns.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/dns.rb
+++ b/gcloud/lib/gcloud/dns.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/logging.rb
+++ b/gcloud/lib/gcloud/logging.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/logging.rb
+++ b/gcloud/lib/gcloud/logging.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/pubsub.rb
+++ b/gcloud/lib/gcloud/pubsub.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/pubsub.rb
+++ b/gcloud/lib/gcloud/pubsub.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/resource_manager.rb
+++ b/gcloud/lib/gcloud/resource_manager.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/resource_manager.rb
+++ b/gcloud/lib/gcloud/resource_manager.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/storage.rb
+++ b/gcloud/lib/gcloud/storage.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/storage.rb
+++ b/gcloud/lib/gcloud/storage.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/translate.rb
+++ b/gcloud/lib/gcloud/translate.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/translate.rb
+++ b/gcloud/lib/gcloud/translate.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/version.rb
+++ b/gcloud/lib/gcloud/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/version.rb
+++ b/gcloud/lib/gcloud/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/lib/gcloud/vision.rb
+++ b/gcloud/lib/gcloud/vision.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/lib/gcloud/vision.rb
+++ b/gcloud/lib/gcloud/vision.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/test/gcloud_test.rb
+++ b/gcloud/test/gcloud_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/test/gcloud_test.rb
+++ b/gcloud/test/gcloud_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcloud/test/helper.rb
+++ b/gcloud/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gcloud/test/helper.rb
+++ b/gcloud/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/LICENSE
+++ b/google-cloud-bigquery/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery/view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/view_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery/view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/view_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/benchmark/benchmark.rb
+++ b/google-cloud-bigquery/benchmark/benchmark.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/benchmark/benchmark.rb
+++ b/google-cloud-bigquery/benchmark/benchmark.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/credentials.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/credentials.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_delay_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_delay_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_delay_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_delay_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_exists_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_exists_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a link of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_schema_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_schema_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reload_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reload_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reload_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reload_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_column_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_column_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_column_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_column_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_data_souce_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_data_souce_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_data_souce_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_data_souce_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_sheets_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_sheets_source_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_sheets_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_sheets_source_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/extract_job_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/extract_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_exists_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_exists_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a extract of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a link of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a load of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reload_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reload_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reload_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reload_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/LICENSE
+++ b/google-cloud-bigtable/LICENSE
@@ -1,6 +1,6 @@
                             Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/Rakefile
+++ b/google-cloud-bigtable/Rakefile
@@ -3,7 +3,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/Rakefile
+++ b/google-cloud-bigtable/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/google-cloud-bigtable/lib/google/bigtable/admin/v2/bigtable_instance_admin_services_pb.rb
+++ b/google-cloud-bigtable/lib/google/bigtable/admin/v2/bigtable_instance_admin_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/bigtable/admin/v2/bigtable_table_admin_services_pb.rb
+++ b/google-cloud-bigtable/lib/google/bigtable/admin/v2/bigtable_table_admin_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/bigtable/v2/bigtable_services_pb.rb
+++ b/google-cloud-bigtable/lib/google/bigtable/v2/bigtable_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/credentials.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/credentials.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_instance_admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_instance_admin.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_instance_admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_instance_admin.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_table_admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_table_admin.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_table_admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_table_admin.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/instance.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/instance.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/table.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/table.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/rpc/status.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/rpc/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/rpc/status.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/overview.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/overview.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/credentials.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/credentials.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/bigtable.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/bigtable.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/bigtable.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/bigtable.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/data.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/data.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/data.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/data.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/wrappers.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/wrappers.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/rpc/status.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/rpc/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/rpc/status.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/overview.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/overview.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/test/google/cloud/bigtable/v2/bigtable_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/v2/bigtable_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-bigtable/test/google/cloud/bigtable/v2/bigtable_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/v2/bigtable_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/LICENSE
+++ b/google-cloud-core/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/lib/google/cloud/core/version.rb
+++ b/google-cloud-core/lib/google/cloud/core/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/lib/google/cloud/core/version.rb
+++ b/google-cloud-core/lib/google/cloud/core/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/lib/google/cloud/credentials.rb
+++ b/google-cloud-core/lib/google/cloud/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/lib/google/cloud/credentials.rb
+++ b/google-cloud-core/lib/google/cloud/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/lib/google/cloud/errors.rb
+++ b/google-cloud-core/lib/google/cloud/errors.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/lib/google/cloud/errors.rb
+++ b/google-cloud-core/lib/google/cloud/errors.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/test/google/cloud/credentials_test.rb
+++ b/google-cloud-core/test/google/cloud/credentials_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/test/google/cloud/credentials_test.rb
+++ b/google-cloud-core/test/google/cloud/credentials_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/error_cause_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0  the "License";
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/test/google/cloud/errors/gapi_errors_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/gapi_errors_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/test/google/cloud/errors/gapi_errors_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/gapi_errors_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/test/google/cloud/errors/grpc_errors_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/grpc_errors_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/test/google/cloud/errors/grpc_errors_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/grpc_errors_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/test/google/cloud/errors/wrapped_gapi_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/wrapped_gapi_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/test/google/cloud/errors/wrapped_gapi_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/wrapped_gapi_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0  the "License";
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/test/google/cloud/errors/wrapped_gax_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/wrapped_gax_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/test/google/cloud/errors/wrapped_gax_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/wrapped_gax_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0  the "License";
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/test/google/cloud/errors/wrapped_grpc_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/wrapped_grpc_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/test/google/cloud/errors/wrapped_grpc_test.rb
+++ b/google-cloud-core/test/google/cloud/errors/wrapped_grpc_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0  the "License";
 # you may not use this file except in compliance with the License.

--- a/google-cloud-core/test/helper.rb
+++ b/google-cloud-core/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-core/test/helper.rb
+++ b/google-cloud-core/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/LICENSE
+++ b/google-cloud-datastore/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/acceptance/datastore_helper.rb
+++ b/google-cloud-datastore/acceptance/datastore_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/acceptance/datastore_helper.rb
+++ b/google-cloud-datastore/acceptance/datastore_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google-cloud-datastore.rb
+++ b/google-cloud-datastore/lib/google-cloud-datastore.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google-cloud-datastore.rb
+++ b/google-cloud-datastore/lib/google-cloud-datastore.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/commit.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/commit.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/commit.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/commit.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/convert.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/credentials.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/credentials.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/cursor.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/errors.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/errors.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/errors.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/errors.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/key.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/key.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/key.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/key.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/properties.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/properties.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/properties.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/properties.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/entity.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/entity.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/query.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/query.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/wrappers.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/wrappers.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/overview.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/overview.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/lib/google/datastore/v1/datastore_services_pb.rb
+++ b/google-cloud-datastore/lib/google/datastore/v1/datastore_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/convert/struct_to_hash_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/convert/struct_to_hash_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/convert/struct_to_hash_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/convert/struct_to_hash_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/convert/value_to_object_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/convert/value_to_object_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/convert/value_to_object_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/convert/value_to_object_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_exclude_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/entity_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/gql_query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/gql_query_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/gql_query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/gql_query_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/key_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/lookup_results/find_all_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/properties_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_more_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/transaction_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/google/cloud/datastore_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/google/cloud/datastore_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-datastore/test/helper.rb
+++ b/google-cloud-datastore/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-datastore/test/helper.rb
+++ b/google-cloud-datastore/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/LICENSE
+++ b/google-cloud-debugger/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/acceptance/debugger/debugger_test.rb
+++ b/google-cloud-debugger/acceptance/debugger/debugger_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/acceptance/debugger/debugger_test.rb
+++ b/google-cloud-debugger/acceptance/debugger/debugger_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/acceptance/debugger_helper.rb
+++ b/google-cloud-debugger/acceptance/debugger_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/acceptance/debugger_helper.rb
+++ b/google-cloud-debugger/acceptance/debugger_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/debugger.c
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/debugger.c
@@ -5,7 +5,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/debugger.h
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/debugger.h
@@ -5,7 +5,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/evaluator.c
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/evaluator.c
@@ -5,7 +5,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/evaluator.h
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/evaluator.h
@@ -5,7 +5,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/extconf.rb
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/extconf.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/extconf.rb
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/extconf.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.c
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.c
@@ -5,7 +5,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.h
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/tracer.h
@@ -5,7 +5,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/integration/common_debugger_test.rb
+++ b/google-cloud-debugger/integration/common_debugger_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/integration/common_debugger_test.rb
+++ b/google-cloud-debugger/integration/common_debugger_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/integration/debugger_helper.rb
+++ b/google-cloud-debugger/integration/debugger_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/integration/debugger_helper.rb
+++ b/google-cloud-debugger/integration/debugger_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google-cloud-debugger.rb
+++ b/google-cloud-debugger/lib/google-cloud-debugger.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google-cloud-debugger.rb
+++ b/google-cloud-debugger/lib/google-cloud-debugger.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/backoff.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/backoff.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/backoff.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/backoff.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/source_location.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/source_location.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/source_location.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/source_location.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/stack_frame.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/stack_frame.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/stack_frame.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/stack_frame.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/status_message.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/status_message.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/status_message.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/status_message.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/validator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/validator.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/validator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/validator.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint_manager.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/credentials.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/credentials.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/debuggee.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/debuggee.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/debuggee.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/debuggee.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/debuggee/app_uniquifier_generator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/debuggee/app_uniquifier_generator.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/debuggee/app_uniquifier_generator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/debuggee/app_uniquifier_generator.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/logpoint.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/project.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/project.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/request_quota_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/request_quota_manager.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/request_quota_manager.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/request_quota_manager.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/service.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/service.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/tracer.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/tracer.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/tracer.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/tracer.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/data.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/data.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/data.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/data.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/debugger.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/debugger.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/source/v1/source_context.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/source/v1/source_context.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/source/v1/source_context.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/source/v1/source_context.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/timestamp.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/timestamp.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/overview.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/overview.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/lib/google/devtools/clouddebugger/v2/controller_services_pb.rb
+++ b/google-cloud-debugger/lib/google/devtools/clouddebugger/v2/controller_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/lib/google/devtools/clouddebugger/v2/debugger_services_pb.rb
+++ b/google-cloud-debugger/lib/google/devtools/clouddebugger/v2/debugger_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/support/doctest_helper.rb
+++ b/google-cloud-debugger/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/support/doctest_helper.rb
+++ b/google-cloud-debugger/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/backoff_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/backoff_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/backoff_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/backoff_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/expression_test_helper.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/expression_test_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/expression_test_helper.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/expression_test_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/immutable_classes_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/immutable_classes_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/immutable_classes_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/immutable_classes_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/source_location_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/source_location_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/source_location_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/source_location_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/stack_frame_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/stack_frame_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/stack_frame_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/stack_frame_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/status_message_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/status_message_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/status_message_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/status_message_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/validator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/validator_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/validator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/validator_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/debuggee/app_uniquifier_generator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/debuggee/app_uniquifier_generator_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/debuggee/app_uniquifier_generator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/debuggee/app_uniquifier_generator_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/debuggee_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/debuggee_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/debuggee_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/debuggee_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/project_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/project_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/request_quota_manager_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/request_quota_manager_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/request_quota_manager_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/request_quota_manager_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/snappoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/snappoint_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/snappoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/snappoint_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper_2.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper_2.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper_2.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_test_helper_2.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger/transmitter_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/transmitter_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger/transmitter_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/transmitter_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/google/cloud/debugger_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/google/cloud/debugger_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-debugger/test/helper.rb
+++ b/google-cloud-debugger/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-debugger/test/helper.rb
+++ b/google-cloud-debugger/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/LICENSE
+++ b/google-cloud-dns/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/acceptance/dns/dns_test.rb
+++ b/google-cloud-dns/acceptance/dns/dns_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/acceptance/dns/dns_test.rb
+++ b/google-cloud-dns/acceptance/dns/dns_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/acceptance/dns_helper.rb
+++ b/google-cloud-dns/acceptance/dns_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/acceptance/dns_helper.rb
+++ b/google-cloud-dns/acceptance/dns_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google-cloud-dns.rb
+++ b/google-cloud-dns/lib/google-cloud-dns.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google-cloud-dns.rb
+++ b/google-cloud-dns/lib/google-cloud-dns.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns.rb
+++ b/google-cloud-dns/lib/google/cloud/dns.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns.rb
+++ b/google-cloud-dns/lib/google/cloud/dns.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/change.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/change.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/change.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/change.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/change/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/change/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/change/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/change/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/credentials.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/credentials.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/importer.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/importer.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/importer.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/importer.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/project.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/project.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/record.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/record.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/record.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/record.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/record/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/record/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/record/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/record/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/service.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/service.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/version.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/version.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/zone.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/zone.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/zone/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/zone/list.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/lib/google/cloud/dns/zone/transaction.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone/transaction.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/lib/google/cloud/dns/zone/transaction.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/zone/transaction.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/support/doctest_helper.rb
+++ b/google-cloud-dns/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/support/doctest_helper.rb
+++ b/google-cloud-dns/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/test/google/cloud/dns/change_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/change_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/test/google/cloud/dns/change_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/change_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/test/google/cloud/dns/importer_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/importer_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/test/google/cloud/dns/importer_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/importer_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/test/google/cloud/dns/project_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/test/google/cloud/dns/project_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/test/google/cloud/dns/record_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/record_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/test/google/cloud/dns/record_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/record_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/test/google/cloud/dns/zone_fqdn_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/zone_fqdn_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/test/google/cloud/dns/zone_fqdn_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/zone_fqdn_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/test/google/cloud/dns/zone_import_export_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/zone_import_export_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/test/google/cloud/dns/zone_import_export_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/zone_import_export_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/test/google/cloud/dns/zone_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/zone_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/test/google/cloud/dns/zone_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/zone_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/test/google/cloud/dns_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/test/google/cloud/dns_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-dns/test/helper.rb
+++ b/google-cloud-dns/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-dns/test/helper.rb
+++ b/google-cloud-dns/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-env/LICENSE
+++ b/google-cloud-env/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-env/lib/google-cloud-env.rb
+++ b/google-cloud-env/lib/google-cloud-env.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-env/lib/google-cloud-env.rb
+++ b/google-cloud-env/lib/google-cloud-env.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-env/lib/google/cloud/env.rb
+++ b/google-cloud-env/lib/google/cloud/env.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-env/lib/google/cloud/env.rb
+++ b/google-cloud-env/lib/google/cloud/env.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-env/lib/google/cloud/env/version.rb
+++ b/google-cloud-env/lib/google/cloud/env/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-env/lib/google/cloud/env/version.rb
+++ b/google-cloud-env/lib/google/cloud/env/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-env/test/google/cloud/env_test.rb
+++ b/google-cloud-env/test/google/cloud/env_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-env/test/google/cloud/env_test.rb
+++ b/google-cloud-env/test/google/cloud/env_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-env/test/helper.rb
+++ b/google-cloud-env/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-env/test/helper.rb
+++ b/google-cloud-env/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/LICENSE
+++ b/google-cloud-error_reporting/LICENSE
@@ -1,6 +1,6 @@
                             Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/acceptance/error_reporting/error_reporting_test.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting/error_reporting_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/acceptance/error_reporting/error_reporting_test.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting/error_reporting_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/integration/common_error_reporting_test.rb
+++ b/google-cloud-error_reporting/integration/common_error_reporting_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/integration/common_error_reporting_test.rb
+++ b/google-cloud-error_reporting/integration/common_error_reporting_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/integration/error_reporting_helper.rb
+++ b/google-cloud-error_reporting/integration/error_reporting_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/integration/error_reporting_helper.rb
+++ b/google-cloud-error_reporting/integration/error_reporting_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/credentials.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/credentials.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0oud
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1.rb
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1.rb
@@ -1,5 +1,5 @@
 
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/error_stats_service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/error_stats_service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/error_stats_service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/error_stats_service.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/report_errors_service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/report_errors_service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/report_errors_service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/report_errors_service.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/duration.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/duration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/duration.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/overview.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/overview.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/lib/google/devtools/clouderrorreporting/v1beta1/error_group_service_services_pb.rb
+++ b/google-cloud-error_reporting/lib/google/devtools/clouderrorreporting/v1beta1/error_group_service_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/devtools/clouderrorreporting/v1beta1/error_stats_service_services_pb.rb
+++ b/google-cloud-error_reporting/lib/google/devtools/clouderrorreporting/v1beta1/error_stats_service_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/lib/google/devtools/clouderrorreporting/v1beta1/report_errors_service_services_pb.rb
+++ b/google-cloud-error_reporting/lib/google/devtools/clouderrorreporting/v1beta1/report_errors_service_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/support/doctest_helper.rb
+++ b/google-cloud-error_reporting/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/support/doctest_helper.rb
+++ b/google-cloud-error_reporting/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/test/google-cloud-error_reporting_test.rb
+++ b/google-cloud-error_reporting/test/google-cloud-error_reporting_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/test/google-cloud-error_reporting_test.rb
+++ b/google-cloud-error_reporting/test/google-cloud-error_reporting_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/async_error_reporter_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/async_error_reporter_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/async_error_reporter_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/async_error_reporter_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/project_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/project_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-error_reporting/test/helper.rb
+++ b/google-cloud-error_reporting/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-error_reporting/test/helper.rb
+++ b/google-cloud-error_reporting/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/LICENSE
+++ b/google-cloud-language/LICENSE
@@ -1,6 +1,6 @@
                             Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -3,7 +3,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language.rb
+++ b/google-cloud-language/lib/google/cloud/language.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/credentials.rb
+++ b/google-cloud-language/lib/google/cloud/language/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/credentials.rb
+++ b/google-cloud-language/lib/google/cloud/language/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/v1.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/v1.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/v1/doc/google/cloud/language/v1/language_service.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/doc/google/cloud/language/v1/language_service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/v1/doc/google/cloud/language/v1/language_service.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/doc/google/cloud/language/v1/language_service.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/v1/doc/overview.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/v1/doc/overview.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/v1/language_service_services_pb.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/language_service_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/v1beta2.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/v1beta2.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/doc/google/cloud/language/v1beta2/language_service.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/doc/google/cloud/language/v1beta2/language_service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/doc/google/cloud/language/v1beta2/language_service.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/doc/google/cloud/language/v1beta2/language_service.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/doc/overview.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/doc/overview.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_services_pb.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/test/google/cloud/language/v1/language_service_client_test.rb
+++ b/google-cloud-language/test/google/cloud/language/v1/language_service_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/test/google/cloud/language/v1/language_service_client_test.rb
+++ b/google-cloud-language/test/google/cloud/language/v1/language_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-language/test/google/cloud/language/v1beta2/language_service_client_test.rb
+++ b/google-cloud-language/test/google/cloud/language/v1beta2/language_service_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-language/test/google/cloud/language/v1beta2/language_service_client_test.rb
+++ b/google-cloud-language/test/google/cloud/language/v1beta2/language_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/LICENSE
+++ b/google-cloud-logging/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/acceptance/logging_helper.rb
+++ b/google-cloud-logging/acceptance/logging_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/acceptance/logging_helper.rb
+++ b/google-cloud-logging/acceptance/logging_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/integration/common_logging_test.rb
+++ b/google-cloud-logging/integration/common_logging_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/integration/common_logging_test.rb
+++ b/google-cloud-logging/integration/common_logging_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/integration/gae/logging_test.rb
+++ b/google-cloud-logging/integration/gae/logging_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/integration/gae/logging_test.rb
+++ b/google-cloud-logging/integration/gae/logging_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/integration/gke/logging_test.rb
+++ b/google-cloud-logging/integration/gke/logging_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/integration/gke/logging_test.rb
+++ b/google-cloud-logging/integration/gke/logging_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/integration/logging_helper.rb
+++ b/google-cloud-logging/integration/logging_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/integration/logging_helper.rb
+++ b/google-cloud-logging/integration/logging_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google-cloud-logging.rb
+++ b/google-cloud-logging/lib/google-cloud-logging.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google-cloud-logging.rb
+++ b/google-cloud-logging/lib/google-cloud-logging.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/convert.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/convert.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/convert.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/convert.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/credentials.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/credentials.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/http_request.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/entry/operation.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/operation.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/entry/operation.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/operation.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/entry/source_location.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/source_location.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/entry/source_location.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/source_location.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/log/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/log/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/log/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/log/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/metric.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/metric.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/metric.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/metric.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/project.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/resource_descriptor.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource_descriptor.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/resource_descriptor.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource_descriptor.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/service.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/service.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/sink.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/sink.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/sink.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/sink.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/distribution.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/distribution.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/distribution.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/distribution.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/label.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/label.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/label.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/label.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/type/http_request.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/type/http_request.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/type/http_request.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/type/http_request.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/log_entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/log_entry.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/log_entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/log_entry.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_metrics.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_metrics.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_metrics.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_metrics.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/duration.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/duration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/duration.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/field_mask.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/field_mask.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/overview.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/overview.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/lib/google/logging/v2/logging_config_services_pb.rb
+++ b/google-cloud-logging/lib/google/logging/v2/logging_config_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/logging/v2/logging_metrics_services_pb.rb
+++ b/google-cloud-logging/lib/google/logging/v2/logging_metrics_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/lib/google/logging/v2/logging_services_pb.rb
+++ b/google-cloud-logging/lib/google/logging/v2/logging_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/convert/hash_to_struct_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/convert/hash_to_struct_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/convert/hash_to_struct_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/convert/hash_to_struct_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/convert/object_to_value_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/convert/object_to_value_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/convert/object_to_value_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/convert/object_to_value_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/entry/operation_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/operation_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/entry/operation_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/operation_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/entry/severity_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/severity_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/entry/severity_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/severity_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/entry_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/entry_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/metric_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/metric_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/metric_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/metric_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project/write_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/write_entries_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project/write_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/write_entries_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/project_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/project_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/rails_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/rails_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/rails_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/rails_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/resource_descriptor_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/resource_descriptor_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/resource_descriptor_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/resource_descriptor_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/resource_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/resource_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/resource_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/resource_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging/sink_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/sink_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging/sink_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/sink_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/google/cloud/logging_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/google/cloud/logging_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/LICENSE
+++ b/google-cloud-monitoring/LICENSE
@@ -1,6 +1,6 @@
                             Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/Rakefile
+++ b/google-cloud-monitoring/Rakefile
@@ -3,7 +3,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/Rakefile
+++ b/google-cloud-monitoring/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/google-cloud-monitoring/lib/google-cloud-monitoring.rb
+++ b/google-cloud-monitoring/lib/google-cloud-monitoring.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google-cloud-monitoring.rb
+++ b/google-cloud-monitoring/lib/google-cloud-monitoring.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/credentials.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/credentials.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/distribution.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/distribution.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/distribution.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/distribution.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/label.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/label.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/label.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/label.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/duration.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/duration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/duration.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/timestamp.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/timestamp.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/overview.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/overview.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/lib/google/monitoring/v3/group_service_services_pb.rb
+++ b/google-cloud-monitoring/lib/google/monitoring/v3/group_service_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/lib/google/monitoring/v3/metric_service_services_pb.rb
+++ b/google-cloud-monitoring/lib/google/monitoring/v3/metric_service_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/LICENSE
+++ b/google-cloud-pubsub/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/acceptance/pubsub/async_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/async_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/acceptance/pubsub/async_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/async_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google-cloud-pubsub.rb
+++ b/google-cloud-pubsub/lib/google-cloud-pubsub.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google-cloud-pubsub.rb
+++ b/google-cloud-pubsub/lib/google-cloud-pubsub.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/batch_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/batch_publisher.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/batch_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/batch_publisher.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/convert.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/convert.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/convert.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/convert.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/credentials.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/credentials.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/policy.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/policy.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/publish_result.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_pusher.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_pusher.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/duration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/field_mask.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/field_mask.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/overview.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/overview.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/lib/google/pubsub/v1/pubsub_services_pb.rb
+++ b/google-cloud-pubsub/lib/google/pubsub/v1/pubsub_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/duration_to_number_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/duration_to_number_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/duration_to_number_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/duration_to_number_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/number_to_duration_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/number_to_duration_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/number_to_duration_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/number_to_duration_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/timestamp_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/timestamp_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/convert/timestamp_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/convert/timestamp_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message/attributes_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message/attributes_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message/attributes_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message/attributes_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message_test.rb
@@ -1,4 +1,4 @@
- # Copyright 2015 Google Inc. All rights reserved.
+ # Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/policy_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/policy_test.rb
@@ -1,4 +1,4 @@
- # Copyright 2016 Google Inc. All rights reserved.
+ # Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/publish_result_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -1,4 +1,4 @@
- # Copyright 2015 Google Inc. All rights reserved.
+ # Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/acknowledge_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/acknowledge_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delay_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delay_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/delete_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/exists_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/lazy_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/name_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/policy_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/pull_wait_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/seek_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/seek_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/seek_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/seek_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/autocreate_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/exists_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/lazy_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/name_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscription_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscriptions_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/LICENSE
+++ b/google-cloud-resource_manager/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/credentials.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/credentials.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/manager.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/manager.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/manager.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/manager.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/list.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/list.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/updater.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/updater.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/updater.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project/updater.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/support/doctest_helper.rb
+++ b/google-cloud-resource_manager/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/support/doctest_helper.rb
+++ b/google-cloud-resource_manager/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/manager_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/manager_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/manager_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/manager_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/policy_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/policy_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/policy_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/policy_test.rb
@@ -1,4 +1,4 @@
- # Copyright 2016 Google Inc. All rights reserved.
+ # Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/project_iam_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/project_iam_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/project_iam_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/project_iam_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/project_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/project_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-resource_manager/test/helper.rb
+++ b/google-cloud-resource_manager/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-resource_manager/test/helper.rb
+++ b/google-cloud-resource_manager/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/edge_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/edge_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/edge_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/edge_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/execute_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/large_data_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/large_data_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/large_data_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/large_data_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/params/bool_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/bool_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-true.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/params/bytes_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/bytes_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/params/bytes_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/bytes_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/params/date_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/date_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-date_value.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/params/float64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/float64_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/params/float64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/float64_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/params/int64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/int64_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/params/int64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/int64_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/params/string_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/string_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/params/string_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/string_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/params/timestamp_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/timestamp_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-timestamp_value.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/read_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/read_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/read_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/read_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/types/bool_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/bool_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/types/bool_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/bool_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/types/bytes_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/bytes_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/types/bytes_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/bytes_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/types/date_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/date_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/types/date_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/date_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/types/float64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/float64_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/types/float64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/float64_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/types/int64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/int64_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/types/int64_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/int64_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/types/string_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/string_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/types/string_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/string_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/client/types/timestamp_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/timestamp_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/client/types/timestamp_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/timestamp_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License 00:00:00Z");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/database_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/database_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/database_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/database_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/instance_config_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/instance_config_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/instance_config_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/instance_config_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner/instance_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/instance_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner/instance_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/instance_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/acceptance/spanner_helper.rb
+++ b/google-cloud-spanner/acceptance/spanner_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/acceptance/spanner_helper.rb
+++ b/google-cloud-spanner/acceptance/spanner_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/benchmark/ycsv.rb
+++ b/google-cloud-spanner/benchmark/ycsv.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/benchmark/ycsv.rb
+++ b/google-cloud-spanner/benchmark/ycsv.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google-cloud-spanner.rb
+++ b/google-cloud-spanner/lib/google-cloud-spanner.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google-cloud-spanner.rb
+++ b/google-cloud-spanner/lib/google-cloud-spanner.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/credentials.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/credentials.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/rpc/status.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/rpc/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/rpc/status.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/overview.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/overview.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/credentials.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/credentials.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/field_mask.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/field_mask.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/rpc/status.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/rpc/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/rpc/status.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/overview.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/overview.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/credentials.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/credentials.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/data.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/data.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/data.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/data.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/database/job.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database/job.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/database/job.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database/job.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/database/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/database/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/errors.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/errors.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/errors.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/errors.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/config.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/config.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/config.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/config.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/config/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/config/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/config/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/config/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/job.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/job.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/job.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/job.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance/list.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/policy.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/policy.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/range.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/range.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/range.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/range.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/status.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/status.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1.rb
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1.rb
@@ -1,5 +1,5 @@
 
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/duration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/struct.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/struct.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/struct.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/struct.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/timestamp.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/timestamp.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/overview.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/overview.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_services_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/admin/database/v1/spanner_database_admin_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_services_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/admin/instance/v1/spanner_instance_admin_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/lib/google/spanner/v1/spanner_services_pb.rb
+++ b/google-cloud-spanner/lib/google/spanner/v1/spanner_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/threads_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/threads_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/threads_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/threads_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/duration_to_number_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/duration_to_number_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/duration_to_number_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/duration_to_number_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/timestamp_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/timestamp_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/timestamp_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/timestamp_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/value_to_raw_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/value_to_raw_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/value_to_raw_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/value_to_raw_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/database/drop_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/drop_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/database/drop_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/drop_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/data_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/data_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/data_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/data_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/delete_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/delete_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/delete_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/delete_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/project_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/project_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/range_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/range_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/emtpy_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/emtpy_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/emtpy_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/emtpy_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_single_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/from_enum_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/merge_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/timestamp_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/session/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/execute_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/session/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/execute_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/session/release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/release_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/session/release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/release_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/metadata_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/metadata_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/metadata_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/metadata_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/range_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/range_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/status_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/status_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/status_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/status_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/range_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/range_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/release_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/release_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/transaction_id_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/transaction_id_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/transaction_id_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/transaction_id_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/LICENSE
+++ b/google-cloud-speech/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/acceptance/speech/async_test.rb
+++ b/google-cloud-speech/acceptance/speech/async_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/acceptance/speech/async_test.rb
+++ b/google-cloud-speech/acceptance/speech/async_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/acceptance/speech/stream_test.rb
+++ b/google-cloud-speech/acceptance/speech/stream_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/acceptance/speech/stream_test.rb
+++ b/google-cloud-speech/acceptance/speech/stream_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/acceptance/speech/sync_test.rb
+++ b/google-cloud-speech/acceptance/speech/sync_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/acceptance/speech/sync_test.rb
+++ b/google-cloud-speech/acceptance/speech/sync_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/acceptance/speech_helper.rb
+++ b/google-cloud-speech/acceptance/speech_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/acceptance/speech_helper.rb
+++ b/google-cloud-speech/acceptance/speech_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google-cloud-speech.rb
+++ b/google-cloud-speech/lib/google-cloud-speech.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google-cloud-speech.rb
+++ b/google-cloud-speech/lib/google-cloud-speech.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/audio.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/audio.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/audio.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/audio.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/convert.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/convert.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/convert.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/convert.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/credentials.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/credentials.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/operation.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/operation.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/operation.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/operation.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/project.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/result.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/result.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/result.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/result.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/service.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/service.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/stream.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/stream.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/stream.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/stream.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/v1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/cloud_speech_services_pb.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/cloud_speech_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/duration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/rpc/status.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/rpc/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/rpc/status.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/overview.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/overview.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/version.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/version.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/support/doctest_helper.rb
+++ b/google-cloud-speech/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/support/doctest_helper.rb
+++ b/google-cloud-speech/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/audio/process_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/process_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/audio/process_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/process_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/audio/recognize_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/convert/duration_to_number_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/convert/duration_to_number_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/convert/duration_to_number_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/convert/duration_to_number_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/convert/number_to_duration_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/convert/number_to_duration_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/convert/number_to_duration_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/convert/number_to_duration_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/interim_result_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/interim_result_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/interim_result_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/interim_result_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/operation_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/operation_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/operation_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/operation_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/project/audio_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/audio_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/project/audio_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/audio_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/project/operation_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/operation_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/project/operation_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/operation_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/project/process_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/process_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/project/process_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/process_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/recognize_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/project/stream_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/stream_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/project/stream_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project/stream_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/project_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/project_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/result_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/result_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/result_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/result_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech/stream_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/stream_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech/stream_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/stream_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/google/cloud/speech_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/google/cloud/speech_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/test/helper.rb
+++ b/google-cloud-speech/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/test/helper.rb
+++ b/google-cloud-speech/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/LICENSE
+++ b/google-cloud-storage/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage/buckets_test.rb
+++ b/google-cloud-storage/acceptance/storage/buckets_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/buckets_test.rb
+++ b/google-cloud-storage/acceptance/storage/buckets_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage/file_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_acl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/file_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_acl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage/filename_test.rb
+++ b/google-cloud-storage/acceptance/storage/filename_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/filename_test.rb
+++ b/google-cloud-storage/acceptance/storage/filename_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage/files_test.rb
+++ b/google-cloud-storage/acceptance/storage/files_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage/files_test.rb
+++ b/google-cloud-storage/acceptance/storage/files_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google-cloud-storage.rb
+++ b/google-cloud-storage/lib/google-cloud-storage.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google-cloud-storage.rb
+++ b/google-cloud-storage/lib/google-cloud-storage.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/acl.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/cors.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/cors.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/cors.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/cors.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/credentials.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/credentials.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/errors.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/errors.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/errors.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/errors.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/notification.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/notification.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/notification.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/notification.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/post_object.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/post_object.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/post_object.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/post_object.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/bucket_compose_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_compose_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_compose_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_compose_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_default_acl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_default_acl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/bucket_post_object_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_post_object_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_post_object_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_post_object_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_acl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_acl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_default_acl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_default_acl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_post_object_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_post_object_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_post_object_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_post_object_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/lazy/signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/signed_url_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/lazy/signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/signed_url_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/notification_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/notification_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/notification_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/notification_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/signed_url_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/signed_url_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/signed_url_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage/verifier_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/verifier_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage/verifier_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/verifier_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/google/cloud/storage_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/google/cloud/storage_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/LICENSE
+++ b/google-cloud-trace/LICENSE
@@ -1,6 +1,6 @@
                             Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/acceptance/trace/trace_test.rb
+++ b/google-cloud-trace/acceptance/trace/trace_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/acceptance/trace/trace_test.rb
+++ b/google-cloud-trace/acceptance/trace/trace_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/acceptance/trace_helper.rb
+++ b/google-cloud-trace/acceptance/trace_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/acceptance/trace_helper.rb
+++ b/google-cloud-trace/acceptance/trace_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/integration/common_trace_test.rb
+++ b/google-cloud-trace/integration/common_trace_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/integration/common_trace_test.rb
+++ b/google-cloud-trace/integration/common_trace_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/integration/trace_helper.rb
+++ b/google-cloud-trace/integration/trace_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/integration/trace_helper.rb
+++ b/google-cloud-trace/integration/trace_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google-cloud-trace.rb
+++ b/google-cloud-trace/lib/google-cloud-trace.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google-cloud-trace.rb
+++ b/google-cloud-trace/lib/google-cloud-trace.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/credentials.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/credentials.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/faraday_middleware.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/label_key.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/label_key.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/label_key.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/label_key.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/notifications.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/notifications.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/notifications.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/notifications.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/call_with_trace.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/project.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/project.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/result_set.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/result_set.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/result_set.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/result_set.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/service.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/service.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/span.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/span.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/span.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/span.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/span_kind.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/span_kind.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/span_kind.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/span_kind.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/time_sampler.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/time_sampler.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/time_sampler.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/time_sampler.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/trace_record.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/trace_record.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/trace_record.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/trace_record.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/utils.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/utils.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v1.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/v1.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/overview.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/overview.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/devtools/cloudtrace/v1/trace_services_pb.rb
+++ b/google-cloud-trace/lib/google/devtools/cloudtrace/v1/trace_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/support/doctest_helper.rb
+++ b/google-cloud-trace/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/support/doctest_helper.rb
+++ b/google-cloud-trace/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/async_reporter_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/async_reporter_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/async_reporter_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/async_reporter_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/label_key_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/label_key_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/label_key_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/label_key_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/notifications_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/notifications_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/notifications_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/notifications_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/project_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/project_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/rails_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/rails_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/rails_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/rails_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/time_sampler_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/time_sampler_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/time_sampler_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/time_sampler_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/google/cloud/trace/utils_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/utils_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/google/cloud/trace/utils_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/utils_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/test/helper.rb
+++ b/google-cloud-trace/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/test/helper.rb
+++ b/google-cloud-trace/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/LICENSE
+++ b/google-cloud-translate/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/acceptance/translate/translate_test.rb
+++ b/google-cloud-translate/acceptance/translate/translate_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/acceptance/translate/translate_test.rb
+++ b/google-cloud-translate/acceptance/translate/translate_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/acceptance/translate_helper.rb
+++ b/google-cloud-translate/acceptance/translate_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/acceptance/translate_helper.rb
+++ b/google-cloud-translate/acceptance/translate_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/lib/google-cloud-translate.rb
+++ b/google-cloud-translate/lib/google-cloud-translate.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/lib/google-cloud-translate.rb
+++ b/google-cloud-translate/lib/google-cloud-translate.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/lib/google/cloud/translate.rb
+++ b/google-cloud-translate/lib/google/cloud/translate.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/lib/google/cloud/translate.rb
+++ b/google-cloud-translate/lib/google/cloud/translate.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/lib/google/cloud/translate/api.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/api.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/lib/google/cloud/translate/api.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/api.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/lib/google/cloud/translate/credentials.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/lib/google/cloud/translate/credentials.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/lib/google/cloud/translate/detection.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/detection.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/lib/google/cloud/translate/detection.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/detection.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/lib/google/cloud/translate/language.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/language.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/lib/google/cloud/translate/language.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/language.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/lib/google/cloud/translate/service.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/lib/google/cloud/translate/service.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/lib/google/cloud/translate/translation.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/translation.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/lib/google/cloud/translate/translation.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/translation.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/lib/google/cloud/translate/version.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/lib/google/cloud/translate/version.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/support/doctest_helper.rb
+++ b/google-cloud-translate/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/support/doctest_helper.rb
+++ b/google-cloud-translate/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/test/google/cloud/translate/detect_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/detect_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/test/google/cloud/translate/detect_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/detect_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/test/google/cloud/translate/languages_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/languages_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/test/google/cloud/translate/languages_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/languages_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/test/google/cloud/translate/service_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/service_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/test/google/cloud/translate/service_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/service_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/test/google/cloud/translate/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/translate_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/test/google/cloud/translate/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate/translate_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/test/google/cloud/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/test/google/cloud/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/test/helper.rb
+++ b/google-cloud-translate/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-translate/test/helper.rb
+++ b/google-cloud-translate/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/LICENSE
+++ b/google-cloud-video_intelligence/LICENSE
@@ -1,6 +1,6 @@
                             Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/Rakefile
+++ b/google-cloud-video_intelligence/Rakefile
@@ -3,7 +3,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/Rakefile
+++ b/google-cloud-video_intelligence/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/google-cloud-video_intelligence/acceptance/google/cloud/video_intelligence/v1/video_intelligence_service_smoke_test.rb
+++ b/google-cloud-video_intelligence/acceptance/google/cloud/video_intelligence/v1/video_intelligence_service_smoke_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/acceptance/google/cloud/video_intelligence/v1/video_intelligence_service_smoke_test.rb
+++ b/google-cloud-video_intelligence/acceptance/google/cloud/video_intelligence/v1/video_intelligence_service_smoke_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/credentials.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/credentials.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/duration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/rpc/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/rpc/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/duration.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/duration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/duration.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/rpc/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google LLC All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/LICENSE
+++ b/google-cloud-vision/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/acceptance/vision/vision_test.rb
+++ b/google-cloud-vision/acceptance/vision/vision_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/acceptance/vision/vision_test.rb
+++ b/google-cloud-vision/acceptance/vision/vision_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/acceptance/vision_helper.rb
+++ b/google-cloud-vision/acceptance/vision_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/acceptance/vision_helper.rb
+++ b/google-cloud-vision/acceptance/vision_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google-cloud-vision.rb
+++ b/google-cloud-vision/lib/google-cloud-vision.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google-cloud-vision.rb
+++ b/google-cloud-vision/lib/google-cloud-vision.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision.rb
+++ b/google-cloud-vision/lib/google/cloud/vision.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision.rb
+++ b/google-cloud-vision/lib/google/cloud/vision.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotate.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotate.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotate.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotate.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotation.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/crop_hint.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/crop_hint.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/crop_hint.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/crop_hint.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/entity.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/face.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/properties.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/safe_search.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/text.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/vertex.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/web.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/web.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/annotation/web.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/annotation/web.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/credentials.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/credentials.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/credentials.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/image.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/image.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/image.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/image.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/location.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/location.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/location.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/location.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/service.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/service.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/service.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/geometry.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/geometry.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/geometry.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/geometry.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/image_annotator.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/image_annotator.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/image_annotator.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/image_annotator.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/text_annotation.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/text_annotation.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/text_annotation.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/text_annotation.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/web_detection.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/web_detection.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/web_detection.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/web_detection.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/any.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/wrappers.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/wrappers.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/rpc/status.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/rpc/status.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/rpc/status.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/type/color.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/type/color.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/type/color.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/type/color.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/type/latlng.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/type/latlng.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/type/latlng.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/type/latlng.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/overview.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/overview.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/overview.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017, Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_services_pb.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/version.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/lib/google/cloud/vision/version.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/support/doctest_helper.rb
+++ b/google-cloud-vision/support/doctest_helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/support/doctest_helper.rb
+++ b/google-cloud-vision/support/doctest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation/crop_hint_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/crop_hint_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation/crop_hint_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/crop_hint_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation/face_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/face_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation/face_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/face_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation/label_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/label_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation/label_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/label_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation/landmark_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/landmark_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation/landmark_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/landmark_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation/logo_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/logo_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation/logo_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/logo_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation/properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/properties_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation/properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/properties_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation/safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/safe_search_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation/safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/safe_search_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation/text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/text_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation/text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/text_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation/web_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/web_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation/web_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation/web_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/annotation_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/annotation_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/annotation_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/annotate_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/annotate_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/annotate_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/annotate_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/context_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/context_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/context_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/context_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/crop_hints_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/crop_hints_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/crop_hints_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/crop_hints_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/document_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/document_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/document_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/document_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/faces_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/faces_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/faces_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/faces_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/labels_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/labels_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/labels_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/labels_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/landmarks_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/landmarks_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/landmarks_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/landmarks_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/logos_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/logos_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/logos_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/logos_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/properties_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/properties_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/safe_search_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/safe_search_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/text_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/text_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image/web_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/web_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image/web_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image/web_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/image_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/image_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/image_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_crop_hints_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_crop_hints_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_crop_hints_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_crop_hints_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_document_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_document_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_document_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_document_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_faces_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_faces_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_faces_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_faces_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_labels_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_labels_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_labels_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_labels_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_landmarks_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_landmarks_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_landmarks_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_landmarks_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_logos_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_logos_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_logos_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_logos_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_properties_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_properties_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_properties_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_safe_search_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_safe_search_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_safe_search_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_text_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_text_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_text_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_web_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_web_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project/annotate_web_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project/annotate_web_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision/project_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision/project_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision/project_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/google/cloud/vision_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/google/cloud/vision_test.rb
+++ b/google-cloud-vision/test/google/cloud/vision_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-vision/test/helper.rb
+++ b/google-cloud-vision/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-vision/test/helper.rb
+++ b/google-cloud-vision/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud/LICENSE
+++ b/google-cloud/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud/lib/google-cloud.rb
+++ b/google-cloud/lib/google-cloud.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud/lib/google-cloud.rb
+++ b/google-cloud/lib/google-cloud.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud/lib/google/cloud/version.rb
+++ b/google-cloud/lib/google/cloud/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud/lib/google/cloud/version.rb
+++ b/google-cloud/lib/google/cloud/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud/test/google/cloud/version_test.rb
+++ b/google-cloud/test/google/cloud/version_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud/test/google/cloud/version_test.rb
+++ b/google-cloud/test/google/cloud/version_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2015 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud/test/helper.rb
+++ b/google-cloud/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud/test/helper.rb
+++ b/google-cloud/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2014 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration/deploy.rb
+++ b/integration/deploy.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration/deploy.rb
+++ b/integration/deploy.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration/helper.rb
+++ b/integration/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration/helper.rb
+++ b/integration/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration/sinatra2_app/app.rb
+++ b/integration/sinatra2_app/app.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration/sinatra2_app/app.rb
+++ b/integration/sinatra2_app/app.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/LICENSE
+++ b/stackdriver-core/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/lib/google/cloud/configuration.rb
+++ b/stackdriver-core/lib/google/cloud/configuration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/lib/google/cloud/configuration.rb
+++ b/stackdriver-core/lib/google/cloud/configuration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/lib/stackdriver-core.rb
+++ b/stackdriver-core/lib/stackdriver-core.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/lib/stackdriver-core.rb
+++ b/stackdriver-core/lib/stackdriver-core.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/lib/stackdriver/core.rb
+++ b/stackdriver-core/lib/stackdriver/core.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/lib/stackdriver/core.rb
+++ b/stackdriver-core/lib/stackdriver/core.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/lib/stackdriver/core/async_actor.rb
+++ b/stackdriver-core/lib/stackdriver/core/async_actor.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/lib/stackdriver/core/async_actor.rb
+++ b/stackdriver-core/lib/stackdriver/core/async_actor.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/lib/stackdriver/core/configuration.rb
+++ b/stackdriver-core/lib/stackdriver/core/configuration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/lib/stackdriver/core/configuration.rb
+++ b/stackdriver-core/lib/stackdriver/core/configuration.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0oud
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/lib/stackdriver/core/trace_context.rb
+++ b/stackdriver-core/lib/stackdriver/core/trace_context.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/lib/stackdriver/core/trace_context.rb
+++ b/stackdriver-core/lib/stackdriver/core/trace_context.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/lib/stackdriver/core/version.rb
+++ b/stackdriver-core/lib/stackdriver/core/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/lib/stackdriver/core/version.rb
+++ b/stackdriver-core/lib/stackdriver/core/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/test/google/cloud/configuration_test.rb
+++ b/stackdriver-core/test/google/cloud/configuration_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/test/google/cloud/configuration_test.rb
+++ b/stackdriver-core/test/google/cloud/configuration_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0oud
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/test/helper.rb
+++ b/stackdriver-core/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/test/helper.rb
+++ b/stackdriver-core/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/test/stackdriver/core/async_actor_test.rb
+++ b/stackdriver-core/test/stackdriver/core/async_actor_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/test/stackdriver/core/async_actor_test.rb
+++ b/stackdriver-core/test/stackdriver/core/async_actor_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/test/stackdriver/core/configuration_test.rb
+++ b/stackdriver-core/test/stackdriver/core/configuration_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc. All rights reserved.
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver-core/test/stackdriver/core/configuration_test.rb
+++ b/stackdriver-core/test/stackdriver/core/configuration_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0oud
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/test/stackdriver/core/trace_context_test.rb
+++ b/stackdriver-core/test/stackdriver/core/trace_context_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver-core/test/stackdriver/core/trace_context_test.rb
+++ b/stackdriver-core/test/stackdriver/core/trace_context_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver/LICENSE
+++ b/stackdriver/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver/lib/stackdriver/version.rb
+++ b/stackdriver/lib/stackdriver/version.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver/lib/stackdriver/version.rb
+++ b/stackdriver/lib/stackdriver/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver/test/helper.rb
+++ b/stackdriver/test/helper.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver/test/helper.rb
+++ b/stackdriver/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver/test/stackdriver/version_test.rb
+++ b/stackdriver/test/stackdriver/version_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver/test/stackdriver/version_test.rb
+++ b/stackdriver/test/stackdriver/version_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stackdriver/test/stackdriver_test.rb
+++ b/stackdriver/test/stackdriver_test.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/stackdriver/test/stackdriver_test.rb
+++ b/stackdriver/test/stackdriver_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update the copyright headers to use the correct copyright format and use HTTPS for the apache URLs.

[fixes #1882]