### PR TITLE
Support disabling of mutation detection in debugger evaluation

### DIFF
--- a/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/evaluator.c
+++ b/google-cloud-debugger/ext/google/cloud/debugger/debugger_c/evaluator.c
@@ -21,8 +21,8 @@
 static void
 eval_trace_callback(void *data, rb_trace_arg_t *trace_arg)
 {
-    rb_event_flag_t event = rb_tracearg_event_flag(trace_arg);
-    VALUE evaluator = (VALUE)data;
+    rb_event_flag_t event;
+    VALUE evaluator;
     VALUE klass;
     VALUE obj;
     VALUE method_id;
@@ -32,15 +32,16 @@ eval_trace_callback(void *data, rb_trace_arg_t *trace_arg)
     CONST_ID(trace_func_cb_id, "trace_func_callback");
     CONST_ID(trace_c_func_cb_id, "trace_c_func_callback");
 
+    event = rb_tracearg_event_flag(trace_arg);
+    evaluator = (VALUE)data;
     obj = rb_tracearg_self(trace_arg);
     method_id = rb_tracearg_method_id(trace_arg);
+    klass = rb_tracearg_defined_class(trace_arg);
 
     if (event & RUBY_EVENT_CALL) {
-        rb_funcall(evaluator, trace_func_cb_id, 2, obj, method_id);
+        rb_funcall(evaluator, trace_func_cb_id, 3, obj, klass, method_id);
     }
     if (event & RUBY_EVENT_C_CALL) {
-        klass = rb_tracearg_defined_class(trace_arg);
-
         rb_funcall(evaluator, trace_c_func_cb_id, 3, obj, klass, method_id);
     }
 
@@ -79,10 +80,13 @@ rb_enable_method_trace_for_thread(VALUE self)
     VALUE current_thread;
     VALUE thread_variables_hash;
     VALUE trace_set;
+    VALUE evaluator;
+    ID current_evaluator_id;
     ID locals_id;
     ID eval_trace_thread_id;
     VALUE eval_trace_thread_flag;
 
+    CONST_ID(current_evaluator_id, "current");
     CONST_ID(locals_id, "locals");
     CONST_ID(eval_trace_thread_id, "gcloud_eval_trace_set");
     eval_trace_thread_flag = ID2SYM(eval_trace_thread_id);
@@ -90,9 +94,10 @@ rb_enable_method_trace_for_thread(VALUE self)
     current_thread = rb_thread_current();
     thread_variables_hash = rb_ivar_get(current_thread, locals_id);
     trace_set = rb_hash_aref(thread_variables_hash, eval_trace_thread_flag);
+    evaluator = rb_funcall(self, current_evaluator_id, 0);
 
     if (!RTEST(trace_set)) {
-        rb_thread_add_event_hook2(current_thread, (rb_event_hook_func_t)eval_trace_callback, RUBY_EVENT_CALL | RUBY_EVENT_C_CALL, self, RUBY_EVENT_HOOK_FLAG_RAW_ARG | RUBY_EVENT_HOOK_FLAG_SAFE);
+        rb_thread_add_event_hook2(current_thread, (rb_event_hook_func_t)eval_trace_callback, RUBY_EVENT_CALL | RUBY_EVENT_C_CALL, evaluator, RUBY_EVENT_HOOK_FLAG_RAW_ARG | RUBY_EVENT_HOOK_FLAG_SAFE);
         rb_hash_aset(thread_variables_hash, eval_trace_thread_flag, Qtrue);
     }
 
@@ -103,8 +108,8 @@ void
 Init_evaluator(VALUE mDebugger)
 {
     VALUE cBreakpoint = rb_define_class_under(mDebugger, "Breakpoint", rb_cObject);
-    VALUE mEvaluator  = rb_define_module_under(cBreakpoint, "Evaluator");
+    VALUE cEvaluator  = rb_define_class_under(cBreakpoint, "Evaluator", rb_cObject);
 
-    rb_define_module_function(mEvaluator, "enable_method_trace_for_thread", rb_enable_method_trace_for_thread, 0);
-    rb_define_module_function(mEvaluator, "disable_method_trace_for_thread", rb_disable_method_trace_for_thread, 0);
+    rb_define_module_function(cEvaluator, "enable_method_trace_for_thread", rb_enable_method_trace_for_thread, 0);
+    rb_define_module_function(cEvaluator, "disable_method_trace_for_thread", rb_disable_method_trace_for_thread, 0);
 }

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -419,36 +419,34 @@ module Google
       # breakpoint expression, because it could change the behavior of your
       # program. However, the checks are currently quite conservative, and may
       # block code that is actually safe to run. If you are certain your
-      # expression is safe to evaluate, you may wrap it in a block using this
-      # method. Here is an example expression:
+      # expression is safe to evaluate, you may use this method to disable
+      # side effect checks.
       #
-      # ```ruby
-      # # An expression to evaluate in your debugger snapshot
-      # Google::Cloud::Debugger.allow_mutating_methods! do
-      #   obj1.method_with_potential_side_effects
-      # end
-      # ```
+      # This method may be called with a block, in which case checks are
+      # disabled within the block. It may also be called without a block to
+      # disable side effect checks for the rest of the current expression; the
+      # default setting will be restored for the next expression.
       #
-      # You may also call this method without a block to disable side effect
-      # checks for the rest of the current expression. The default setting
-      # will be restored for the next expression.
-      #
-      # ```ruby
-      # # An expression to evaluate in your debugger snapshot
-      # Google::Cloud::Debugger.allow_mutating_methods!
-      # obj1.method_with_potential_side_effects
-      # obj2.another_method_with_potential_side_effects
-      # ```
-      #
-      # This may be called only from a debugger condition or expression
+      # This method may be called only from a debugger condition or expression
       # evaluation, and will throw an exception if you call it from normal
-      # application code. If you want to disable the side effect checker
-      # globally for your app, you may set the following configuration:
+      # application code. Set the `allow_mutating_methods` configuration if you
+      # want to disable the side effect checker globally for your app.
       #
-      # ```ruby
-      # # In your application initialization code
-      # Google::Cloud::Debugger.configure.allow_mutating_methods = true
-      # ```
+      # @example Disabling side effect detection in a block
+      #   # This is an expression evaluated in a debugger snapshot
+      #   Google::Cloud::Debugger.allow_mutating_methods! do
+      #     obj1.method_with_potential_side_effects
+      #   end
+      #
+      # @example Disabling side effect detection for the rest of the expression
+      #   # This is an expression evaluated in a debugger snapshot
+      #   Google::Cloud::Debugger.allow_mutating_methods!
+      #   obj1.method_with_potential_side_effects
+      #   obj2.another_method_with_potential_side_effects
+      #
+      # @example Globally disabling side effect detection at app initialization
+      #   require "google/cloud/debugger"
+      #   Google::Cloud::Debugger.configure.allow_mutating_methods = true
       #
       def self.allow_mutating_methods! &block
         evaluator = Breakpoint::Evaluator.current

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -320,7 +320,7 @@ module Google
     # See {Google::Cloud::Debugger::V2::Debugger2Client} for details.
     #
     module Debugger
-      # Initialize :error_reporting as a nested Configuration under
+      # Initialize :debugger as a nested Configuration under
       # Google::Cloud if haven't already
       unless Google::Cloud.configure.option? :debugger
         Google::Cloud.configure.add_options :debugger
@@ -402,12 +402,30 @@ module Google
       # for full configuration parameters.
       #
       # @return [Stackdriver::Core::Configuration] The configuration object
-      #   the Google::Cloud::ErrorReporting module uses.
+      #   the Google::Cloud::Debugger module uses.
       #
       def self.configure
         yield Google::Cloud.configure[:debugger] if block_given?
 
         Google::Cloud.configure[:debugger]
+      end
+
+      ##
+      # Allow calling of mutating methods even if mutation detection is
+      # configured to be active. This may be called only during debugger
+      # condition or expression evaluation.
+      #
+      # If you pass in a block, it will be evaluated with mutation detection
+      # disabled, and the original setting will be restored afterward. If you
+      # do not pass a block, mutation detection will be disabled for the
+      # remainder of the current evaluation.
+      #
+      def self.allow_mutating_methods! &block
+        evaluator = Breakpoint::Evaluator.current
+        if evaluator.nil?
+          fail "allow_mutating_methods can be called only during evaluation"
+        end
+        evaluator.allow_mutating_methods!(&block)
       end
     end
   end

--- a/google-cloud-debugger/lib/google/cloud/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger.rb
@@ -411,14 +411,44 @@ module Google
       end
 
       ##
-      # Allow calling of mutating methods even if mutation detection is
-      # configured to be active. This may be called only during debugger
-      # condition or expression evaluation.
+      # Allow calling of potentially state-changing methods even if mutation
+      # detection is configured to be active.
       #
-      # If you pass in a block, it will be evaluated with mutation detection
-      # disabled, and the original setting will be restored afterward. If you
-      # do not pass a block, mutation detection will be disabled for the
-      # remainder of the current evaluation.
+      # Generally it is unwise to run code that may change the program state
+      # (e.g. modifying instance variables or causing other side effects) in a
+      # breakpoint expression, because it could change the behavior of your
+      # program. However, the checks are currently quite conservative, and may
+      # block code that is actually safe to run. If you are certain your
+      # expression is safe to evaluate, you may wrap it in a block using this
+      # method. Here is an example expression:
+      #
+      # ```ruby
+      # # An expression to evaluate in your debugger snapshot
+      # Google::Cloud::Debugger.allow_mutating_methods! do
+      #   obj1.method_with_potential_side_effects
+      # end
+      # ```
+      #
+      # You may also call this method without a block to disable side effect
+      # checks for the rest of the current expression. The default setting
+      # will be restored for the next expression.
+      #
+      # ```ruby
+      # # An expression to evaluate in your debugger snapshot
+      # Google::Cloud::Debugger.allow_mutating_methods!
+      # obj1.method_with_potential_side_effects
+      # obj2.another_method_with_potential_side_effects
+      # ```
+      #
+      # This may be called only from a debugger condition or expression
+      # evaluation, and will throw an exception if you call it from normal
+      # application code. If you want to disable the side effect checker
+      # globally for your app, you may set the following configuration:
+      #
+      # ```ruby
+      # # In your application initialization code
+      # Google::Cloud::Debugger.configure.allow_mutating_methods = true
+      # ```
       #
       def self.allow_mutating_methods! &block
         evaluator = Breakpoint::Evaluator.current

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/evaluator.rb
@@ -803,7 +803,7 @@ module Google
           # context binding. Handles any exceptions raised.
           #
           # @param [Binding] binding The binding object from the context
-          # @param [String] expression A string of code to be evaluates
+          # @param [String] expression A string of code to be evaluated
           #
           # @return [Object] The result Ruby object from evaluating the
           #   expression. If the expression is blocked from mutating

--- a/google-cloud-debugger/support/doctest_helper.rb
+++ b/google-cloud-debugger/support/doctest_helper.rb
@@ -77,6 +77,8 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Debugger::V2::Debugger2Client"
   doctest.skip "Google::Devtools::Clouddebugger::V2"
 
+  # Skip methods that work only during evaluation
+  doctest.skip "Google::Cloud::Debugger.allow_mutating_methods!"
 
   # Skip all aliases
   doctest.skip "Google::Cloud::Debugger::Project#attach"


### PR DESCRIPTION
This addresses https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1875 by providing two ways to disable mutation detection:

* An application can do so globally by setting a configuration called `allow_mutating_methods`
* An expression can call `Google::Cloud::Debugger.allow_mutating_methods!` explicitly to disable mutation detection for just that expression.

As part of this, `Evaluator` became a class rather than a module, and most of the evaluation steps are now instance methods rather than module methods. (Unfortunately, the bulk of the changes here are just the resulting indentation changes, although it doesn't show up very well in the diff.)