### PR TITLE
Remove some trailing whitespace

### DIFF
--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -2,10 +2,10 @@
 
 [Stackdriver Error Reporting](https://cloud.google.com/error-reporting/) counts,
 analyzes and aggregates errors raised in your running cloud services. A
-centralized error management interface displays the results with sorting 
-and filtering capabilities. A dedicated view shows the error details: time 
-chart, occurrences, affected user count, first and last seen dates and a 
-cleaned exception stack trace. Opt-in to receive email and mobile alerts on 
+centralized error management interface displays the results with sorting
+and filtering capabilities. A dedicated view shows the error details: time
+chart, occurrences, affected user count, first and last seen dates and a
+cleaned exception stack trace. Opt-in to receive email and mobile alerts on
 new errors.
 
 - [google-cloud-error_reporting API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-error_reporting/latest)
@@ -35,26 +35,26 @@ gem "google-cloud-error_reporting"
 $ bundle install
 ```
 
-Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes 
+Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes
 the `google-cloud-error_reporting` gem.
 
 ## Enable Stackdriver Error Reporting API
 
 The Stackdriver Error Reporting library needs the [Stackdriver Error
-Reporting API](https://console.cloud.google.com/apis/library/clouderrorreporting.googleapis.com) 
-to be enabled on your Google Cloud project. Make sure it's enabled if not 
+Reporting API](https://console.cloud.google.com/apis/library/clouderrorreporting.googleapis.com)
+to be enabled on your Google Cloud project. Make sure it's enabled if not
 already.
 
 ## Reporting errors in Rack-based frameworks
 
-The Stackdriver Error Reporting library for Ruby makes it easy to integrate 
-Stackdriver Error Reporting into popular Rack-based Ruby web frameworks such as 
-Ruby on Rails and Sinatra. When the library integration is enabled, it 
+The Stackdriver Error Reporting library for Ruby makes it easy to integrate
+Stackdriver Error Reporting into popular Rack-based Ruby web frameworks such as
+Ruby on Rails and Sinatra. When the library integration is enabled, it
 automatically reports exceptions captured from the application's Rack stack.
 
 ### With Ruby on Rails
 
-You can load the Railtie that comes with the library into your Ruby 
+You can load the Railtie that comes with the library into your Ruby
 on Rails application by explicitly requiring it during the application startup:
 
 ```ruby
@@ -62,12 +62,12 @@ on Rails application by explicitly requiring it during the application startup:
 require "google/cloud/error_reporting/rails"
 ```
 
-If you're using the `stackdriver` gem, it automatically loads the Railtie into 
+If you're using the `stackdriver` gem, it automatically loads the Railtie into
 your application when it starts.
 
 ### With other Rack-based frameworks
 
-Other Rack-based frameworks, such as Sinatra, can use the Rack Middleware 
+Other Rack-based frameworks, such as Sinatra, can use the Rack Middleware
 provided by the library:
 
 ```ruby
@@ -90,58 +90,58 @@ end
 
 ## Configuring the library
 
-You can customize the behavior of the Stackdriver Error Reporting library for 
-Ruby. See the [configuration guide](../stackdriver/docs/configuration.md) for a list 
+You can customize the behavior of the Stackdriver Error Reporting library for
+Ruby. See the [configuration guide](../stackdriver/docs/configuration.md) for a list
 of possible configuration options.
 
 ## Running on Google Cloud Platform
 
-The Stackdriver Error Reporting library for Ruby should work without you 
-manually providing authentication credentials for instances running on Google 
-Cloud Platform, as long as the Stackdriver Error Reporting API access scope is 
+The Stackdriver Error Reporting library for Ruby should work without you
+manually providing authentication credentials for instances running on Google
+Cloud Platform, as long as the Stackdriver Error Reporting API access scope is
 enabled on that instance.
 
 ### App Engine
 
-On Google App Engine, the Stackdriver Error Reporting API access scope is 
-enabled by default, and the Stackdriver Error Reporting library for Ruby can 
+On Google App Engine, the Stackdriver Error Reporting API access scope is
+enabled by default, and the Stackdriver Error Reporting library for Ruby can
 be used without providing credentials or a project ID.
 
 ### Container Engine
 
-On Google Container Engine, you must explicitly add the `cloud-platform` OAuth 
+On Google Container Engine, you must explicitly add the `cloud-platform` OAuth
 scope when creating the cluster:
 
 ```sh
 $ gcloud container clusters create example-cluster-name --scopes https://www.googleapis.com/auth/cloud-platform
 ```
 
-You may also do this through the Google Cloud Platform Console. Select 
+You may also do this through the Google Cloud Platform Console. Select
 **Enabled** in the **Cloud Platform** section of **Create a container cluster**.
 
 ### Compute Engine
 
-For Google Compute Engine instances, you must explicitly enable the 
-`cloud-platform` access scope for each instance. When you create a new instance 
-through the Google Cloud Platform Console, you can do this under Identity and 
-API access: Use the Compute Engine default service account and select "Allow 
+For Google Compute Engine instances, you must explicitly enable the
+`cloud-platform` access scope for each instance. When you create a new instance
+through the Google Cloud Platform Console, you can do this under Identity and
+API access: Use the Compute Engine default service account and select "Allow
 full access to all Cloud APIs" under Access scopes.
 
 ## Running locally and elsewhere
 
-To run the Stackdriver Error Reporting outside of Google Cloud Platform, you 
-must supply your GCP project ID and appropriate service account credentials 
-directly to the Stackdriver Error Reporting. This applies to running the 
-library on your own workstation, on your datacenter's computers, or on the VM 
-instances of another cloud provider. See the [Authentication 
+To run the Stackdriver Error Reporting outside of Google Cloud Platform, you
+must supply your GCP project ID and appropriate service account credentials
+directly to the Stackdriver Error Reporting. This applies to running the
+library on your own workstation, on your datacenter's computers, or on the VM
+instances of another cloud provider. See the [Authentication
 section](#authentication) for instructions on how to do so.
 
 ## Authentication
 
-The Instrumentation client and API use Service Account credentials to connect 
-to Google Cloud services. When running on Google Cloud Platform environments, 
-the credentials will be discovered automatically. When running on other 
-environments the Service Account credentials can be specified by providing in 
+The Instrumentation client and API use Service Account credentials to connect
+to Google Cloud services. When running on Google Cloud Platform environments,
+the credentials will be discovered automatically. When running on other
+environments the Service Account credentials can be specified by providing in
 several ways.
 
 The best way to provide authentication information if you're using Ruby on Rails
@@ -161,7 +161,7 @@ end
 
 Other Rack-based applications that are loading the Rack Middleware directly or
 using the manually reporting interface can leverage the configration interface:
- 
+
 ```ruby
 require "google/cloud/error_reporting"
 Google::Cloud.configure do |config|
@@ -174,8 +174,8 @@ Google::Cloud.configure do |config|
 end
 ```
 
-This library also supports the other authentication methods provided by the 
-`google-cloud-ruby` suite. Instructions and configuration options are covered 
+This library also supports the other authentication methods provided by the
+`google-cloud-ruby` suite. Instructions and configuration options are covered
 in the [Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-debugger/guides/authentication).
 
 ## Supported Ruby Versions
@@ -186,19 +186,19 @@ This library is supported on Ruby 2.0+.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-It is currently in major version zero (0.y.z), which means that anything may 
+It is currently in major version zero (0.y.z), which means that anything may
 change at any time and the public API should not be considered stable.
 
 ## Contributing
 
 Contributions to this library are always welcome and highly encouraged.
 
-See the 
-[Contributing Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/contributing) 
+See the
+[Contributing Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/contributing)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
-participating in this project you agree to abide by its terms. See 
+participating in this project you agree to abide by its terms. See
 [Code of Conduct](../CODE_OF_CONDUCT.md) for more information.
 
 ## License
@@ -208,9 +208,9 @@ This library is licensed under Apache 2.0. Full license text is available in
 
 ## Support
 
-Please 
+Please
 [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to 
-[ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) 
+Don't hesitate to
+[ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby)
 about the client or APIs on [StackOverflow](http://stackoverflow.com).
 

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -28,7 +28,7 @@ gem "google-cloud-logging"
 $ bundle install
 ```
 
-Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes 
+Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes
 the `google-cloud-logging` gem.
 
 ## Logging using client library
@@ -61,13 +61,13 @@ logging.write_entries entry
 
 ## Using Stackdriver Logging in frameworks
 
-The `google-cloud-logging` library provides framework integration for popular 
-Rack-based frameworks, such as Ruby on Rails and Sinatra, which sets the default 
+The `google-cloud-logging` library provides framework integration for popular
+Rack-based frameworks, such as Ruby on Rails and Sinatra, which sets the default
 Rack logger to an instance of the Stackdriver Logging logger.
 
 ### With Ruby on Rails
 
-You can load the Railtie that comes with the library into your Ruby 
+You can load the Railtie that comes with the library into your Ruby
 on Rails application by explicitly requiring it during the application startup:
 
 ```ruby
@@ -75,7 +75,7 @@ on Rails application by explicitly requiring it during the application startup:
 require "google/cloud/logging/rails"
 ```
 
-If you're using the `stackdriver` gem, it automatically loads the Railtie into 
+If you're using the `stackdriver` gem, it automatically loads the Railtie into
 your application when it starts.
 
 You'll be able to use Stackdriver logger through the standard Rails logger:
@@ -88,7 +88,7 @@ logger.warn "Hola Mundo"
 
 ### With other Rack-based frameworks
 
-Other Rack-based applications can use the Rack Middleware to replace the Rack 
+Other Rack-based applications can use the Rack Middleware to replace the Rack
 logger with the Stackdriver Logging logger:
 
 ```ruby
@@ -96,8 +96,8 @@ require "google/cloud/logging"
 use Google::Cloud::Logging::Middleware
 ```
 
-Once the Rack logger is set, some Rack-based frameworks, such as Ruby on Rails 
-and Sinatra, automatically initialize the default application logger to use the 
+Once the Rack logger is set, some Rack-based frameworks, such as Ruby on Rails
+and Sinatra, automatically initialize the default application logger to use the
 Rack logger:
 
 ```ruby
@@ -106,26 +106,26 @@ logger.warn "Hola Mundo"
 logger.error "Bonjour Monde"
 ```
 
-For other frameworks, consult the documentations on how to utilize the Rack 
+For other frameworks, consult the documentations on how to utilize the Rack
 logger.
 
 ### Configuring the framework integration
 
-You can customize the behavior of the Stackdriver Logging framework integration 
-for Ruby. See the [configuration guide](../stackdriver/configuration.md) for a 
+You can customize the behavior of the Stackdriver Logging framework integration
+for Ruby. See the [configuration guide](../stackdriver/configuration.md) for a
 list of possible configuration options.
 
 ## Authentication
 
-This library uses Service Account credentials to connect to Google Cloud 
-services. When running on Compute Engine the credentials will be discovered 
-automatically. When running on other environments the Service Account 
+This library uses Service Account credentials to connect to Google Cloud
+services. When running on Compute Engine the credentials will be discovered
+automatically. When running on other environments the Service Account
 credentials can be specified by providing in several ways.
 
-If you're using Ruby on Rails and the library's Rails integration feature, you 
-can provide the authentication parameters through the Rails configuration 
+If you're using Ruby on Rails and the library's Rails integration feature, you
+can provide the authentication parameters through the Rails configuration
 interface:
- 
+
 ```ruby
 # Add this to config/environments/*.rb
 Rails.application.configure do |config|
@@ -137,7 +137,7 @@ Rails.application.configure do |config|
   config.google_cloud.logging.keyfile    = "/path/to/key.json"
 end
 ```
-Other Rack-based applications that are loading the Rack Middleware directly can 
+Other Rack-based applications that are loading the Rack Middleware directly can
 use the configration interface:
 
 ```ruby
@@ -152,7 +152,7 @@ Google::Cloud.configure do |config|
 end
 ```
 
-See the [Authentication 
+See the [Authentication
 Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/guides/authentication).
 for more ways to authenticate the client library.
 

--- a/google-cloud-trace/README.md
+++ b/google-cloud-trace/README.md
@@ -1,11 +1,11 @@
 # google-cloud-trace
 
-[Stackdriver Trace](https://cloud.google.com/trace/) is a distributed tracing 
-system that collects latency data from your applications and displays it in the 
+[Stackdriver Trace](https://cloud.google.com/trace/) is a distributed tracing
+system that collects latency data from your applications and displays it in the
 Google Cloud Platform Console. You can track how requests propagate through your
-application and receive detailed near real-time performance insights. 
-Stackdriver Trace automatically analyzes all of your application's traces to 
-generate in-depth latency reports to surface performance degradations, and can 
+application and receive detailed near real-time performance insights.
+Stackdriver Trace automatically analyzes all of your application's traces to
+generate in-depth latency reports to surface performance degradations, and can
 capture traces from all of your VMs, containers, or Google App Engine projects.
 
 - [google-cloud-trace API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-trace/latest)
@@ -35,26 +35,26 @@ gem "google-cloud-trace"
 $ bundle install
 ```
 
-Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes 
+Alternatively, check out the [`stackdriver`](../stackdriver) gem that includes
 the `google-cloud-trace` gem.
 
 ## Enable Stackdriver Trace API
 
-The Stackdriver Trace library needs the [Stackdriver Trace 
-API](https://console.cloud.google.com/apis/library/cloudtrace.googleapis.com) 
-to be enabled on your Google Cloud project. Make sure it's enabled if not 
+The Stackdriver Trace library needs the [Stackdriver Trace
+API](https://console.cloud.google.com/apis/library/cloudtrace.googleapis.com)
+to be enabled on your Google Cloud project. Make sure it's enabled if not
 already.
 
 ## Tracing on Rack-based frameworks
 
-The Stackdriver Trace library for Ruby makes it easy to integrate Stackdriver 
-Trace into popular Rack-based Ruby web frameworks such as Ruby on Rails and 
-Sinatra. When the library integration is enabled, it automatically traces 
+The Stackdriver Trace library for Ruby makes it easy to integrate Stackdriver
+Trace into popular Rack-based Ruby web frameworks such as Ruby on Rails and
+Sinatra. When the library integration is enabled, it automatically traces
 incoming requests in the application.
 
 ### With Ruby on Rails
 
-You can load the Railtie that comes with the library into your Ruby 
+You can load the Railtie that comes with the library into your Ruby
 on Rails application by explicitly requiring it during the application startup:
 
 ```ruby
@@ -62,12 +62,12 @@ on Rails application by explicitly requiring it during the application startup:
 require "google/cloud/trace/rails"
 ```
 
-If you're using the `stackdriver` gem, it automatically loads the Railtie into 
+If you're using the `stackdriver` gem, it automatically loads the Railtie into
 your application when it starts.
 
 ### With other Rack-based frameworks
 
-Other Rack-based frameworks, such as Sinatra, can use the Rack Middleware 
+Other Rack-based frameworks, such as Sinatra, can use the Rack Middleware
 provided by the library:
 
 ```ruby
@@ -78,7 +78,7 @@ use Google::Cloud::Trace::Middleware
 ### Adding Custom Trace Spans
 
 The Stackdriver Trace Rack Middleware automatically creates a trace record for
-incoming requests. You can add additional custom trace spans within each 
+incoming requests. You can add additional custom trace spans within each
 request:
 
 ```ruby
@@ -93,26 +93,26 @@ end
 
 ### Configuring the library
 
-You can customize the behavior of the Stackdriver Trace library for Ruby. See 
-the [configuration guide](../stackdriver/configuration.md) for a list of 
+You can customize the behavior of the Stackdriver Trace library for Ruby. See
+the [configuration guide](../stackdriver/configuration.md) for a list of
 possible configuration options.
 
 ## Running on Google Cloud Platform
 
-The Stackdriver Trace library for Ruby should work without you manually 
-providing authentication credentials for instances running on Google Cloud 
-Platform, as long as the Stackdriver Trace API access scope is enabled on that 
+The Stackdriver Trace library for Ruby should work without you manually
+providing authentication credentials for instances running on Google Cloud
+Platform, as long as the Stackdriver Trace API access scope is enabled on that
 instance.
 
 ### App Engine
 
-On Google App Engine, the Stackdriver Trace API access scope is enabled by 
-default, and the Stackdriver Trace library for Ruby can be used without 
+On Google App Engine, the Stackdriver Trace API access scope is enabled by
+default, and the Stackdriver Trace library for Ruby can be used without
 providing credentials or a project ID
 
 ### Container Engine
 
-On Google Container Engine, you must explicitly add the `trace.append` OAuth 
+On Google Container Engine, you must explicitly add the `trace.append` OAuth
 scope when creating the cluster:
 
 ```sh
@@ -121,32 +121,32 @@ $ gcloud container clusters create example-cluster-name --scopes https://www.goo
 
 ### Compute Engine
 
-For Google Compute Engine instances, you need to explicitly enable the 
-`trace.append` Stackdriver Trace API access scope for each instance. When 
-creating a new instance through the Google Cloud Platform Console, you can do 
-this under Identity and API access: Use the Compute Engine default service 
+For Google Compute Engine instances, you need to explicitly enable the
+`trace.append` Stackdriver Trace API access scope for each instance. When
+creating a new instance through the Google Cloud Platform Console, you can do
+this under Identity and API access: Use the Compute Engine default service
 account and select "Allow full access to all Cloud APIs" under Access scopes.
 
-To use something other than the Compute Engine default service account see the 
-docs for Creating and Enabling Service Accounts for Instances and the Running 
+To use something other than the Compute Engine default service account see the
+docs for Creating and Enabling Service Accounts for Instances and the Running
 elsewhere section below. The important thing is that the service account you use
 has the Cloud Trace Agent role.
 
 ## Running locally and elsewhere
 
-To run the Stackdriver Trace outside of Google Cloud Platform, you must supply 
+To run the Stackdriver Trace outside of Google Cloud Platform, you must supply
 your GCP project ID and appropriate service account credentials directly to the
-Stackdriver Trace. This applies to running the library on your own workstation, 
-on your datacenter's computers, or on the VM instances of another cloud 
-provider. See the [Authentication section](#authentication) for instructions on 
+Stackdriver Trace. This applies to running the library on your own workstation,
+on your datacenter's computers, or on the VM instances of another cloud
+provider. See the [Authentication section](#authentication) for instructions on
 how to do so.
 
 ## Authentication
 
-The Instrumentation client and API use Service Account credentials to connect 
-to Google Cloud services. When running on Google Cloud Platform environments, 
-the credentials will be discovered automatically. When running on other 
-environments the Service Account credentials can be specified by providing in 
+The Instrumentation client and API use Service Account credentials to connect
+to Google Cloud services. When running on Google Cloud Platform environments,
+the credentials will be discovered automatically. When running on other
+environments the Service Account credentials can be specified by providing in
 several ways.
 
 The best way to provide authentication information if you're using Ruby on Rails
@@ -166,7 +166,7 @@ end
 
 Other Rack-based applications that are loading the Rack Middleware directly can use
 the configration interface:
- 
+
 ```ruby
 require "google/cloud/trace"
 Google::Cloud.configure do |config|
@@ -179,8 +179,8 @@ Google::Cloud.configure do |config|
 end
 ```
 
-This library also supports the other authentication methods provided by the 
-`google-cloud-ruby` suite. Instructions and configuration options are covered 
+This library also supports the other authentication methods provided by the
+`google-cloud-ruby` suite. Instructions and configuration options are covered
 in the [Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-trace/guides/authentication).
 
 ## Supported Ruby Versions
@@ -191,19 +191,19 @@ This library is supported on Ruby 2.0+.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-It is currently in major version zero (0.y.z), which means that anything may 
+It is currently in major version zero (0.y.z), which means that anything may
 change at any time and the public API should not be considered stable.
 
 ## Contributing
 
 Contributions to this library are always welcome and highly encouraged.
 
-See the 
-[Contributing Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/contributing) 
+See the
+[Contributing Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/contributing)
 for more information on how to get started.
 
 Please note that this project is released with a Contributor Code of Conduct. By
-participating in this project you agree to abide by its terms. See 
+participating in this project you agree to abide by its terms. See
 [Code of Conduct](../CODE_OF_CONDUCT.md) for more information.
 
 ## License
@@ -213,8 +213,8 @@ This library is licensed under Apache 2.0. Full license text is available in
 
 ## Support
 
-Please 
+Please
 [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
-Don't hesitate to 
-[ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby) 
+Don't hesitate to
+[ask questions](http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby)
 about the client or APIs on [StackOverflow](http://stackoverflow.com).


### PR DESCRIPTION
This just removes a bunch of trailing spaces that were bugging me in the READMEs for `error_reporting`, `logging`, and `trace`. No other content changes.