### PR TITLE
Fix acceptance test env var order

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -104,15 +104,15 @@ task :acceptance, [:project, :keyfile, :key] => :compile do |t, args|
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or GCLOUD_TEST_PROJECT=test123 GCLOUD_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # always overwrite when running tests
-  ENV["GOOGLE_CLOUD_PROJECT"] = project
-  ENV["GOOGLE_CLOUD_KEYFILE"] = nil
-  ENV["GOOGLE_CLOUD_KEYFILE_JSON"] = keyfile
+  ENV["GCLOUD_TEST_PROJECT"] = project
+  ENV["GCLOUD_TEST_KEYFILE"] = nil
+  ENV["GCLOUD_TEST_KEYFILE_JSON"] = keyfile
 
   key = args[:key] || ENV["GCLOUD_TEST_KEY"]
   if key.nil?
     fail "You must provide an API KEY for translate acceptance tests."
   end  # always overwrite when running tests
-  ENV["GOOGLE_CLOUD_KEY"] = key
+  ENV["GCLOUD_TEST_KEY"] = key
 
   valid_gems.each do |gem|
     $LOAD_PATH.unshift "#{gem}/lib", "#{gem}/acceptance"

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -28,23 +28,32 @@ end
 desc "Run the bigquery acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["BIGQUERY_TEST_PROJECT"]
