### PR TITLE
fixed acceptance tests running from a bad copy paste

### DIFF
--- a/google-cloud-dlp/Rakefile
+++ b/google-cloud-dlp/Rakefile
@@ -66,7 +66,7 @@ end
 
 # Acceptance tests
 desc "Run the google-cloud-dlp acceptance tests."
-task :acceptance do
+task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DLP_TEST_PROJECT"]
   keyfile = args[:keyfile]

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dlp"
-  gem.version       = "0.20.0"
+  gem.version       = "0.2.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dlp"
-  gem.version       = "0.2.0"
+  gem.version       = "0.1.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"


### PR DESCRIPTION
My last change #1899 broke the CI. I think it was just this copy/paste error (missed the first line).

I don't think the docs ask to run the acceptance test locally, should we add that just in case?

Also, double check the version number you mentioned last time.