### PR TITLE
Rename BigQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ gem install google-cloud-bigquery
 ```ruby
 require "google/cloud/bigquery"
 
-bigquery = Google::Cloud::Bigquery.new(
+bigquery = Google::Cloud::BigQuery.new(
   project_id: "my-todo-project",
   credentials: "/path/to/keyfile.json"
 )

--- a/gcloud/test/gcloud_test.rb
+++ b/gcloud/test/gcloud_test.rb
@@ -23,7 +23,9 @@ describe Gcloud do
   it "can require BigQuery" do
     require "gcloud/bigquery"
 
-    Gcloud::Bigquery.must_equal Google::Cloud::Bigquery
+    Gcloud::BigQuery.must_equal Google::Cloud::BigQuery
+    # alias
+    Gcloud::Bigquery.must_equal Google::Cloud::BigQuery
   end
 
   it "can require Datastore" do

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -23,7 +23,7 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ```ruby
 require "google/cloud/bigquery"
 
-bigquery = Google::Cloud::Bigquery.new(
+bigquery = Google::Cloud::BigQuery.new(
   project_id: "my-todo-project",
   credentials: "/path/to/keyfile.json"
 )

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -14,7 +14,7 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery, :advanced, :bigquery do
+describe Google::Cloud::BigQuery, :advanced, :bigquery do
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) { bigquery.dataset(dataset_id) || bigquery.create_dataset(dataset_id) }
   let(:table_id) { "examples_table" }
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
   it "queries values in standard mode" do
     rows = bigquery.query "SELECT * FROM #{dataset_id}.#{table_id} WHERE id = ?", params: [2]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     row = rows.first
 
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
   it "queries repeated scalars in legacy mode" do
     rows = bigquery.query "SELECT name, scores FROM [#{table.id}] WHERE id = 2", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 3
     rows[0].must_equal({ name: "Gandalf", scores: 100.0})
     rows[1].must_equal({ name: "Gandalf", scores: 99.0})
@@ -53,7 +53,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
   it "queries repeated records in legacy mode" do
     rows = bigquery.query "SELECT name, spells.name, spells.properties.name, spells.properties.power FROM [#{table.id}] WHERE id = 2", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 3
     rows[0].must_equal({ name: "Gandalf", spells_name: "Skydragon", spells_properties_name: "Flying",   spells_properties_power: 1.0 })
     rows[1].must_equal({ name: "Gandalf", spells_name: "Skydragon", spells_properties_name: "Creature", spells_properties_power: 1.0 })
@@ -155,7 +155,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
         is_magic: false,
         scores: [],
         spells: [],
-        tea_time: Google::Cloud::Bigquery::Time.new("10:00:00"),
+        tea_time: Google::Cloud::BigQuery::Time.new("10:00:00"),
         next_vacation: Date.parse("2017-09-22"),
         favorite_time: Time.parse("2031-04-01T05:09:27").utc.to_datetime
       }, {
@@ -177,7 +177,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
             last_used: Time.parse("2015-10-31 23:59:56 UTC")
           }
         ],
-        tea_time: Google::Cloud::Bigquery::Time.new("15:00:00"),
+        tea_time: Google::Cloud::BigQuery::Time.new("15:00:00"),
         next_vacation: Date.parse("2666-06-06"),
         favorite_time: Time.parse("2001-12-19T23:59:59").utc.to_datetime
       }, {
@@ -195,7 +195,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
             last_used: Time.parse("2017-02-14 12:07:23 UTC")
           }
         ],
-        tea_time: Google::Cloud::Bigquery::Time.new("12:00:00"),
+        tea_time: Google::Cloud::BigQuery::Time.new("12:00:00"),
         next_vacation: Date.parse("2017-03-14"),
         favorite_time: Time.parse("2000-10-31T23:27:46").utc.to_datetime
       }

