### PR TITLE
BigQuery: Fix "unitialized constant" error when an invalid type is used in schema

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -371,7 +371,7 @@ module Google
           type = type.to_s.upcase
           unless Field::TYPES.include? type
             fail ArgumentError,
-                 "Type '#{type}' not found in #{TYPES.inspect}"
+                 "Type '#{type}' not found"
           end
           type
         end


### PR DESCRIPTION
I ran into this when messing around with `Schema#add_field`, which I realize is not a public interface. However, when you send a type to that method that's not listed in `Field::TYPES` it raises a `NameError` because the message for the `ArgumentError` references an undefined constant.

This resolves that.

I didn't see any relevant tests (clearly) and didn't know where to put a test of this either, given that it's not a public interface. If you want me to add a test, let me know a good place to put it.
  