### PR TITLE
Skip Tag Builds on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ rvm:
 - 2.3.5
 - 2.2.8
 - 2.1.10
+branches:
+  except:
+  - gh-pages
+  - /\/v\d/
 script:
 - gem install bundler
 - bundle exec rake travis:build


### PR DESCRIPTION
This PR add config to skip tag builds on Travis-CI. We don't need the tags to build on Travis-CI, since we are releasing on CircleCI now.

The config added looks for a match like `/v0` in the tag name. So tags like "google-cloud-trace/v0.30.0" will match, and be excluded from the build.