### PR TITLE
Remove reference to sync and async queries

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -92,10 +92,6 @@ module Google
     # as discussed in the guide [Migrating from legacy
     # SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql).
     #
-    # In addition, BigQuery offers both synchronous and asynchronous methods, as
-    # explained in [Querying
-    # Data](https://cloud.google.com/bigquery/querying-data).
-    #
     # ### Standard SQL
     #
     # Standard SQL is the preferred SQL dialect for querying data stored in

--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -195,9 +195,9 @@ module Google
     # See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types)
     # for an overview of each BigQuery data type, including allowed values.
     #
-    # ### Synchronous queries
+    # ### Running Queries
     #
-    # Let's start with the simpler synchronous approach. Notice that this time
+    # Let's start with the simplest way to run a query. Notice that this time
     # you are connecting using your own default project. It is necessary to have
     # write access to the project for running a query, since queries need to
     # create tables to hold results.
@@ -221,14 +221,13 @@ module Google
     # SQL)](https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators)
     # for a full listing.
     #
-    # ### Asynchronous queries
+    # ### Query Jobs
     #
     # It is usually best not to block for most BigQuery operations, including
     # querying as well as importing, exporting, and copying data. Therefore, the
     # BigQuery API provides facilities for managing longer-running jobs. With
-    # the asynchronous approach to running a query, an instance of
-    # {Google::Cloud::Bigquery::QueryJob} is returned, rather than an instance
-    # of {Google::Cloud::Bigquery::Data}.
+    # this approach, an instance of {Google::Cloud::Bigquery::QueryJob} is
+    # returned, rather than an instance of {Google::Cloud::Bigquery::Data}.
     #
     # ```ruby
     # require "google/cloud/bigquery"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -668,8 +668,8 @@ module Google
         end
 
         ##
-        # Queries data using the [asynchronous
-        # method](https://cloud.google.com/bigquery/querying-data).
+        # Queries data by creating a [query
+        # job](https://cloud.google.com/bigquery/docs/query-overview#query_jobs).
         #
         # Sets the current dataset as the default dataset in the query. Useful
         # for using unqualified table names.
@@ -908,10 +908,10 @@ module Google
         end
 
         ##
-        # Queries data using a synchronous method that blocks for a response. In
-        # this method, a {QueryJob} is created and its results are saved
-        # to a temporary table, then read from the table. Timeouts and transient
-        # errors are generally handled as needed to complete the query.
+        # Queries data and waits for the results. In this method, a {QueryJob}
+        # is created and its results are saved to a temporary table, then read
+        # from the table. Timeouts and transient errors are generally handled
+        # as needed to complete the query.
         #
         # Sets the current dataset as the default dataset in the query. Useful
         # for using unqualified table names.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -95,8 +95,8 @@ module Google
         end
 
         ##
-        # Queries data using the [asynchronous
-        # method](https://cloud.google.com/bigquery/querying-data).
+        # Queries data by creating a [query
+        # job](https://cloud.google.com/bigquery/docs/query-overview#query_jobs).
         #
         # When using standard SQL and passing arguments using `params`, Ruby
         # types are mapped to BigQuery types as follows:
@@ -340,10 +340,10 @@ module Google
         end
 
         ##
-        # Queries data using a synchronous method that blocks for a response. In
-        # this method, a {QueryJob} is created and its results are saved
-        # to a temporary table, then read from the table. Timeouts and transient
-        # errors are generally handled as needed to complete the query.
+        # Queries data and waits for the results. In this method, a {QueryJob}
+        # is created and its results are saved to a temporary table, then read
+        # from the table. Timeouts and transient errors are generally handled
+        # as needed to complete the query.
         #
         # When using standard SQL and passing arguments using `params`, Ruby
         # types are mapped to BigQuery types as follows:


### PR DESCRIPTION
BigQuery makes no distinction between synchronous and asynchronous queries. This was a misunderstanding that unfortunately propagated to the docs. Such language has now been removed from https://cloud.google.com/bigquery/docs/running-queries

In all cases, BigQuery creates a query "job" to run the query, which can then be polled until it is complete.