+  project ||= ENV["BIGQUERY_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["BIGQUERY_TEST_KEYFILE"]
+  keyfile ||= ENV["BIGQUERY_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["BIGQUERY_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["BIGQUERY_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or BIGQUERY_TEST_PROJECT=test123 BIGQUERY_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/bigquery/credentials"
+  (Google::Cloud::Bigquery::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Bigquery::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
+  require "google/cloud/storage/credentials"
+  (Google::Cloud::Storage::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Storage::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["BIGQUERY_PROJECT"] = project
-  ENV["BIGQUERY_KEYFILE"] = nil
   ENV["BIGQUERY_KEYFILE_JSON"] = keyfile
   ENV["STORAGE_PROJECT"] = project
-  ENV["STORAGE_KEYFILE"] = nil
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
@@ -66,20 +75,25 @@ namespace :acceptance do
   desc "Removes *ALL* BigQuery datasets and tables. Use with caution."
   task :cleanup, :project, :keyfile do |t, args|
     project = args[:project]
-    project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["BIGQUERY_TEST_PROJECT"]
+    project ||= ENV["BIGQUERY_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
     keyfile = args[:keyfile]
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["BIGQUERY_TEST_KEYFILE"]
+    keyfile ||= ENV["BIGQUERY_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
     if keyfile
       keyfile = File.read keyfile
     else
-      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["BIGQUERY_TEST_KEYFILE_JSON"]
+      keyfile ||= ENV["BIGQUERY_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
     end
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or BIGQUERY_TEST_PROJECT=test123 BIGQUERY_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
+    # clear any env var already set
+    require "google/cloud/bigquery/credentials"
+    (Google::Cloud::Bigquery::Credentials::PATH_ENV_VARS +
+     Google::Cloud::Bigquery::Credentials::JSON_ENV_VARS).each do |path|
+      ENV[path] = nil
+    end
     # always overwrite when running tests
     ENV["BIGQUERY_PROJECT"] = project
-    ENV["BIGQUERY_KEYFILE"] = nil
     ENV["BIGQUERY_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"

--- a/google-cloud-container/Rakefile
+++ b/google-cloud-container/Rakefile
@@ -68,20 +68,25 @@ end
 desc "Run the google-cloud-container acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["CONTAINER_TEST_PROJECT"]
+  project ||= ENV["CONTAINER_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["CONTAINER_TEST_KEYFILE"]
+  keyfile ||= ENV["CONTAINER_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["CONTAINER_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["CONTAINER_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or CONTAINER_TEST_PROJECT=test123 CONTAINER_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/container/credentials"
+  (Google::Cloud::Container::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Container::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["CONTAINER_PROJECT"] = project
-  ENV["CONTAINER_KEYFILE"] = nil
   ENV["CONTAINER_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke

--- a/google-cloud-dataproc/Rakefile
+++ b/google-cloud-dataproc/Rakefile
@@ -68,20 +68,25 @@ end
 desc "Run the google-cloud-dataproc acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DATAPROC_TEST_PROJECT"]
+  project ||= ENV["DATAPROC_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DATAPROC_TEST_KEYFILE"]
+  keyfile ||= ENV["DATAPROC_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DATAPROC_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["DATAPROC_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or DATAPROC_TEST_PROJECT=test123 VIDEO_INTELLIGENCE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/dataproc/credentials"
+  (Google::Cloud::Dataproc::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Dataproc::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["DATAPROC_PROJECT"] = project
-  ENV["DATAPROC_KEYFILE"] = nil
   ENV["DATAPROC_KEYFILE_JSON"] = keyfile
 
   # Required for smoke tests

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -30,20 +30,25 @@ end
 desc "Run the datastore acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DATASTORE_TEST_PROJECT"]
+  project ||= ENV["DATASTORE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DATASTORE_TEST_KEYFILE"]
+  keyfile ||= ENV["DATASTORE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DATASTORE_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["DATASTORE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or DATASTORE_TEST_PROJECT=test123 DATASTORE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/datastore/credentials"
+  (Google::Cloud::Datastore::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Datastore::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["DATASTORE_PROJECT"] = project
-  ENV["DATASTORE_KEYFILE"] = nil
   ENV["DATASTORE_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke

--- a/google-cloud-debugger/Rakefile
+++ b/google-cloud-debugger/Rakefile
@@ -53,23 +53,32 @@ end
 desc "Runs the trace acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DEBUGGER_TEST_PROJECT"]
+  project ||= ENV["DEBUGGER_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DEBUGGER_TEST_KEYFILE"]
+  keyfile ||= ENV["DEBUGGER_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DEBUGGER_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["DEBUGGER_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123,/path/to/keyfile.json] or DEBUGGER_TEST_PROJECT=test123 DEBUGGER_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/debugger/credentials"
+  (Google::Cloud::Debugger::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Debugger::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
+  require "google/cloud/logging/credentials"
+  (Google::Cloud::Logging::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Logging::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["DEBUGGER_PROJECT"] = project
-  ENV["DEBUGGER_KEYFILE"] = nil
   ENV["DEBUGGER_KEYFILE_JSON"] = keyfile
   ENV["LOGGING_PROJECT"] = project
-  ENV["LOGGING_KEYFILE"] = nil
   ENV["LOGGING_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke

--- a/google-cloud-dlp/Rakefile
+++ b/google-cloud-dlp/Rakefile
@@ -68,20 +68,25 @@ end
 desc "Run the google-cloud-dlp acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DLP_TEST_PROJECT"]
+  project ||= ENV["DLP_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DLP_TEST_KEYFILE"]
+  keyfile ||= ENV["DLP_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DLP_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["DLP_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or DLP_TEST_PROJECT=test123 DLP_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/dlp/credentials"
+  (Google::Cloud::Dlp::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Dlp::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["DLP_PROJECT"] = project
-  ENV["DLP_KEYFILE"] = nil
   ENV["DLP_KEYFILE_JSON"] = keyfile
 
   # Required for smoke tests

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -28,20 +28,25 @@ end
 desc "Run the dns acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DNS_TEST_PROJECT"]
+  project ||= ENV["DNS_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DNS_TEST_KEYFILE"]
+  keyfile ||= ENV["DNS_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DNS_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["DNS_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or DNS_TEST_PROJECT=test123 DNS_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/dns/credentials"
+  (Google::Cloud::Dns::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Dns::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["DNS_PROJECT"] = project
-  ENV["DNS_KEYFILE"] = nil
   ENV["DNS_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
@@ -63,20 +68,25 @@ namespace :acceptance do
   desc "Removes *ALL* DNS zones and records. Use with caution."
   task :cleanup do |t, args|
     project = args[:project]
-    project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DNS_TEST_PROJECT"]
+    project ||= ENV["DNS_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
     keyfile = args[:keyfile]
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DNS_TEST_KEYFILE"]
+    keyfile ||= ENV["DNS_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
     if keyfile
       keyfile = File.read keyfile
     else
-      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["DNS_TEST_KEYFILE_JSON"]
+      keyfile ||= ENV["DNS_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
     end
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or DNS_TEST_PROJECT=test123 DNS_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
+    # clear any env var already set
+    require "google/cloud/dns/credentials"
+    (Google::Cloud::Dns::Credentials::PATH_ENV_VARS +
+     Google::Cloud::Dns::Credentials::JSON_ENV_VARS).each do |path|
+      ENV[path] = nil
+    end
     # always overwrite when running tests
     ENV["DNS_PROJECT"] = project
-    ENV["DNS_KEYFILE"] = nil
     ENV["DNS_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -35,21 +35,26 @@ end
 desc "Run the logging acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["ERROR_REPORTING_TEST_PROJECT"]
+  project ||= ENV["ERROR_REPORTING_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["ERROR_REPORTING_TEST_KEYFILE"]
+  keyfile ||= ENV["ERROR_REPORTING_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["ERROR_REPORTING_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["ERROR_REPORTING_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123,/path/to/keyfile.json] " \
       "or ERROR_REPORTING_TEST_PROJECT=test123 ERROR_REPORTING_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/error_reporting/credentials"
+  (Google::Cloud::ErrorReporting::Credentials::PATH_ENV_VARS +
+   Google::Cloud::ErrorReporting::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["ERROR_REPORTING_PROJECT"] = project
-  ENV["ERROR_REPORTING_KEYFILE"] = nil
   ENV["ERROR_REPORTING_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -68,20 +68,25 @@ end
 desc "Run the google-cloud-language acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["LANGUAGE_TEST_PROJECT"]
+  project ||= ENV["LANGUAGE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["LANGUAGE_TEST_KEYFILE"]
+  keyfile ||= ENV["LANGUAGE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["LANGUAGE_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["LANGUAGE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or LANGUAGE_TEST_PROJECT=test123 LANGUAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/language/credentials"
+  (Google::Cloud::Language::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Language::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["LANGUAGE_PROJECT"] = project
-  ENV["LANGUAGE_KEYFILE"] = nil
   ENV["LANGUAGE_KEYFILE_JSON"] = keyfile
 
   # Required for smoke tests

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -30,20 +30,25 @@ end
 desc "Run the logging acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["LOGGING_TEST_PROJECT"]
+  project ||= ENV["LOGGING_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["LOGGING_TEST_KEYFILE"]
+  keyfile ||= ENV["LOGGING_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["LOGGING_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["LOGGING_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or LOGGING_TEST_PROJECT=test123 LOGGING_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/logging/credentials"
+  (Google::Cloud::Logging::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Logging::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["LOGGING_PROJECT"] = project
-  ENV["LOGGING_KEYFILE"] = nil
   ENV["LOGGING_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
@@ -65,20 +70,25 @@ namespace :acceptance do
   desc "Removes *ALL* Logging logs, sinks, and metrics. Use with caution."
   task :cleanup do |t, args|
     project = args[:project]
-    project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["LOGGING_TEST_PROJECT"]
+    project ||= ENV["LOGGING_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
     keyfile = args[:keyfile]
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["LOGGING_TEST_KEYFILE"]
+    keyfile ||= ENV["LOGGING_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
     if keyfile
       keyfile = File.read keyfile
     else
-      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["LOGGING_TEST_KEYFILE_JSON"]
+      keyfile ||= ENV["LOGGING_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
     end
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or LOGGING_TEST_PROJECT=test123 LOGGING_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
+    # clear any env var already set
+    require "google/cloud/logging/credentials"
+    (Google::Cloud::Logging::Credentials::PATH_ENV_VARS +
+     Google::Cloud::Logging::Credentials::JSON_ENV_VARS).each do |path|
+      ENV[path] = nil
+    end
     # always overwrite when running tests
     ENV["LOGGING_PROJECT"] = project
-    ENV["LOGGING_KEYFILE"] = nil
     ENV["LOGGING_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"

--- a/google-cloud-monitoring/Rakefile
+++ b/google-cloud-monitoring/Rakefile
@@ -68,20 +68,25 @@ end
 desc "Run the google-cloud-monitoring acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["MONITORING_TEST_PROJECT"]
+  project ||= ENV["MONITORING_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["MONITORING_TEST_KEYFILE"]
+  keyfile ||= ENV["MONITORING_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["MONITORING_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["MONITORING_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or MONITORING_TEST_PROJECT=test123 MONITORING_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/monitoring/credentials"
+  (Google::Cloud::Monitoring::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Monitoring::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["MONITORING_PROJECT"] = project
-  ENV["MONITORING_KEYFILE"] = nil
   ENV["MONITORING_KEYFILE_JSON"] = keyfile
 
   # Required for smoke tests

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -30,20 +30,25 @@ end
 desc "Run the pubsub acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["PUBSUB_TEST_PROJECT"]
+  project ||= ENV["PUBSUB_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["PUBSUB_TEST_KEYFILE"]
+  keyfile ||= ENV["PUBSUB_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["PUBSUB_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["PUBSUB_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/pubsub/credentials"
+  (Google::Cloud::Pubsub::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Pubsub::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["PUBSUB_PROJECT"] = project
-  ENV["PUBSUB_KEYFILE"] = nil
   ENV["PUBSUB_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
@@ -65,20 +70,25 @@ namespace :acceptance do
   desc "Removes *ALL* topics and subscriptions. Use with caution."
   task :cleanup do |t, args|
     project = args[:project]
-    project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["PUBSUB_TEST_PROJECT"]
+    project ||= ENV["PUBSUB_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
     keyfile = args[:keyfile]
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["PUBSUB_TEST_KEYFILE"]
+    keyfile ||= ENV["PUBSUB_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
     if keyfile
       keyfile = File.read keyfile
     else
-      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["PUBSUB_TEST_KEYFILE_JSON"]
+      keyfile ||= ENV["PUBSUB_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
     end
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or PUBSUB_TEST_PROJECT=test123 PUBSUB_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
+    # clear any env var already set
+    require "google/cloud/pubsub/credentials"
+    (Google::Cloud::Pubsub::Credentials::PATH_ENV_VARS +
+     Google::Cloud::Pubsub::Credentials::JSON_ENV_VARS).each do |path|
+      ENV[path] = nil
+    end
     # always overwrite when running tests
     ENV["PUBSUB_PROJECT"] = project
-    ENV["PUBSUB_KEYFILE"] = nil
     ENV["PUBSUB_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"

--- a/google-cloud-spanner/Rakefile
+++ b/google-cloud-spanner/Rakefile
@@ -32,20 +32,25 @@ end
 desc "Run the spanner acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["SPANNER_TEST_PROJECT"]
+  project ||= ENV["SPANNER_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["SPANNER_TEST_KEYFILE"]
+  keyfile ||= ENV["SPANNER_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["SPANNER_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["SPANNER_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or SPANNER_TEST_PROJECT=test123 SPANNER_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/spanner/credentials"
+  (Google::Cloud::Spanner::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Spanner::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["SPANNER_PROJECT"] = project
-  ENV["SPANNER_KEYFILE"] = nil
   ENV["SPANNER_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
@@ -67,20 +72,25 @@ namespace :acceptance do
   desc "Run acceptance cleanup."
   task :cleanup, :project, :keyfile do |t, args|
     project = args[:project]
-    project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["SPANNER_TEST_PROJECT"]
+    project ||= ENV["SPANNER_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
     keyfile = args[:keyfile]
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["SPANNER_TEST_KEYFILE"]
+    keyfile ||= ENV["SPANNER_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
     if keyfile
       keyfile = File.read keyfile
     else
-      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["SPANNER_TEST_KEYFILE_JSON"]
+      keyfile ||= ENV["SPANNER_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
     end
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or SPANNER_TEST_PROJECT=test123 SPANNER_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
     end
+    # clear any env var already set
+    require "google/cloud/spanner/credentials"
+    (Google::Cloud::Spanner::Credentials::PATH_ENV_VARS +
+     Google::Cloud::Spanner::Credentials::JSON_ENV_VARS).each do |path|
+      ENV[path] = nil
+    end
     # always overwrite when running tests
     ENV["SPANNER_PROJECT"] = project
-    ENV["SPANNER_KEYFILE"] = nil
     ENV["SPANNER_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -29,23 +29,32 @@ end
 desc "Run the speech acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["SPEECH_TEST_PROJECT"]
+  project ||= ENV["SPEECH_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["SPEECH_TEST_KEYFILE"]
+  keyfile ||= ENV["SPEECH_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["SPEECH_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["SPEECH_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or SPEECH_TEST_PROJECT=test123 SPEECH_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/speech/credentials"
+  (Google::Cloud::Speech::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Speech::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
+  require "google/cloud/storage/credentials"
+  (Google::Cloud::Storage::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Storage::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["SPEECH_PROJECT"] = project
-  ENV["SPEECH_KEYFILE"] = nil
   ENV["SPEECH_KEYFILE_JSON"] = keyfile
   ENV["STORAGE_PROJECT"] = project
-  ENV["STORAGE_KEYFILE"] = nil
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -28,23 +28,32 @@ end
 desc "Run the storage acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["STORAGE_TEST_PROJECT"]
+  project ||= ENV["STORAGE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["STORAGE_TEST_KEYFILE"]
+  keyfile ||= ENV["STORAGE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["STORAGE_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["STORAGE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or STORAGE_TEST_PROJECT=test123 STORAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/storage/credentials"
+  (Google::Cloud::Storage::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Storage::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
+  require "google/cloud/pubsub/credentials"
+  (Google::Cloud::Pubsub::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Pubsub::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["STORAGE_PROJECT"] = project
-  ENV["STORAGE_KEYFILE"] = nil
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
   ENV["PUBSUB_PROJECT"] = project
-  ENV["PUBSUB_KEYFILE"] = nil
   ENV["PUBSUB_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
@@ -66,20 +75,25 @@ namespace :acceptance do
   desc "Removes *ALL* buckets and files. Use with caution."
   task :cleanup do |t, args|
     project = args[:project]
-    project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["STORAGE_TEST_PROJECT"]
+    project ||= ENV["STORAGE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
     keyfile = args[:keyfile]
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["STORAGE_TEST_KEYFILE"]
+    keyfile ||= ENV["STORAGE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
     if keyfile
       keyfile = File.read keyfile
     else
-      keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["STORAGE_TEST_KEYFILE_JSON"]
+      keyfile ||= ENV["STORAGE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
     end
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake acceptance:cleanup[test123, /path/to/keyfile.json] or STORAGE_TEST_PROJECT=test123 STORAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance:cleanup"
     end
+    # clear any env var already set
+    require "google/cloud/storage/credentials"
+    (Google::Cloud::Storage::Credentials::PATH_ENV_VARS +
+     Google::Cloud::Storage::Credentials::JSON_ENV_VARS).each do |path|
+      ENV[path] = nil
+    end
     # always overwrite when running tests
     ENV["STORAGE_PROJECT"] = project
-    ENV["STORAGE_KEYFILE"] = nil
     ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
     $LOAD_PATH.unshift "lib"

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -43,20 +43,25 @@ end
 desc "Runs the trace acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["TRACE_TEST_PROJECT"]
+  project ||= ENV["TRACE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["TRACE_TEST_KEYFILE"]
+  keyfile ||= ENV["TRACE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["TRACE_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["TRACE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or TRACE_TEST_PROJECT=test123 TRACE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/trace/credentials"
+  (Google::Cloud::Trace::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Trace::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["TRACE_PROJECT"] = project
-  ENV["TRACE_KEYFILE"] = nil
   ENV["TRACE_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -28,19 +28,19 @@ end
 desc "Run the translate acceptance tests."
 task :acceptance, :project, :keyfile, :key do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["TRANSLATE_TEST_PROJECT"]
+  project ||= ENV["TRANSLATE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["TRANSLATE_TEST_KEYFILE"]
+  keyfile ||= ENV["TRANSLATE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["TRANSLATE_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["TRANSLATE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or TRANSLATE_TEST_PROJECT=test123 TRANSLATE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   key = args[:key]
-  key ||= ENV["GCLOUD_TEST_KEY"] || ENV["TRANSLATE_TEST_KEY"]
+  key ||= ENV["TRANSLATE_TEST_KEY"] || ENV["GCLOUD_TEST_KEY"]
 
   # run tests with api key credentials when available
   if key
@@ -52,9 +52,14 @@ task :acceptance, :project, :keyfile, :key do |t, args|
   # always run tests with service account credentials
   puts "running acceptance tests with service account"
 
+  # clear any env var already set
+  require "google/cloud/translate/credentials"
+  (Google::Cloud::Translate::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Translate::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["TRANSLATE_PROJECT"] = project
-  ENV["TRANSLATE_KEYFILE"] = nil
   ENV["TRANSLATE_KEYFILE_JSON"] = keyfile
   ENV["TRANSLATE_KEY"] = nil
 
@@ -64,18 +69,17 @@ end
 namespace :acceptance do
   task :key, :key do |t, args|
     key = args[:key]
-    key ||= ENV["GCLOUD_TEST_KEY"] || ENV["TRANSLATE_TEST_KEY"]
+    key ||= ENV["TRANSLATE_TEST_KEY"] || ENV["GCLOUD_TEST_KEY"]
     if key.nil?
       fail "unable to run acceptance tests with api key credentials"
     end
+    # clear any env var already set
+    require "google/cloud/translate/credentials"
+    (Google::Cloud::Translate::Credentials::PATH_ENV_VARS +
+     Google::Cloud::Translate::Credentials::JSON_ENV_VARS).each do |path|
+      ENV[path] = nil
+    end
     # always overwrite when running tests
-    ENV["TRANSLATE_PROJECT"] = nil
-    ENV["TRANSLATE_KEYFILE"] = nil
-    ENV["GOOGLE_CLOUD_KEYFILE"] = nil
-    ENV["GCLOUD_KEYFILE"] = nil
-    ENV["TRANSLATE_KEYFILE_JSON"] = nil
-    ENV["GOOGLE_CLOUD_KEYFILE_JSON"] = nil
-    ENV["GCLOUD_KEYFILE_JSON"] = nil
     ENV["TRANSLATE_KEY"] = key
 
     Rake::Task["acceptance:run"].invoke

--- a/google-cloud-video_intelligence/Rakefile
+++ b/google-cloud-video_intelligence/Rakefile
@@ -68,16 +68,22 @@ end
 desc "Run the google-cloud-video_intelligence acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["VIDEO_INTELLIGENCE_TEST_PROJECT"]
+  project ||= ENV["VIDEO_INTELLIGENCE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["VIDEO_INTELLIGENCE_TEST_KEYFILE"]
+  keyfile ||= ENV["VIDEO_INTELLIGENCE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["VIDEO_INTELLIGENCE_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["VIDEO_INTELLIGENCE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or VIDEO_INTELLIGENCE_TEST_PROJECT=test123 VIDEO_INTELLIGENCE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+  end
+  # clear any env var already set
+  require "google/cloud/video_intelligence/credentials"
+  (Google::Cloud::VideoIntelligence::Credentials::PATH_ENV_VARS +
+   Google::Cloud::VideoIntelligence::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
   end
   # always overwrite when running tests
   ENV["VIDEO_INTELLIGENCE_PROJECT"] = project

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -29,23 +29,32 @@ end
 desc "Run the vision acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
-  project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["VISION_TEST_PROJECT"]
+  project ||= ENV["VISION_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["VISION_TEST_KEYFILE"]
+  keyfile ||= ENV["VISION_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
-    keyfile ||= ENV["GCLOUD_TEST_KEYFILE_JSON"] || ENV["VISION_TEST_KEYFILE_JSON"]
+    keyfile ||= ENV["VISION_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or VISION_TEST_PROJECT=test123 VISION_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
+  # clear any env var already set
+  require "google/cloud/vision/credentials"
+  (Google::Cloud::Vision::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Vision::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
+  require "google/cloud/storage/credentials"
+  (Google::Cloud::Storage::Credentials::PATH_ENV_VARS +
+   Google::Cloud::Storage::Credentials::JSON_ENV_VARS).each do |path|
+    ENV[path] = nil
+  end
   # always overwrite when running tests
   ENV["VISION_PROJECT"] = project
-  ENV["VISION_KEYFILE"] = nil
   ENV["VISION_KEYFILE_JSON"] = keyfile
   ENV["STORAGE_PROJECT"] = project
-  ENV["STORAGE_KEYFILE"] = nil
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke


### PR DESCRIPTION
The service-specific env vars should be prioritized ahead of the shared env vars.