### PR TITLE
Datastore Query+offset Pagination Fix

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -157,6 +157,7 @@ module Google
             return nil if end_cursor.nil?
             ensure_service!
             query.start_cursor = cursor.to_grpc # should always be a Cursor...
+            query.offset = 0 # Never carry an offset across batches
             query_res = service.run_query query, namespace
             self.class.from_grpc query_res, service, namespace, query
           end

--- a/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_offset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/query_results/all_with_offset_test.rb
@@ -14,13 +14,13 @@
 
 require "helper"
 
-describe Google::Cloud::Datastore::Dataset, :all_with_more, :mock_datastore do
-  let(:first_run_query) { Google::Cloud::Datastore::Query.new.kind("Task").to_grpc }
+describe Google::Cloud::Datastore::Dataset, :all_with_offset, :mock_datastore do
+  let(:first_run_query) { Google::Cloud::Datastore::Query.new.kind("Task").offset(5).to_grpc }
   let(:first_run_query_res) do
     run_query_res_entities = 25.times.map do |i|
       Google::Datastore::V1::EntityResult.new(
         entity: Google::Cloud::Datastore::Entity.new.tap do |e|
-          e.key = Google::Cloud::Datastore::Key.new "ds-test", 1000+i
+          e.key = Google::Cloud::Datastore::Key.new "ds-test", 1005+i
           e["name"] = "thingamajig"
         end.to_grpc,
         cursor: "result-cursor-1-#{i}".force_encoding("ASCII-8BIT")
@@ -43,7 +43,7 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more, :mock_datastore do
     run_query_res_entities = 25.times.map do |i|
       Google::Datastore::V1::EntityResult.new(
         entity: Google::Cloud::Datastore::Entity.new.tap do |e|
-          e.key = Google::Cloud::Datastore::Key.new "ds-test", 2000+i
+          e.key = Google::Cloud::Datastore::Key.new "ds-test", 2005+i
           e["name"] = "thingamajig"
         end.to_grpc,
         cursor: "result-cursor-2-#{i}".force_encoding("ASCII-8BIT")
@@ -69,7 +69,7 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more, :mock_datastore do
   end
 
   it "run will fulfill a query and can use the all and limit api calls" do
-    entities = dataset.run dataset.query("Task")
+    entities = dataset.run dataset.query("Task").offset(5)
     # set request_limit to 1 to only make one more request
     entities.all(request_limit: 1) do |entity|
       entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -77,13 +77,13 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more, :mock_datastore do
   end
 
   it "run will fulfill a query and can use the all as a lazy enumerator" do
-    entities = dataset.run dataset.query("Task")
+    entities = dataset.run dataset.query("Task").offset(5)
     # no request_limit set, enumerator should only make 2 total requests though
     entities.all.lazy.take(30).count.must_equal 30
   end
 
   it "run will fulfill a query and can use the all_with_cursor and limit api calls" do
-    entities = dataset.run dataset.query("Task")
+    entities = dataset.run dataset.query("Task").offset(5)
     # set request_limit to 1 to only make one more request
     entities.all_with_cursor(request_limit: 1) do |entity, cursor|
       entity.must_be_kind_of Google::Cloud::Datastore::Entity
@@ -92,8 +92,8 @@ describe Google::Cloud::Datastore::Dataset, :all_with_more, :mock_datastore do
   end
 
   it "run will fulfill a query and can use the all_with_cursor as a lazy enumerator" do
-    entities = dataset.run dataset.query("Task")
+    entities = dataset.run dataset.query("Task").offset(5)
     # no request_limit set, enumerator should only make 2 total requests though
-    entities.all_with_cursor.lazy.take(30).count.must_equal 30
+    entities.all_with_cursor.take(30).count.must_equal 30
   end
 end


### PR DESCRIPTION
This PR is to fix a bug that was discovered while researching #1922. The problem is that if a query is using `offset` without `limit`, so intending to skip forward in the query results, and the number of results span across multiple pagination batches, the `offset` is applied to each pagination batch. This is because query result pagination uses cursors, and `offset` is applied to the query _after_ the cursor.

To fix this, we should remove the `offset`value from the query when performing pagination.

I have demonstrated both the previous bad behavior and the corrected good behavior in my manual testing. This PR also adds a unit test that ensures that the `offset` value is removed when paging query results.