### PR TITLE
BigQuery: Allow a URI as the storage url for a load job

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1146,9 +1146,9 @@ module Google
         # Request](https://cloud.google.com/bigquery/loading-data-post-request#multipart).
         #
         # @param [String] table_id The destination table to load the data into.
-        # @param [File, Google::Cloud::Storage::File, String] file A file or the
-        #   URI of a Google Cloud Storage file containing data to load into the
-        #   table.
+        # @param [File, Google::Cloud::Storage::File, String, URI] file A file
+        #   or the URI of a Google Cloud Storage file containing data to load
+        #   into the table.
         # @param [String] format The exported file format. The default value is
         #   `csv`.
         #
@@ -1378,9 +1378,9 @@ module Google
         # Request](https://cloud.google.com/bigquery/loading-data-post-request#multipart).
         #
         # @param [String] table_id The destination table to load the data into.
-        # @param [File, Google::Cloud::Storage::File, String] file A file or the
-        #   URI of a Google Cloud Storage file containing data to load into the
-        #   table.
+        # @param [File, Google::Cloud::Storage::File, String, URI] file A file
+        #   or the URI of a Google Cloud Storage file containing data to load
+        #   into the table.
         # @param [String] format The exported file format. The default value is
         #   `csv`.
         #
@@ -1948,6 +1948,7 @@ module Google
         def load_storage table_id, url, options = {}
           # Convert to storage URL
           url = url.to_gs_url if url.respond_to? :to_gs_url
+          url = url.to_s if url.is_a? URI
 
           gapi = service.load_table_gs_url dataset_id, table_id, url, options
           Job.from_gapi gapi, service
@@ -1964,7 +1965,9 @@ module Google
         def storage_url? file
           file.respond_to?(:to_gs_url) ||
             (file.respond_to?(:to_str) &&
-            file.to_str.downcase.start_with?("gs://"))
+            file.to_str.downcase.start_with?("gs://")) ||
+            (file.is_a?(URI) &&
+            file.to_s.downcase.start_with?("gs://"))
         end
 
         def local_file? file

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1319,9 +1319,9 @@ module Google
         # file directly. See [Loading Data with a POST Request](
         # https://cloud.google.com/bigquery/loading-data-post-request#multipart).
         #
-        # @param [File, Google::Cloud::Storage::File, String] file A file or the
-        #   URI of a Google Cloud Storage file containing data to load into the
-        #   table.
+        # @param [File, Google::Cloud::Storage::File, String, URI] file A file
+        #   or the URI of a Google Cloud Storage file containing data to load
+        #   into the table.
         # @param [String] format The exported file format. The default value is
         #   `csv`.
         #
@@ -1495,9 +1495,9 @@ module Google
         # file directly. See [Loading Data with a POST Request](
         # https://cloud.google.com/bigquery/loading-data-post-request#multipart).
         #
-        # @param [File, Google::Cloud::Storage::File, String] file A file or the
-        #   URI of a Google Cloud Storage file containing data to load into the
-        #   table.
+        # @param [File, Google::Cloud::Storage::File, String, URI] file A file
+        #   or the URI of a Google Cloud Storage file containing data to load
+        #   into the table.
         # @param [String] format The exported file format. The default value is
         #   `csv`.
         #
@@ -1995,6 +1995,7 @@ module Google
         def load_storage url, options = {}
           # Convert to storage URL
           url = url.to_gs_url if url.respond_to? :to_gs_url
+          url = url.to_s if url.is_a? URI
 
           gapi = service.load_table_gs_url dataset_id, table_id, url, options
           Job.from_gapi gapi, service
@@ -2011,7 +2012,9 @@ module Google
         def storage_url? file
           file.respond_to?(:to_gs_url) ||
             (file.respond_to?(:to_str) &&
-            file.to_str.downcase.start_with?("gs://"))
+            file.to_str.downcase.start_with?("gs://")) ||
+            (file.is_a?(URI) &&
+            file.to_s.downcase.start_with?("gs://"))
         end
 
         def local_file? file

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
@@ -174,7 +174,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     mock.verify
   end
 
-  it "can specify a storage url" do
+  it "can specify a storage url as a string" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_reference, load_url
     mock.expect :insert_job, load_job_resp_gapi(load_url),
@@ -182,6 +182,19 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     dataset.service.mocked_service = mock
 
     job = dataset.load_job table_id, load_url
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
+  it "can specify a storage url as a URI" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_reference, load_url
+    mock.expect :insert_job, load_job_resp_gapi(load_url),
+                [project, job_gapi]
+    dataset.service.mocked_service = mock
+
+    job = dataset.load_job table_id, URI(load_url)
     job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
@@ -174,7 +174,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     mock.verify
   end
 
-  it "can specify a storage url" do
+  it "can specify a storage url as a string" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_reference, load_url
     mock.expect :insert_job, load_job_resp_gapi(load_url),
@@ -182,6 +182,19 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     result = dataset.load table_id, load_url
+    result.must_equal true
+
+    mock.verify
+  end
+
+  it "can specify a storage url as a URI" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_reference, load_url
+    mock.expect :insert_job, load_job_resp_gapi(load_url),
+                [project, job_gapi]
+    dataset.service.mocked_service = mock
+
+    result = dataset.load table_id, URI(load_url)
     result.must_equal true
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
@@ -155,7 +155,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     mock.verify
   end
 
-  it "can specify a storage url" do
+  it "can specify a storage url as a string" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
     mock.expect :insert_job, load_job_resp_gapi(table, load_url),
@@ -163,6 +163,19 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     job = table.load_job load_url
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
+  it "can specify a storage url as a URI" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
+    mock.expect :insert_job, load_job_resp_gapi(table, load_url),
+                [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job URI load_url
     job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
 
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
@@ -155,7 +155,7 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     mock.verify
   end
 
-  it "can specify a storage url" do
+  it "can specify a storage url as a string" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
     mock.expect :insert_job, load_job_resp_gapi(table, load_url),
@@ -163,6 +163,19 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     table.service.mocked_service = mock
 
     result = table.load load_url
+    result.must_equal true
+
+    mock.verify
+  end
+
+  it "can specify a storage url as a URI" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
+    mock.expect :insert_job, load_job_resp_gapi(table, load_url),
+      [project, job_gapi]
+    table.service.mocked_service = mock
+
+    result = table.load URI load_url
     result.must_equal true
 
     mock.verify


### PR DESCRIPTION
In the [BigQuery `load_job` documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery/v0.30.0/google/cloud/bigquery/table?method=load_job-instance), it states that you can use "a file or the URI of a Google Cloud Storage file", which I understood to be a [`URI`](https://docs.ruby-lang.org/en/2.4.0/URI.html) type object. 

After having this fail, I noticed that the docs do list the types that the object can be and that `URI` isn't listed. But I thought this could be useful to others (and is to us as we're using a `URI`). 

This pull request updates the method to accept a `URI` type parameter. In fact, this alters the method to accept any object that's `#to_s` returns a string representing a GS url.