### PR TITLE
Handle EHOSTDOWN when connecting to env

### DIFF
--- a/google-cloud-env/lib/google/cloud/env.rb
+++ b/google-cloud-env/lib/google/cloud/env.rb
@@ -305,7 +305,8 @@ module Google
             resp = connection.get METADATA_ROOT_PATH
             metadata_cache[METADATA_ROOT_PATH] = \
               resp.status == 200 && resp.headers["Metadata-Flavor"] == "Google"
-          rescue ::Faraday::TimeoutError, ::Faraday::ConnectionFailed
+          rescue ::Faraday::TimeoutError, ::Faraday::ConnectionFailed,
+                 Errno::EHOSTDOWN
             metadata_cache[METADATA_ROOT_PATH] = false
           end
         end
@@ -330,7 +331,8 @@ module Google
               req.headers = { "Metadata-Flavor" => "Google" }
             end
             metadata_cache[path] = resp.status == 200 ? resp.body.strip : nil
-          rescue ::Faraday::TimeoutError, ::Faraday::ConnectionFailed
+          rescue ::Faraday::TimeoutError, ::Faraday::ConnectionFailed,
+                 Errno::EHOSTDOWN
             metadata_cache[path] = nil
           end
         end


### PR DESCRIPTION
I'm seeing the following error when running some of the acceptance tests on my local network:

```
Errno::EHOSTDOWN: Failed to open TCP connection to 169.254.169.254:80 (Host is down - connect(2) for "169.254.169.254" port 80)
```

I figure if the host is down, as it is in my my network's case, then these env methods should return `false` or `nil` instead of raising an error.