### PR TITLE
Minor fixes to stackdriver README

### DIFF
--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -100,12 +100,11 @@ send data.
     # In your app initialization code
     Google::Cloud.configure do |config|
       config.project_id = "your-project-id"
-      config.keyfile = "/path/to/servce-account-keyfile.json"
+      config.credentials = "/path/to/servce-account-keyfile.json"
     end
     ```
 
-For more information, consult the
-[Authentication Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-debugger/guides/authentication).
+See the individual gem documentation for each gem for more information.
 
 ## Compatibility
 

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -104,7 +104,7 @@ send data.
     end
     ```
 
-See the individual gem documentation for each gem for more information.
+See the gem documentation for each individual gem for more information.
 
 ## Compatibility
 


### PR DESCRIPTION
* Fix an example to use `credentials` config key in preference over `keyfile`.
* Don't reference the debugger authentication guide specifically from here.
