### PR TITLE
Alpha -> GA Overview for Datastore

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/overview.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Datastore API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Datastore API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Datastore API][Product Documentation]:
     # Accesses the schemaless NoSQL database to provide fully managed, robust,


### PR DESCRIPTION
Datastore is GA, but the Overview page states it's Alpha. Change is to update status.