--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -14,7 +14,7 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery, :bigquery do
+describe Google::Cloud::BigQuery, :bigquery do
   let(:publicdata_query) { "SELECT url FROM publicdata.samples.github_nested LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
@@ -66,7 +66,7 @@ describe Google::Cloud::Bigquery, :bigquery do
     # The code in before ensures we have at least one dataset
     datasets.count.wont_be :zero?
     datasets.all(request_limit: 1).each do |ds|
-      ds.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      ds.must_be_kind_of Google::Cloud::BigQuery::Dataset
       ds.created_at.must_be_kind_of Time # Loads full representation
     end
     more_datasets = datasets.next
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigquery, :bigquery do
     datasets = bigquery.datasets filter: filter
     datasets.count.must_equal 1
     ds = datasets.first
-    ds.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    ds.must_be_kind_of Google::Cloud::BigQuery::Dataset
     ds.labels.must_equal labels
   end
 
@@ -96,26 +96,26 @@ describe Google::Cloud::Bigquery, :bigquery do
 
   it "should run an query" do
     rows = bigquery.query publicdata_query
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 100
   end
 
   it "should run an query without legacy SQL syntax" do
     rows = bigquery.query "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100", legacy_sql: false
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 100
   end
 
   it "should run an query with standard SQL syntax" do
     rows = bigquery.query "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100", standard_sql: true
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 100
   end
 
   it "should run a query job with job id" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     job = bigquery.query_job publicdata_query, job_id: job_id
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
+    job.must_be_kind_of Google::Cloud::BigQuery::Job
     job.job_id.must_equal job_id
     job.user_email.wont_be_nil
     job.wait_until_done!
@@ -125,31 +125,31 @@ describe Google::Cloud::Bigquery, :bigquery do
 
   it "should run a query job with job labels" do
     job = bigquery.query_job publicdata_query, labels: labels
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
+    job.must_be_kind_of Google::Cloud::BigQuery::Job
     job.labels.must_equal labels
   end
 
   it "should run a query job with user defined function resources" do
     job = bigquery.query_job publicdata_query, udfs: udfs
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
+    job.must_be_kind_of Google::Cloud::BigQuery::Job
     job.udfs.must_equal udfs
   end
 
   it "should get a list of jobs" do
     jobs = bigquery.jobs.all request_limit: 3
-    jobs.each { |job| job.must_be_kind_of Google::Cloud::Bigquery::Job }
+    jobs.each { |job| job.must_be_kind_of Google::Cloud::BigQuery::Job }
   end
 
   it "should get a list of projects" do
     projects = bigquery.projects.all
     projects.count.must_be :>, 0
     projects.each do |project|
-      project.must_be_kind_of Google::Cloud::Bigquery::Project
+      project.must_be_kind_of Google::Cloud::BigQuery::Project
       project.name.must_be_kind_of String
-      project.service.must_be_kind_of Google::Cloud::Bigquery::Service
+      project.service.must_be_kind_of Google::Cloud::BigQuery::Service
       project.service.project.must_be_kind_of String
       project.datasets.each do |ds|
-        ds.must_be_kind_of Google::Cloud::Bigquery::Dataset
+        ds.must_be_kind_of Google::Cloud::BigQuery::Dataset
       end
     end
   end

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
@@ -14,7 +14,7 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery::Dataset, :access, :bigquery do
+describe Google::Cloud::BigQuery::Dataset, :access, :bigquery do
   let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -14,7 +14,7 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
+describe Google::Cloud::BigQuery::Dataset, :reference, :bigquery do
   let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
   end
 
   it "has the attributes of a dataset after reload" do
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.project_id.must_equal bigquery.project
     dataset.dataset_id.must_equal dataset.dataset_id
     dataset.etag.must_be_nil
@@ -120,7 +120,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
 
     fresh = bigquery.dataset dataset.dataset_id
     fresh.wont_be_nil
-    fresh.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    fresh.must_be_kind_of Google::Cloud::BigQuery::Dataset
     fresh.dataset_id.must_equal dataset.dataset_id
     fresh.name.must_equal new_name
     fresh.description.must_equal new_desc
@@ -182,14 +182,14 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    query_job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     query_job.job_id.must_equal job_id
     query_job.wait_until_done!
     query_job.done?.must_equal true
     query_job.data.total.wont_be_nil
 
     data = dataset.query query
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.total.wont_be_nil
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -14,7 +14,7 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery::Dataset, :bigquery do
+describe Google::Cloud::BigQuery::Dataset, :bigquery do
   let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
 
   it "has the attributes of a dataset" do
     fresh = bigquery.dataset dataset_id
-    fresh.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    fresh.must_be_kind_of Google::Cloud::BigQuery::Dataset
 
     fresh.project_id.must_equal bigquery.project
     fresh.dataset_id.must_equal dataset.dataset_id
@@ -104,7 +104,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
 
     fresh = bigquery.dataset dataset.dataset_id
     fresh.wont_be :nil?
-    fresh.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    fresh.must_be_kind_of Google::Cloud::BigQuery::Dataset
     fresh.dataset_id.must_equal dataset.dataset_id
     fresh.name.must_equal new_name
     fresh.description.must_equal new_desc
@@ -166,7 +166,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       schema.string    "name",  description: "name description",  mode: :required
       schema.timestamp "dob",   description: "dob description",   mode: :required
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     job.job_id.must_equal job_id
     job.wait_until_done!
     job.output_rows.must_equal 3
@@ -227,7 +227,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     insert_response.error_rows.must_be :empty?
 
     data = table_with_schema.data max: 1
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
     [nil, 0].must_include data.total
@@ -247,7 +247,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
 
     insert_response.insert_errors.wont_be :empty?
     insert_response.insert_errors.count.must_equal 1
-    insert_response.insert_errors.first.class.must_equal Google::Cloud::Bigquery::InsertResponse::InsertError
+    insert_response.insert_errors.first.class.must_equal Google::Cloud::BigQuery::InsertResponse::InsertError
     insert_response.insert_errors.first.index.must_equal 1
 
     bigquery_row = invalid_rows[insert_response.insert_errors.first.index]
@@ -280,7 +280,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     table.wont_be_nil
 
     data = table.data max: 1
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
     [nil, 0].must_include data.total
@@ -312,7 +312,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     table.wont_be_nil
 
     data = table.data max: 1
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
     [nil, 0].must_include data.total

--- a/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
@@ -14,12 +14,12 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
+describe Google::Cloud::BigQuery, :legacy_query_types, :bigquery do
 
   it "queries a string value" do
     rows = bigquery.query "SELECT 'hello' AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal "hello"
   end
@@ -27,7 +27,7 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
   it "queries an integer value" do
     rows = bigquery.query "SELECT 999 AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal 999
   end
@@ -35,7 +35,7 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
   it "queries a float value" do
     rows = bigquery.query "SELECT 12.0 AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal 12.0
   end
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
   it "queries a boolean value" do
     rows = bigquery.query "SELECT false AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal false
   end
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
   it "queries a date value" do
     rows = bigquery.query "SELECT CAST(CURRENT_DATE() AS DATE) AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of Date
   end
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
   it "queries a timestamp value" do
     rows = bigquery.query "SELECT CAST(CURRENT_TIMESTAMP() AS TIMESTAMP) AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of ::Time
   end
@@ -71,15 +71,15 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
   it "queries a time value" do
     rows = bigquery.query "SELECT CAST(CURRENT_TIME() AS TIME) AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
+    rows.first[:value].must_be_kind_of Google::Cloud::BigQuery::Time
   end
 
   it "queries a bytes value" do
     rows = bigquery.query "SELECT CAST('hello' AS BYTES) AS value", legacy_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of StringIO
     rows.first[:value].read.must_equal "hello"

--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -14,11 +14,11 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery, :named_params, :bigquery do
+describe Google::Cloud::BigQuery, :named_params, :bigquery do
   it "queries the data with a string parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: "hello" }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal "hello"
   end
@@ -26,7 +26,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
   it "queries the data with an integer parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: 999 }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal 999
   end
@@ -34,7 +34,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
   it "queries the data with a float parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: 12.0 }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal 12.0
   end
@@ -42,7 +42,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
   it "queries the data with a boolean parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: false }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal false
   end
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     today = Date.today
     rows = bigquery.query "SELECT @value AS value", params: { value: today }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal Date.today
   end
@@ -60,7 +60,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     now = Time.now.utc.to_datetime
     rows = bigquery.query "SELECT @value AS value", params: { value: now }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of DateTime
     rows.first[:value].must_be_close_to now
@@ -71,7 +71,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     now = Time.now
     rows = bigquery.query "SELECT @value AS value", params: { value: now }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of ::Time
     rows.first[:value].must_be_close_to now
@@ -80,16 +80,16 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
   it "queries the data with a time parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: bigquery.time(12, 30, 0) }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
+    rows.first[:value].must_be_kind_of Google::Cloud::BigQuery::Time
     rows.first[:value].value.must_equal "12:30:00"
   end
 
   it "queries the data with a bytes parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: StringIO.new("hello world!") }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of StringIO
     rows.first[:value].read.must_equal "hello world!"
@@ -98,7 +98,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
   it "queries the data with an array of integers parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: [1, 2, 3, 4] }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal [1, 2, 3, 4]
   end
@@ -106,7 +106,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
   it "queries the data with an array of strings parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: ["foo", "bar", "baz"] }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal ["foo", "bar", "baz"]
   end
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
   it "queries the data with a struct parameter" do
     rows = bigquery.query "SELECT @hitchhiker.message, @hitchhiker.repeat", params: { hitchhiker: { message: "hello", repeat: 1 } }
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first.must_equal({ message: "hello", repeat: 1 })
   end

--- a/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
@@ -14,11 +14,11 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery, :positional_params, :bigquery do
+describe Google::Cloud::BigQuery, :positional_params, :bigquery do
   it "queries the data with a string parameter" do
     rows = bigquery.query "SELECT ? AS value", params: ["hello"]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal "hello"
   end
@@ -26,7 +26,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
   it "queries the data with an integer parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [999]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal 999
   end
@@ -34,7 +34,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
   it "queries the data with a float parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [12.0]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal 12.0
   end
@@ -42,7 +42,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
   it "queries the data with a boolean parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [false]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal false
   end
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     today = Date.today
     rows = bigquery.query "SELECT ? AS value", params: [today]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal Date.today
   end
@@ -60,7 +60,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     now = Time.now.utc.to_datetime
     rows = bigquery.query "SELECT ? AS value", params: [now]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of DateTime
     rows.first[:value].must_be_close_to now
@@ -71,7 +71,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     now = Time.now
     rows = bigquery.query "SELECT ? AS value", params: [now]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of ::Time
     rows.first[:value].must_be_close_to now
@@ -80,16 +80,16 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
   it "queries the data with a time parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [bigquery.time(12, 30, 0)]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
+    rows.first[:value].must_be_kind_of Google::Cloud::BigQuery::Time
     rows.first[:value].value.must_equal "12:30:00"
   end
 
   it "queries the data with a bytes parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [StringIO.new("hello world!")]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of StringIO
     rows.first[:value].read.must_equal "hello world!"
@@ -98,7 +98,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
   it "queries the data with an array of integers parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [[1, 2, 3, 4]]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal [1, 2, 3, 4]
   end
@@ -106,7 +106,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
   it "queries the data with an array of strings parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [["foo", "bar", "baz"]]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal ["foo", "bar", "baz"]
   end
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
   it "queries the data with a struct parameter" do
     rows = bigquery.query "SELECT ?.message, ?.repeat", params: [{ message: "hello" }, { repeat: 1 }]
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first.must_equal({ message: "hello", repeat: 1 })
   end

--- a/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
@@ -15,7 +15,7 @@
 require "bigquery_helper"
 require "csv"
 
-describe Google::Cloud::Bigquery::External, :bigquery do
+describe Google::Cloud::BigQuery::External, :bigquery do
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id

--- a/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
@@ -14,12 +14,12 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
+describe Google::Cloud::BigQuery, :standard_query_types, :bigquery do
 
   it "queries a string value" do
     rows = bigquery.query "SELECT 'hello' AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal "hello"
   end
@@ -27,7 +27,7 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries an integer value" do
     rows = bigquery.query "SELECT 999 AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal 999
   end
@@ -35,7 +35,7 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries a float value" do
     rows = bigquery.query "SELECT 12.0 AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal 12.0
   end
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries a boolean value" do
     rows = bigquery.query "SELECT false AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal false
   end
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries a date value" do
     rows = bigquery.query "SELECT CURRENT_DATE() AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of Date
   end
@@ -59,7 +59,7 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries a datetime value" do
     rows = bigquery.query "SELECT CURRENT_DATETIME() AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of DateTime
   end
@@ -67,7 +67,7 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries a timestamp value" do
     rows = bigquery.query "SELECT CURRENT_TIMESTAMP() AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of ::Time
   end
@@ -75,15 +75,15 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries a time value" do
     rows = bigquery.query "SELECT CURRENT_TIME() AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
-    rows.first[:value].must_be_kind_of Google::Cloud::Bigquery::Time
+    rows.first[:value].must_be_kind_of Google::Cloud::BigQuery::Time
   end
 
   it "queries a bytes value" do
     rows = bigquery.query "SELECT CAST('hello' AS BYTES) AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_be_kind_of StringIO
     rows.first[:value].read.must_equal "hello"
@@ -92,7 +92,7 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries an array of integers value" do
     rows = bigquery.query "SELECT [1, 2, 3, 4] AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal [1, 2, 3, 4]
   end
@@ -100,7 +100,7 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
   it "queries an array of strings value" do
     rows = bigquery.query "SELECT ['foo', 'bar', 'baz'] AS value", standard_sql: true
 
-    rows.class.must_equal Google::Cloud::Bigquery::Data
+    rows.class.must_equal Google::Cloud::BigQuery::Data
     rows.count.must_equal 1
     rows.first[:value].must_equal ["foo", "bar", "baz"]
   end

--- a/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
@@ -15,7 +15,7 @@
 require "bigquery_helper"
 require "csv"
 
-describe Google::Cloud::Bigquery::Table, :external, :bigquery do
+describe Google::Cloud::BigQuery::Table, :external, :bigquery do
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id
@@ -57,7 +57,7 @@ describe Google::Cloud::Bigquery::Table, :external, :bigquery do
     table.must_be :external?
     table.external.wont_be :nil?
     table.external.must_be :frozen?
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    table.external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
 
     data = dataset.query "SELECT id, name, breed FROM #{table_id} ORDER BY id"
     data.count.must_equal 3
@@ -86,7 +86,7 @@ describe Google::Cloud::Bigquery::Table, :external, :bigquery do
     table.must_be :external?
     table.external.wont_be :nil?
     table.external.must_be :frozen?
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    table.external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
 
     data = dataset.query "SELECT id, name, breed FROM #{table_id} ORDER BY id"
     data.count.must_equal 3

--- a/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
@@ -14,7 +14,7 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
+describe Google::Cloud::BigQuery::Table, :reference, :bigquery do
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id
@@ -53,7 +53,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
   let(:labels) { { "foo" => "bar" } }
 
   it "has the attributes of a table" do
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
 
     table.table_id.must_equal table_id
     table.dataset_id.must_equal dataset_id
@@ -150,14 +150,14 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    query_job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     query_job.job_id.must_equal job_id
     query_job.wait_until_done!
     query_job.done?.must_equal true
     query_job.data.total.wont_be_nil
 
     data = table.data max: 1
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     [nil, 0].must_include data.total
     data.count.wont_be :nil?
     data.all(request_limit: 2).each do |row|
@@ -179,7 +179,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     inserter.flush
     inserter.stop.wait!
 
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    insert_result.must_be_kind_of Google::Cloud::BigQuery::Table::AsyncInserter::Result
     insert_result.must_be :success?
     insert_result.insert_count.must_equal 3
     insert_result.insert_errors.must_be :empty?
@@ -187,14 +187,14 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    query_job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     query_job.job_id.must_equal job_id
     query_job.wait_until_done!
     query_job.done?.must_equal true
     query_job.data.total.wont_be :nil?
 
     data = table.data max: 1
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
     [nil, 0].must_include data.total
@@ -210,7 +210,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
   it "imports data from a local file with load_job" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     job = table.load_job local_file, job_id: job_id, labels: labels
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     job.job_id.must_equal job_id
     job.labels.must_equal labels
     job.wont_be :autodetect?
@@ -228,7 +228,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     copy_job = table.copy_job target_table_id, create: :needed, write: :empty, job_id: job_id, labels: labels
 
-    copy_job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    copy_job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
     copy_job.job_id.must_equal job_id
     copy_job.labels.must_equal labels
     copy_job.wait_until_done!

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -14,7 +14,7 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery::Table, :bigquery do
+describe Google::Cloud::BigQuery::Table, :bigquery do
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
   it "has the attributes of a table" do
     fresh = dataset.table table.table_id
-    fresh.must_be_kind_of Google::Cloud::Bigquery::Table
+    fresh.must_be_kind_of Google::Cloud::BigQuery::Table
 
     fresh.project_id.must_equal bigquery.project
     fresh.id.must_equal "#{bigquery.project}:#{dataset.dataset_id}.#{table.table_id}"
@@ -93,7 +93,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     fresh.buffer_rows.must_be_kind_of Integer if fresh.buffer_rows
     fresh.buffer_oldest_at.must_be_kind_of Time if fresh.buffer_oldest_at
 
-    fresh.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    fresh.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     fresh.schema.wont_be :empty?
     [:id, :breed, :name, :dob].each { |k| fresh.headers.must_include k }
 
@@ -209,7 +209,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    query_job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     query_job.job_id.must_equal job_id
     query_job.wait_until_done!
 
@@ -235,7 +235,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     query_job.cache_hit?.must_equal false
     query_job.bytes_processed.wont_be :nil?
     query_job.destination.wont_be :nil?
-    query_job.data.class.must_equal Google::Cloud::Bigquery::Data
+    query_job.data.class.must_equal Google::Cloud::BigQuery::Data
     query_job.data.total.wont_be :nil?
 
     # Query Job - Statistics Query Plan
@@ -243,7 +243,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     query_job.query_plan.must_be_kind_of Array
     query_job.query_plan.wont_be :empty?
     stage = query_job.query_plan.first
-    stage.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
+    stage.must_be_kind_of Google::Cloud::BigQuery::QueryJob::Stage
     stage.compute_ratio_avg.must_be_kind_of Float
     stage.compute_ratio_max.must_be_kind_of Float
     stage.id.must_be_kind_of Integer
@@ -261,14 +261,14 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     stage.steps.must_be_kind_of Array
     stage.steps.wont_be :empty?
     step = stage.steps.first
-    step.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
+    step.must_be_kind_of Google::Cloud::BigQuery::QueryJob::Step
     step.kind.must_be_kind_of String
     step.substeps.wont_be_nil
     step.substeps.must_be_kind_of Array
     step.substeps.wont_be :empty?
 
     data = table.data max: 1
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
     [nil, 0].must_include data.total
@@ -281,9 +281,9 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     more_data.wont_be :nil?
 
     data = dataset.query query
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.total.wont_be(:nil?)
-    data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    data.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     data.fields.count.must_equal 4
     [:id, :breed, :name, :dob].each { |k| data.headers.must_include k }
     data.all.each do |row|
@@ -300,7 +300,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
     insert_response.insert_errors.wont_be :empty?
     insert_response.insert_errors.count.must_equal 1
-    insert_response.insert_errors.first.class.must_equal Google::Cloud::Bigquery::InsertResponse::InsertError
+    insert_response.insert_errors.first.class.must_equal Google::Cloud::BigQuery::InsertResponse::InsertError
     insert_response.insert_errors.first.index.must_equal 1
 
     bigquery_row = invalid_rows[insert_response.insert_errors.first.index]
@@ -327,7 +327,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     inserter.flush
     inserter.stop.wait!
 
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    insert_result.must_be_kind_of Google::Cloud::BigQuery::Table::AsyncInserter::Result
     insert_result.must_be :success?
     insert_result.insert_count.must_equal 3
     insert_result.insert_errors.must_be :empty?
@@ -335,7 +335,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     query_job = dataset.query_job query, job_id: job_id
-    query_job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    query_job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     query_job.job_id.must_equal job_id
     query_job.wait_until_done!
 
@@ -361,7 +361,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     query_job.cache_hit?.must_equal false
     query_job.bytes_processed.wont_be :nil?
     query_job.destination.wont_be :nil?
-    query_job.data.class.must_equal Google::Cloud::Bigquery::Data
+    query_job.data.class.must_equal Google::Cloud::BigQuery::Data
     query_job.data.total.wont_be :nil?
 
     # Query Job - Statistics Query Plan
@@ -369,7 +369,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     query_job.query_plan.must_be_kind_of Array
     query_job.query_plan.wont_be :empty?
     stage = query_job.query_plan.first
-    stage.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
+    stage.must_be_kind_of Google::Cloud::BigQuery::QueryJob::Stage
     stage.compute_ratio_avg.must_be_kind_of Float
     stage.compute_ratio_max.must_be_kind_of Float
     stage.id.must_be_kind_of Integer
@@ -387,14 +387,14 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     stage.steps.must_be_kind_of Array
     stage.steps.wont_be :empty?
     step = stage.steps.first
-    step.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
+    step.must_be_kind_of Google::Cloud::BigQuery::QueryJob::Step
     step.kind.must_be_kind_of String
     step.substeps.wont_be_nil
     step.substeps.must_be_kind_of Array
     step.substeps.wont_be :empty?
 
     data = table.data max: 1
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.kind.wont_be :nil?
     data.etag.wont_be :nil?
     [nil, 0].must_include data.total
@@ -407,9 +407,9 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     more_data.wont_be :nil?
 
     data = dataset.query query
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.total.wont_be(:nil?)
-    data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    data.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     data.fields.count.must_equal 4
     [:id, :breed, :name, :dob].each { |k| data.headers.must_include k }
     data.all.each do |row|
@@ -421,7 +421,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   it "imports data from a local file with load_job" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     job = table.load_job local_file, job_id: job_id, labels: labels
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     job.job_id.must_equal job_id
     job.labels.must_equal labels
     job.wont_be :autodetect?
@@ -472,7 +472,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
     copy_job = table.copy_job target_table_id, create: :needed, write: :empty, job_id: job_id, labels: labels
 
-    copy_job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    copy_job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
     copy_job.job_id.must_equal job_id
     copy_job.labels.must_equal labels
     copy_job.wait_until_done!
@@ -495,7 +495,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   it "creates and cancels jobs" do
     load_job = table.load_job local_file
 
-    load_job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    load_job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     load_job.wont_be :done?
 
     load_job.cancel
@@ -511,7 +511,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       # Make sure there is data to extract...
       load_job = table.load_job local_file
 
-      load_job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      load_job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
       load_job.wait_until_done!
 
       load_job.wont_be :failed?
@@ -528,7 +528,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       load_job.backup?.must_equal false
       load_job.allow_jagged_rows?.must_equal false
       load_job.ignore_unknown_values?.must_equal false
-      load_job.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+      load_job.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
       load_job.schema.wont_be :empty?
       load_job.input_files.must_equal 1
       load_job.input_file_bytes.must_be :>, 0
@@ -540,7 +540,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
         extract_url = "gs://#{bucket.name}/kitten-test-data-backup.json"
         extract_job = table.extract_job extract_url, labels: labels
 
-        extract_job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+        extract_job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
         extract_job.labels.must_equal labels
         extract_job.wait_until_done!
 

--- a/google-cloud-bigquery/acceptance/bigquery/view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/view_test.rb
@@ -14,7 +14,7 @@
 
 require "bigquery_helper"
 
-describe Google::Cloud::Bigquery::Table, :view, :bigquery do
+describe Google::Cloud::BigQuery::Table, :view, :bigquery do
   let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
   let(:publicdata_query_2) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 50" }
   let(:dataset_id) { "#{prefix}_dataset" }
@@ -36,7 +36,7 @@ describe Google::Cloud::Bigquery::Table, :view, :bigquery do
 
   it "has the attributes of a view" do
     fresh = dataset.table view.table_id
-    fresh.must_be_kind_of  Google::Cloud::Bigquery::Table
+    fresh.must_be_kind_of  Google::Cloud::BigQuery::Table
 
     fresh.project_id.must_equal bigquery.project
     fresh.id.must_equal "#{bigquery.project}:#{dataset.dataset_id}.#{view.table_id}"
@@ -50,7 +50,7 @@ describe Google::Cloud::Bigquery::Table, :view, :bigquery do
     fresh.table?.must_equal false
     fresh.view?.must_equal true
     #fresh.location.must_equal "US"       TODO why nil? Set in dataset
-    fresh.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    fresh.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     fresh.headers.must_equal [:url]
   end
 

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -41,7 +41,7 @@ module Acceptance
   #       your.code.must_be :thing?
   #     end
   #   end
-  class BigqueryTest < Minitest::Test
+  class BigQueryTest < Minitest::Test
     attr_accessor :bigquery
     attr_accessor :prefix
 

--- a/google-cloud-bigquery/benchmark/benchmark.rb
+++ b/google-cloud-bigquery/benchmark/benchmark.rb
@@ -20,7 +20,7 @@ if ARGV.length < 1
   exit 1
 end
 
-bigquery = Google::Cloud::Bigquery.new
+bigquery = Google::Cloud::BigQuery.new
 queries = JSON.parse(File.read(ARGV[0]))
 
 queries.each do |query|

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -3,7 +3,7 @@ require File.expand_path("../lib/google/cloud/bigquery/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-bigquery"
-  gem.version       = Google::Cloud::Bigquery::VERSION
+  gem.version       = Google::Cloud::BigQuery::VERSION
 
   gem.authors       = ["Mike Moore", "Chris Smith"]
   gem.email         = ["mike@blowmage.com", "quartzmo@gmail.com"]

--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -42,7 +42,7 @@ module Google
     #   error. The default value is `5`. Optional.
     # @param [Integer] timeout Default request timeout in seconds. Optional.
     #
-    # @return [Google::Cloud::Bigquery::Project]
+    # @return [Google::Cloud::BigQuery::Project]
     #
     # @example
     #   require "google/cloud"
@@ -79,7 +79,7 @@ module Google
     #   present, the default project for the credentials is used.
     # @param [String, Hash, Google::Auth::Credentials] credentials The path to
     #   the keyfile as a String, the contents of the keyfile as a Hash, or a
-    #   Google::Auth::Credentials object. (See {Bigquery::Credentials})
+    #   Google::Auth::Credentials object. (See {BigQuery::Credentials})
     # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
     #   set of resources and operations that the connection can access. See
     #   [Using OAuth 2.0 to Access Google
@@ -92,7 +92,7 @@ module Google
     #   error. The default value is `5`. Optional.
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     #
-    # @return [Google::Cloud::Bigquery::Project]
+    # @return [Google::Cloud::BigQuery::Project]
     #
     # @example
     #   require "google/cloud"
@@ -104,7 +104,7 @@ module Google
     def self.bigquery project_id = nil, credentials = nil, scope: nil,
                       retries: nil, timeout: nil
       require "google/cloud/bigquery"
-      Google::Cloud::Bigquery.new project_id: project_id,
+      Google::Cloud::BigQuery.new project_id: project_id,
                                   credentials: credentials,
                                   scope: scope, retries: retries,
                                   timeout: timeout

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -51,7 +51,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new project: "publicdata"
+    # bigquery = Google::Cloud::BigQuery.new project: "publicdata"
     #
     # bigquery.datasets.count #=> 1
     # bigquery.datasets.first.dataset_id #=> "samples"
@@ -71,7 +71,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new project: "publicdata"
+    # bigquery = Google::Cloud::BigQuery.new project: "publicdata"
     #
     # dataset = bigquery.dataset "samples"
     # table = dataset.table "shakespeare"
@@ -121,7 +121,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     #
     # sql = "SELECT word, SUM(word_count) AS word_count " \
     #       "FROM `bigquery-public-data.samples.shakespeare`" \
@@ -145,7 +145,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     #
     # sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " \
     #       "FROM [publicdata:samples.shakespeare]"
@@ -164,7 +164,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     #
     # sql = "SELECT word, SUM(word_count) AS word_count " \
     #       "FROM `bigquery-public-data.samples.shakespeare`" \
@@ -209,7 +209,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     #
     # sql = "SELECT APPROX_TOP_COUNT(corpus, 10) as title, " \
     #       "COUNT(*) as unique_words " \
@@ -231,13 +231,13 @@ module Google
     # querying as well as importing, exporting, and copying data. Therefore, the
     # BigQuery API provides facilities for managing longer-running jobs. With
     # the asynchronous approach to running a query, an instance of
-    # {Google::Cloud::Bigquery::QueryJob} is returned, rather than an instance
-    # of {Google::Cloud::Bigquery::Data}.
+    # {Google::Cloud::BigQuery::QueryJob} is returned, rather than an instance
+    # of {Google::Cloud::BigQuery::Data}.
     #
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     #
     # sql = "SELECT APPROX_TOP_COUNT(corpus, 10) as title, " \
     #       "COUNT(*) as unique_words " \
@@ -252,7 +252,7 @@ module Google
     # ```
     #
     # Once you have determined that the job is done and has not failed, you can
-    # obtain an instance of {Google::Cloud::Bigquery::Data} by calling `data` on
+    # obtain an instance of {Google::Cloud::BigQuery::Data} by calling `data` on
     # the job instance. The query results for both of the above examples are
     # stored in temporary tables with a lifetime of about 24 hours. See the
     # final example below for a demonstration of how to store query results in a
@@ -261,13 +261,13 @@ module Google
     # ## Creating Datasets and Tables
     #
     # The first thing you need to do in a new BigQuery project is to create a
-    # {Google::Cloud::Bigquery::Dataset}. Datasets hold tables and control
+    # {Google::Cloud::BigQuery::Dataset}. Datasets hold tables and control
     # access to them.
     #
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     #
     # dataset = bigquery.create_dataset "my_dataset"
     # ```
@@ -282,7 +282,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     # dataset = bigquery.dataset "my_dataset"
     #
     # table = dataset.create_table "people" do |schema|
@@ -316,7 +316,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     # dataset = bigquery.dataset "my_dataset"
     # table = dataset.table "people"
     #
@@ -355,7 +355,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     # dataset = bigquery.dataset "my_dataset", skip_lookup: true
     # table = dataset.table "people", skip_lookup: true
     #
@@ -400,7 +400,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     # dataset = bigquery.dataset "my_dataset"
     # table = dataset.create_table "baby_names" do |schema|
     #   schema.string "name", mode: :required
@@ -429,7 +429,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new
+    # bigquery = Google::Cloud::BigQuery.new
     # dataset = bigquery.dataset "my_dataset"
     # source_table = dataset.table "baby_names"
     # result_table = dataset.create_table "baby_names_results"
@@ -479,14 +479,14 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new retries: 10, timeout: 120
+    # bigquery = Google::Cloud::BigQuery.new retries: 10, timeout: 120
     # ```
     #
     # See the [BigQuery error
     # table](https://cloud.google.com/bigquery/troubleshooting-errors#errortable)
     # for a list of error conditions.
     #
-    module Bigquery
+    module BigQuery
       # Creates a new `Project` instance connected to the BigQuery service.
       # Each call creates a new connection.
       #
@@ -498,7 +498,7 @@ module Google
       #   present, the default project for the credentials is used.
       # @param [String, Hash, Google::Auth::Credentials] credentials The path to
       #   the keyfile as a String, the contents of the keyfile as a Hash, or a
-      #   Google::Auth::Credentials object. (See {Bigquery::Credentials})
+      #   Google::Auth::Credentials object. (See {BigQuery::Credentials})
       # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
       #   the set of resources and operations that the connection can access.
       #   See # [Using OAuth 2.0 to Access Google #
@@ -514,30 +514,34 @@ module Google
       # @param [String] keyfile Alias for the `credentials` argument.
       #   Deprecated.
       #
-      # @return [Google::Cloud::Bigquery::Project]
+      # @return [Google::Cloud::BigQuery::Project]
       #
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.table "my_table"
       #
       def self.new project_id: nil, credentials: nil, scope: nil, retries: nil,
                    timeout: nil, project: nil, keyfile: nil
-        project_id ||= (project || Bigquery::Project.default_project_id)
+        project_id ||= (project || BigQuery::Project.default_project_id)
         project_id = project_id.to_s # Always cast to a string
         fail ArgumentError, "project_id is missing" if project_id.empty?
 
-        credentials ||= (keyfile || Bigquery::Credentials.default(scope: scope))
+        credentials ||= (keyfile || BigQuery::Credentials.default(scope: scope))
         unless credentials.is_a? Google::Auth::Credentials
-          credentials = Bigquery::Credentials.new credentials, scope: scope
+          credentials = BigQuery::Credentials.new credentials, scope: scope
         end
 
-        Bigquery::Project.new(
-          Bigquery::Service.new(
+        BigQuery::Project.new(
+          BigQuery::Service.new(
             project_id, credentials, retries: retries, timeout: timeout))
       end
     end
+
+    ##
+    # @private Alias namespace with the old name
+    Bigquery = BigQuery
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -21,13 +21,13 @@ require "date"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       # rubocop:disable all
 
       ##
       # @private
       #
-      # Internal conversion of raw data values to/from Bigquery values
+      # Internal conversion of raw data values to/from BigQuery values
       #
       # | BigQuery    | Ruby           | Notes  |
       # |-------------|----------------|---|
@@ -90,7 +90,7 @@ module Google
           elsif field.type == "TIMESTAMP"
             ::Time.at Float(value[:v])
           elsif field.type == "TIME"
-            Bigquery::Time.new value[:v]
+            BigQuery::Time.new value[:v]
           elsif field.type == "DATETIME"
             ::Time.parse("#{value[:v]} UTC").to_datetime
           elsif field.type == "DATE"
@@ -159,7 +159,7 @@ module Google
               parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
                 value: value.strftime("%Y-%m-%d %H:%M:%S.%6N%:z"))
             )
-          elsif Bigquery::Time === value
+          elsif BigQuery::Time === value
             return Google::Apis::BigqueryV2::QueryParameter.new(
               parameter_type:  Google::Apis::BigqueryV2::QueryParameterType.new(
               type: "TIME"),
@@ -231,7 +231,7 @@ module Google
             value.to_s
           elsif ::Time === value
             value.strftime "%Y-%m-%d %H:%M:%S.%6N%:z"
-          elsif Bigquery::Time === value
+          elsif BigQuery::Time === value
             value.value
           elsif value.respond_to?(:read) && value.respond_to?(:rewind)
             value.rewind

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # CopyJob
       #
@@ -30,7 +30,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.table "my_table"
       #   destination_table = dataset.table "my_destination_table"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/credentials.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/credentials.rb
@@ -17,7 +17,7 @@ require "googleauth"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # Credentials
       #
@@ -28,9 +28,9 @@ module Google
       #   require "google/cloud/bigquery"
       #
       #   keyfile = "/path/to/keyfile.json"
-      #   creds = Google::Cloud::Bigquery::Credentials.new keyfile
+      #   creds = Google::Cloud::BigQuery::Credentials.new keyfile
       #
-      #   bigquery = Google::Cloud::Bigquery.new(
+      #   bigquery = Google::Cloud::BigQuery.new(
       #     project_id: "my-project",
       #     credentials: creds
       #   )

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -18,7 +18,7 @@ require "google/cloud/bigquery/service"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # Data
       #
@@ -29,7 +29,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.table "my_table"
       #
@@ -96,7 +96,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -123,7 +123,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -146,7 +146,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -169,7 +169,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -191,7 +191,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -212,7 +212,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -253,7 +253,7 @@ module Google
         # @example Iterating each rows by passing a block:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -264,7 +264,7 @@ module Google
         # @example Using the enumerator by not passing a block:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -275,7 +275,7 @@ module Google
         # @example Limit the number of API calls made:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -24,7 +24,7 @@ require "google/apis/bigquery_v2"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # Dataset
       #
@@ -36,7 +36,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #
       #   dataset = bigquery.create_dataset "my_dataset",
       #                                     name: "My Dataset",
@@ -291,7 +291,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   labels = dataset.labels
@@ -328,7 +328,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   dataset.labels = { "department" => "shipping" }
@@ -356,12 +356,12 @@ module Google
         # @yield [access] a block for setting rules
         # @yieldparam [Dataset::Access] access the object accepting rules
         #
-        # @return [Google::Cloud::Bigquery::Dataset::Access] The access object.
+        # @return [Google::Cloud::BigQuery::Dataset::Access] The access object.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   access = dataset.access
@@ -370,7 +370,7 @@ module Google
         # @example Manage the access rules by passing a block:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   dataset.access do |access|
@@ -408,7 +408,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   dataset.delete
@@ -435,12 +435,12 @@ module Google
         # @yield [table] a block for setting the table
         # @yieldparam [Table] table the table object to be updated
         #
-        # @return [Google::Cloud::Bigquery::Table] A new table object.
+        # @return [Google::Cloud::BigQuery::Table] A new table object.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   table = dataset.create_table "my_table"
@@ -448,7 +448,7 @@ module Google
         # @example You can also pass name and description options.
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   table = dataset.create_table "my_table",
@@ -458,7 +458,7 @@ module Google
         # @example Or the table's schema can be configured with the block.
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   table = dataset.create_table "my_table" do |t|
@@ -472,7 +472,7 @@ module Google
         # @example You can define the schema using a nested block.
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   table = dataset.create_table "my_table" do |t|
@@ -539,12 +539,12 @@ module Google
         #   containing the same code. See [User-Defined
         #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
         #
-        # @return [Google::Cloud::Bigquery::Table] A new table object.
+        # @return [Google::Cloud::BigQuery::Table] A new table object.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   view = dataset.create_view "my_view",
@@ -553,7 +553,7 @@ module Google
         # @example A name and description can be provided:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   view = dataset.create_view "my_view",
@@ -592,13 +592,13 @@ module Google
         #   service. Calls made on this object will raise errors if the resource
         #   does not exist. Default is `false`. Optional.
         #
-        # @return [Google::Cloud::Bigquery::Table, nil] Returns `nil` if the
+        # @return [Google::Cloud::BigQuery::Table, nil] Returns `nil` if the
         #   table does not exist.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   table = dataset.table "my_table"
@@ -607,7 +607,7 @@ module Google
         # @example Avoid retrieving the table resource with `skip_lookup`:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #
@@ -633,13 +633,13 @@ module Google
         #   part of the larger set of results to view.
         # @param [Integer] max Maximum number of tables to return.
         #
-        # @return [Array<Google::Cloud::Bigquery::Table>] An array of tables
-        #   (See {Google::Cloud::Bigquery::Table::List})
+        # @return [Array<Google::Cloud::BigQuery::Table>] An array of tables
+        #   (See {Google::Cloud::BigQuery::Table::List})
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   tables = dataset.tables
@@ -650,7 +650,7 @@ module Google
         # @example Retrieve all tables: (See {Table::List#all})
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   tables = dataset.tables
@@ -798,12 +798,12 @@ module Google
         #   containing the same code. See [User-Defined
         #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
         #
-        # @return [Google::Cloud::Bigquery::QueryJob] A new query job object.
+        # @return [Google::Cloud::BigQuery::QueryJob] A new query job object.
         #
         # @example Query using standard SQL:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   job = dataset.query_job "SELECT name FROM my_table"
@@ -818,7 +818,7 @@ module Google
         # @example Query using legacy SQL:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   job = dataset.query_job "SELECT name FROM my_table",
@@ -834,7 +834,7 @@ module Google
         # @example Query using positional query parameters:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   job = dataset.query_job "SELECT name FROM my_table WHERE id = ?",
@@ -850,7 +850,7 @@ module Google
         # @example Query using named query parameters:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   job = dataset.query_job "SELECT name FROM my_table WHERE id = @id",
@@ -866,7 +866,7 @@ module Google
         # @example Query using external data source:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   csv_url = "gs://bucket/path/to/data.csv"
@@ -984,12 +984,12 @@ module Google
         #   ignored; the query will be run as if `large_results` is true and
         #   `flatten` is false. Optional. The default value is false.
         #
-        # @return [Google::Cloud::Bigquery::Data] A new data object.
+        # @return [Google::Cloud::BigQuery::Data] A new data object.
         #
         # @example Query using standard SQL:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   data = dataset.query "SELECT name FROM my_table"
@@ -1001,7 +1001,7 @@ module Google
         # @example Query using legacy SQL:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   data = dataset.query "SELECT name FROM my_table",
@@ -1014,7 +1014,7 @@ module Google
         # @example Query using positional query parameters:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   data = dataset.query "SELECT name FROM my_table WHERE id = ?",
@@ -1027,7 +1027,7 @@ module Google
         # @example Query using named query parameters:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   data = dataset.query "SELECT name FROM my_table WHERE id = @id",
@@ -1040,7 +1040,7 @@ module Google
         # @example Query using external data source:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   csv_url = "gs://bucket/path/to/data.csv"
@@ -1110,7 +1110,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #
@@ -1236,7 +1236,7 @@ module Google
         #   file that BigQuery will skip when loading the data. The default
         #   value is `0`. This property is useful if you have header rows in the
         #   file that should be skipped.
-        # @param [Google::Cloud::Bigquery::Schema] schema The schema for the
+        # @param [Google::Cloud::BigQuery::Schema] schema The schema for the
         #   destination table. Optional. The schema can be omitted if the
         #   destination table already exists, or if you're loading data from a
         #   Google Cloud Datastore backup.
@@ -1271,16 +1271,16 @@ module Google
         #   table. The schema can be omitted if the destination table already
         #   exists, or if you're loading data from a Google Cloud Datastore
         #   backup.
-        # @yieldparam [Google::Cloud::Bigquery::Schema] schema The schema
+        # @yieldparam [Google::Cloud::BigQuery::Schema] schema The schema
         #   instance provided using the `schema` option, or a new, empty schema
         #   instance
         #
-        # @return [Google::Cloud::Bigquery::LoadJob] A new load job object.
+        # @return [Google::Cloud::BigQuery::LoadJob] A new load job object.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   gs_url = "gs://my-bucket/file-name.csv"
@@ -1296,7 +1296,7 @@ module Google
         #   require "google/cloud/bigquery"
         #   require "google/cloud/storage"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   storage = Google::Cloud::Storage.new
@@ -1313,7 +1313,7 @@ module Google
         # @example Upload a file directly:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   file = File.open "my_data.csv"
@@ -1328,7 +1328,7 @@ module Google
         # @example Schema is not required with a Cloud Datastore backup:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   load_job = dataset.load_job "my_new_table",
@@ -1468,7 +1468,7 @@ module Google
         #   file that BigQuery will skip when loading the data. The default
         #   value is `0`. This property is useful if you have header rows in the
         #   file that should be skipped.
-        # @param [Google::Cloud::Bigquery::Schema] schema The schema for the
+        # @param [Google::Cloud::BigQuery::Schema] schema The schema for the
         #   destination table. Optional. The schema can be omitted if the
         #   destination table already exists, or if you're loading data from a
         #   Google Cloud Datastore backup.
@@ -1481,7 +1481,7 @@ module Google
         #   table. The schema can be omitted if the destination table already
         #   exists, or if you're loading data from a Google Cloud Datastore
         #   backup.
-        # @yieldparam [Google::Cloud::Bigquery::Schema] schema The schema
+        # @yieldparam [Google::Cloud::BigQuery::Schema] schema The schema
         #   instance provided using the `schema` option, or a new, empty schema
         #   instance
         #
@@ -1490,7 +1490,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   gs_url = "gs://my-bucket/file-name.csv"
@@ -1506,7 +1506,7 @@ module Google
         #   require "google/cloud/bigquery"
         #   require "google/cloud/storage"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   storage = Google::Cloud::Storage.new
@@ -1523,7 +1523,7 @@ module Google
         # @example Upload a file directly:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   file = File.open "my_data.csv"
@@ -1538,7 +1538,7 @@ module Google
         # @example Schema is not required with a Cloud Datastore backup:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   dataset.load "my_new_table",
@@ -1583,13 +1583,13 @@ module Google
         ##
         # Reloads the dataset with current data from the BigQuery service.
         #
-        # @return [Google::Cloud::Bigquery::Dataset] Returns the reloaded
+        # @return [Google::Cloud::BigQuery::Dataset] Returns the reloaded
         #   dataset.
         #
         # @example Skip retrieving the dataset from the service, then load it:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset", skip_lookup: true
         #   dataset.reload!
@@ -1613,7 +1613,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset", skip_lookup: true
         #   dataset.exists? # true
@@ -1639,7 +1639,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset", skip_lookup: true
         #
@@ -1661,7 +1661,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset", skip_lookup: true
         #
@@ -1688,7 +1688,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.datasets.first
         #
@@ -1710,7 +1710,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #
@@ -1764,13 +1764,13 @@ module Google
         #   a new table with the given `table_id`, if no table is found for
         #   `table_id`. The default value is false.
         #
-        # @return [Google::Cloud::Bigquery::InsertResponse] An insert response
+        # @return [Google::Cloud::BigQuery::InsertResponse] An insert response
         #   object.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   rows = [
@@ -1782,7 +1782,7 @@ module Google
         # @example Avoid retrieving the dataset with `skip_lookup`:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset", skip_lookup: true
         #
@@ -1795,7 +1795,7 @@ module Google
         # @example Using `autocreate` to create a new table if none exists.
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   rows = [
@@ -1865,7 +1865,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #   inserter = table.insert_async do |result|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       class Dataset
         ##
         # # Dataset Access Control
@@ -28,7 +28,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   dataset.access do |access|
@@ -112,7 +112,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -131,7 +131,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -151,7 +151,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -171,7 +171,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -185,7 +185,7 @@ module Google
           ##
           # Add reader access to a view.
           #
-          # @param [Google::Cloud::Bigquery::Table, String] view A table object
+          # @param [Google::Cloud::BigQuery::Table, String] view A table object
           #   or a string identifier as specified by the [Query
           #   Reference](https://cloud.google.com/bigquery/query-reference#from):
           #   `project_name:datasetId.tableId`.
@@ -193,7 +193,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   other_dataset = bigquery.dataset "my_other_dataset"
           #
@@ -215,7 +215,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -234,7 +234,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -254,7 +254,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -274,7 +274,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -293,7 +293,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -312,7 +312,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -332,7 +332,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -352,7 +352,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -371,7 +371,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -390,7 +390,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -410,7 +410,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -430,7 +430,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -444,7 +444,7 @@ module Google
           ##
           # Remove reader access from a view.
           #
-          # @param [Google::Cloud::Bigquery::Table, String] view A table object
+          # @param [Google::Cloud::BigQuery::Table, String] view A table object
           #   or a string identifier as specified by the [Query
           #   Reference](https://cloud.google.com/bigquery/query-reference#from):
           #   `project_name:datasetId.tableId`.
@@ -452,7 +452,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   other_dataset = bigquery.dataset "my_other_dataset"
           #
@@ -474,7 +474,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -493,7 +493,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -513,7 +513,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -533,7 +533,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -552,7 +552,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -571,7 +571,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -591,7 +591,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -611,7 +611,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.access do |access|
@@ -630,7 +630,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -648,7 +648,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -667,7 +667,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -686,7 +686,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -699,7 +699,7 @@ module Google
           ##
           # Checks reader access for a view.
           #
-          # @param [Google::Cloud::Bigquery::Table, String] view A table object
+          # @param [Google::Cloud::BigQuery::Table, String] view A table object
           #   or a string identifier as specified by the [Query
           #   Reference](https://cloud.google.com/bigquery/query-reference#from):
           #   `project_name:datasetId.tableId`.
@@ -707,7 +707,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   other_dataset = bigquery.dataset "my_other_dataset"
           #
@@ -728,7 +728,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -746,7 +746,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -765,7 +765,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -784,7 +784,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -802,7 +802,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -820,7 +820,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -839,7 +839,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access
@@ -858,7 +858,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   access = dataset.access

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
@@ -17,7 +17,7 @@ require "delegate"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       class Dataset
         ##
         # Dataset::List is a special case Array with additional values.
@@ -44,7 +44,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   datasets = bigquery.datasets
           #   if datasets.next?
@@ -62,7 +62,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   datasets = bigquery.datasets
           #   if datasets.next?
@@ -97,7 +97,7 @@ module Google
           # @example Iterating each result by passing a block:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigquery.datasets.all do |dataset|
           #     puts dataset.name
@@ -106,7 +106,7 @@ module Google
           # @example Using the enumerator by not passing a block:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   all_names = bigquery.datasets.all.map do |dataset|
           #     dataset.name
@@ -115,7 +115,7 @@ module Google
           # @example Limit the number of API calls made:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigquery.datasets.all(request_limit: 10) do |dataset|
           #     puts dataset.name

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/external.rb
@@ -18,7 +18,7 @@ require "base64"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # External
       #
@@ -34,7 +34,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #
       #   csv_url = "gs://bucket/path/to/data.csv"
       #   csv_table = bigquery.external csv_url do |csv|
@@ -136,7 +136,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   avro_url = "gs://bucket/path/to/data.avro"
         #   avro_table = bigquery.external avro_url do |avro|
@@ -173,7 +173,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url
@@ -192,7 +192,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url
@@ -212,7 +212,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   json_url = "gs://bucket/path/to/data.json"
           #   json_table = bigquery.external json_url
@@ -232,7 +232,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   sheets_url = "https://docs.google.com/spreadsheets/d/1234567980"
           #   sheets_table = bigquery.external sheets_url
@@ -252,7 +252,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   avro_url = "gs://bucket/path/to/data.avro"
           #   avro_table = bigquery.external avro_url
@@ -272,7 +272,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   backup_url = "gs://bucket/path/to/data.backup_info"
           #   backup_table = bigquery.external backup_url
@@ -292,7 +292,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
           #   bigtable_table = bigquery.external bigtable_url
@@ -320,7 +320,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url
@@ -340,7 +340,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -362,7 +362,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -387,7 +387,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -410,7 +410,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -441,7 +441,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -471,7 +471,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -498,7 +498,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -524,7 +524,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -572,7 +572,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   csv_url = "gs://bucket/path/to/data.csv"
         #   csv_table = bigquery.external csv_url do |csv|
@@ -604,7 +604,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -626,7 +626,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -649,7 +649,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -671,7 +671,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -693,7 +693,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -714,7 +714,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -737,7 +737,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -760,7 +760,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -782,7 +782,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -803,7 +803,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -825,7 +825,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -846,7 +846,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -869,7 +869,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -891,7 +891,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -915,12 +915,12 @@ module Google
           # @yield [schema] a block for setting the schema
           # @yieldparam [Schema] schema the object accepting the schema
           #
-          # @return [Google::Cloud::Bigquery::Schema]
+          # @return [Google::Cloud::BigQuery::Schema]
           #
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_url = "gs://bucket/path/to/data.csv"
           #   csv_table = bigquery.external csv_url do |csv|
@@ -951,7 +951,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   csv_shema = bigquery.schema do |schema|
           #     schema.string "name", mode: :required
@@ -1012,11 +1012,11 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   json_url = "gs://bucket/path/to/data.json"
         #   json_table = bigquery.external json_url do |json|
@@ -1046,12 +1046,12 @@ module Google
           # @yield [schema] a block for setting the schema
           # @yieldparam [Schema] schema the object accepting the schema
           #
-          # @return [Google::Cloud::Bigquery::Schema]
+          # @return [Google::Cloud::BigQuery::Schema]
           #
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   json_url = "gs://bucket/path/to/data.json"
           #   json_table = bigquery.external json_url do |json|
@@ -1082,7 +1082,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   json_shema = bigquery.schema do |schema|
           #     schema.string "name", mode: :required
@@ -1143,7 +1143,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   sheets_url = "https://docs.google.com/spreadsheets/d/1234567980"
         #   sheets_table = bigquery.external sheets_url do |sheets|
@@ -1188,7 +1188,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   sheets_url = "https://docs.google.com/spreadsheets/d/1234567980"
           #   sheets_table = bigquery.external sheets_url do |sheets|
@@ -1210,7 +1210,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   sheets_url = "https://docs.google.com/spreadsheets/d/1234567980"
           #   sheets_table = bigquery.external sheets_url do |sheets|
@@ -1237,7 +1237,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
         #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1282,7 +1282,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
           #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1323,7 +1323,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
           #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1359,7 +1359,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
           #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1381,7 +1381,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
           #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1438,7 +1438,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
           #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1474,7 +1474,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1503,7 +1503,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1527,7 +1527,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1548,7 +1548,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1573,7 +1573,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1597,7 +1597,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1632,7 +1632,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1666,7 +1666,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1690,7 +1690,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1737,7 +1737,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1777,7 +1777,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1812,7 +1812,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1847,7 +1847,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1882,7 +1882,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1917,7 +1917,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -1978,7 +1978,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
           #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2020,7 +2020,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2049,7 +2049,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2093,7 +2093,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2123,7 +2123,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2151,7 +2151,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2178,7 +2178,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2206,7 +2206,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2232,7 +2232,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2270,7 +2270,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|
@@ -2306,7 +2306,7 @@ module Google
             # @example
             #   require "google/cloud/bigquery"
             #
-            #   bigquery = Google::Cloud::Bigquery.new
+            #   bigquery = Google::Cloud::BigQuery.new
             #
             #   bigtable_url = "https://googleapis.com/bigtable/projects/..."
             #   bigtable_table = bigquery.external bigtable_url do |bt|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # ExtractJob
       #
@@ -31,7 +31,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.table "my_table"
       #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/insert_response.rb
@@ -17,7 +17,7 @@ require "json"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # InsertResponse
       #
@@ -32,7 +32,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #
       #   rows = [

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -20,7 +20,7 @@ require "json"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # Job
       #
@@ -41,7 +41,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #
       #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
       #                            "publicdata.samples.shakespeare"
@@ -282,7 +282,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
         #                            "publicdata.samples.shakespeare"
@@ -302,7 +302,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
         #                            "publicdata.samples.shakespeare"
@@ -322,7 +322,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
         #                            "publicdata.samples.shakespeare"
@@ -346,7 +346,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
@@ -17,7 +17,7 @@ require "delegate"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       class Job
         ##
         # Job::List is a special case Array with additional values.
@@ -44,7 +44,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   jobs = bigquery.jobs
           #   if jobs.next?
@@ -62,7 +62,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   jobs = bigquery.jobs
           #   if jobs.next?
@@ -97,7 +97,7 @@ module Google
           # @example Iterating each job by passing a block:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigquery.jobs.all do |job|
           #     puts job.state
@@ -106,7 +106,7 @@ module Google
           # @example Using the enumerator by not passing a block:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   all_states = bigquery.jobs.all.map do |job|
           #     job.state
@@ -115,7 +115,7 @@ module Google
           # @example Limit the number of API calls made:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigquery.jobs.all(request_limit: 10) do |job|
           #     puts job.state

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -17,7 +17,7 @@ require "google/cloud/bigquery/service"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # LoadJob
       #
@@ -33,7 +33,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #
       #   gs_url = "gs://my-bucket/file-name.csv"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -26,7 +26,7 @@ require "google/cloud/bigquery/schema"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # Project
       #
@@ -34,9 +34,9 @@ module Google
       # information about billing and authorized users, and they contain
       # BigQuery data. Each project has a friendly name and a unique ID.
       #
-      # Google::Cloud::Bigquery::Project is the main object for interacting with
-      # Google BigQuery. {Google::Cloud::Bigquery::Dataset} objects are created,
-      # accessed, and deleted by Google::Cloud::Bigquery::Project.
+      # Google::Cloud::BigQuery::Project is the main object for interacting with
+      # Google BigQuery. {Google::Cloud::BigQuery::Dataset} objects are created,
+      # accessed, and deleted by Google::Cloud::BigQuery::Project.
       #
       # See {Google::Cloud#bigquery}.
       #
@@ -48,7 +48,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.table "my_table"
       #
@@ -73,7 +73,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new(
+        #   bigquery = Google::Cloud::BigQuery.new(
         #     project_id: "my-project",
         #     credentials: "/path/to/keyfile.json"
         #   )
@@ -230,12 +230,12 @@ module Google
         #   containing the same code. See [User-Defined
         #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
         #
-        # @return [Google::Cloud::Bigquery::QueryJob]
+        # @return [Google::Cloud::BigQuery::QueryJob]
         #
         # @example Query using standard SQL:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "`my_project.my_dataset.my_table`"
@@ -250,7 +250,7 @@ module Google
         # @example Query using legacy SQL:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "[my_project:my_dataset.my_table]",
@@ -266,7 +266,7 @@ module Google
         # @example Query using positional query parameters:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "`my_dataset.my_table`" \
@@ -283,7 +283,7 @@ module Google
         # @example Query using named query parameters:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "`my_dataset.my_table`" \
@@ -300,7 +300,7 @@ module Google
         # @example Query using external data source:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   csv_url = "gs://bucket/path/to/data.csv"
         #   csv_table = bigquery.external csv_url do |csv|
@@ -420,12 +420,12 @@ module Google
         #   ignored; the query will be run as if `large_results` is true and
         #   `flatten` is false. Optional. The default value is false.
         #
-        # @return [Google::Cloud::Bigquery::Data]
+        # @return [Google::Cloud::BigQuery::Data]
         #
         # @example Query using standard SQL:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   sql = "SELECT name FROM `my_project.my_dataset.my_table`"
         #   data = bigquery.query sql
@@ -437,7 +437,7 @@ module Google
         # @example Query using legacy SQL:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   sql = "SELECT name FROM [my_project:my_dataset.my_table]"
         #   data = bigquery.query sql, legacy_sql: true
@@ -449,7 +449,7 @@ module Google
         # @example Retrieve all rows: (See {Data#all})
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   data = bigquery.query "SELECT name FROM `my_dataset.my_table`"
         #
@@ -460,7 +460,7 @@ module Google
         # @example Query using positional query parameters:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   data = bigquery.query "SELECT name " \
         #                         "FROM `my_dataset.my_table`" \
@@ -474,7 +474,7 @@ module Google
         # @example Query using named query parameters:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   data = bigquery.query "SELECT name " \
         #                         "FROM `my_dataset.my_table`" \
@@ -488,7 +488,7 @@ module Google
         # @example Query using external data source:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   csv_url = "gs://bucket/path/to/data.csv"
         #   csv_table = bigquery.external csv_url do |csv|
@@ -556,7 +556,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   csv_url = "gs://bucket/path/to/data.csv"
         #   csv_table = bigquery.external csv_url do |csv|
@@ -586,13 +586,13 @@ module Google
         #   service. Calls made on this object will raise errors if the resource
         #   does not exist. Default is `false`. Optional.
         #
-        # @return [Google::Cloud::Bigquery::Dataset, nil] Returns `nil` if the
+        # @return [Google::Cloud::BigQuery::Dataset, nil] Returns `nil` if the
         #   dataset does not exist.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #   puts dataset.name
@@ -600,7 +600,7 @@ module Google
         # @example Avoid retrieving the dataset resource with `skip_lookup`:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset", skip_lookup: true
         #
@@ -631,22 +631,22 @@ module Google
         #   should reside. Possible values include `EU` and `US`. The default
         #   value is `US`.
         # @yield [access] a block for setting rules
-        # @yieldparam [Google::Cloud::Bigquery::Dataset] access the object
+        # @yieldparam [Google::Cloud::BigQuery::Dataset] access the object
         #   accepting rules
         #
-        # @return [Google::Cloud::Bigquery::Dataset]
+        # @return [Google::Cloud::BigQuery::Dataset]
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.create_dataset "my_dataset"
         #
         # @example A name and description can be provided:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.create_dataset "my_dataset",
         #                                     name: "My Dataset",
@@ -655,7 +655,7 @@ module Google
         # @example Or, configure access with a block: (See {Dataset::Access})
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.create_dataset "my_dataset" do |dataset|
         #     dataset.access.add_writer_user "writers@example.com"
@@ -701,13 +701,13 @@ module Google
         #   part of the larger set of results to view.
         # @param [Integer] max Maximum number of datasets to return.
         #
-        # @return [Array<Google::Cloud::Bigquery::Dataset>] (See
-        #   {Google::Cloud::Bigquery::Dataset::List})
+        # @return [Array<Google::Cloud::BigQuery::Dataset>] (See
+        #   {Google::Cloud::BigQuery::Dataset::List})
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   datasets = bigquery.datasets
         #   datasets.each do |dataset|
@@ -717,14 +717,14 @@ module Google
         # @example Retrieve hidden datasets with the `all` optional arg:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   all_datasets = bigquery.datasets all: true
         #
         # @example Retrieve all datasets: (See {Dataset::List#all})
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   datasets = bigquery.datasets
         #   datasets.all do |dataset|
@@ -743,13 +743,13 @@ module Google
         #
         # @param [String] job_id The ID of a job.
         #
-        # @return [Google::Cloud::Bigquery::Job, nil] Returns `nil` if the job
+        # @return [Google::Cloud::BigQuery::Job, nil] Returns `nil` if the job
         #   does not exist.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   job = bigquery.job "my_job"
         #
@@ -777,13 +777,13 @@ module Google
         #   * `pending` - Pending jobs
         #   * `running` - Running jobs
         #
-        # @return [Array<Google::Cloud::Bigquery::Job>] (See
-        #   {Google::Cloud::Bigquery::Job::List})
+        # @return [Array<Google::Cloud::BigQuery::Job>] (See
+        #   {Google::Cloud::BigQuery::Job::List})
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   jobs = bigquery.jobs
         #   jobs.each do |job|
@@ -793,7 +793,7 @@ module Google
         # @example Retrieve only running jobs using the `filter` optional arg:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   running_jobs = bigquery.jobs filter: "running"
         #   running_jobs.each do |job|
@@ -803,7 +803,7 @@ module Google
         # @example Retrieve all jobs: (See {Job::List#all})
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   jobs = bigquery.jobs
         #   jobs.all do |job|
@@ -828,13 +828,13 @@ module Google
         #   part of the larger set of results to view.
         # @param [Integer] max Maximum number of projects to return.
         #
-        # @return [Array<Google::Cloud::Bigquery::Project>] (See
-        #   {Google::Cloud::Bigquery::Project::List})
+        # @return [Array<Google::Cloud::BigQuery::Project>] (See
+        #   {Google::Cloud::BigQuery::Project::List})
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   projects = bigquery.projects
         #   projects.each do |project|
@@ -847,7 +847,7 @@ module Google
         # @example Retrieve all projects: (See {Project::List#all})
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   projects = bigquery.projects
         #
@@ -866,7 +866,7 @@ module Google
         end
 
         ##
-        # Creates a Bigquery::Time object to represent a time, independent of a
+        # Creates a BigQuery::Time object to represent a time, independent of a
         # specific date.
         #
         # @param [Integer] hour Hour, valid values from 0 to 23.
@@ -874,12 +874,12 @@ module Google
         # @param [Integer, Float] second Second, valid values from 0 to 59. Can
         #   contain microsecond precision.
         #
-        # @return [Bigquery::Time]
+        # @return [BigQuery::Time]
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   fourpm = bigquery.time 16, 0, 0
         #   data = bigquery.query "SELECT name " \
@@ -894,7 +894,7 @@ module Google
         # @example Create Time with fractional seconds:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   precise_time = bigquery.time 16, 35, 15.376541
         #   data = bigquery.query "SELECT name " \
@@ -907,7 +907,7 @@ module Google
         #   end
         #
         def time hour, minute, second
-          Bigquery::Time.new "#{hour}:#{minute}:#{second}"
+          BigQuery::Time.new "#{hour}:#{minute}:#{second}"
         end
 
         ##
@@ -923,12 +923,12 @@ module Google
         # @yield [schema] a block for setting the schema
         # @yieldparam [Schema] schema the object accepting the schema
         #
-        # @return [Google::Cloud::Bigquery::Schema]
+        # @return [Google::Cloud::BigQuery::Schema]
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   schema = bigquery.schema do |s|
         #     s.string "first_name", mode: :required

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
@@ -17,7 +17,7 @@ require "delegate"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       class Project
         ##
         # Project::List is a special case Array with additional values.
@@ -45,7 +45,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   projects = bigquery.projects
           #   if projects.next?
@@ -63,7 +63,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   projects = bigquery.projects
           #   if projects.next?
@@ -98,7 +98,7 @@ module Google
           # @example Iterating each result by passing a block:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigquery.projects.all do |project|
           #     puts project.name
@@ -107,7 +107,7 @@ module Google
           # @example Using the enumerator by not passing a block:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   all_project_ids = bigquery.projects.all.map do |project|
           #     project.name
@@ -116,7 +116,7 @@ module Google
           # @example Limit the number of API calls made:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #
           #   bigquery.projects.all(request_limit: 10) do |project|
           #     puts project.name

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -18,7 +18,7 @@ require "google/cloud/bigquery/data"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # QueryJob
       #
@@ -33,7 +33,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #
       #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
       #                            "publicdata.samples.shakespeare"
@@ -163,13 +163,13 @@ module Google
         ##
         # Describes the execution plan for the query.
         #
-        # @return [Array<Google::Cloud::Bigquery::QueryJob::Stage>] An array
+        # @return [Array<Google::Cloud::BigQuery::QueryJob::Stage>] An array
         #   containing the stages of the execution plan.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   sql = "SELECT word FROM publicdata.samples.shakespeare"
         #   job = bigquery.query_job sql
@@ -251,7 +251,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   sql = "SELECT word FROM publicdata.samples.shakespeare"
         #   job = bigquery.query_job sql
@@ -281,13 +281,13 @@ module Google
         # @param [Integer] max Maximum number of results to return.
         # @param [Integer] start Zero-based index of the starting row to read.
         #
-        # @return [Google::Cloud::Bigquery::Data] An object providing access to
+        # @return [Google::Cloud::BigQuery::Data] An object providing access to
         #   data read from the destination table for the job.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   sql = "SELECT word FROM publicdata.samples.shakespeare"
         #   job = bigquery.query_job sql
@@ -345,7 +345,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   sql = "SELECT word FROM publicdata.samples.shakespeare"
         #   job = bigquery.query_job sql
@@ -414,7 +414,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   sql = "SELECT word FROM publicdata.samples.shakespeare"
         #   job = bigquery.query_job sql

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -17,7 +17,7 @@ require "google/cloud/bigquery/schema/field"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # Table Schema
       #
@@ -31,7 +31,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.create_table "my_table"
       #
@@ -52,7 +52,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -78,7 +78,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table"
         #
@@ -100,7 +100,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -287,7 +287,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table"
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       class Schema
         ##
         # # Schema Field
@@ -28,7 +28,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -496,7 +496,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table"
           #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -24,9 +24,9 @@ require "date"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
-      # @private Represents the Bigquery service and API calls.
+      # @private Represents the BigQuery service and API calls.
       class Service
         ##
         # Alias to the Google Client API module
@@ -56,14 +56,14 @@ module Google
             service = API::BigqueryService.new
             service.client_options.application_name    = "gcloud-ruby"
             service.client_options.application_version = \
-              Google::Cloud::Bigquery::VERSION
+              Google::Cloud::BigQuery::VERSION
             service.client_options.open_timeout_sec = timeout
             service.client_options.read_timeout_sec = timeout
             service.client_options.send_timeout_sec = timeout
             service.request_options.retries = 0 # handle retries in #execute
             service.request_options.header ||= {}
             service.request_options.header["x-goog-api-client"] = \
-              "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::Bigquery::VERSION}"
+              "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::BigQuery::VERSION}"
             service.authorization = @credentials.client
             service
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -25,7 +25,7 @@ require "google/apis/bigquery_v2"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # Table
       #
@@ -48,7 +48,7 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #
       #   table = dataset.create_table "my_table" do |schema|
@@ -77,7 +77,7 @@ module Google
       # @example Creating a BigQuery view:
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   view = dataset.create_view "my_view",
       #            "SELECT name, age FROM `my_project.my_dataset.my_table`"
@@ -201,7 +201,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table" do |table|
         #     table.time_partitioning_type = "DAY"
@@ -253,7 +253,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table" do |table|
         #     table.time_partitioning_type = "DAY"
@@ -308,7 +308,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -577,7 +577,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -615,7 +615,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -645,12 +645,12 @@ module Google
         # @yield [schema] a block for setting the schema
         # @yieldparam [Schema] schema the object accepting the schema
         #
-        # @return [Google::Cloud::Bigquery::Schema, nil] A frozen schema object.
+        # @return [Google::Cloud::BigQuery::Schema, nil] A frozen schema object.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.create_table "my_table"
         #
@@ -687,7 +687,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -710,7 +710,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -859,7 +859,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   view = dataset.table "my_view"
         #
@@ -900,7 +900,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   view = dataset.table "my_view"
         #
@@ -976,12 +976,12 @@ module Google
         # @param [Integer] max Maximum number of results to return.
         # @param [Integer] start Zero-based index of the starting row to read.
         #
-        # @return [Google::Cloud::Bigquery::Data]
+        # @return [Google::Cloud::BigQuery::Data]
         #
         # @example Paginate rows of data: (See {Data#next})
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -996,7 +996,7 @@ module Google
         # @example Retrieve all rows of data: (See {Data#all})
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1069,12 +1069,12 @@ module Google
         #   optional. Label keys must start with a letter and each label in the
         #   list must have a different key.
         #
-        # @return [Google::Cloud::Bigquery::CopyJob]
+        # @return [Google::Cloud::BigQuery::CopyJob]
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #   destination_table = dataset.table "my_destination_table"
@@ -1084,7 +1084,7 @@ module Google
         # @example Passing a string identifier for the destination table:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1138,7 +1138,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #   destination_table = dataset.table "my_destination_table"
@@ -1148,7 +1148,7 @@ module Google
         # @example Passing a string identifier for the destination table:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1226,12 +1226,12 @@ module Google
         #   list must have a different key.
         #
         #
-        # @return [Google::Cloud::Bigquery::ExtractJob]
+        # @return [Google::Cloud::BigQuery::ExtractJob]
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1285,7 +1285,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1432,12 +1432,12 @@ module Google
         #   optional. Label keys must start with a letter and each label in the
         #   list must have a different key.
         #
-        # @return [Google::Cloud::Bigquery::LoadJob]
+        # @return [Google::Cloud::BigQuery::LoadJob]
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1447,7 +1447,7 @@ module Google
         #   require "google/cloud/bigquery"
         #   require "google/cloud/storage"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1459,7 +1459,7 @@ module Google
         # @example Upload a file directly:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1586,12 +1586,12 @@ module Google
         #   value is `0`. This property is useful if you have header rows in the
         #   file that should be skipped.
         #
-        # @return [Google::Cloud::Bigquery::LoadJob]
+        # @return [Google::Cloud::BigQuery::LoadJob]
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1601,7 +1601,7 @@ module Google
         #   require "google/cloud/bigquery"
         #   require "google/cloud/storage"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1613,7 +1613,7 @@ module Google
         # @example Upload a file directly:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1669,12 +1669,12 @@ module Google
         #   do not match the schema. The unknown values are ignored. Default is
         #   false, which treats unknown values as errors.
         #
-        # @return [Google::Cloud::Bigquery::InsertResponse]
+        # @return [Google::Cloud::BigQuery::InsertResponse]
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1687,7 +1687,7 @@ module Google
         # @example Avoid retrieving the dataset and table with `skip_lookup`:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset", skip_lookup: true
         #   table = dataset.table "my_table", skip_lookup: true
         #
@@ -1736,7 +1736,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #   inserter = table.insert_async do |result|
@@ -1775,7 +1775,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
@@ -1792,13 +1792,13 @@ module Google
         ##
         # Reloads the table with current data from the BigQuery service.
         #
-        # @return [Google::Cloud::Bigquery::Table] Returns the reloaded
+        # @return [Google::Cloud::BigQuery::Table] Returns the reloaded
         #   table.
         #
         # @example Skip retrieving the table from the service, then load it:
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table", skip_lookup: true
@@ -1824,7 +1824,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table", skip_lookup: true
@@ -1851,7 +1851,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table", skip_lookup: true
@@ -1874,7 +1874,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table", skip_lookup: true
@@ -1902,7 +1902,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.tables.first
@@ -1925,7 +1925,7 @@ module Google
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
@@ -2084,12 +2084,12 @@ module Google
           # @yield [schema] a block for setting the schema
           # @yieldparam [Schema] schema the object accepting the schema
           #
-          # @return [Google::Cloud::Bigquery::Schema]
+          # @return [Google::Cloud::BigQuery::Schema]
           #
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |t|
           #     t.name = "My Table",
@@ -2135,7 +2135,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.string "first_name", mode: :required
@@ -2163,7 +2163,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.integer "age", mode: :required
@@ -2191,7 +2191,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.float "price", mode: :required
@@ -2219,7 +2219,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.boolean "active", mode: :required
@@ -2247,7 +2247,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.bytes "avatar", mode: :required
@@ -2275,7 +2275,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.timestamp "creation_date", mode: :required
@@ -2303,7 +2303,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.time "duration", mode: :required
@@ -2331,7 +2331,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.datetime "target_end", mode: :required
@@ -2359,7 +2359,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.date "birthday", mode: :required
@@ -2393,7 +2393,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.create_table "my_table" do |schema|
           #     schema.record "cities_lived", mode: :repeated do |cities_lived|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -19,18 +19,18 @@ require "concurrent"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       class Table
         ##
         # # AsyncInserter
         #
         # Used to insert multiple rows in batches to a topic. See
-        # {Google::Cloud::Bigquery::Table#insert_async}.
+        # {Google::Cloud::BigQuery::Table#insert_async}.
         #
         # @example
         #   require "google/cloud/bigquery"
         #
-        #   bigquery = Google::Cloud::Bigquery.new
+        #   bigquery = Google::Cloud::BigQuery.new
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #   inserter = table.insert_async do |result|
@@ -96,7 +96,7 @@ module Google
           ##
           # Adds rows to the async inserter to be inserted. Rows will be
           # collected in batches and inserted together.
-          # See {Google::Cloud::Bigquery::Table#insert_async}.
+          # See {Google::Cloud::BigQuery::Table#insert_async}.
           #
           # @param [Hash, Array<Hash>] rows A hash object or array of hash
           #   objects containing the data.
@@ -291,7 +291,7 @@ module Google
           # @see https://cloud.google.com/bigquery/streaming-data-into-bigquery
           #   Streaming Data Into BigQuery
           #
-          # @attr_reader [Google::Cloud::Bigquery::InsertResponse, nil]
+          # @attr_reader [Google::Cloud::BigQuery::InsertResponse, nil]
           #   insert_response The response from the insert operation if no
           #   error was encountered, or `nil` if the insert operation
           #   encountered an error.
@@ -301,7 +301,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #   table = dataset.table "my_table"
           #   inserter = table.insert_async do |result|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
@@ -17,7 +17,7 @@ require "delegate"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       class Table
         ##
         # Table::List is a special case Array with additional values.
@@ -47,7 +47,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   tables = dataset.tables
@@ -67,7 +67,7 @@ module Google
           # @example
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   tables = dataset.tables
@@ -104,7 +104,7 @@ module Google
           # @example Iterating each result by passing a block:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.tables.all do |table|
@@ -114,7 +114,7 @@ module Google
           # @example Using the enumerator by not passing a block:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   all_names = dataset.tables.all.map do |table|
@@ -124,7 +124,7 @@ module Google
           # @example Limit the number of API requests made:
           #   require "google/cloud/bigquery"
           #
-          #   bigquery = Google::Cloud::Bigquery.new
+          #   bigquery = Google::Cloud::BigQuery.new
           #   dataset = bigquery.dataset "my_dataset"
           #
           #   dataset.tables.all(request_limit: 10) do |table|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/time.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       ##
       # # Time
       #
@@ -26,9 +26,9 @@ module Google
       # @example
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #
-      #   fourpm = Google::Cloud::Bigquery::Time.new "16:00:00"
+      #   fourpm = Google::Cloud::BigQuery::Time.new "16:00:00"
       #   data = bigquery.query "SELECT name " \
       #                         "FROM `my_project.my_dataset.my_table`" \
       #                         "WHERE time_of_date = @time",
@@ -41,9 +41,9 @@ module Google
       # @example Create Time with fractional seconds:
       #   require "google/cloud/bigquery"
       #
-      #   bigquery = Google::Cloud::Bigquery.new
+      #   bigquery = Google::Cloud::BigQuery.new
       #
-      #   precise_time = Google::Cloud::Bigquery::Time.new "16:35:15.376541"
+      #   precise_time = Google::Cloud::BigQuery::Time.new "16:35:15.376541"
       #   data = bigquery.query "SELECT name " \
       #                         "FROM `my_project.my_dataset.my_table`" \
       #                         "WHERE time_of_date >= @time",

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       VERSION = "0.30.0"
     end
   end

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -17,7 +17,7 @@ require "google/cloud/storage"
 
 module Google
   module Cloud
-    module Bigquery
+    module BigQuery
       def self.stub_new
         define_singleton_method :new do |*args|
           yield *args
@@ -49,9 +49,9 @@ module Google
 end
 
 def mock_bigquery
-  Google::Cloud::Bigquery.stub_new do |*args|
+  Google::Cloud::BigQuery.stub_new do |*args|
     credentials = OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {}))
-    bigquery = Google::Cloud::Bigquery::Project.new(Google::Cloud::Bigquery::Service.new("my-project", credentials))
+    bigquery = Google::Cloud::BigQuery::Project.new(Google::Cloud::BigQuery::Service.new("my-project", credentials))
 
     bigquery.service.mocked_service = Minitest::Mock.new
     yield bigquery.service.mocked_service
@@ -71,9 +71,9 @@ end
 
 YARD::Doctest.configure do |doctest|
   # Skip aliases
-  doctest.skip "Google::Cloud::Bigquery::Dataset#refresh!"
-  doctest.skip "Google::Cloud::Bigquery::Job#refresh!"
-  doctest.skip "Google::Cloud::Bigquery::QueryJob#query_results"
+  doctest.skip "Google::Cloud::BigQuery::Dataset#refresh!"
+  doctest.skip "Google::Cloud::BigQuery::Job#refresh!"
+  doctest.skip "Google::Cloud::BigQuery::QueryJob#query_results"
 
 
   # Google::Cloud#bigquery@The default scope can be overridden with the `scope` option:
@@ -93,7 +93,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery.new" do
+  doctest.before "Google::Cloud::BigQuery.new" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -101,14 +101,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.skip "Google::Cloud::Bigquery::Credentials" # occasionally getting "This code example is not yet mocked"
+  doctest.skip "Google::Cloud::BigQuery::Credentials" # occasionally getting "This code example is not yet mocked"
 
-  # Google::Cloud::Bigquery::Data#all@Iterating each rows by passing a block:
-  # Google::Cloud::Bigquery::Data#all@Limit the number of API calls made:
-  # Google::Cloud::Bigquery::Data#all@Using the enumerator by not passing a block:
-  # Google::Cloud::Bigquery::Data#next
-  # Google::Cloud::Bigquery::Data#next?
-  doctest.before "Google::Cloud::Bigquery::Data" do
+  # Google::Cloud::BigQuery::Data#all@Iterating each rows by passing a block:
+  # Google::Cloud::BigQuery::Data#all@Limit the number of API calls made:
+  # Google::Cloud::BigQuery::Data#all@Using the enumerator by not passing a block:
+  # Google::Cloud::BigQuery::Data#next
+  # Google::Cloud::BigQuery::Data#next?
+  doctest.before "Google::Cloud::BigQuery::Data" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -116,14 +116,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset" do
+  doctest.before "Google::Cloud::BigQuery::Dataset" do
     mock_bigquery do |mock|
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project", Google::Apis::BigqueryV2::Dataset]
     end
   end
 
-  # Google::Cloud::Bigquery::Dataset#access@Manage the access rules by passing a block:
-  doctest.before "Google::Cloud::Bigquery::Dataset#access" do
+  # Google::Cloud::BigQuery::Dataset#access@Manage the access rules by passing a block:
+  doctest.before "Google::Cloud::BigQuery::Dataset#access" do
     mock_bigquery do |mock|
       def other_dataset_view_object
         "foo"
@@ -134,42 +134,42 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Dataset#create_table@Or the table's schema can be configured with the block.
-  # Google::Cloud::Bigquery::Dataset#create_table@The table's schema fields can be passed as an argument.
-  # Google::Cloud::Bigquery::Dataset#create_table@You can also pass name and description options.
-  # Google::Cloud::Bigquery::Dataset#create_table@You can define the schema using a nested block.
-  doctest.before "Google::Cloud::Bigquery::Dataset#create_table" do
+  # Google::Cloud::BigQuery::Dataset#create_table@Or the table's schema can be configured with the block.
+  # Google::Cloud::BigQuery::Dataset#create_table@The table's schema fields can be passed as an argument.
+  # Google::Cloud::BigQuery::Dataset#create_table@You can also pass name and description options.
+  # Google::Cloud::BigQuery::Dataset#create_table@You can define the schema using a nested block.
+  doctest.before "Google::Cloud::BigQuery::Dataset#create_table" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project", "my_dataset", Google::Apis::BigqueryV2::Table]
     end
   end
 
-  # Google::Cloud::Bigquery::Dataset#create_view@A name and description can be provided:
-  doctest.before "Google::Cloud::Bigquery::Dataset#create_view" do
+  # Google::Cloud::BigQuery::Dataset#create_view@A name and description can be provided:
+  doctest.before "Google::Cloud::BigQuery::Dataset#create_view" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_table, view_full_gapi, ["my-project", "my_dataset", Google::Apis::BigqueryV2::Table]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#delete" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#delete" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :delete_dataset, nil, ["my-project", "my_dataset", Hash]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#exists?" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#exists?" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
     end
   end
 
-  # Google::Cloud::Bigquery::Dataset#query@Query using named query parameters:
-  # Google::Cloud::Bigquery::Dataset#query@Query using positional query parameters:
-  # Google::Cloud::Bigquery::Dataset#query@Query using standard SQL:
-  doctest.before "Google::Cloud::Bigquery::Dataset#query" do
+  # Google::Cloud::BigQuery::Dataset#query@Query using named query parameters:
+  # Google::Cloud::BigQuery::Dataset#query@Query using positional query parameters:
+  # Google::Cloud::BigQuery::Dataset#query@Query using standard SQL:
+  doctest.before "Google::Cloud::BigQuery::Dataset#query" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
@@ -178,10 +178,10 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Dataset#query_job@Query using named query parameters:
-  # Google::Cloud::Bigquery::Dataset#query_job@Query using positional query parameters:
-  # Google::Cloud::Bigquery::Dataset#query_job@Query using standard SQL:
-  doctest.before "Google::Cloud::Bigquery::Dataset#query_job" do
+  # Google::Cloud::BigQuery::Dataset#query_job@Query using named query parameters:
+  # Google::Cloud::BigQuery::Dataset#query_job@Query using positional query parameters:
+  # Google::Cloud::BigQuery::Dataset#query_job@Query using standard SQL:
+  doctest.before "Google::Cloud::BigQuery::Dataset#query_job" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
@@ -191,22 +191,22 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#table" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#table" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
     end
   end
 
-  # Google::Cloud::Bigquery::Dataset#tables@Retrieve all tables: (See {Table::List#all})
-  doctest.before "Google::Cloud::Bigquery::Dataset#tables" do
+  # Google::Cloud::BigQuery::Dataset#tables@Retrieve all tables: (See {Table::List#all})
+  doctest.before "Google::Cloud::BigQuery::Dataset#tables" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :list_tables, list_tables_gapi, ["my-project", "my_dataset", Hash]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#labels" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#labels" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -214,7 +214,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#load" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#load" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -222,11 +222,11 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#load_job@Upload a file directly:" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#load_job@Upload a file directly:" do
     skip "This creates a File object, which is difficult to mock with doctest."
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#load_job@Pass a google-cloud-storage `File` instance:" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#load_job@Pass a google-cloud-storage `File` instance:" do
     mock_storage do |mock|
       mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
       mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
@@ -238,11 +238,11 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#load@Upload a file directly:" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#load@Upload a file directly:" do
     skip "This creates a File object, which is difficult to mock with doctest."
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#load@Pass a google-cloud-storage `File` instance:" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#load@Pass a google-cloud-storage `File` instance:" do
     mock_storage do |mock|
       mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
       mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
@@ -254,7 +254,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#insert" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#insert" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -264,38 +264,38 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#reference?" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#reference?" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#reload!" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#reload!" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#resource?" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#resource?" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#resource_full?" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#resource_full?" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#resource_partial?" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#resource_partial?" do
     mock_bigquery do |mock|
       mock.expect :list_datasets, list_datasets_gapi, ["my-project", Hash]
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset::Access" do
+  doctest.before "Google::Cloud::BigQuery::Dataset::Access" do
     mock_bigquery do |mock|
       def other_dataset_view_object
         "foo"
@@ -308,18 +308,18 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Dataset::List#all@Iterating each result by passing a block:
-  # Google::Cloud::Bigquery::Dataset::List#all@Limit the number of API calls made:
-  # Google::Cloud::Bigquery::Dataset::List#all@Using the enumerator by not passing a block:
-  # Google::Cloud::Bigquery::Dataset::List#next
-  # Google::Cloud::Bigquery::Dataset::List#next?
-  doctest.before "Google::Cloud::Bigquery::Dataset::List" do
+  # Google::Cloud::BigQuery::Dataset::List#all@Iterating each result by passing a block:
+  # Google::Cloud::BigQuery::Dataset::List#all@Limit the number of API calls made:
+  # Google::Cloud::BigQuery::Dataset::List#all@Using the enumerator by not passing a block:
+  # Google::Cloud::BigQuery::Dataset::List#next
+  # Google::Cloud::BigQuery::Dataset::List#next?
+  doctest.before "Google::Cloud::BigQuery::Dataset::List" do
     mock_bigquery do |mock|
       mock.expect :list_datasets, list_datasets_gapi, ["my-project", Hash]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::CopyJob" do
+  doctest.before "Google::Cloud::BigQuery::CopyJob" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -328,7 +328,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::ExtractJob" do
+  doctest.before "Google::Cloud::BigQuery::ExtractJob" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -336,7 +336,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::InsertResponse" do
+  doctest.before "Google::Cloud::BigQuery::InsertResponse" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -346,9 +346,9 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Job
-  # Google::Cloud::Bigquery::Job#wait_until_done!
-  doctest.before "Google::Cloud::Bigquery::Job" do
+  # Google::Cloud::BigQuery::Job
+  # Google::Cloud::BigQuery::Job#wait_until_done!
+  doctest.before "Google::Cloud::BigQuery::Job" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -358,35 +358,35 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Job#cancel" do
+  doctest.before "Google::Cloud::BigQuery::Job#cancel" do
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :cancel_job, OpenStruct.new(job: query_job_gapi), ["my-project", "1234567890"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Job#rerun!" do
+  doctest.before "Google::Cloud::BigQuery::Job#rerun!" do
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Job#reload!" do
+  doctest.before "Google::Cloud::BigQuery::Job#reload!" do
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job, query_job_gapi, ["my-project", "1234567890"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::LoadJob" do
+  doctest.before "Google::Cloud::BigQuery::LoadJob" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::QueryJob" do
+  doctest.before "Google::Cloud::BigQuery::QueryJob" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -396,21 +396,21 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Job::List#all@Iterating each job by passing a block:
-  # Google::Cloud::Bigquery::Job::List#all@Limit the number of API calls made:
-  # Google::Cloud::Bigquery::Job::List#all@Using the enumerator by not passing a block:
-  # Google::Cloud::Bigquery::Job::List#next
-  # Google::Cloud::Bigquery::Job::List#next?
-  doctest.before "Google::Cloud::Bigquery::Job::List" do
+  # Google::Cloud::BigQuery::Job::List#all@Iterating each job by passing a block:
+  # Google::Cloud::BigQuery::Job::List#all@Limit the number of API calls made:
+  # Google::Cloud::BigQuery::Job::List#all@Using the enumerator by not passing a block:
+  # Google::Cloud::BigQuery::Job::List#next
+  # Google::Cloud::BigQuery::Job::List#next?
+  doctest.before "Google::Cloud::BigQuery::Job::List" do
     mock_bigquery do |mock|
       mock.expect :list_jobs, list_jobs_gapi, ["my-project", Hash]
     end
   end
 
-  # Google::Cloud::Bigquery::Project#dataset
-  # Google::Cloud::Bigquery::Project#job
-  # Google::Cloud::Bigquery::Project#project
-  doctest.before "Google::Cloud::Bigquery::Project" do
+  # Google::Cloud::BigQuery::Project#dataset
+  # Google::Cloud::BigQuery::Project#job
+  # Google::Cloud::BigQuery::Project#project
+  doctest.before "Google::Cloud::BigQuery::Project" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -418,40 +418,40 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Project#create_dataset
-  # Google::Cloud::Bigquery::Project#create_dataset@A name and description can be provided:
-  # Google::Cloud::Bigquery::Project#create_dataset@Access rules can be provided with the `access` option:
-  # Google::Cloud::Bigquery::Project#create_dataset@Or, configure access with a block: (See {Dataset::Access})
-  doctest.before "Google::Cloud::Bigquery::Project#create_dataset" do
+  # Google::Cloud::BigQuery::Project#create_dataset
+  # Google::Cloud::BigQuery::Project#create_dataset@A name and description can be provided:
+  # Google::Cloud::BigQuery::Project#create_dataset@Access rules can be provided with the `access` option:
+  # Google::Cloud::BigQuery::Project#create_dataset@Or, configure access with a block: (See {Dataset::Access})
+  doctest.before "Google::Cloud::BigQuery::Project#create_dataset" do
     mock_bigquery do |mock|
       mock.expect :insert_dataset, dataset_full_gapi, ["my-project", Google::Apis::BigqueryV2::Dataset]
     end
   end
 
-  # Google::Cloud::Bigquery::Project#datasets@Retrieve all datasets: (See {Dataset::List#all})
-  # Google::Cloud::Bigquery::Project#datasets@Retrieve hidden datasets with the `all` optional arg:
-  doctest.before "Google::Cloud::Bigquery::Project#datasets" do
+  # Google::Cloud::BigQuery::Project#datasets@Retrieve all datasets: (See {Dataset::List#all})
+  # Google::Cloud::BigQuery::Project#datasets@Retrieve hidden datasets with the `all` optional arg:
+  doctest.before "Google::Cloud::BigQuery::Project#datasets" do
     mock_bigquery do |mock|
       mock.expect :list_datasets, list_datasets_gapi, ["my-project", Hash]
     end
   end
 
-  # Google::Cloud::Bigquery::Project#jobs@Retrieve all jobs: (See {Job::List#all})
-  # Google::Cloud::Bigquery::Project#jobs@Retrieve only running jobs using the `filter` optional arg:
-  doctest.before "Google::Cloud::Bigquery::Project#jobs" do
+  # Google::Cloud::BigQuery::Project#jobs@Retrieve all jobs: (See {Job::List#all})
+  # Google::Cloud::BigQuery::Project#jobs@Retrieve only running jobs using the `filter` optional arg:
+  doctest.before "Google::Cloud::BigQuery::Project#jobs" do
     mock_bigquery do |mock|
       mock.expect :list_jobs, list_jobs_gapi, ["my-project", Hash]
     end
   end
 
-  # Google::Cloud::Bigquery::Project#projects@Retrieve all projects: (See {Project::List#all})
-  doctest.before "Google::Cloud::Bigquery::Project#projects" do
+  # Google::Cloud::BigQuery::Project#projects@Retrieve all projects: (See {Project::List#all})
+  doctest.before "Google::Cloud::BigQuery::Project#projects" do
     skip "This creates new Service objects, and we can't easily stub them out."
   end
 
-  # Google::Cloud::Bigquery::Project#time
-  # Google::Cloud::Bigquery::Project#time@Create Time with fractional seconds:
-  doctest.before "Google::Cloud::Bigquery::Project#time" do
+  # Google::Cloud::BigQuery::Project#time
+  # Google::Cloud::BigQuery::Project#time@Create Time with fractional seconds:
+  doctest.before "Google::Cloud::BigQuery::Project#time" do
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project", "1234567890", Hash]
@@ -459,11 +459,11 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Project#query@Query using named query parameters:
-  # Google::Cloud::Bigquery::Project#query@Query using positional query parameters:
-  # Google::Cloud::Bigquery::Project#query@Query using standard SQL:
-  # Google::Cloud::Bigquery::Project#query@Retrieve all rows: (See {Data#all})
-  doctest.before "Google::Cloud::Bigquery::Project#query" do
+  # Google::Cloud::BigQuery::Project#query@Query using named query parameters:
+  # Google::Cloud::BigQuery::Project#query@Query using positional query parameters:
+  # Google::Cloud::BigQuery::Project#query@Query using standard SQL:
+  # Google::Cloud::BigQuery::Project#query@Retrieve all rows: (See {Data#all})
+  doctest.before "Google::Cloud::BigQuery::Project#query" do
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project", "1234567890", Hash]
@@ -471,10 +471,10 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Project#query_job@Query using named query parameters:
-  # Google::Cloud::Bigquery::Project#query_job@Query using positional query parameters:
-  # Google::Cloud::Bigquery::Project#query_job@Query using standard SQL:
-  doctest.before "Google::Cloud::Bigquery::Project#query_job" do
+  # Google::Cloud::BigQuery::Project#query_job@Query using named query parameters:
+  # Google::Cloud::BigQuery::Project#query_job@Query using positional query parameters:
+  # Google::Cloud::BigQuery::Project#query_job@Query using standard SQL:
+  doctest.before "Google::Cloud::BigQuery::Project#query_job" do
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job, query_job_gapi, ["my-project", "1234567890"]
@@ -483,7 +483,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Project#schema" do
+  doctest.before "Google::Cloud::BigQuery::Project#schema" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -491,19 +491,19 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Project::List#all@Iterating each result by passing a block:
-  # Google::Cloud::Bigquery::Project::List#all@Limit the number of API calls made:
-  # Google::Cloud::Bigquery::Project::List#all@Using the enumerator by not passing a block:
-  # Google::Cloud::Bigquery::Project::List#next
-  # Google::Cloud::Bigquery::Project::List#next?
-  doctest.before "Google::Cloud::Bigquery::Project::List" do
+  # Google::Cloud::BigQuery::Project::List#all@Iterating each result by passing a block:
+  # Google::Cloud::BigQuery::Project::List#all@Limit the number of API calls made:
+  # Google::Cloud::BigQuery::Project::List#all@Using the enumerator by not passing a block:
+  # Google::Cloud::BigQuery::Project::List#next
+  # Google::Cloud::BigQuery::Project::List#next?
+  doctest.before "Google::Cloud::BigQuery::Project::List" do
     mock_bigquery do |mock|
       mock.expect :list_projects, list_projects_gapi, [Hash]
     end
   end
 
-  # Google::Cloud::Bigquery::QueryJob#data
-  doctest.before "Google::Cloud::Bigquery::QueryJob" do
+  # Google::Cloud::BigQuery::QueryJob#data
+  doctest.before "Google::Cloud::BigQuery::QueryJob" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
@@ -512,8 +512,8 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Schema#record
-  doctest.before "Google::Cloud::Bigquery::Schema" do
+  # Google::Cloud::BigQuery::Schema#record
+  doctest.before "Google::Cloud::BigQuery::Schema" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project", "my_dataset", Google::Apis::BigqueryV2::Table]
@@ -522,21 +522,21 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Schema#field" do
+  doctest.before "Google::Cloud::BigQuery::Schema#field" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Schema::Field" do
+  doctest.before "Google::Cloud::BigQuery::Schema::Field" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Schema::Field#record" do
+  doctest.before "Google::Cloud::BigQuery::Schema::Field#record" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project", "my_dataset", Google::Apis::BigqueryV2::Table]
@@ -545,7 +545,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table" do
+  doctest.before "Google::Cloud::BigQuery::Table" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project", "my_dataset", Google::Apis::BigqueryV2::Table]
@@ -557,7 +557,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#copy" do
+  doctest.before "Google::Cloud::BigQuery::Table#copy" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -566,8 +566,8 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Table#copy_job@Passing a string identifier for the destination table:
-  doctest.before "Google::Cloud::Bigquery::Table#copy_job" do
+  # Google::Cloud::BigQuery::Table#copy_job@Passing a string identifier for the destination table:
+  doctest.before "Google::Cloud::BigQuery::Table#copy_job" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -576,9 +576,9 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Table#data@Paginate rows of data: (See {Data#next})
-  # Google::Cloud::Bigquery::Table#data@Retrieve all rows of data: (See {Data#all})
-  doctest.before "Google::Cloud::Bigquery::Table#data" do
+  # Google::Cloud::BigQuery::Table#data@Paginate rows of data: (See {Data#next})
+  # Google::Cloud::BigQuery::Table#data@Retrieve all rows of data: (See {Data#all})
+  doctest.before "Google::Cloud::BigQuery::Table#data" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -586,7 +586,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#delete" do
+  doctest.before "Google::Cloud::BigQuery::Table#delete" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -594,14 +594,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#exists?" do
+  doctest.before "Google::Cloud::BigQuery::Table#exists?" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#extract" do
+  doctest.before "Google::Cloud::BigQuery::Table#extract" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -609,7 +609,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#insert" do
+  doctest.before "Google::Cloud::BigQuery::Table#insert" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -619,7 +619,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#labels=" do
+  doctest.before "Google::Cloud::BigQuery::Table#labels=" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -628,7 +628,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#load" do
+  doctest.before "Google::Cloud::BigQuery::Table#load" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -636,11 +636,11 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#load_job@Upload a file directly:" do
+  doctest.before "Google::Cloud::BigQuery::Table#load_job@Upload a file directly:" do
     skip "This creates a File object, which is difficult to mock with doctest."
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#load_job@Pass a google-cloud-storage `File` instance:" do
+  doctest.before "Google::Cloud::BigQuery::Table#load_job@Pass a google-cloud-storage `File` instance:" do
     mock_storage do |mock|
       mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
       mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
@@ -652,11 +652,11 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#load@Upload a file directly:" do
+  doctest.before "Google::Cloud::BigQuery::Table#load@Upload a file directly:" do
     skip "This creates a File object, which is difficult to mock with doctest."
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#load@Pass a google-cloud-storage `File` instance:" do
+  doctest.before "Google::Cloud::BigQuery::Table#load@Pass a google-cloud-storage `File` instance:" do
     mock_storage do |mock|
       mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
       mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
@@ -668,7 +668,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#query=" do
+  doctest.before "Google::Cloud::BigQuery::Table#query=" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, view_full_gapi, ["my-project", "my_dataset", "my_view"]
@@ -677,7 +677,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#set_query" do
+  doctest.before "Google::Cloud::BigQuery::Table#set_query" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, view_full_gapi, ["my-project", "my_dataset", "my_view"]
@@ -686,7 +686,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#query_id" do
+  doctest.before "Google::Cloud::BigQuery::Table#query_id" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
@@ -696,7 +696,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#schema" do
+  doctest.before "Google::Cloud::BigQuery::Table#schema" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project", "my_dataset", Google::Apis::BigqueryV2::Table]
@@ -705,35 +705,35 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#reference?" do
+  doctest.before "Google::Cloud::BigQuery::Table#reference?" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#reload!" do
+  doctest.before "Google::Cloud::BigQuery::Table#reload!" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#resource?" do
+  doctest.before "Google::Cloud::BigQuery::Table#resource?" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#resource_full?" do
+  doctest.before "Google::Cloud::BigQuery::Table#resource_full?" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Table#resource_partial?" do
+  doctest.before "Google::Cloud::BigQuery::Table#resource_partial?" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :list_tables, list_tables_gapi, ["my-project", "my_dataset", Hash]
@@ -741,35 +741,35 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  # Google::Cloud::Bigquery::Table::List#all@Iterating each result by passing a block:
-  # Google::Cloud::Bigquery::Table::List#all@Limit the number of API requests made:
-  # Google::Cloud::Bigquery::Table::List#all@Using the enumerator by not passing a block:
-  # Google::Cloud::Bigquery::Table::List#next
-  # Google::Cloud::Bigquery::Table::List#next?
-  doctest.before "Google::Cloud::Bigquery::Table::List" do
+  # Google::Cloud::BigQuery::Table::List#all@Iterating each result by passing a block:
+  # Google::Cloud::BigQuery::Table::List#all@Limit the number of API requests made:
+  # Google::Cloud::BigQuery::Table::List#all@Using the enumerator by not passing a block:
+  # Google::Cloud::BigQuery::Table::List#next
+  # Google::Cloud::BigQuery::Table::List#next?
+  doctest.before "Google::Cloud::BigQuery::Table::List" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :list_tables, list_tables_gapi, ["my-project", "my_dataset", Hash]
     end
   end
 
-  # Google::Cloud::Bigquery::Table::Updater#boolean
-  # Google::Cloud::Bigquery::Table::Updater#float
-  # Google::Cloud::Bigquery::Table::Updater#integer
-  # Google::Cloud::Bigquery::Table::Updater#record
-  # Google::Cloud::Bigquery::Table::Updater#schema
-  # Google::Cloud::Bigquery::Table::Updater#string
-  # Google::Cloud::Bigquery::Table::Updater#timestamp
-  doctest.before "Google::Cloud::Bigquery::Table::Updater" do
+  # Google::Cloud::BigQuery::Table::Updater#boolean
+  # Google::Cloud::BigQuery::Table::Updater#float
+  # Google::Cloud::BigQuery::Table::Updater#integer
+  # Google::Cloud::BigQuery::Table::Updater#record
+  # Google::Cloud::BigQuery::Table::Updater#schema
+  # Google::Cloud::BigQuery::Table::Updater#string
+  # Google::Cloud::BigQuery::Table::Updater#timestamp
+  doctest.before "Google::Cloud::BigQuery::Table::Updater" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_table, table_full_gapi, ["my-project", "my_dataset", Google::Apis::BigqueryV2::Table]
     end
   end
 
-  # Google::Cloud::Bigquery::Time
-  # Google::Cloud::Bigquery::Time@Create Time with fractional seconds:
-  doctest.before "Google::Cloud::Bigquery::Time" do
+  # Google::Cloud::BigQuery::Time
+  # Google::Cloud::BigQuery::Time@Create Time with fractional seconds:
+  doctest.before "Google::Cloud::BigQuery::Time" do
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project", "1234567890", Hash]
@@ -777,7 +777,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Project#external" do
+  doctest.before "Google::Cloud::BigQuery::Project#external" do
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project", "1234567890", Hash]
@@ -785,7 +785,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::Dataset#external" do
+  doctest.before "Google::Cloud::BigQuery::Dataset#external" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
@@ -794,7 +794,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Bigquery::External" do
+  doctest.before "Google::Cloud::BigQuery::External" do
     mock_bigquery do |mock|
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project", "1234567890", Hash]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_delay_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_delay_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Service::Backoff, :delay do
+describe Google::Cloud::BigQuery::Service::Backoff, :delay do
   class BackoffVerifier
     def initialize
       @mock = Minitest::Mock.new
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :delay do
     end
 
     # Use the lambda, but give it a new binding context that will use the sleep mock.
-    define_method :backoff, &Google::Cloud::Bigquery::Service::Backoff.backoff
+    define_method :backoff, &Google::Cloud::BigQuery::Service::Backoff.backoff
   end
 
   it "has a lambda that calls sleep with the delay given 0" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/backoff_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 require "json"
 
-describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
+describe Google::Cloud::BigQuery::Service::Backoff, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
 
   it "finds a dataset without any retry or backoff" do
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.dataset_id.must_equal dataset_id
   end
 
@@ -63,10 +63,10 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     end
     bigquery.service.mocked_service = stub
 
-    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+    Google::Cloud::BigQuery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
       dataset = bigquery.dataset dataset_id
 
-      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
       dataset.dataset_id.must_equal dataset_id
     end
 
@@ -104,10 +104,10 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     end
     bigquery.service.mocked_service = stub
 
-    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+    Google::Cloud::BigQuery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
       dataset = bigquery.dataset dataset_id
 
-      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
       dataset.dataset_id.must_equal dataset_id
     end
 
@@ -127,7 +127,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     end
     bigquery.service.mocked_service = stub
 
-    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+    Google::Cloud::BigQuery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
       err = assert_raises Google::Cloud::InvalidArgumentError do
         bigquery.dataset dataset_id
       end
@@ -172,10 +172,10 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     end
     bigquery.service.mocked_service = stub
 
-    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+    Google::Cloud::BigQuery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
       dataset = bigquery.dataset dataset_id
 
-      dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
       dataset.dataset_id.must_equal dataset_id
     end
 
@@ -205,7 +205,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     end
     bigquery.service.mocked_service = stub
 
-    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+    Google::Cloud::BigQuery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
       err = assert_raises Google::Cloud::InvalidArgumentError do
         bigquery.dataset dataset_id
       end
@@ -235,7 +235,7 @@ describe Google::Cloud::Bigquery::Service::Backoff, :mock_bigquery do
     end
     bigquery.service.mocked_service = stub
 
-    Google::Cloud::Bigquery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
+    Google::Cloud::BigQuery::Service::Backoff.stub :backoff, -> { mocked_backoff } do
       err = assert_raises Google::Cloud::InvalidArgumentError do
         bigquery.dataset dataset_id
       end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/copy_job_test.rb
@@ -16,13 +16,13 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::CopyJob, :mock_bigquery do
-  let(:job) { Google::Cloud::Bigquery::Job.from_gapi copy_job_gapi,
+describe Google::Cloud::BigQuery::CopyJob, :mock_bigquery do
+  let(:job) { Google::Cloud::BigQuery::Job.from_gapi copy_job_gapi,
                                               bigquery.service }
   let(:job_id) { job.job_id }
 
   it "knows it is copy job" do
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
   it "knows its copy tables" do
@@ -32,14 +32,14 @@ describe Google::Cloud::Bigquery::CopyJob, :mock_bigquery do
     mock.expect :get_table, source_table_gapi, ["source_project_id", "source_dataset_id", "source_table_id"]
 
     source = job.source
-    source.must_be_kind_of Google::Cloud::Bigquery::Table
+    source.must_be_kind_of Google::Cloud::BigQuery::Table
     source.project_id.must_equal "source_project_id"
     source.dataset_id.must_equal "source_dataset_id"
     source.table_id.must_equal   "source_table_id"
 
     mock.expect :get_table, destination_table_gapi, ["target_project_id", "target_dataset_id", "target_table_id"]
     destination = job.destination
-    destination.must_be_kind_of Google::Cloud::Bigquery::Table
+    destination.must_be_kind_of Google::Cloud::BigQuery::Table
     destination.project_id.must_equal "target_project_id"
     destination.dataset_id.must_equal "target_dataset_id"
     destination.table_id.must_equal   "target_table_id"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -14,13 +14,13 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Data, :mock_bigquery do
+describe Google::Cloud::BigQuery::Data, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_table" }
   let(:table_name) { "My Table" }
   let(:description) { "This is my table" }
   let(:table_gapi) { random_table_gapi dataset_id, table_id, table_name, description }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi,
                                                   bigquery.service }
 
   it "returns data as a list of hashes" do
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data = table.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     data[0].must_be_kind_of Hash
     data[0][:name].must_equal "Heidi"
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[0][:avatar].must_be_kind_of StringIO
     data[0][:avatar].read.must_equal "image data"
     data[0][:started_at].must_equal Time.parse("2016-12-25 13:00:00 UTC")
-    data[0][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
+    data[0][:duration].must_equal Google::Cloud::BigQuery::Time.new("04:00:00")
     data[0][:target_end].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
     data[0][:birthday].must_equal Date.parse("1968-10-20")
 
@@ -54,7 +54,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data[1][:active].must_equal false
     data[1][:avatar].must_be :nil?
     data[1][:started_at].must_be :nil?
-    data[1][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
+    data[1][:duration].must_equal Google::Cloud::BigQuery::Time.new("04:32:10.555555")
     data[1][:target_end].must_be :nil?
     data[1][:birthday].must_be :nil?
 
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data = table.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.kind.must_equal "bigquery#tableDataList"
     data.etag.must_equal "etag1234567890"
     data.token.must_equal "token1234567890"
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data = table.data
     mock.verify
 
-    data.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    data.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     data.schema.must_be :frozen?
     data.fields.must_equal data.schema.fields
     data.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]
@@ -113,7 +113,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     nil_data = table.data
     mock.verify
 
-    nil_data.class.must_equal Google::Cloud::Bigquery::Data
+    nil_data.class.must_equal Google::Cloud::BigQuery::Data
     nil_data.count.must_equal 0
   end
 
@@ -138,7 +138,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     nested_table_gapi = random_table_gapi dataset_id, table_id, table_name, description
     nested_table_gapi.schema = Google::Apis::BigqueryV2::TableSchema.from_json schema_hash.to_json
-    nested_table = Google::Cloud::Bigquery::Table.from_gapi nested_table_gapi, bigquery.service
+    nested_table = Google::Cloud::BigQuery::Table.from_gapi nested_table_gapi, bigquery.service
 
     nested_table_data_hash = table_data_hash
     nested_table_data_hash["rows"] = rows_array
@@ -153,7 +153,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     nested_data = nested_table.data
     mock.verify
 
-    nested_data.class.must_equal Google::Cloud::Bigquery::Data
+    nested_data.class.must_equal Google::Cloud::BigQuery::Data
     nested_data.count.must_equal 1
 
     nested_data.must_equal [{ nums: [1, 2, 3], scores: [100.0, 99.9, 0.001], msgs: ["hello", "world"], flags: [true, false] }]
@@ -183,7 +183,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     nested_table_gapi = random_table_gapi dataset_id, table_id, table_name, description
     nested_table_gapi.schema = Google::Apis::BigqueryV2::TableSchema.from_json schema_hash.to_json
-    nested_table = Google::Cloud::Bigquery::Table.from_gapi nested_table_gapi, bigquery.service
+    nested_table = Google::Cloud::BigQuery::Table.from_gapi nested_table_gapi, bigquery.service
 
     nested_table_data_hash = table_data_hash
     nested_table_data_hash["rows"] = rows_array
@@ -198,7 +198,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     nested_data = nested_table.data
     mock.verify
 
-    nested_data.class.must_equal Google::Cloud::Bigquery::Data
+    nested_data.class.must_equal Google::Cloud::BigQuery::Data
     nested_data.count.must_equal 1
 
     nested_data.must_equal [{ name: "mike", foo: [{ bar: "hey", baz: { bif: 1 } }, { bar: "world", baz: { bif: 2 } }] }]
@@ -216,11 +216,11 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     data1 = table.data
 
-    data1.class.must_equal Google::Cloud::Bigquery::Data
+    data1.class.must_equal Google::Cloud::BigQuery::Data
     data1.token.wont_be :nil?
     data1.token.must_equal "token1234567890"
     data2 = table.data token: data1.token
-    data2.class.must_equal Google::Cloud::Bigquery::Data
+    data2.class.must_equal Google::Cloud::BigQuery::Data
     mock.verify
   end
 
@@ -236,13 +236,13 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
 
     data1 = table.data
 
-    data1.class.must_equal Google::Cloud::Bigquery::Data
+    data1.class.must_equal Google::Cloud::BigQuery::Data
     data1.token.wont_be :nil?
     data1.next?.must_equal true # can't use must_be :next?
     data2 = data1.next
     data2.token.must_be :nil?
     data2.next?.must_equal false
-    data2.class.must_equal Google::Cloud::Bigquery::Data
+    data2.class.must_equal Google::Cloud::BigQuery::Data
     mock.verify
   end
 
@@ -321,7 +321,7 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
                 [project, dataset_id, table_id, {  max_results: 3, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = table.data max: 3
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
   end
 
   it "paginates data with start set" do
@@ -334,6 +334,6 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     data = table.data start: 25
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_access_test.rb
@@ -14,11 +14,11 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :access, :mock_bigquery do
   # Create a dataset object with the project's mocked connection object
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
 
   it "gets the access rules" do
@@ -34,13 +34,13 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
     patch_gapi = Google::Apis::BigqueryV2::Dataset.new access: [new_access], etag: dataset_gapi.etag
     mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi, {options: {header: {"If-Match" => dataset_gapi.etag}}}]
 
-    dataset.access.must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
+    dataset.access.must_be_kind_of Google::Cloud::BigQuery::Dataset::Access
     dataset.access.must_be :frozen?
 
     refute dataset.access.writer_user? "writer@example.com"
 
     dataset.access do |acl|
-      acl.must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
+      acl.must_be_kind_of Google::Cloud::BigQuery::Dataset::Access
       acl.wont_be :frozen?
 
       refute acl.writer_user? "writer@example.com"
@@ -48,7 +48,7 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
       assert acl.writer_user? "writer@example.com"
     end
 
-    dataset.access.must_be_kind_of Google::Cloud::Bigquery::Dataset::Access
+    dataset.access.must_be_kind_of Google::Cloud::BigQuery::Dataset::Access
     dataset.access.must_be :frozen?
 
     assert dataset.access.writer_user? "writer@example.com"
@@ -110,7 +110,7 @@ describe Google::Cloud::Bigquery::Dataset, :access, :mock_bigquery do
   describe :view do
     let(:view_id) { "new-view" }
     let(:view_gapi) { random_view_gapi dataset_id, view_id }
-    let(:view) { Google::Cloud::Bigquery::Table.from_gapi view_gapi,
+    let(:view) { Google::Cloud::BigQuery::Table.from_gapi view_gapi,
                                                   bigquery.service }
 
     it "adds an access entry with specifying a view object" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Dataset, :attributes, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :attributes, :mock_bigquery do
   # Create a dataset object with the project's mocked connection object
   let(:dataset_id) { "my_dataset" }
   let(:dataset_name) { "My Dataset" }
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigquery::Dataset, :attributes, :mock_bigquery do
   let(:dataset_gapi) {  Google::Apis::BigqueryV2::DatasetList::Dataset.from_json random_dataset_small_hash(dataset_id, dataset_name).to_json }
   let(:dataset_full_json) { random_dataset_hash(dataset_id, dataset_name, description, default_expiration).to_json }
   let(:dataset_full_gapi) { Google::Apis::BigqueryV2::Dataset.from_json dataset_full_json }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
 
   it "gets full data for created_at" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_exists_test.rb
@@ -14,11 +14,11 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :exists, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :exists, :mock_bigquery do
   # Create a dataset object with the project's mocked connection object
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
 
   it "knows if full resource exists when created with an HTTP method" do
@@ -41,7 +41,7 @@ describe Google::Cloud::Bigquery::Dataset, :exists, :mock_bigquery do
 
   describe "partial dataset resource from list of a dataset that exists" do
     let(:dataset_partial_gapi) { list_datasets_gapi(1).datasets.first }
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.from_gapi dataset_partial_gapi, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.from_gapi dataset_partial_gapi, bigquery.service }
 
     it "knows if partial resource exists when created with an HTTP method" do
       # The absence of a mock means this test will fail
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Dataset, :exists, :mock_bigquery do
   end
 
   describe "dataset reference of a dataset that exists" do
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
     it "checks if the dataset exists by making an HTTP call" do
       mock = Minitest::Mock.new
@@ -89,7 +89,7 @@ describe Google::Cloud::Bigquery::Dataset, :exists, :mock_bigquery do
   end
 
   describe "dataset reference of a dataset that does not exist" do
-    let(:dataset) { Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+    let(:dataset) { Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
     it "checks if the dataset exists by making an HTTP call" do
       stub = Object.new

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_external_test.rb
@@ -14,10 +14,10 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :external, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
 
   it "raises if not given valid arguments" do
@@ -26,7 +26,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
   it "creates a simple external table" do
     external = dataset.external "gs://my-bucket/path/to/file.csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
     external.must_be :csv?
     external.format.must_equal "CSV"
@@ -35,7 +35,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
   describe "CSV" do
     it "determines CSV from one URL" do
       external = dataset.external "gs://my-bucket/path/to/file.csv"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines CSV from multiple URL" do
       external = dataset.external ["some url", "gs://my-bucket/path/to/file.csv"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines CSV from the format (:csv)" do
       external = dataset.external "some url", format: :csv
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -59,7 +59,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines CSV from the format (csv)" do
       external = dataset.external "some url", format: "csv"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -67,7 +67,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines CSV from the format (:CSV)" do
       external = dataset.external "some url", format: :CSV
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -75,7 +75,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines CSV from the format (CSV)" do
       external = dataset.external "some url", format: "CSV"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -85,7 +85,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
   describe "JSON" do
     it "determines JSON from one URL" do
       external = dataset.external "gs://my-bucket/path/to/file.json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -93,7 +93,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines JSON from multiple URL" do
       external = dataset.external ["some url", "gs://my-bucket/path/to/file.json"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.json"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -101,7 +101,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines JSON from the format (:json)" do
       external = dataset.external "some url", format: :json
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -109,7 +109,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines JSON from the format (json)" do
       external = dataset.external "some url", format: "json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -117,7 +117,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines JSON from the format (:JSON)" do
       external = dataset.external "some url", format: :JSON
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -125,7 +125,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines JSON from the format (JSON)" do
       external = dataset.external "some url", format: "JSON"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -133,7 +133,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines JSON from the format (:newline_delimited_json)" do
       external = dataset.external "some url", format: :newline_delimited_json
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -141,7 +141,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines JSON from the format (newline_delimited_json)" do
       external = dataset.external "some url", format: "newline_delimited_json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -149,7 +149,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines JSON from the format (:NEWLINE_DELIMITED_JSON)" do
       external = dataset.external "some url", format: :NEWLINE_DELIMITED_JSON
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -157,7 +157,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines JSON from the format (NEWLINE_DELIMITED_JSON)" do
       external = dataset.external "some url", format: "NEWLINE_DELIMITED_JSON"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -167,7 +167,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
   describe "Google Sheets" do
     it "determines CSV from one URL" do
       external = dataset.external "https://docs.google.com/spreadsheets/d/1234567980"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -175,7 +175,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines CSV from multiple URL" do
       external = dataset.external ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -183,7 +183,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (:sheets)" do
       external = dataset.external "some url", format: :sheets
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -191,7 +191,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (sheets)" do
       external = dataset.external "some url", format: "sheets"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -199,7 +199,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (:SHEETS)" do
       external = dataset.external "some url", format: :SHEETS
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -207,7 +207,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (SHEETS)" do
       external = dataset.external "some url", format: "SHEETS"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -215,7 +215,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (:google_sheets)" do
       external = dataset.external "some url", format: :google_sheets
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -223,7 +223,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (google_sheets)" do
       external = dataset.external "some url", format: "google_sheets"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -231,7 +231,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (:GOOGLE_SHEETS)" do
       external = dataset.external "some url", format: :GOOGLE_SHEETS
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -239,7 +239,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (GOOGLE_SHEETS)" do
       external = dataset.external "some url", format: "GOOGLE_SHEETS"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -249,7 +249,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
   describe "AVRO" do
     it "determines AVRO from one URL" do
       external = dataset.external "gs://my-bucket/path/to/file.avro"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["gs://my-bucket/path/to/file.avro"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -257,7 +257,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines AVRO from multiple URL" do
       external = dataset.external ["some url", "gs://my-bucket/path/to/file.avro"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.avro"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -265,7 +265,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines AVRO from the format (:avro)" do
       external = dataset.external "some url", format: :avro
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -273,7 +273,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines AVRO from the format (avro)" do
       external = dataset.external "some url", format: "avro"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -281,7 +281,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines AVRO from the format (:AVRO)" do
       external = dataset.external "some url", format: :AVRO
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -289,7 +289,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines AVRO from the format (AVRO)" do
       external = dataset.external "some url", format: "AVRO"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -299,7 +299,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
   describe "Datastore Backup" do
     it "determines BACKUP from one URL" do
       external = dataset.external "gs://my-bucket/path/to/file.backup_info"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["gs://my-bucket/path/to/file.backup_info"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -307,7 +307,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from multiple URL" do
       external = dataset.external ["some url", "gs://my-bucket/path/to/file.backup_info"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.backup_info"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -315,7 +315,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:backup)" do
       external = dataset.external "some url", format: :backup
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -323,7 +323,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (backup)" do
       external = dataset.external "some url", format: "backup"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -331,7 +331,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:BACKUP)" do
       external = dataset.external "some url", format: :BACKUP
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -339,7 +339,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (BACKUP)" do
       external = dataset.external "some url", format: "BACKUP"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -347,7 +347,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:datastore)" do
       external = dataset.external "some url", format: :datastore
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -355,7 +355,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (datastore)" do
       external = dataset.external "some url", format: "datastore"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -363,7 +363,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:DATASTORE)" do
       external = dataset.external "some url", format: :DATASTORE
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -371,7 +371,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (DATASTORE)" do
       external = dataset.external "some url", format: "DATASTORE"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -379,7 +379,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:datastore_backup)" do
       external = dataset.external "some url", format: :datastore_backup
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -387,7 +387,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (datastore_backup)" do
       external = dataset.external "some url", format: "datastore_backup"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -395,7 +395,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:DATASTORE_BACKUP)" do
       external = dataset.external "some url", format: :DATASTORE_BACKUP
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -403,7 +403,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (DATASTORE_BACKUP)" do
       external = dataset.external "some url", format: "DATASTORE_BACKUP"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -413,7 +413,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
   describe "BIGTABLE" do
     it "determines BIGTABLE from one URL" do
       external = dataset.external "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -421,7 +421,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BIGTABLE from multiple URL" do
       external = dataset.external ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -429,7 +429,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BIGTABLE from the format (:bigtable)" do
       external = dataset.external "some url", format: :bigtable
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -437,7 +437,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BIGTABLE from the format (bigtable)" do
       external = dataset.external "some url", format: "bigtable"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -445,7 +445,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BIGTABLE from the format (:BIGTABLE)" do
       external = dataset.external "some url", format: :BIGTABLE
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -453,7 +453,7 @@ describe Google::Cloud::Bigquery::Dataset, :external, :mock_bigquery do
 
     it "determines BIGTABLE from the format (BIGTABLE)" do
       external = dataset.external "some url", format: "BIGTABLE"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
@@ -16,11 +16,11 @@ require "helper"
 
 Thread.abort_on_exception = true
 
-describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :insert_async, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:dataset_hash) { random_dataset_hash dataset_id }
   let(:dataset_gapi) { Google::Apis::BigqueryV2::Dataset.from_json dataset_hash.to_json }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   let(:table_id) { "my_table" }
   let(:table_hash) { random_table_hash dataset_id, table_id }
@@ -71,7 +71,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
   end
 
   describe "dataset reference" do
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
     it "inserts one row" do
       mock = Minitest::Mock.new
@@ -209,7 +209,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
     end
 
     insert_result.wont_be_nil
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    insert_result.must_be_kind_of Google::Cloud::BigQuery::Table::AsyncInserter::Result
     insert_result.wont_be :error?
     insert_result.error.must_be_nil
     insert_result.must_be :success?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
@@ -14,10 +14,10 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :insert, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
 
   let(:rows) { [{"name"=>"Heidi", "age"=>"36", "score"=>"7.65", "active"=>"true"},
@@ -34,7 +34,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
   let(:table_id) { "table_id" }
   let(:table_hash) { random_table_hash dataset_id, table_id }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   it "raises if rows is an empty array" do
     expect { dataset.insert table_id, [] }.must_raise ArgumentError
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
   end
 
   describe "dataset reference" do
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
     it "can insert one row" do
       mock = Minitest::Mock.new
@@ -221,7 +221,7 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
           last_used: Time.parse("2015-10-31 23:59:56 UTC")
         }
       ],
-      tea_time: Google::Cloud::Bigquery::Time.new("15:00:00"),
+      tea_time: Google::Cloud::BigQuery::Time.new("15:00:00"),
       next_vacation: Date.parse("2666-06-06"),
       favorite_time: Time.parse("2001-12-19T23:59:59 UTC").utc.to_datetime
     }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
@@ -14,10 +14,10 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :load_job, :local, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
   let(:table_id) { "table_id" }
   let(:table_reference) { Google::Apis::BigqueryV2::TableReference.new(
@@ -35,7 +35,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, load_job_gapi(table_reference, "CSV"), upload_source: file, content_type: "text/comma-separated-values"]
 
       job = dataset.load_job table_id, file, format: :csv
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     end
     mock.verify
   end
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
       job = dataset.load_job table_id, file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
         quote: "'", skip_leading: 1
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     end
 
     mock.verify
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, load_job_gapi(table_reference), upload_source: file, content_type: "application/json"]
 
       job = dataset.load_job table_id, file, format: "JSON"
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     end
 
     mock.verify
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
 
     local_json = "acceptance/data/kitten-test-data.json"
     job = dataset.load_job table_id, local_json
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -100,7 +100,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = dataset.load_job table_id, file, format: "JSON", job_id: job_id
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
       job.job_id.must_equal job_id
     end
 
@@ -121,7 +121,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = dataset.load_job table_id, file, format: "JSON", prefix: prefix
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
       job.job_id.must_equal job_id
     end
 
@@ -139,7 +139,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = dataset.load_job table_id, file, format: "JSON", job_id: job_id, prefix: "IGNORED"
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
       job.job_id.must_equal job_id
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :load_job, :schema, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
   let(:load_bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
@@ -24,7 +24,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
   let(:table_id) { "table_id" }
   let(:table_reference) { Google::Apis::BigqueryV2::TableReference.new(
@@ -75,7 +75,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       schema.boolean "active"
       schema.bytes "avatar"
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
     schema.bytes "avatar"
 
     job = dataset.load_job table_id, load_file, create: :needed, schema: schema
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -120,7 +120,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       schema.boolean "active"
       schema.bytes "avatar"
     end
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :load_job, :storage, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
   let(:load_bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
@@ -24,7 +24,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
   let(:table_id) { "table_id" }
   let(:table_reference) { Google::Apis::BigqueryV2::TableReference.new(
@@ -46,13 +46,13 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
 
   describe "dataset reference" do
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
     it "can specify a storage file" do
       mock = Minitest::Mock.new
@@ -62,7 +62,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
       dataset.service.mocked_service = mock
 
       job = dataset.load_job table_id, load_file
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
       mock.verify
     end
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file, format: :csv
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -116,7 +116,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     job = dataset.load_job table_id, special_file, jagged_rows: true, quoted_newlines: true, autodetect: true,
       encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
       quote: "'", skip_leading: 1
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -133,7 +133,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -150,7 +150,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -169,7 +169,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, special_file, projection_fields: projection_fields
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -182,7 +182,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -196,7 +196,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, dryrun: true
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -210,7 +210,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, create: "CREATE_NEVER"
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -224,7 +224,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, create: :never
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -238,7 +238,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, write: "WRITE_TRUNCATE"
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -252,7 +252,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url, write: :truncate
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
@@ -14,10 +14,10 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :load, :local, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :load, :local, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
   let(:table_id) { "table_id" }
   let(:table_reference) { Google::Apis::BigqueryV2::TableReference.new(

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_schema_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :load, :schema, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :load, :schema, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
   let(:load_bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
@@ -24,7 +24,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :schema, :mock_bigquery do
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
   let(:table_id) { "table_id" }
   let(:table_reference) { Google::Apis::BigqueryV2::TableReference.new(

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :load, :storage, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
   let(:load_bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
@@ -24,7 +24,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
   let(:table_id) { "table_id" }
   let(:table_reference) { Google::Apis::BigqueryV2::TableReference.new(
@@ -52,7 +52,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
   end
 
   describe "dataset reference" do
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
     it "can specify a storage file" do
       mock = Minitest::Mock.new

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_external_test.rb
@@ -14,13 +14,13 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :query, :external, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :query, :external, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM my_csv" }
   let(:job_id) { "job_9876543210" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   it "queries with external data" do
     job_gapi = query_job_gapi query
@@ -48,7 +48,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :external, :mock_bigquery do
     data = dataset.query query, external: { my_csv: external_csv }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_external_test.rb
@@ -14,13 +14,13 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :query_job, :external, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :query_job, :external, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM my_csv" }
   let(:job_id) { "job_9876543210" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   it "queries with external data" do
     job_gapi = query_job_gapi query
@@ -42,6 +42,6 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :external, :mock_bigquery
     job = dataset.query_job query, external: { my_csv: external_csv }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -14,11 +14,11 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :query_job, :named_params, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   let(:query_job_gapi) do
     Google::Apis::BigqueryV2::Job.from_json(query_job_json("SELECT * FROM tbl")).tap do |r|
@@ -50,7 +50,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with an integer parameter" do
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a float parameter" do
@@ -98,7 +98,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a true parameter" do
@@ -122,7 +122,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE active = @active", params: { active: true }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a false parameter" do
@@ -146,7 +146,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE active = @active", params: { active: false }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a date parameter" do
@@ -172,7 +172,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a datetime parameter" do
@@ -198,7 +198,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a timestamp parameter" do
@@ -224,7 +224,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a time parameter" do
@@ -250,7 +250,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
     it "queries the data with a File parameter" do
@@ -276,7 +276,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
       job = dataset.query_job "#{query} WHERE avatar = @file", params: { file: file }
       mock.verify
 
-      job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+      job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     end
 
     it "queries the data with a StringIO parameter" do
@@ -302,7 +302,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
       job = dataset.query_job "#{query} WHERE avatar = @file", params: { file: file }
       mock.verify
 
-      job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+      job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     end
 
   it "queries the data with many parameters" do
@@ -393,7 +393,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with an array parameter" do
@@ -424,7 +424,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a struct parameter" do
@@ -467,6 +467,6 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     job = dataset.query_job "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -14,11 +14,11 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :query_job, :positional_params, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   let(:query_job_gapi) do
     Google::Apis::BigqueryV2::Job.from_json(query_job_json("SELECT * FROM tbl")).tap do |r|
@@ -49,7 +49,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE name = ?", params: ["Testy McTesterson"]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with an integer parameter" do
@@ -72,7 +72,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE age > ?", params: [35]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a float parameter" do
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE score > ?", params: [90.0]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a true parameter" do
@@ -118,7 +118,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE active = ?", params: [true]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a false parameter" do
@@ -141,7 +141,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE active = ?", params: [false]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a date parameter" do
@@ -166,7 +166,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE create_date = ?", params: [today]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a datetime parameter" do
@@ -191,7 +191,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a timestamp parameter" do
@@ -216,7 +216,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a time parameter" do
@@ -241,7 +241,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a File parameter" do
@@ -266,7 +266,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a StringIO parameter" do
@@ -291,7 +291,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with many parameters" do
@@ -370,7 +370,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with an array parameter" do
@@ -400,7 +400,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a struct parameter" do
@@ -442,6 +442,6 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     job = dataset.query_job "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -14,15 +14,15 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :query_job, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active FROM `some_project.some_dataset.users`" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
   let(:table_id) { "my_table" }
   let(:table_gapi) { random_table_gapi dataset_id, table_id }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi,
                                                   bigquery.service }
   let(:labels) { { "foo" => "bar" } }
   let(:udfs) { [ "return x+1;", "gs://my-bucket/my-lib.js" ] }
@@ -41,11 +41,11 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   describe "dataset reference" do
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
     it "queries the data with default dataset option set" do
       mock = Minitest::Mock.new
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
       job = dataset.query_job query
       mock.verify
 
-      job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+      job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     end
   end
 
@@ -94,7 +94,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
                             maximum_bytes_billed: 12345678901234
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with job_id option" do
@@ -113,7 +113,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.job_id.must_equal job_id
   end
 
@@ -136,7 +136,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.job_id.must_equal job_id
   end
 
@@ -156,7 +156,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.job_id.must_equal job_id
   end
 
@@ -175,7 +175,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.labels.must_equal labels
   end
 
@@ -194,7 +194,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, udfs: udfs
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.udfs.must_equal udfs
   end
 
@@ -213,7 +213,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     job = dataset.query_job query, udfs: "gs://my-bucket/my-lib.js"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.udfs.must_equal ["gs://my-bucket/my-lib.js"]
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -14,12 +14,12 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :query, :named_params, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
   let(:job_id) { "job_9876543210" }
 
   let(:dataset_id) { "my_dataset" }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
 
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -115,7 +115,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -147,7 +147,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE active = @active", params: { active: true }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -179,7 +179,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE active = @active", params: { active: false }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -213,7 +213,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -247,7 +247,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -281,7 +281,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -315,7 +315,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -349,7 +349,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -383,7 +383,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -482,7 +482,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
 
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -521,7 +521,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -572,7 +572,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     data = dataset.query "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -14,12 +14,12 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :query, :positional_params, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
   let(:job_id) { "job_9876543210" }
 
   let(:dataset_id) { "my_dataset" }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
 
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE name = ?", params: ["Testy McTesterson"]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -82,7 +82,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE age > ?", params: [35]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE score > ?", params: [90.0]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -144,7 +144,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE active = ?", params: [true]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -175,7 +175,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE active = ?", params: [false]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -208,7 +208,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE create_date = ?", params: [today]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -241,7 +241,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -274,7 +274,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -307,7 +307,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -340,7 +340,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
       data = dataset.query "#{query} WHERE avatar = ?", params: [file]
       mock.verify
 
-      data.class.must_equal Google::Cloud::Bigquery::Data
+      data.class.must_equal Google::Cloud::BigQuery::Data
       assert_valid_data data
     end
 
@@ -373,7 +373,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
       data = dataset.query "#{query} WHERE avatar = ?", params: [file]
       mock.verify
 
-      data.class.must_equal Google::Cloud::Bigquery::Data
+      data.class.must_equal Google::Cloud::BigQuery::Data
       assert_valid_data data
     end
 
@@ -460,7 +460,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
 
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -498,7 +498,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -548,7 +548,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     data = dataset.query "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_test.rb
@@ -14,13 +14,13 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :query, :mock_bigquery do
   let(:query) { "SELECT * FROM `some_project.some_dataset.users`" }
 
   let(:job_id) { "job_9876543210" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
 
   it "queries the data with default dataset option set" do
@@ -38,13 +38,13 @@ describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query query
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     mock.verify
   end
 
   describe "dataset reference" do
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
     it "queries the data with default dataset option set" do
       mock = Minitest::Mock.new
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :mock_bigquery do
                   [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
       data = dataset.query query
-      data.class.must_equal Google::Cloud::Bigquery::Data
+      data.class.must_equal Google::Cloud::BigQuery::Data
       data.count.must_equal 3
       mock.verify
     end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :reference, :mock_bigquery do
   # Create a dataset object with the project's mocked connection object
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_table" }
@@ -26,7 +26,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
   let(:view_name) { "My View" }
   let(:view_description) { "This is my view" }
   let(:query) { "SELECT * FROM [table]" }
-  let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+  let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
   it "knows its attributes" do
     dataset.dataset_id.must_equal dataset_id
@@ -81,7 +81,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal table_id
     table.must_be :table?
     table.wont_be :view?
@@ -107,7 +107,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal view_id
     table.query.must_equal query
     table.must_be :query_standard_sql?
@@ -128,7 +128,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
     mock.verify
 
     tables.size.must_equal 3
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
   end
 
   it "paginates tables" do
@@ -145,13 +145,13 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
     mock.verify
 
     first_tables.count.must_equal 3
-    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
     first_tables.token.wont_be :nil?
     first_tables.token.must_equal "next_page_token"
     first_tables.total.must_equal 5
 
     second_tables.count.must_equal 2
-    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
     second_tables.token.must_be :nil?
     second_tables.total.must_equal 5
   end
@@ -167,7 +167,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal found_table_id
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
@@ -14,14 +14,14 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :reference, :update, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :reference, :update, :mock_bigquery do
   # Create a dataset object with the project's mocked connection object
   let(:dataset_id) { "my_dataset" }
   let(:dataset_name) { "My Dataset" }
   let(:description) { "This is my dataset" }
   let(:default_expiration) { 999 }
   let(:dataset_gapi) { random_dataset_gapi dataset_id, dataset_name, description, default_expiration }
-  let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+  let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
   it "updates its name" do
     new_dataset_name = "My Updated Dataset"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reload_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reload_test.rb
@@ -14,11 +14,11 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :reload, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :reload, :mock_bigquery do
   # Create a dataset object with the project's mocked connection object
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
 
   it "loads the dataset full resource by making an HTTP call" do
@@ -42,7 +42,7 @@ describe Google::Cloud::Bigquery::Dataset, :reload, :mock_bigquery do
 
   describe "partial dataset resource from list" do
     let(:dataset_partial_gapi) { list_datasets_gapi(1).datasets.first }
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.from_gapi dataset_partial_gapi, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.from_gapi dataset_partial_gapi, bigquery.service }
 
     it "loads the dataset full resource by making an HTTP call" do
       mock = Minitest::Mock.new
@@ -65,7 +65,7 @@ describe Google::Cloud::Bigquery::Dataset, :reload, :mock_bigquery do
   end
 
   describe "dataset reference" do
-    let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
+    let(:dataset) {Google::Cloud::BigQuery::Dataset.new_reference project, dataset_id, bigquery.service }
 
     it "loads the dataset full resource by making an HTTP call" do
       mock = Minitest::Mock.new

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :mock_bigquery do
   # Create a dataset object with the project's mocked connection object
   let(:dataset_id) { "my_dataset" }
   let(:dataset_name) { "My Dataset" }
@@ -53,7 +53,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:api_url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset_id}" }
   let(:dataset_hash) { random_dataset_hash dataset_id, dataset_name, dataset_description, default_expiration }
   let(:dataset_gapi) { Google::Apis::BigqueryV2::Dataset.from_json dataset_hash.to_json }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   it "knows its attributes" do
     dataset.name.must_equal dataset_name
@@ -111,7 +111,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal table_id
     table.must_be :table?
     table.wont_be :view?
@@ -136,7 +136,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal table_id
     table.name.must_equal table_name
     table.description.must_equal table_description
@@ -165,7 +165,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal table_id
     table.name.must_equal table_name
     table.description.must_equal table_description
@@ -199,7 +199,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal table_id
     table.name.must_equal table_name
     table.description.must_equal table_description
@@ -251,7 +251,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal table_id
     table.name.must_equal table_name
     table.description.must_equal table_description
@@ -288,7 +288,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal table_id
     table.name.must_equal table_name
     table.description.must_equal table_description
@@ -318,7 +318,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal view_id
     table.query.must_equal query
     table.must_be :query_standard_sql?
@@ -352,7 +352,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal view_id
     table.query.must_equal query
     table.name.must_equal view_name
@@ -384,7 +384,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal view_id
     table.query.must_equal query
     table.must_be :query_standard_sql?
@@ -414,7 +414,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal view_id
     table.query.must_equal query
     table.wont_be :query_standard_sql?
@@ -449,7 +449,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal view_id
     table.query.must_equal query
     table.must_be :query_standard_sql?
@@ -481,7 +481,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal view_id
     table.query.must_equal query
     table.must_be :query_standard_sql?
@@ -513,7 +513,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal view_id
     table.query.must_equal query
     table.must_be :query_standard_sql?
@@ -534,7 +534,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
     tables.size.must_equal 3
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
   end
 
   it "lists tables with max set" do
@@ -548,7 +548,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
     tables.count.must_equal 3
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
     tables.token.wont_be :nil?
     tables.token.must_equal "next_page_token"
   end
@@ -567,13 +567,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
     first_tables.count.must_equal 3
-    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
     first_tables.token.wont_be :nil?
     first_tables.token.must_equal "next_page_token"
     first_tables.total.must_equal 5
 
     second_tables.count.must_equal 2
-    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
     second_tables.token.must_be :nil?
     second_tables.total.must_equal 5
   end
@@ -592,13 +592,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
     first_tables.count.must_equal 3
-    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
     first_tables.token.wont_be :nil?
     first_tables.token.must_equal "next_page_token"
     first_tables.total.must_equal 5
 
     second_tables.count.must_equal 2
-    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
     second_tables.token.must_be :nil?
     second_tables.total.must_equal 5
   end
@@ -617,12 +617,12 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
     first_tables.count.must_equal 3
-    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    first_tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
     first_tables.next?.must_equal true
     first_tables.total.must_equal 5
 
     second_tables.count.must_equal 2
-    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    second_tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
     second_tables.next?.must_equal false
     second_tables.total.must_equal 5
   end
@@ -640,7 +640,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
     tables.count.must_equal 5
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
   end
 
   it "paginates tables with all and max" do
@@ -656,7 +656,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
     tables.count.must_equal 5
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
   end
 
   it "iterates tables with all using Enumerator" do
@@ -672,7 +672,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
     tables.count.must_equal 5
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
   end
 
   it "iterates tables with all with request_limit set" do
@@ -688,7 +688,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     mock.verify
 
     tables.count.must_equal 6
-    tables.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Table }
+    tables.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Table }
   end
 
   it "finds a table" do
@@ -702,7 +702,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     mock.verify
 
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
     table.table_id.must_equal found_table_id
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
+describe Google::Cloud::BigQuery::Dataset, :update, :mock_bigquery do
   # Create a dataset object with the project's mocked connection object
   let(:dataset_id) { "my_dataset" }
   let(:dataset_name) { "My Dataset" }
@@ -22,7 +22,7 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
   let(:default_expiration) { 999 }
   let(:labels) { { "foo" => "bar" } }
   let(:dataset_gapi) { random_dataset_gapi dataset_id, dataset_name, description, default_expiration }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
 
   it "updates its name" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_column_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_column_test.rb
@@ -14,56 +14,56 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::External::BigtableSource::Column, :mock_bigquery do
+describe Google::Cloud::BigQuery::External::BigtableSource::Column, :mock_bigquery do
   it "raises if not given valid arguments" do
     expect { bigquery.external nil }.must_raise ArgumentError
   end
 
   it "creates a simple external table" do
     external = bigquery.external "gs://my-bucket/path/to/file.csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
     external.format.must_equal "CSV"
   end
 
   it "determines CSV from one URL" do
     external = bigquery.external "gs://my-bucket/path/to/file.csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
     external.format.must_equal "CSV"
   end
 
   it "determines CSV from multiple URL" do
     external = bigquery.external ["some url", "gs://my-bucket/path/to/file.csv"]
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
     external.format.must_equal "CSV"
   end
 
   it "determines CSV from the format (:csv)" do
     external = bigquery.external "some url", format: :csv
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     external.urls.must_equal ["some url"]
     external.format.must_equal "CSV"
   end
 
   it "determines CSV from the format (csv)" do
     external = bigquery.external "some url", format: "csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     external.urls.must_equal ["some url"]
     external.format.must_equal "CSV"
   end
 
   it "determines CSV from the format (:CSV)" do
     external = bigquery.external "some url", format: :CSV
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     external.urls.must_equal ["some url"]
     external.format.must_equal "CSV"
   end
 
   it "determines CSV from the format (CSV)" do
     external = bigquery.external "some url", format: "CSV"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     external.urls.must_equal ["some url"]
     external.format.must_equal "CSV"
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_bigtable_source_test.rb
@@ -14,9 +14,9 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::External::BigtableSource do
+describe Google::Cloud::BigQuery::External::BigtableSource do
   it "can be used for BIGTABLE" do
-    table = Google::Cloud::Bigquery::External::BigtableSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::BigtableSource.new.tap do |e|
       e.gapi.source_uris = ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
       e.gapi.source_format = "BIGTABLE"
     end
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
       )
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    table.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
     table.urls.must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
     table.must_be :bigtable?
     table.format.must_equal "BIGTABLE"
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
   end
 
   it "sets rowkey_as_string" do
-    table = Google::Cloud::Bigquery::External::BigtableSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::BigtableSource.new.tap do |e|
       e.gapi.source_uris = ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
       e.gapi.source_format = "BIGTABLE"
     end
@@ -66,7 +66,7 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
   end
 
   it "adds column families using block" do
-    table = Google::Cloud::Bigquery::External::BigtableSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::BigtableSource.new.tap do |e|
       e.gapi.source_uris = ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
       e.gapi.source_format = "BIGTABLE"
     end
@@ -100,22 +100,22 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
 
     table.families.wont_be :empty?
     table.families.count.must_equal 1
-    table.families[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::ColumnFamily
+    table.families[0].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::ColumnFamily
     table.families[0].family_id.must_equal "user"
     table.families[0].columns.count.must_equal 5
-    table.families[0].columns[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[0].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[0].qualifier.must_equal "name"
     table.families[0].columns[0].type.must_equal "STRING"
-    table.families[0].columns[1].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[1].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[1].qualifier.must_equal "age"
     table.families[0].columns[1].type.must_equal "INTEGER"
-    table.families[0].columns[2].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[2].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[2].qualifier.must_equal "score"
     table.families[0].columns[2].type.must_equal "FLOAT"
-    table.families[0].columns[3].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[3].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[3].qualifier.must_equal "active"
     table.families[0].columns[3].type.must_equal "BOOLEAN"
-    table.families[0].columns[4].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[4].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[4].qualifier.must_equal "avatar"
     table.families[0].columns[4].type.must_equal "BYTES"
 
@@ -123,7 +123,7 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
   end
 
   it "adds column families inline" do
-    table = Google::Cloud::Bigquery::External::BigtableSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::BigtableSource.new.tap do |e|
       e.gapi.source_uris = ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
       e.gapi.source_format = "BIGTABLE"
     end
@@ -156,22 +156,22 @@ describe Google::Cloud::Bigquery::External::BigtableSource do
 
     table.families.wont_be :empty?
     table.families.count.must_equal 1
-    table.families[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::ColumnFamily
+    table.families[0].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::ColumnFamily
     table.families[0].family_id.must_equal "user"
     table.families[0].columns.count.must_equal 5
-    table.families[0].columns[0].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[0].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[0].qualifier.must_equal "name"
     table.families[0].columns[0].type.must_equal "STRING"
-    table.families[0].columns[1].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[1].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[1].qualifier.must_equal "age"
     table.families[0].columns[1].type.must_equal "INTEGER"
-    table.families[0].columns[2].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[2].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[2].qualifier.must_equal "score"
     table.families[0].columns[2].type.must_equal "FLOAT"
-    table.families[0].columns[3].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[3].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[3].qualifier.must_equal "active"
     table.families[0].columns[3].type.must_equal "BOOLEAN"
-    table.families[0].columns[4].must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource::Column
+    table.families[0].columns[4].must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource::Column
     table.families[0].columns[4].qualifier.must_equal "avatar"
     table.families[0].columns[4].type.must_equal "BYTES"
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
@@ -14,9 +14,9 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::External::CsvSource do
+describe Google::Cloud::BigQuery::External::CsvSource do
   it "can be used for CSV" do
-    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::CsvSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
       e.gapi.source_format = "CSV"
     end
@@ -26,7 +26,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       csv_options: Google::Apis::BigqueryV2::CsvOptions.new
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    table.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
     table.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
     table.must_be :csv?
     table.format.must_equal "CSV"
@@ -41,7 +41,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
   end
 
   it "sets jagged_rows" do
-    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::CsvSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
       e.gapi.source_format = "CSV"
     end
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
   end
 
   it "sets quoted_newlines" do
-    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::CsvSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
       e.gapi.source_format = "CSV"
     end
@@ -85,7 +85,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
   end
 
   it "sets encoding" do
-    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::CsvSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
       e.gapi.source_format = "CSV"
     end
@@ -117,7 +117,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
   end
 
   it "sets delimiter" do
-    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::CsvSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
       e.gapi.source_format = "CSV"
     end
@@ -139,7 +139,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
   end
 
   it "sets quote" do
-    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::CsvSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
       e.gapi.source_format = "CSV"
     end
@@ -161,7 +161,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
   end
 
   it "sets skip_leading_rows" do
-    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::CsvSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
       e.gapi.source_format = "CSV"
     end
@@ -183,7 +183,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
   end
 
   it "sets schema using block" do
-    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::CsvSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
       e.gapi.source_format = "CSV"
     end
@@ -204,7 +204,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       csv_options: Google::Apis::BigqueryV2::CsvOptions.new
     )
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     table.schema.must_be :empty?
 
     table.schema do |s|
@@ -228,7 +228,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
   end
 
   it "sets schema using object" do
-    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::CsvSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
       e.gapi.source_format = "CSV"
     end
@@ -249,11 +249,11 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       csv_options: Google::Apis::BigqueryV2::CsvOptions.new
     )
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     table.schema.must_be :empty?
 
     # this object is usually created by calling bigquery.schema
-    schema = Google::Cloud::Bigquery::Schema.from_gapi
+    schema = Google::Cloud::BigQuery::Schema.from_gapi
     schema.string "name", mode: :required
     schema.integer "age"
     schema.float "score", description: "A score from 0.0 to 10.0"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_data_souce_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_data_souce_test.rb
@@ -14,9 +14,9 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::External::DataSource do
+describe Google::Cloud::BigQuery::External::DataSource do
   it "can be used for AVRO" do
-    table = Google::Cloud::Bigquery::External::DataSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::DataSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
       e.gapi.source_format = "AVRO"
     end
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigquery::External::DataSource do
       source_format: "AVRO"
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    table.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
     table.urls.must_equal ["gs://my-bucket/path/to/file.avro"]
     table.must_be :avro?
     table.format.must_equal "AVRO"
@@ -40,7 +40,7 @@ describe Google::Cloud::Bigquery::External::DataSource do
   end
 
   it "can be used for DATASTORE_BACKUP" do
-    table = Google::Cloud::Bigquery::External::DataSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::DataSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.backup_info"]
       e.gapi.source_format = "DATASTORE_BACKUP"
     end
@@ -49,7 +49,7 @@ describe Google::Cloud::Bigquery::External::DataSource do
       source_format: "DATASTORE_BACKUP"
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    table.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
     table.urls.must_equal ["gs://my-bucket/path/to/file.backup_info"]
     table.must_be :backup?
     table.format.must_equal "DATASTORE_BACKUP"
@@ -64,7 +64,7 @@ describe Google::Cloud::Bigquery::External::DataSource do
   end
 
   it "sets autodetect" do
-    table = Google::Cloud::Bigquery::External::DataSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::DataSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
       e.gapi.source_format = "AVRO"
     end
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigquery::External::DataSource do
   end
 
   it "sets compression" do
-    table = Google::Cloud::Bigquery::External::DataSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::DataSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
       e.gapi.source_format = "AVRO"
     end
@@ -104,7 +104,7 @@ describe Google::Cloud::Bigquery::External::DataSource do
   end
 
   it "sets ignore_unknown" do
-    table = Google::Cloud::Bigquery::External::DataSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::DataSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
       e.gapi.source_format = "AVRO"
     end
@@ -124,7 +124,7 @@ describe Google::Cloud::Bigquery::External::DataSource do
   end
 
   it "sets max_bad_records" do
-    table = Google::Cloud::Bigquery::External::DataSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::DataSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.avro"]
       e.gapi.source_format = "AVRO"
     end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
@@ -14,9 +14,9 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::External::JsonSource do
+describe Google::Cloud::BigQuery::External::JsonSource do
   it "can be used for JSON" do
-    table = Google::Cloud::Bigquery::External::JsonSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::JsonSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.json"]
       e.gapi.source_format = "NEWLINE_DELIMITED_JSON"
     end
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigquery::External::JsonSource do
       source_format: "NEWLINE_DELIMITED_JSON"
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    table.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
     table.urls.must_equal ["gs://my-bucket/path/to/file.json"]
     table.must_be :json?
     table.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -40,7 +40,7 @@ describe Google::Cloud::Bigquery::External::JsonSource do
   end
 
   it "sets schema using block" do
-    table = Google::Cloud::Bigquery::External::JsonSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::JsonSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.json"]
       e.gapi.source_format = "NEWLINE_DELIMITED_JSON"
     end
@@ -60,7 +60,7 @@ describe Google::Cloud::Bigquery::External::JsonSource do
       ])
     )
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     table.schema.must_be :empty?
 
     table.schema do |s|
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigquery::External::JsonSource do
   end
 
   it "sets schema using object" do
-    table = Google::Cloud::Bigquery::External::JsonSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::JsonSource.new.tap do |e|
       e.gapi.source_uris = ["gs://my-bucket/path/to/file.json"]
       e.gapi.source_format = "NEWLINE_DELIMITED_JSON"
     end
@@ -104,11 +104,11 @@ describe Google::Cloud::Bigquery::External::JsonSource do
       ])
     )
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     table.schema.must_be :empty?
 
     # this object is usually created by calling bigquery.schema
-    schema = Google::Cloud::Bigquery::Schema.from_gapi
+    schema = Google::Cloud::BigQuery::Schema.from_gapi
     schema.string "name", mode: :required
     schema.integer "age"
     schema.float "score", description: "A score from 0.0 to 10.0"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_sheets_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_sheets_source_test.rb
@@ -14,9 +14,9 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::External::SheetsSource do
+describe Google::Cloud::BigQuery::External::SheetsSource do
   it "can be used for CSV" do
-    table = Google::Cloud::Bigquery::External::SheetsSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::SheetsSource.new.tap do |e|
       e.gapi.source_uris = ["https://docs.google.com/spreadsheets/d/1234567980"]
       e.gapi.source_format = "GOOGLE_SHEETS"
     end
@@ -26,7 +26,7 @@ describe Google::Cloud::Bigquery::External::SheetsSource do
       google_sheets_options: Google::Apis::BigqueryV2::GoogleSheetsOptions.new
     )
 
-    table.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+    table.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
     table.urls.must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
     table.must_be :sheets?
     table.format.must_equal "GOOGLE_SHEETS"
@@ -41,7 +41,7 @@ describe Google::Cloud::Bigquery::External::SheetsSource do
   end
 
   it "sets skip_leading_rows" do
-    table = Google::Cloud::Bigquery::External::SheetsSource.new.tap do |e|
+    table = Google::Cloud::BigQuery::External::SheetsSource.new.tap do |e|
       e.gapi.source_uris = ["https://docs.google.com/spreadsheets/d/1234567980"]
       e.gapi.source_format = "GOOGLE_SHEETS"
     end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/extract_job_test.rb
@@ -16,13 +16,13 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::ExtractJob, :mock_bigquery do
-  let(:job) { Google::Cloud::Bigquery::Job.from_gapi extract_job_gapi,
+describe Google::Cloud::BigQuery::ExtractJob, :mock_bigquery do
+  let(:job) { Google::Cloud::BigQuery::Job.from_gapi extract_job_gapi,
                                               bigquery.service }
   let(:job_id) { job.job_id }
 
   it "knows it is extract job" do
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "knows its destination uris" do
@@ -38,7 +38,7 @@ describe Google::Cloud::Bigquery::ExtractJob, :mock_bigquery do
     mock.expect :get_table, source_table_gapi, ["source_project_id", "source_dataset_id", "source_table_id"]
 
     source = job.source
-    source.must_be_kind_of Google::Cloud::Bigquery::Table
+    source.must_be_kind_of Google::Cloud::BigQuery::Table
     source.project_id.must_equal "source_project_id"
     source.dataset_id.must_equal "source_dataset_id"
     source.table_id.must_equal   "source_table_id"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Job, :mock_bigquery do
+describe Google::Cloud::BigQuery::Job, :mock_bigquery do
   # Create a job object with the project's mocked connection object
   let(:labels) { { "foo" => "bar" } }
   let(:job_hash) { random_job_hash }
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
     job_gapi.configuration.labels = labels
     job_gapi
   end
-  let(:job) { Google::Cloud::Bigquery::Job.from_gapi job_gapi,
+  let(:job) { Google::Cloud::BigQuery::Job.from_gapi job_gapi,
                                               bigquery.service }
   let(:job_id) { job.job_id }
 
@@ -46,7 +46,7 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
     hash
   end
   let(:failed_job_gapi) { Google::Apis::BigqueryV2::Job.from_json failed_job_hash.to_json }
-  let(:failed_job) { Google::Cloud::Bigquery::Job.from_gapi failed_job_gapi,
+  let(:failed_job) { Google::Cloud::BigQuery::Job.from_gapi failed_job_gapi,
                                               bigquery.service }
   let(:failed_job_id) { failed_job.job_id }
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -16,15 +16,15 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
+describe Google::Cloud::BigQuery::LoadJob, :mock_bigquery do
   let(:job_defaults_gapi) { Google::Apis::BigqueryV2::Job.from_json load_job_defaults_hash.to_json }
-  let(:job_defaults) { Google::Cloud::Bigquery::Job.from_gapi job_defaults_gapi, bigquery.service }
+  let(:job_defaults) { Google::Cloud::BigQuery::Job.from_gapi job_defaults_gapi, bigquery.service }
   let(:job_gapi) { Google::Apis::BigqueryV2::Job.from_json load_job_hash.to_json }
-  let(:job) { Google::Cloud::Bigquery::Job.from_gapi job_gapi, bigquery.service }
+  let(:job) { Google::Cloud::BigQuery::Job.from_gapi job_gapi, bigquery.service }
   let(:job_id) { job.job_id }
 
   it "knows it is load job" do
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
   end
 
   it "knows its source uris" do
@@ -41,7 +41,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     job.service.mocked_service = mock
 
     table = job.destination
-    table.must_be_kind_of Google::Cloud::Bigquery::Table
+    table.must_be_kind_of Google::Cloud::BigQuery::Table
 
     mock.verify
 
@@ -92,7 +92,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
   end
 
   it "knows its schema" do
-    job.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    job.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     job.schema.must_be :frozen?
     job.schema.fields.wont_be :empty?
     job.schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end", "birthday"]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_external_test.rb
@@ -14,14 +14,14 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :external, :mock_bigquery do
   it "raises if not given valid arguments" do
     expect { bigquery.external nil }.must_raise ArgumentError
   end
 
   it "creates a simple external table" do
     external = bigquery.external "gs://my-bucket/path/to/file.csv"
-    external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
     external.must_be :csv?
     external.format.must_equal "CSV"
@@ -30,7 +30,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
   describe "CSV" do
     it "determines CSV from one URL" do
       external = bigquery.external "gs://my-bucket/path/to/file.csv"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -38,7 +38,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines CSV from multiple URL" do
       external = bigquery.external ["some url", "gs://my-bucket/path/to/file.csv"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.csv"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -46,7 +46,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines CSV from the format (:csv)" do
       external = bigquery.external "some url", format: :csv
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -54,7 +54,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines CSV from the format (csv)" do
       external = bigquery.external "some url", format: "csv"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -62,7 +62,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines CSV from the format (:CSV)" do
       external = bigquery.external "some url", format: :CSV
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines CSV from the format (CSV)" do
       external = bigquery.external "some url", format: "CSV"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
       external.urls.must_equal ["some url"]
       external.must_be :csv?
       external.format.must_equal "CSV"
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
   describe "JSON" do
     it "determines JSON from one URL" do
       external = bigquery.external "gs://my-bucket/path/to/file.json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -88,7 +88,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines JSON from multiple URL" do
       external = bigquery.external ["some url", "gs://my-bucket/path/to/file.json"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.json"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -96,7 +96,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines JSON from the format (:json)" do
       external = bigquery.external "some url", format: :json
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -104,7 +104,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines JSON from the format (json)" do
       external = bigquery.external "some url", format: "json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -112,7 +112,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines JSON from the format (:JSON)" do
       external = bigquery.external "some url", format: :JSON
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -120,7 +120,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines JSON from the format (JSON)" do
       external = bigquery.external "some url", format: "JSON"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -128,7 +128,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines JSON from the format (:newline_delimited_json)" do
       external = bigquery.external "some url", format: :newline_delimited_json
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -136,7 +136,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines JSON from the format (newline_delimited_json)" do
       external = bigquery.external "some url", format: "newline_delimited_json"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -144,7 +144,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines JSON from the format (:NEWLINE_DELIMITED_JSON)" do
       external = bigquery.external "some url", format: :NEWLINE_DELIMITED_JSON
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -152,7 +152,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines JSON from the format (NEWLINE_DELIMITED_JSON)" do
       external = bigquery.external "some url", format: "NEWLINE_DELIMITED_JSON"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
       external.urls.must_equal ["some url"]
       external.must_be :json?
       external.format.must_equal "NEWLINE_DELIMITED_JSON"
@@ -162,7 +162,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
   describe "Google Sheets" do
     it "determines CSV from one URL" do
       external = bigquery.external "https://docs.google.com/spreadsheets/d/1234567980"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["https://docs.google.com/spreadsheets/d/1234567980"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -170,7 +170,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines CSV from multiple URL" do
       external = bigquery.external ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url", "https://docs.google.com/spreadsheets/d/1234567980"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -178,7 +178,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (:sheets)" do
       external = bigquery.external "some url", format: :sheets
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -186,7 +186,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (sheets)" do
       external = bigquery.external "some url", format: "sheets"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -194,7 +194,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (:SHEETS)" do
       external = bigquery.external "some url", format: :SHEETS
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -202,7 +202,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (SHEETS)" do
       external = bigquery.external "some url", format: "SHEETS"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -210,7 +210,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (:google_sheets)" do
       external = bigquery.external "some url", format: :google_sheets
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -218,7 +218,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (google_sheets)" do
       external = bigquery.external "some url", format: "google_sheets"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -226,7 +226,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (:GOOGLE_SHEETS)" do
       external = bigquery.external "some url", format: :GOOGLE_SHEETS
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -234,7 +234,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines SHEETS from the format (GOOGLE_SHEETS)" do
       external = bigquery.external "some url", format: "GOOGLE_SHEETS"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::SheetsSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::SheetsSource
       external.urls.must_equal ["some url"]
       external.must_be :sheets?
       external.format.must_equal "GOOGLE_SHEETS"
@@ -244,7 +244,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
   describe "AVRO" do
     it "determines AVRO from one URL" do
       external = bigquery.external "gs://my-bucket/path/to/file.avro"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["gs://my-bucket/path/to/file.avro"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -252,7 +252,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines AVRO from multiple URL" do
       external = bigquery.external ["some url", "gs://my-bucket/path/to/file.avro"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.avro"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -260,7 +260,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines AVRO from the format (:avro)" do
       external = bigquery.external "some url", format: :avro
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -268,7 +268,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines AVRO from the format (avro)" do
       external = bigquery.external "some url", format: "avro"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -276,7 +276,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines AVRO from the format (:AVRO)" do
       external = bigquery.external "some url", format: :AVRO
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -284,7 +284,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines AVRO from the format (AVRO)" do
       external = bigquery.external "some url", format: "AVRO"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :avro?
       external.format.must_equal "AVRO"
@@ -294,7 +294,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
   describe "Datastore Backup" do
     it "determines BACKUP from one URL" do
       external = bigquery.external "gs://my-bucket/path/to/file.backup_info"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["gs://my-bucket/path/to/file.backup_info"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -302,7 +302,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from multiple URL" do
       external = bigquery.external ["some url", "gs://my-bucket/path/to/file.backup_info"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url", "gs://my-bucket/path/to/file.backup_info"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -310,7 +310,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:backup)" do
       external = bigquery.external "some url", format: :backup
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -318,7 +318,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (backup)" do
       external = bigquery.external "some url", format: "backup"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -326,7 +326,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:BACKUP)" do
       external = bigquery.external "some url", format: :BACKUP
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -334,7 +334,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (BACKUP)" do
       external = bigquery.external "some url", format: "BACKUP"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -342,7 +342,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:datastore)" do
       external = bigquery.external "some url", format: :datastore
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -350,7 +350,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (datastore)" do
       external = bigquery.external "some url", format: "datastore"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -358,7 +358,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:DATASTORE)" do
       external = bigquery.external "some url", format: :DATASTORE
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -366,7 +366,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (DATASTORE)" do
       external = bigquery.external "some url", format: "DATASTORE"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -374,7 +374,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:datastore_backup)" do
       external = bigquery.external "some url", format: :datastore_backup
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -382,7 +382,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (datastore_backup)" do
       external = bigquery.external "some url", format: "datastore_backup"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -390,7 +390,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (:DATASTORE_BACKUP)" do
       external = bigquery.external "some url", format: :DATASTORE_BACKUP
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -398,7 +398,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BACKUP from the format (DATASTORE_BACKUP)" do
       external = bigquery.external "some url", format: "DATASTORE_BACKUP"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::DataSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::DataSource
       external.urls.must_equal ["some url"]
       external.must_be :backup?
       external.format.must_equal "DATASTORE_BACKUP"
@@ -408,7 +408,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
   describe "BIGTABLE" do
     it "determines BIGTABLE from one URL" do
       external = bigquery.external "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -416,7 +416,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BIGTABLE from multiple URL" do
       external = bigquery.external ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url", "https://googleapis.com/bigtable/projects/my-project/instances/my-instance/tables/my-table"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -424,7 +424,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BIGTABLE from the format (:bigtable)" do
       external = bigquery.external "some url", format: :bigtable
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -432,7 +432,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BIGTABLE from the format (bigtable)" do
       external = bigquery.external "some url", format: "bigtable"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -440,7 +440,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BIGTABLE from the format (:BIGTABLE)" do
       external = bigquery.external "some url", format: :BIGTABLE
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"
@@ -448,7 +448,7 @@ describe Google::Cloud::Bigquery::Project, :external, :mock_bigquery do
 
     it "determines BIGTABLE from the format (BIGTABLE)" do
       external = bigquery.external "some url", format: "BIGTABLE"
-      external.must_be_kind_of Google::Cloud::Bigquery::External::BigtableSource
+      external.must_be_kind_of Google::Cloud::BigQuery::External::BigtableSource
       external.urls.must_equal ["some url"]
       external.must_be :bigtable?
       external.format.must_equal "BIGTABLE"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_external_test.rb
@@ -14,13 +14,13 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Project, :query, :external, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :query, :external, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM my_csv" }
   let(:job_id) { "job_9876543210" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   it "queries with external data" do
     job_gapi = query_job_gapi query
@@ -47,7 +47,7 @@ describe Google::Cloud::Bigquery::Project, :query, :external, :mock_bigquery do
     data = bigquery.query query, external: { my_csv: external_csv }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_external_test.rb
@@ -14,13 +14,13 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Project, :query_job, :external, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :query_job, :external, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM my_csv" }
   let(:job_id) { "job_9876543210" }
 
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   it "queries with external data" do
     job_gapi = query_job_gapi query
@@ -41,6 +41,6 @@ describe Google::Cloud::Bigquery::Project, :query_job, :external, :mock_bigquery
     job = bigquery.query_job query, external: { my_csv: external_csv }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -14,14 +14,14 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :query_job, :named_params, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   let(:table_id) { "my_table" }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   let(:query_job_gapi) do
     Google::Apis::BigqueryV2::Job.from_json(query_job_json("SELECT * FROM tbl")).tap do |r|
@@ -53,7 +53,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with an integer parameter" do
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a float parameter" do
@@ -101,7 +101,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a true parameter" do
@@ -125,7 +125,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE active = @active", params: { active: true }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a false parameter" do
@@ -149,7 +149,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE active = @active", params: { active: false }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a date parameter" do
@@ -175,7 +175,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a datetime parameter" do
@@ -201,7 +201,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a timestamp parameter" do
@@ -227,7 +227,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a time parameter" do
@@ -253,7 +253,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a File parameter" do
@@ -279,7 +279,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a StringIO parameter" do
@@ -305,7 +305,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with many parameters" do
@@ -396,7 +396,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with an array parameter" do
@@ -427,7 +427,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a struct parameter" do
@@ -470,6 +470,6 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     job = bigquery.query_job "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -14,14 +14,14 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :query_job, :positional_params, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
 
   let(:dataset_id) { "my_dataset" }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   let(:table_id) { "my_table" }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   let(:query_job_gapi) do
     Google::Apis::BigqueryV2::Job.from_json(query_job_json("SELECT * FROM tbl")).tap do |r|
@@ -52,7 +52,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE name = ?", params: ["Testy McTesterson"]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with an integer parameter" do
@@ -75,7 +75,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE age > ?", params: [35]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a float parameter" do
@@ -98,7 +98,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE score > ?", params: [90.0]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a true parameter" do
@@ -121,7 +121,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE active = ?", params: [true]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a false parameter" do
@@ -144,7 +144,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE active = ?", params: [false]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a date parameter" do
@@ -169,7 +169,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE create_date = ?", params: [today]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a datetime parameter" do
@@ -194,7 +194,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a timestamp parameter" do
@@ -219,7 +219,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a time parameter" do
@@ -244,7 +244,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a File parameter" do
@@ -269,7 +269,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a StringIO parameter" do
@@ -294,7 +294,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with many parameters" do
@@ -373,7 +373,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with an array parameter" do
@@ -403,7 +403,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE name = ?", params: [%w{name1 name2 name3}]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with a struct parameter" do
@@ -445,6 +445,6 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     job = bigquery.query_job "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -14,15 +14,15 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :query_job, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active FROM `some_project.some_dataset.users`" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
   let(:table_id) { "my_table" }
   let(:table_gapi) { random_table_gapi dataset_id, table_id }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi,
                                                   bigquery.service }
   let(:labels) { { "foo" => "bar" } }
   let(:udfs) { [ "return x+1;", "gs://my-bucket/my-lib.js" ] }
@@ -37,7 +37,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with options set" do
@@ -52,7 +52,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, priority: :batch, cache: false
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with table options" do
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
                                 maximum_bytes_billed: 12345678901234
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with dataset option as a Dataset" do
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, dataset: dataset
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with dataset and project options" do
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, dataset: "some_random_dataset", project: "some_random_project"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "queries the data with job_id option" do
@@ -129,7 +129,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.job_id.must_equal job_id
   end
 
@@ -148,7 +148,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.job_id.must_equal job_id
   end
 
@@ -164,7 +164,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.job_id.must_equal job_id
   end
 
@@ -179,7 +179,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.labels.must_equal labels
   end
 
@@ -194,7 +194,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, udfs: udfs
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.udfs.must_equal udfs
   end
 
@@ -209,7 +209,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     job = bigquery.query_job query, udfs: "gs://my-bucket/my-lib.js"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
     job.udfs.must_equal ["gs://my-bucket/my-lib.js"]
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -14,15 +14,15 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :query, :named_params, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
   let(:job_id) { "job_9876543210" }
 
   let(:dataset_id) { "my_dataset" }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   let(:table_id) { "my_table" }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
   let(:table_gapi) { random_table_gapi dataset_id, table_id }
@@ -54,7 +54,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE name = @name", params: { name: "Testy McTesterson" }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -86,7 +86,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE age > @age", params: { age: 35 }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -118,7 +118,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE score > @score", params: { score: 90.0 }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -150,7 +150,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE active = @active", params: { active: true }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -182,7 +182,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE active = @active", params: { active: false }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -216,7 +216,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE create_date = @day", params: { day: today }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -250,7 +250,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE update_datetime < @when", params: { when: now }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -284,7 +284,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE update_timestamp < @when", params: { when: now }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -318,7 +318,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE create_time = @time", params: { time: timeofday }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -352,7 +352,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -386,7 +386,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE avatar = @file", params: { file: file }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -485,7 +485,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
 
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -524,7 +524,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -575,7 +575,7 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     data = bigquery.query "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -14,15 +14,15 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :query, :positional_params, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active, create_date, update_timestamp FROM `some_project.some_dataset.users`" }
   let(:job_id) { "job_9876543210" }
 
   let(:dataset_id) { "my_dataset" }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi, bigquery.service }
 
   let(:table_id) { "my_table" }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
   let(:table_gapi) { random_table_gapi dataset_id, table_id }
@@ -54,7 +54,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE name = ?", params: ["Testy McTesterson"]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -85,7 +85,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE age > ?", params: [35]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -116,7 +116,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE score > ?", params: [90.0]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -147,7 +147,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE active = ?", params: [true]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -178,7 +178,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE active = ?", params: [false]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -211,7 +211,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE create_date = ?", params: [today]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -244,7 +244,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE update_datetime < ?", params: [now]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -277,7 +277,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE update_timestamp < ?", params: [now]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -310,7 +310,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE create_time = ?", params: [timeofday]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -343,7 +343,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -376,7 +376,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE avatar = ?", params: [file]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -463,7 +463,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
 
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -501,7 +501,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 
@@ -551,7 +551,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     data = bigquery.query "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     assert_valid_data data
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
@@ -14,17 +14,17 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :query, :mock_bigquery do
   let(:query) { "SELECT name, age, score, active FROM `some_project.some_dataset.users`" }
 
   let(:job_id) { "job_9876543210" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+  let(:dataset) { Google::Cloud::BigQuery::Dataset.from_gapi dataset_gapi,
                                                       bigquery.service }
   let(:table_id) { "my_table" }
   let(:table_gapi) { random_table_gapi dataset_id, table_id }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi,
                                                   bigquery.service }
 
   it "queries the data" do
@@ -42,8 +42,8 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
 
     data = bigquery.query query
     mock.verify
-    # data.must_be_kind_of Google::Cloud::Bigquery::Data
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    # data.must_be_kind_of Google::Cloud::BigQuery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     data[0].must_be_kind_of Hash
     data[0][:name].must_equal "Heidi"
@@ -79,14 +79,14 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: "token1234567890", start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query
-    # data.must_be_kind_of Google::Cloud::Bigquery::Data
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    # data.must_be_kind_of Google::Cloud::BigQuery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     data.token.must_equal "token1234567890"
     data.next?.must_equal true
 
     data2 = data.next
-    data2.class.must_equal Google::Cloud::Bigquery::Data
+    data2.class.must_equal Google::Cloud::BigQuery::Data
     data2.count.must_equal 3
     mock.verify
   end
@@ -105,7 +105,7 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 [project, "target_dataset_id", "target_table_id", {  max_results: 42, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query, max: 42
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     mock.verify
   end
@@ -127,7 +127,7 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query query, dataset: "some_random_dataset"
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     mock.verify
   end
@@ -150,7 +150,7 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
 
     data = bigquery.query query, dataset: "some_random_dataset",
                                  project: "some_random_project"
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     mock.verify
   end
@@ -172,7 +172,7 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
 
 
     data = bigquery.query query, cache: false
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
@@ -15,7 +15,7 @@
 require "helper"
 require "json"
 
-describe Google::Cloud::Bigquery::Project, :mock_bigquery do
+describe Google::Cloud::BigQuery::Project, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:filter) { "labels.foo:bar" }
 
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
   end
 
   it "creates a dataset with options" do
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.name.must_equal name
     dataset.description.must_equal description
     dataset.default_expiration.must_equal default_expiration
@@ -91,7 +91,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.access.wont_be :empty?
   end
 
@@ -133,7 +133,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.name.must_equal name
     dataset.description.must_equal description
     dataset.default_expiration.must_equal default_expiration
@@ -173,7 +173,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.name.must_equal name
     dataset.description.must_equal description
     dataset.default_expiration.must_equal default_expiration
@@ -205,7 +205,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     datasets.size.must_equal 3
     datasets.each do |ds|
-      ds.must_be_kind_of Google::Cloud::Bigquery::Dataset
+      ds.must_be_kind_of Google::Cloud::BigQuery::Dataset
       ds.wont_be :reference?
       ds.must_be :resource?
       ds.must_be :resource_partial?
@@ -224,7 +224,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     datasets.count.must_equal 3
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     datasets.token.wont_be :nil?
     datasets.token.must_equal "next_page_token"
   end
@@ -240,7 +240,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     datasets.count.must_equal 3
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     datasets.token.wont_be :nil?
     datasets.token.must_equal "next_page_token"
   end
@@ -256,7 +256,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     datasets.count.must_equal 3
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     datasets.token.wont_be :nil?
     datasets.token.must_equal "next_page_token"
   end
@@ -275,12 +275,12 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     first_datasets.token.wont_be :nil?
     first_datasets.token.must_equal "next_page_token"
 
     second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     second_datasets.token.must_be :nil?
   end
 
@@ -298,11 +298,11 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     first_datasets.next?.must_equal true
 
     second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     second_datasets.next?.must_equal false
   end
 
@@ -320,11 +320,11 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     first_datasets.next?.must_equal true
 
     second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     second_datasets.next?.must_equal false
   end
 
@@ -342,11 +342,11 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     first_datasets.next?.must_equal true
 
     second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     second_datasets.next?.must_equal false
   end
 
@@ -364,11 +364,11 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_datasets.count.must_equal 3
-    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    first_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     first_datasets.next?.must_equal true
 
     second_datasets.count.must_equal 2
-    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    second_datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
     second_datasets.next?.must_equal false
   end
 
@@ -385,7 +385,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
   end
 
   it "paginates datasets with all with all/hidden set" do
@@ -401,7 +401,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
   end
 
   it "paginates datasets with all with filter set" do
@@ -417,7 +417,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
   end
 
   it "paginates datasets with all with max set" do
@@ -433,7 +433,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
   end
 
   it "iterates datasets with all using Enumerator" do
@@ -449,7 +449,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     datasets.count.must_equal 5
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
   end
 
   it "iterates datasets with all with request_limit set" do
@@ -465,7 +465,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     datasets.count.must_equal 6
-    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Dataset }
+    datasets.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Dataset }
   end
 
   it "finds a dataset" do
@@ -481,7 +481,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.dataset_id.must_equal dataset_id
     dataset.name.must_equal dataset_name
   end
@@ -492,7 +492,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     dataset = bigquery.dataset dataset_id, skip_lookup: true
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.must_be :reference?
     dataset.wont_be :resource?
     dataset.wont_be :resource_partial?
@@ -510,7 +510,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     dataset = bigquery.dataset dataset_id, skip_lookup: true
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.must_be :reference?
     dataset.wont_be :resource?
     dataset.wont_be :resource_partial?
@@ -538,7 +538,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     dataset = bigquery.dataset dataset_id, skip_lookup: true
 
-    dataset.must_be_kind_of Google::Cloud::Bigquery::Dataset
+    dataset.must_be_kind_of Google::Cloud::BigQuery::Dataset
     dataset.must_be :reference?
     dataset.project_id.must_equal project # does not call reload! internally
     dataset.dataset_id.must_equal dataset_id # does not call reload! internally
@@ -569,7 +569,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     jobs.size.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
   end
 
   it "lists jobs with max set" do
@@ -583,7 +583,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
     jobs.token.wont_be :nil?
     jobs.token.must_equal "next_page_token"
   end
@@ -599,7 +599,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     jobs.count.must_equal 3
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
     jobs.token.wont_be :nil?
     jobs.token.must_equal "next_page_token"
   end
@@ -618,12 +618,12 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_jobs.count.must_equal 3
-    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
     first_jobs.token.wont_be :nil?
     first_jobs.token.must_equal "next_page_token"
 
     second_jobs.count.must_equal 2
-    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
     second_jobs.token.must_be :nil?
   end
 
@@ -641,11 +641,11 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_jobs.count.must_equal 3
-    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
     first_jobs.next?.must_equal true
 
     second_jobs.count.must_equal 2
-    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
     second_jobs.next?.must_equal false
   end
 
@@ -663,11 +663,11 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_jobs.count.must_equal 3
-    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    first_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
     first_jobs.next?.must_equal true
 
     second_jobs.count.must_equal 2
-    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    second_jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
     second_jobs.next?.must_equal false
   end
 
@@ -684,7 +684,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     jobs.count.must_equal 5
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
   end
 
   it "paginates jobs with all and filter set" do
@@ -700,7 +700,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     jobs.count.must_equal 5
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
   end
 
   it "iterates jobs with all using Enumerator" do
@@ -716,7 +716,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     jobs.count.must_equal 5
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
   end
 
   it "iterates jobs with all with request_limit set" do
@@ -732,7 +732,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     jobs.count.must_equal 6
-    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Job }
+    jobs.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Job }
   end
 
   it "finds a job" do
@@ -747,7 +747,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::Job
+    job.must_be_kind_of Google::Cloud::BigQuery::Job
     job.job_id.must_equal job_id
   end
 
@@ -763,7 +763,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
 
     projects.size.must_equal 3
     projects.each do |project|
-      project.must_be_kind_of Google::Cloud::Bigquery::Project
+      project.must_be_kind_of Google::Cloud::BigQuery::Project
       project.name.must_equal "project-name"
       project.numeric_id.must_equal 1234567890
       project.project.must_equal "project-id-12345"
@@ -781,7 +781,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     projects.count.must_equal 3
-    projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    projects.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Project }
     projects.token.wont_be :nil?
     projects.token.must_equal "next_page_token"
   end
@@ -800,12 +800,12 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_projects.count.must_equal 3
-    first_projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    first_projects.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Project }
     first_projects.token.wont_be :nil?
     first_projects.token.must_equal "next_page_token"
 
     second_projects.count.must_equal 2
-    second_projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    second_projects.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Project }
     second_projects.token.must_be :nil?
   end
 
@@ -823,11 +823,11 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     first_projects.count.must_equal 3
-    first_projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    first_projects.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Project }
     first_projects.next?.must_equal true
 
     second_projects.count.must_equal 2
-    second_projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    second_projects.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Project }
     second_projects.next?.must_equal false
   end
 
@@ -844,7 +844,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     projects.count.must_equal 5
-    projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    projects.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Project }
   end
 
   it "iterates projects with all using Enumerator" do
@@ -860,7 +860,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     projects.count.must_equal 5
-    projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    projects.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Project }
   end
 
   it "iterates projects with all with request_limit set" do
@@ -876,12 +876,12 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     mock.verify
 
     projects.count.must_equal 6
-    projects.each { |ds| ds.must_be_kind_of Google::Cloud::Bigquery::Project }
+    projects.each { |ds| ds.must_be_kind_of Google::Cloud::BigQuery::Project }
   end
 
   it "creates a schema" do
     schema = bigquery.schema
-    schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     schema.wont_be :frozen?
     schema.fields.must_be :empty?
   end
@@ -890,7 +890,7 @@ describe Google::Cloud::Bigquery::Project, :mock_bigquery do
     schema = bigquery.schema do |s|
       s.string "first_name", mode: :required
     end
-    schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     schema.wont_be :frozen?
     schema.fields.wont_be :empty?
     schema.fields.size.must_equal 1

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
@@ -14,10 +14,10 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
+describe Google::Cloud::BigQuery::QueryJob, :data, :mock_bigquery do
   let(:dataset_id) { "target_dataset_id" }
   let(:table_id) { "target_table_id" }
-  let(:job) { Google::Cloud::Bigquery::Job.from_gapi query_job_gapi,
+  let(:job) { Google::Cloud::BigQuery::Job.from_gapi query_job_gapi,
                                               bigquery.service }
   let(:job_id) { job.job_id }
 
@@ -35,7 +35,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data = job.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     data[0].must_be_kind_of Hash
     data[0][:name].must_equal "Heidi"
@@ -45,7 +45,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data[0][:avatar].must_be_kind_of StringIO
     data[0][:avatar].read.must_equal "image data"
     data[0][:started_at].must_equal Time.parse("2016-12-25 13:00:00 UTC")
-    data[0][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
+    data[0][:duration].must_equal Google::Cloud::BigQuery::Time.new("04:00:00")
     data[0][:target_end].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
     data[0][:birthday].must_equal Date.parse("1968-10-20")
 
@@ -56,7 +56,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data[1][:active].must_equal false
     data[1][:avatar].must_be :nil?
     data[1][:started_at].must_be :nil?
-    data[1][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
+    data[1][:duration].must_equal Google::Cloud::BigQuery::Time.new("04:32:10.555555")
     data[1][:target_end].must_be :nil?
     data[1][:birthday].must_be :nil?
 
@@ -85,7 +85,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data = job.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     data[0].must_be_kind_of Hash
     data[0][:name].must_equal "Heidi"
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data[0][:avatar].must_be_kind_of StringIO
     data[0][:avatar].read.must_equal "image data"
     data[0][:started_at].must_equal Time.parse("2016-12-25 13:00:00 UTC")
-    data[0][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:00:00")
+    data[0][:duration].must_equal Google::Cloud::BigQuery::Time.new("04:00:00")
     data[0][:target_end].must_equal Time.parse("2017-01-01 00:00:00 UTC").to_datetime
     data[0][:birthday].must_equal Date.parse("1968-10-20")
 
@@ -106,7 +106,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data[1][:active].must_equal false
     data[1][:avatar].must_be :nil?
     data[1][:started_at].must_be :nil?
-    data[1][:duration].must_equal Google::Cloud::Bigquery::Time.new("04:32:10.555555")
+    data[1][:duration].must_equal Google::Cloud::BigQuery::Time.new("04:32:10.555555")
     data[1][:target_end].must_be :nil?
     data[1][:birthday].must_be :nil?
 
@@ -137,11 +137,11 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
 
     data1 = job.data
 
-    data1.class.must_equal Google::Cloud::Bigquery::Data
+    data1.class.must_equal Google::Cloud::BigQuery::Data
     data1.token.wont_be :nil?
     data1.token.must_equal "token1234567890"
     data2 = job.data token: data1.token
-    data2.class.must_equal Google::Cloud::Bigquery::Data
+    data2.class.must_equal Google::Cloud::BigQuery::Data
     mock.verify
   end
 
@@ -160,13 +160,13 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
 
     data1 = job.data
 
-    data1.class.must_equal Google::Cloud::Bigquery::Data
+    data1.class.must_equal Google::Cloud::BigQuery::Data
     data1.token.wont_be :nil?
     data1.next?.must_equal true # can't use must_be :next?
     data2 = data1.next
     data2.token.must_be :nil?
     data2.next?.must_equal false
-    data2.class.must_equal Google::Cloud::Bigquery::Data
+    data2.class.must_equal Google::Cloud::BigQuery::Data
     mock.verify
   end
 
@@ -260,7 +260,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
                 [project, dataset_id, table_id, {  max_results: 3, page_token: nil, start_index: nil, options:{skip_deserialization: true} }]
 
     data = job.data max: 3
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
   end
 
   it "paginates data with start set" do
@@ -276,7 +276,7 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     data = job.data start: 25
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
   end
 
   def query_job_gapi

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -16,13 +16,13 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
-  let(:job) { Google::Cloud::Bigquery::Job.from_gapi query_job_gapi,
+describe Google::Cloud::BigQuery::QueryJob, :mock_bigquery do
+  let(:job) { Google::Cloud::BigQuery::Job.from_gapi query_job_gapi,
                                               bigquery.service }
   let(:job_id) { job.job_id }
 
   it "knows it is query job" do
-    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.must_be_kind_of Google::Cloud::BigQuery::QueryJob
   end
 
   it "knows its destination table" do
@@ -32,7 +32,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     mock.expect :get_table, destination_table_gapi, ["target_project_id", "target_dataset_id", "target_table_id"]
 
     destination = job.destination
-    destination.must_be_kind_of Google::Cloud::Bigquery::Table
+    destination.must_be_kind_of Google::Cloud::BigQuery::Table
     destination.project_id.must_equal "target_project_id"
     destination.dataset_id.must_equal "target_dataset_id"
     destination.table_id.must_equal   "target_table_id"
@@ -68,7 +68,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     job.query_plan.must_be_kind_of Array
     job.query_plan.count.must_equal 1
     stage = job.query_plan.first
-    stage.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Stage
+    stage.must_be_kind_of Google::Cloud::BigQuery::QueryJob::Stage
     stage.compute_ratio_avg.must_equal 1.0
     stage.compute_ratio_max.must_equal 1.0
     stage.id.must_equal 1
@@ -87,7 +87,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     stage.steps.must_be_kind_of Array
     stage.steps.count.must_equal 1
     step = stage.steps.first
-    step.must_be_kind_of Google::Cloud::Bigquery::QueryJob::Step
+    step.must_be_kind_of Google::Cloud::BigQuery::QueryJob::Step
     step.kind.must_equal "READ"
     step.substeps.wont_be_nil
     step.substeps.must_be_kind_of Array

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
@@ -16,12 +16,12 @@ require "helper"
 
 Thread.abort_on_exception = true
 
-describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table::AsyncInserter, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_table" }
   let(:table_hash) { random_table_hash dataset_id, table_id }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   let(:rows) { [{"name"=>"Heidi", "age"=>"36", "score"=>"7.65", "active"=>"true"},
                 {"name"=>"Aaron", "age"=>"42", "score"=>"8.15", "active"=>"false"},
@@ -166,7 +166,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     end
 
     insert_result.wont_be_nil
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    insert_result.must_be_kind_of Google::Cloud::BigQuery::Table::AsyncInserter::Result
     insert_result.wont_be :error?
     insert_result.error.must_be_nil
     insert_result.must_be :success?
@@ -214,7 +214,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     inserter.batch.must_be :nil?
 
     insert_result.wont_be_nil
-    insert_result.must_be_kind_of Google::Cloud::Bigquery::Table::AsyncInserter::Result
+    insert_result.must_be_kind_of Google::Cloud::BigQuery::Table::AsyncInserter::Result
     insert_result.must_be :error?
     insert_result.error.must_be_kind_of Google::Cloud::UnavailableError
     insert_result.wont_be :success?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :attributes, :mock_bigquery do
   # Create a table object with the project's mocked connection object
   let(:table_id) { "my_table" }
   let(:table_name) { "My Table" }
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
   let(:table_full_hash) { random_table_hash "my_table", table_id, table_name, description }
   let(:table_gapi) { Google::Apis::BigqueryV2::TableList::Table.from_json table_hash.to_json }
   let(:table_full_gapi) { Google::Apis::BigqueryV2::Table.from_json table_full_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   it "gets full data for created_at" do
     mock = Minitest::Mock.new
@@ -91,7 +91,7 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     table.schema.must_be :frozen?
     table.schema.fields.wont_be :empty?
     table.fields.wont_be :empty?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :copy_job, :mock_bigquery do
   let(:source_dataset) { "source_dataset" }
   let(:source_table_id) { "source_table_id" }
   let(:source_table_name) { "Source Table" }
@@ -23,7 +23,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
                                               source_table_id,
                                               source_table_name,
                                               source_description }
-  let(:source_table) { Google::Cloud::Bigquery::Table.from_gapi source_table_gapi,
+  let(:source_table) { Google::Cloud::BigQuery::Table.from_gapi source_table_gapi,
                                                          bigquery.service }
   let(:target_dataset) { "target_dataset" }
   let(:target_table_id) { "target_table_id" }
@@ -33,14 +33,14 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
                                               target_table_id,
                                               target_table_name,
                                               target_description }
-  let(:target_table) { Google::Cloud::Bigquery::Table.from_gapi target_table_gapi,
+  let(:target_table) { Google::Cloud::BigQuery::Table.from_gapi target_table_gapi,
                                                          bigquery.service }
   let(:target_table_other_proj_gapi) { random_table_gapi target_dataset,
                                               target_table_id,
                                               target_table_name,
                                               target_description,
                                               "target-project" }
-  let(:target_table_other_proj) { Google::Cloud::Bigquery::Table.from_gapi target_table_other_proj_gapi,
+  let(:target_table_other_proj) { Google::Cloud::BigQuery::Table.from_gapi target_table_other_proj_gapi,
                                                          bigquery.service }
   let(:labels) { { "foo" => "bar" } }
 
@@ -53,7 +53,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
   it "can copy to a table identified by a string" do
@@ -66,13 +66,13 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job "target-project:target_dataset.target_table_id"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
   it "can copy to a table name string only" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    new_target_table = Google::Cloud::Bigquery::Table.from_gapi(
+    new_target_table = Google::Cloud::BigQuery::Table.from_gapi(
       random_table_gapi(source_dataset,
                         "new_target_table_id",
                         target_table_name,
@@ -86,7 +86,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job "new_target_table_id"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
   it "can copy itself as a dryrun" do
@@ -100,7 +100,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, dryrun: true
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
   it "can copy itself with create disposition" do
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, create: "CREATE_NEVER"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
   it "can copy itself with create disposition symbol" do
@@ -128,7 +128,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, create: :never
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
 
@@ -143,7 +143,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, write: "WRITE_TRUNCATE"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
   it "can copy itself with write disposition symbol" do
@@ -157,7 +157,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, write: :truncate
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
   it "can copy itself with job_id option" do
@@ -171,7 +171,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
     job.job_id.must_equal job_id
   end
 
@@ -189,7 +189,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
     job.job_id.must_equal job_id
   end
 
@@ -204,7 +204,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
     job.job_id.must_equal job_id
   end
 
@@ -218,7 +218,7 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :mock_bigquery do
     job = source_table.copy_job target_table, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
     job.labels.must_equal labels
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :copy, :mock_bigquery do
   let(:source_dataset) { "source_dataset" }
   let(:source_table_id) { "source_table_id" }
   let(:source_table_name) { "Source Table" }
@@ -23,7 +23,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
                                               source_table_id,
                                               source_table_name,
                                               source_description }
-  let(:source_table) { Google::Cloud::Bigquery::Table.from_gapi source_table_gapi,
+  let(:source_table) { Google::Cloud::BigQuery::Table.from_gapi source_table_gapi,
                                                          bigquery.service }
   let(:target_dataset) { "target_dataset" }
   let(:target_table_id) { "target_table_id" }
@@ -33,14 +33,14 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
                                               target_table_id,
                                               target_table_name,
                                               target_description }
-  let(:target_table) { Google::Cloud::Bigquery::Table.from_gapi target_table_gapi,
+  let(:target_table) { Google::Cloud::BigQuery::Table.from_gapi target_table_gapi,
                                                          bigquery.service }
   let(:target_table_other_proj_gapi) { random_table_gapi target_dataset,
                                               target_table_id,
                                               target_table_name,
                                               target_description,
                                               "target-project" }
-  let(:target_table_other_proj) { Google::Cloud::Bigquery::Table.from_gapi target_table_other_proj_gapi,
+  let(:target_table_other_proj) { Google::Cloud::BigQuery::Table.from_gapi target_table_other_proj_gapi,
                                                          bigquery.service }
 
   it "can copy itself" do
@@ -75,7 +75,7 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
   it "can copy to a table name string only" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    new_target_table = Google::Cloud::Bigquery::Table.from_gapi(
+    new_target_table = Google::Cloud::BigQuery::Table.from_gapi(
       random_table_gapi(source_dataset,
                         "new_target_table_id",
                         target_table_name,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_exists_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_exists_test.rb
@@ -14,12 +14,12 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :exists, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :exists, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_table" }
   let(:table_hash) { random_table_hash dataset_id, table_id }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   it "knows if full resource exists when created with an HTTP method" do
     # The absence of a mock means this test will fail
@@ -41,7 +41,7 @@ describe Google::Cloud::Bigquery::Table, :exists, :mock_bigquery do
 
   describe "partial dataset resource from list of a dataset that exists" do
     let(:table_partial_gapi) { list_tables_gapi(1).tables.first }
-    let(:table) {Google::Cloud::Bigquery::Table.from_gapi table_partial_gapi, bigquery.service }
+    let(:table) {Google::Cloud::BigQuery::Table.from_gapi table_partial_gapi, bigquery.service }
 
     it "knows if partial resource exists when created with an HTTP method" do
       # The absence of a mock means this test will fail
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigquery::Table, :exists, :mock_bigquery do
   end
 
   describe "dataset reference of a dataset that exists" do
-    let(:table) {Google::Cloud::Bigquery::Table.new_reference project, dataset_id, table_id, bigquery.service }
+    let(:table) {Google::Cloud::BigQuery::Table.new_reference project, dataset_id, table_id, bigquery.service }
 
     it "checks if the dataset exists by making an HTTP call" do
       mock = Minitest::Mock.new
@@ -89,7 +89,7 @@ describe Google::Cloud::Bigquery::Table, :exists, :mock_bigquery do
   end
 
   describe "dataset reference of a dataset that does not exist" do
-    let(:table) { Google::Cloud::Bigquery::Table.new_reference project, dataset_id, table_id, bigquery.service }
+    let(:table) { Google::Cloud::BigQuery::Table.new_reference project, dataset_id, table_id, bigquery.service }
 
     it "checks if the dataset exists by making an HTTP call" do
       stub = Object.new

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Table, :external, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :external, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_table" }
   let(:table_name) { "My Table" }
@@ -35,11 +35,11 @@ describe Google::Cloud::Bigquery::Table, :external, :mock_bigquery do
     )
     gapi
   end
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
   let(:etag) { "etag123456789" }
 
   it "can have a permanent external data source" do
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::CsvSource
+    table.external.must_be_kind_of Google::Cloud::BigQuery::External::CsvSource
     table.external.urls.must_equal ["gs://my-bucket/path/to/file.csv"]
     table.external.format.must_equal "CSV"
     table.external.autodetect.must_equal true
@@ -82,12 +82,12 @@ describe Google::Cloud::Bigquery::Table, :external, :mock_bigquery do
 
     mock.verify
 
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+    table.external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
     table.external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
     table.external.format.must_equal "NEWLINE_DELIMITED_JSON"
     table.external.autodetect.must_be :nil?
     table.external.schema.wont_be :empty?
-    table.external.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.external.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     table.external.schema.must_be :frozen?
     table.external.must_be :frozen?
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :extract_job, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
   let(:extract_bucket_gapi) {  Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
                                        table_id,
                                        table_name,
                                        description }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi,
                                                   bigquery.service }
   let(:labels) { { "foo" => "bar" } }
 
@@ -47,7 +47,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_file
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself to a storage url" do
@@ -60,7 +60,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself as a dryrun" do
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, dryrun: true
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself and determine the csv format" do
@@ -89,7 +89,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job "#{extract_url}.csv"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself and specify the csv format" do
@@ -103,7 +103,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, format: :csv
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself and specify the csv format and options" do
@@ -120,7 +120,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, format: :csv, compression: "GZIP", delimiter: "\t", header: false
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself and determine the json format" do
@@ -135,7 +135,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job "#{extract_url}.json"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself and specify the json format" do
@@ -149,7 +149,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, format: :json
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself and determine the avro format" do
@@ -164,7 +164,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job "#{extract_url}.avro"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself and specify the avro format" do
@@ -178,7 +178,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, format: :avro
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself with job_id option" do
@@ -192,7 +192,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, job_id: job_id
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
     job.job_id.must_equal job_id
   end
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, prefix: prefix
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
     job.job_id.must_equal job_id
   end
 
@@ -225,7 +225,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_url, job_id: job_id, prefix: "IGNORED"
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
     job.job_id.must_equal job_id
   end
 
@@ -240,7 +240,7 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :mock_bigquery do
     job = table.extract_job extract_file, labels: labels
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
     job.labels.must_equal labels
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :extract, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
   let(:extract_bucket_gapi) {  Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
                                        table_id,
                                        table_name,
                                        description }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi,
                                                   bigquery.service }
 
   it "can extract itself to a storage file" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :insert, :mock_bigquery do
   let(:rows) { [{"name"=>"Heidi", "age"=>"36", "score"=>"7.65", "active"=>"true"},
                 {"name"=>"Aaron", "age"=>"42", "score"=>"8.15", "active"=>"false"},
                 {"name"=>"Sally", "age"=>nil, "score"=>nil, "active"=>nil}] }
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
   let(:dataset_id) { "dataset" }
   let(:table_hash) { random_table_hash dataset_id }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   it "raises if rows is an empty array" do
     expect { table.insert [] }.must_raise ArgumentError
@@ -191,7 +191,7 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
           last_used: Time.parse("2015-10-31 23:59:56 UTC")
         }
       ],
-      tea_time: Google::Cloud::Bigquery::Time.new("15:00:00"),
+      tea_time: Google::Cloud::BigQuery::Time.new("15:00:00"),
       next_vacation: Date.parse("2666-06-06"),
       favorite_time: Time.parse("2001-12-19T23:59:59 UTC").utc.to_datetime
     }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
@@ -14,14 +14,14 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :load_job, :local, :mock_bigquery do
   let(:dataset) { "dataset" }
   let(:table_id) { "table_id" }
   let(:table_name) { "Target Table" }
   let(:description) { "This is the target table" }
   let(:table_hash) { random_table_hash dataset, table_id, table_name, description }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
   let(:labels) { { "foo" => "bar" } }
 
   it "can upload a csv file" do
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, load_job_gapi(table_gapi.table_reference, "CSV"), upload_source: file, content_type: "text/comma-separated-values"]
 
       job = table.load_job file, format: :csv
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     end
 
     mock.verify
@@ -50,7 +50,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
       job = table.load_job file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
         quote: "'", skip_leading: 1
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     end
 
     mock.verify
@@ -69,7 +69,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, load_job_gapi(table_gapi.table_reference), upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON"
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     end
 
     mock.verify
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
 
     local_json = "acceptance/data/kitten-test-data.json"
     job = table.load_job local_json
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -99,7 +99,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON", job_id: job_id
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
       job.job_id.must_equal job_id
     end
 
@@ -120,7 +120,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON", prefix: prefix
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
       job.job_id.must_equal job_id
     end
 
@@ -138,7 +138,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON", job_id: job_id, prefix: "IGNORED"
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
       job.job_id.must_equal job_id
     end
 
@@ -156,7 +156,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
         [project, job_gapi, upload_source: file, content_type: "application/json"]
 
       job = table.load_job file, format: "JSON", labels: labels
-      job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+      job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
       job.labels.must_equal labels
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :load_job, :storage, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
   let(:load_bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
   let(:description) { "This is the target table" }
   let(:table_hash) { random_table_hash dataset, table_id, table_name, description }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
   let(:labels) { { "foo" => "bar" } }
 
   def storage_file path = nil
@@ -44,7 +44,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file, format: :csv
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -78,7 +78,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     job = table.load_job special_file, jagged_rows: true, quoted_newlines: true, autodetect: true,
       encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",
       quote: "'", skip_leading: 1
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -131,7 +131,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -150,7 +150,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job special_file, projection_fields: projection_fields
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -163,7 +163,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -177,7 +177,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, dryrun: true
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -191,7 +191,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, create: "CREATE_NEVER"
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -205,7 +205,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, create: :never
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -219,7 +219,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, write: "WRITE_TRUNCATE"
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -233,7 +233,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url, write: :truncate
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end
@@ -247,7 +247,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_file, labels: labels
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
     job.labels.must_equal labels
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
@@ -14,14 +14,14 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :load, :local, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :load, :local, :mock_bigquery do
   let(:dataset) { "dataset" }
   let(:table_id) { "table_id" }
   let(:table_name) { "Target Table" }
   let(:description) { "This is the target table" }
   let(:table_hash) { random_table_hash dataset, table_id, table_name, description }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   it "can upload a csv file" do
     mock = Minitest::Mock.new

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :load, :storage, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
   let(:load_bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
   let(:description) { "This is the target table" }
   let(:table_hash) { random_table_hash dataset, table_id, table_name, description }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   def storage_file path = nil
     gapi = Google::Apis::StorageV1::Object.from_json random_file_hash(load_bucket.name, path).to_json

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -16,23 +16,23 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :reference, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_table" }
   let(:table_hash) { random_table_hash dataset_id, table_id }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) {Google::Cloud::Bigquery::Table.new_reference project, dataset_id, table_id, bigquery.service }
+  let(:table) {Google::Cloud::BigQuery::Table.new_reference project, dataset_id, table_id, bigquery.service }
 
   let(:etag) { "etag123456789" }
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", description: nil, fields: [] }
-  let(:field_timestamp) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_timestamp_gapi }
+  let(:field_timestamp) { Google::Cloud::BigQuery::Schema::Field.from_gapi field_timestamp_gapi }
 
   let(:target_dataset) { "target_dataset" }
   let(:target_table_id) { "target_table_id" }
   let(:target_table_name) { "Target Table" }
   let(:target_description) { "This is the target table" }
   let(:target_table_gapi) { random_table_gapi target_dataset, target_table_id }
-  let(:target_table) { Google::Cloud::Bigquery::Table.from_gapi target_table_gapi, bigquery.service }
+  let(:target_table) { Google::Cloud::BigQuery::Table.from_gapi target_table_gapi, bigquery.service }
 
   let(:credentials) { OpenStruct.new }
   let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
@@ -184,12 +184,12 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
 
     mock.verify
 
-    table.external.must_be_kind_of Google::Cloud::Bigquery::External::JsonSource
+    table.external.must_be_kind_of Google::Cloud::BigQuery::External::JsonSource
     table.external.urls.must_equal ["gs://my-bucket/path/to/file.json"]
     table.external.format.must_equal "NEWLINE_DELIMITED_JSON"
     table.external.autodetect.must_be :nil?
     table.external.schema.wont_be :empty?
-    table.external.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.external.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     table.external.schema.must_be :frozen?
     table.external.must_be :frozen?
   end
@@ -205,7 +205,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     data = table.data
     mock.verify
 
-    data.class.must_equal Google::Cloud::Bigquery::Data
+    data.class.must_equal Google::Cloud::BigQuery::Data
     data.count.must_equal 3
     data[0].must_be_kind_of Hash
   end
@@ -219,7 +219,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     job = table.copy_job target_table
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.must_be_kind_of Google::Cloud::BigQuery::CopyJob
   end
 
   it "can copy itself with copy" do
@@ -246,7 +246,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     job = table.extract_job storage_file
     mock.verify
 
-    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.must_be_kind_of Google::Cloud::BigQuery::ExtractJob
   end
 
   it "can extract itself with extract" do
@@ -272,7 +272,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_file
-    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.must_be_kind_of Google::Cloud::BigQuery::LoadJob
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
@@ -14,14 +14,14 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :reference, :update, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_table" }
   let(:table_name) { "My Table" }
   let(:description) { "This is my table" }
   let(:labels) { { "foo" => "bar" } }
   let(:table_gapi) { random_table_gapi dataset_id, table_id, table_name, description }
-  let(:table) {Google::Cloud::Bigquery::Table.new_reference project, dataset_id, table_id, bigquery.service }
+  let(:table) {Google::Cloud::BigQuery::Table.new_reference project, dataset_id, table_id, bigquery.service }
 
 
   let(:schema) { table.schema.dup }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reload_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reload_test.rb
@@ -14,13 +14,13 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :reload, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :reload, :mock_bigquery do
   # Create a table object with the project's mocked connection object
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_table" }
   let(:table_hash) { random_table_hash dataset_id, table_id }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   it "loads the table full resource by making an HTTP call" do
     mock = Minitest::Mock.new
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery::Table, :reload, :mock_bigquery do
 
   describe "partial table resource from list" do
     let(:table_partial_gapi) { list_tables_gapi(1).tables.first }
-    let(:table) {Google::Cloud::Bigquery::Table.from_gapi table_partial_gapi, bigquery.service }
+    let(:table) {Google::Cloud::BigQuery::Table.from_gapi table_partial_gapi, bigquery.service }
 
     it "loads the table full resource by making an HTTP call" do
       mock = Minitest::Mock.new
@@ -66,7 +66,7 @@ describe Google::Cloud::Bigquery::Table, :reload, :mock_bigquery do
   end
 
   describe "table reference" do
-    let(:table) {Google::Cloud::Bigquery::Table.new_reference project, dataset_id, table_id, bigquery.service }
+    let(:table) {Google::Cloud::BigQuery::Table.new_reference project, dataset_id, table_id, bigquery.service }
 
     it "loads the table full resource by making an HTTP call" do
       mock = Minitest::Mock.new

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Table, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :mock_bigquery do
   # Create a table object with the project's mocked connection object
   let(:dataset) { "my_dataset" }
 
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{table_id}" }
   let(:table_hash) { random_table_hash dataset, table_id, table_name, description }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   let(:schema_hash) { table_gapi.schema.to_h }
 
@@ -45,17 +45,17 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_date_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "birthday", type: "DATE", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_record_repeated_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "cities_lived", type: "RECORD", mode: "REPEATED", description: nil, fields: [ field_integer_gapi, field_timestamp_gapi ] }
 
-  let(:field_string_required) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_string_required_gapi }
-  let(:field_integer) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_integer_gapi }
-  let(:field_float) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_float_gapi }
-  let(:field_boolean) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_boolean_gapi }
-  let(:field_timestamp) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_timestamp_gapi }
-  let(:field_record_repeated) { Google::Cloud::Bigquery::Schema::Field.from_gapi field_record_repeated_gapi }
+  let(:field_string_required) { Google::Cloud::BigQuery::Schema::Field.from_gapi field_string_required_gapi }
+  let(:field_integer) { Google::Cloud::BigQuery::Schema::Field.from_gapi field_integer_gapi }
+  let(:field_float) { Google::Cloud::BigQuery::Schema::Field.from_gapi field_float_gapi }
+  let(:field_boolean) { Google::Cloud::BigQuery::Schema::Field.from_gapi field_boolean_gapi }
+  let(:field_timestamp) { Google::Cloud::BigQuery::Schema::Field.from_gapi field_timestamp_gapi }
+  let(:field_record_repeated) { Google::Cloud::BigQuery::Schema::Field.from_gapi field_record_repeated_gapi }
 
   let(:etag) { "etag123456789" }
 
   it "gets the schema, fields, and headers" do
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     table.schema.must_be :frozen?
     table.schema.fields.count.must_equal 9
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Table, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :mock_bigquery do
   let(:dataset) { "my_dataset" }
   let(:table_id) { "my_table" }
   let(:table_name) { "My Table" }
@@ -27,7 +27,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:api_url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{table_id}" }
   let(:table_hash) { random_table_hash dataset, table_id, table_name, description }
   let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi, bigquery.service }
 
   it "knows its attributes" do
     table.table_id.must_equal table_id
@@ -85,7 +85,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   end
 
   it "knows schema, fields, and headers" do
-    table.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    table.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     table.schema.must_be :frozen?
     table.fields.map(&:name).must_equal table.schema.fields.map(&:name)
     table.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -14,14 +14,14 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :update, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_table" }
   let(:table_name) { "My Table" }
   let(:description) { "This is my table" }
   let(:labels) { { "foo" => "bar" } }
   let(:table_gapi) { random_table_gapi dataset_id, table_id, table_name, description }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+  let(:table) { Google::Cloud::BigQuery::Table.from_gapi table_gapi,
                                                   bigquery.service }
 
   let(:schema) { table.schema.dup }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :view, :attributes, :mock_bigquery do
   # Create a view object with the project's mocked connection object
   let(:table_id) { "my_view" }
   let(:table_name) { "My View" }
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
   let(:view_full_hash) { random_view_hash "my_view", table_id, table_name, description }
   let(:view_gapi) { Google::Apis::BigqueryV2::TableList::Table.from_json view_hash.to_json }
   let(:view_full_gapi) { Google::Apis::BigqueryV2::Table.from_json view_full_hash.to_json }
-  let(:view) { Google::Cloud::Bigquery::Table.from_gapi view_gapi, bigquery.service }
+  let(:view) { Google::Cloud::BigQuery::Table.from_gapi view_gapi, bigquery.service }
 
   it "gets full data for created_at" do
     mock = Minitest::Mock.new
@@ -75,7 +75,7 @@ describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
       [view.project_id, view.dataset_id, view.table_id]
     view.service.mocked_service = mock
 
-    view.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    view.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     view.schema.must_be :frozen?
     view.schema.fields.wont_be :empty?
     view.fields.wont_be :empty?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -16,7 +16,7 @@ require "helper"
 require "json"
 require "uri"
 
-describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :view, :mock_bigquery do
   # Create a view object with the project's mocked connection object
   let(:dataset) { "my_dataset" }
   let(:table_id) { "my_view" }
@@ -27,7 +27,7 @@ describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
   let(:api_url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{table_id}" }
   let(:view_hash) { random_view_hash dataset, table_id, table_name, description }
   let(:view_gapi) { Google::Apis::BigqueryV2::Table.from_json view_hash.to_json }
-  let(:view) { Google::Cloud::Bigquery::Table.from_gapi view_gapi,
+  let(:view) { Google::Cloud::BigQuery::Table.from_gapi view_gapi,
                                                 bigquery.service }
 
   it "knows its attributes" do
@@ -57,7 +57,7 @@ describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
   end
 
   it "knows schema, fields, and headers" do
-    view.schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    view.schema.must_be_kind_of Google::Cloud::BigQuery::Schema
     view.schema.must_be :frozen?
     view.fields.map(&:name).must_equal view.schema.fields.map(&:name)
     view.headers.must_equal [:name, :age, :score, :active, :avatar, :started_at, :duration, :target_end, :birthday]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
@@ -14,14 +14,14 @@
 
 require "helper"
 
-describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
+describe Google::Cloud::BigQuery::Table, :view, :update, :mock_bigquery do
   let(:dataset_id) { "my_dataset" }
   let(:table_id) { "my_view" }
   let(:table_name) { "My View" }
   let(:description) { "This is my view" }
   let(:view_hash) { random_view_hash dataset_id, table_id, table_name, description }
   let(:view_gapi) { Google::Apis::BigqueryV2::Table.from_json view_hash.to_json }
-  let(:view) { Google::Cloud::Bigquery::Table.from_gapi view_gapi,
+  let(:view) { Google::Cloud::BigQuery::Table.from_gapi view_gapi,
                                                 bigquery.service }
 
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery_test.rb
@@ -81,9 +81,9 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
-          Google::Cloud::Bigquery::Credentials.stub :default, default_credentials do
+          Google::Cloud::BigQuery::Credentials.stub :default, default_credentials do
             bigquery = Google::Cloud.bigquery
-            bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+            bigquery.must_be_kind_of Google::Cloud::BigQuery::Project
             bigquery.project.must_equal "project-id"
             bigquery.service.credentials.must_equal default_credentials
           end
@@ -109,10 +109,10 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         File.stub :file?, true, ["path/to/keyfile.json"] do
           File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
+            Google::Cloud::BigQuery::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::BigQuery::Service.stub :new, stubbed_service do
                 bigquery = Google::Cloud.bigquery "project-id", "path/to/keyfile.json"
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+                bigquery.must_be_kind_of Google::Cloud::BigQuery::Project
                 bigquery.project.must_equal "project-id"
                 bigquery.service.must_be_kind_of OpenStruct
               end
@@ -123,7 +123,7 @@ describe Google::Cloud do
     end
   end
 
-  describe "Bigquery.new" do
+  describe "BigQuery.new" do
     let(:default_credentials) do
       creds = OpenStruct.new empty: true
       def creds.is_a? target
@@ -138,9 +138,9 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
-          Google::Cloud::Bigquery::Credentials.stub :default, default_credentials do
-            bigquery = Google::Cloud::Bigquery.new
-            bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+          Google::Cloud::BigQuery::Credentials.stub :default, default_credentials do
+            bigquery = Google::Cloud::BigQuery.new
+            bigquery.must_be_kind_of Google::Cloud::BigQuery::Project
             bigquery.project.must_equal "project-id"
             bigquery.service.credentials.must_equal default_credentials
           end
@@ -166,10 +166,10 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         File.stub :file?, true, ["path/to/keyfile.json"] do
           File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
-                bigquery = Google::Cloud::Bigquery.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+            Google::Cloud::BigQuery::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::BigQuery::Service.stub :new, stubbed_service do
+                bigquery = Google::Cloud::BigQuery.new project_id: "project-id", credentials: "path/to/keyfile.json"
+                bigquery.must_be_kind_of Google::Cloud::BigQuery::Project
                 bigquery.project.must_equal "project-id"
                 bigquery.service.must_be_kind_of OpenStruct
               end
@@ -197,10 +197,10 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         File.stub :file?, true, ["path/to/keyfile.json"] do
           File.stub :read, found_credentials, ["path/to/keyfile.json"] do
-            Google::Cloud::Bigquery::Credentials.stub :new, stubbed_credentials do
-              Google::Cloud::Bigquery::Service.stub :new, stubbed_service do
-                bigquery = Google::Cloud::Bigquery.new project: "project-id", keyfile: "path/to/keyfile.json"
-                bigquery.must_be_kind_of Google::Cloud::Bigquery::Project
+            Google::Cloud::BigQuery::Credentials.stub :new, stubbed_credentials do
+              Google::Cloud::BigQuery::Service.stub :new, stubbed_service do
+                bigquery = Google::Cloud::BigQuery.new project: "project-id", keyfile: "path/to/keyfile.json"
+                bigquery.must_be_kind_of Google::Cloud::BigQuery::Project
                 bigquery.project.must_equal "project-id"
                 bigquery.service.must_be_kind_of OpenStruct
               end
@@ -209,5 +209,9 @@ describe Google::Cloud do
         end
       end
     end
+  end
+
+  it "maintains the previous namespace" do
+    Google::Cloud::Bigquery.must_equal Google::Cloud::BigQuery
   end
 end

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -36,17 +36,17 @@ module Google::Apis::Core::Hashable
   end
 end
 
-class MockBigquery < Minitest::Spec
+class MockBigQuery < Minitest::Spec
   let(:project) { bigquery.service.project }
   let(:credentials) { bigquery.service.credentials }
   let(:service) do
-    Google::Cloud::Bigquery::Service.new("test-project", OpenStruct.new).tap do |s|
+    Google::Cloud::BigQuery::Service.new("test-project", OpenStruct.new).tap do |s|
       s.define_singleton_method :generate_id do
         "9876543210"
       end
     end
   end
-  let(:bigquery) { Google::Cloud::Bigquery::Project.new service }
+  let(:bigquery) { Google::Cloud::BigQuery::Project.new service }
 
   # Register this spec type for when :mock_bigquery is used.
   register_spec_type(self) do |desc, *addl|


### PR DESCRIPTION
Per feedback from the BigQuery team, use `BigQuery` instead of `Bigquery` in the namespace.
Maintain `Bigquery` as an alias to `BigQuery` for backwards compatibility.

[closes #1884]