### PR TITLE
Restore a bunch of allow_nils for deferred config values

### DIFF
--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -126,10 +126,11 @@ Google::Cloud.configure.add_config! :bigquery do |config|
     )
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :retries, nil, match: Integer

--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -111,7 +111,7 @@ Google::Cloud.configure do |config|
       "GCLOUD_KEYFILE", "GCLOUD_KEYFILE_JSON"
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds, match: Object
   config.add_alias! :keyfile, :credentials

--- a/google-cloud-datastore/lib/google-cloud-datastore.rb
+++ b/google-cloud-datastore/lib/google-cloud-datastore.rb
@@ -141,13 +141,15 @@ Google::Cloud.configure.add_config! :datastore do |config|
     ENV["DATASTORE_EMULATOR_HOST"]
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer
   config.add_field! :client_config, nil, match: Hash
-  config.add_field! :emulator_host, default_emulator, match: String
+  config.add_field! :emulator_host, default_emulator,
+                    match: String, allow_nil: true
 end

--- a/google-cloud-debugger/lib/google-cloud-debugger.rb
+++ b/google-cloud-debugger/lib/google-cloud-debugger.rb
@@ -160,13 +160,16 @@ Google::Cloud.configure.add_config! :debugger do |config|
     ENV["DEBUGGER_SERVICE_VERSION"]
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
-  config.add_field! :service_name, default_service, match: String
-  config.add_field! :service_version, default_version, match: String
+  config.add_field! :service_name, default_service,
+                    match: String, allow_nil: true
+  config.add_field! :service_version, default_version,
+                    match: String, allow_nil: true
   config.add_field! :app_root, nil, match: String
   config.add_field! :root, nil, match: String
   config.add_field! :scope, nil, match: [String, Array]

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -98,17 +98,17 @@ module Google
         # already.
         #
         def load_config **kwargs
-          configuration.project_id = kwargs[:project] ||
-                                     kwargs[:project_id] ||
-                                     configuration.project_id
-          configuration.credentials = kwargs[:credentials] ||
-                                      kwargs[:keyfile] ||
-                                      configuration.credentials
+          project_id = kwargs[:project] || kwargs[:project_id]
+          configuration.project_id = project_id unless project_id.nil?
 
-          configuration.service_name = kwargs[:service_name] ||
-                                       configuration.service_name
-          configuration.service_version = kwargs[:service_version] ||
-                                          configuration.service_version
+          creds = kwargs[:credentials] || kwargs[:keyfile]
+          configuration.credentials = creds unless creds.nil?
+
+          service_name = kwargs[:service_name]
+          configuration.service_name = service_name unless service_name.nil?
+
+          service_vers = kwargs[:service_version]
+          configuration.service_version = service_vers unless service_vers.nil?
 
           init_default_config
         end

--- a/google-cloud-dns/lib/google-cloud-dns.rb
+++ b/google-cloud-dns/lib/google-cloud-dns.rb
@@ -123,10 +123,11 @@ Google::Cloud.configure.add_config! :dns do |config|
     )
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :retries, nil, match: Integer

--- a/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
@@ -148,15 +148,18 @@ Google::Cloud.configure.add_config! :error_reporting do |config|
     ENV["ERROR_REPORTING_VERSION"]
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer
   config.add_field! :client_config, nil, match: Hash
-  config.add_field! :service_name, default_service, match: String
-  config.add_field! :service_version, default_version, match: String
+  config.add_field! :service_name, default_service,
+                    match: String, allow_nil: true
+  config.add_field! :service_version, default_version,
+                    match: String, allow_nil: true
   config.add_field! :ignore_classes, nil, match: Array
 end

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -154,18 +154,20 @@ module Google
         # already.
         #
         def load_config **kwargs
-          configuration.project_id = kwargs[:project_id] ||
-                                     kwargs[:project] ||
-                                     configuration.project_id
-          configuration.credentials = kwargs[:credentials] ||
-                                      kwargs[:keyfile] ||
-                                      configuration.credentials
-          configuration.service_name = kwargs[:service_name] ||
-                                       configuration.service_name
-          configuration.service_version = kwargs[:service_version] ||
-                                          configuration.service_version
-          configuration.ignore_classes = kwargs[:ignore_classes] ||
-                                         configuration.ignore_classes
+          project_id = kwargs[:project] || kwargs[:project_id]
+          configuration.project_id = project_id unless project_id.nil?
+
+          creds = kwargs[:credentials] || kwargs[:keyfile]
+          configuration.credentials = creds unless creds.nil?
+
+          service_name = kwargs[:service_name]
+          configuration.service_name = service_name unless service_name.nil?
+
+          service_vers = kwargs[:service_version]
+          configuration.service_version = service_vers unless service_vers.nil?
+
+          ignores = kwargs[:ignore_classes]
+          configuration.ignore_classes = ignores unless ignores.nil?
 
           init_default_config
         end

--- a/google-cloud-firestore/lib/google-cloud-firestore.rb
+++ b/google-cloud-firestore/lib/google-cloud-firestore.rb
@@ -119,10 +119,11 @@ Google::Cloud.configure.add_config! :firestore do |config|
     )
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer

--- a/google-cloud-logging/lib/google-cloud-logging.rb
+++ b/google-cloud-logging/lib/google-cloud-logging.rb
@@ -139,10 +139,11 @@ Google::Cloud.configure.add_config! :logging do |config|
     )
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -260,14 +260,14 @@ module Google
         # already.
         #
         def load_config **kwargs
-          configuration.project_id = kwargs[:project_id] ||
-                                     kwargs[:project] ||
-                                     configuration.project_id
-          configuration.credentials = kwargs[:credentials] ||
-                                      kwargs[:keyfile] ||
-                                      configuration.credentials
-          configuration.log_name_map ||= kwargs[:log_name_map] ||
-                                         configuration.log_name_map
+          project_id = kwargs[:project] || kwargs[:project_id]
+          configuration.project_id = project_id unless project_id.nil?
+
+          creds = kwargs[:credentials] || kwargs[:keyfile]
+          configuration.credentials = creds unless creds.nil?
+
+          log_name_map = kwargs[:log_name_map]
+          configuration.log_name_map = log_name_map unless log_name_map.nil?
 
           init_default_config
         end

--- a/google-cloud-pubsub/lib/google-cloud-pubsub.rb
+++ b/google-cloud-pubsub/lib/google-cloud-pubsub.rb
@@ -128,13 +128,15 @@ Google::Cloud.configure.add_config! :pubsub do |config|
     ENV["PUBSUB_EMULATOR_HOST"]
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer
   config.add_field! :client_config, nil, match: Hash
-  config.add_field! :emulator_host, default_emulator, match: String
+  config.add_field! :emulator_host, default_emulator,
+                    match: String, allow_nil: true
 end

--- a/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
@@ -121,7 +121,8 @@ Google::Cloud.configure.add_config! :resource_manager do |config|
   end
 
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :retries, nil, match: Integer

--- a/google-cloud-spanner/lib/google-cloud-spanner.rb
+++ b/google-cloud-spanner/lib/google-cloud-spanner.rb
@@ -122,10 +122,11 @@ Google::Cloud.configure.add_config! :spanner do |config|
     )
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer

--- a/google-cloud-speech/lib/google-cloud-speech.rb
+++ b/google-cloud-speech/lib/google-cloud-speech.rb
@@ -130,10 +130,11 @@ Google::Cloud.configure.add_config! :speech do |config|
     )
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer

--- a/google-cloud-storage/lib/google-cloud-storage.rb
+++ b/google-cloud-storage/lib/google-cloud-storage.rb
@@ -129,10 +129,11 @@ Google::Cloud.configure.add_config! :storage do |config|
     )
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :retries, nil, match: Integer

--- a/google-cloud-trace/lib/google-cloud-trace.rb
+++ b/google-cloud-trace/lib/google-cloud-trace.rb
@@ -127,10 +127,11 @@ Google::Cloud.configure.add_config! :trace do |config|
     )
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -364,12 +364,14 @@ module Google
         # already.
         #
         def load_config **kwargs
-          configuration.capture_stack = kwargs[:capture_stack] ||
-                                        configuration.capture_stack
-          configuration.sampler = kwargs[:sampler] ||
-                                  configuration.sampler
-          configuration.span_id_generator = kwargs[:span_id_generator] ||
-                                            configuration.span_id_generator
+          capture_stack = kwargs[:capture_stack]
+          configuration.capture_stack = capture_stack unless capture_stack.nil?
+
+          sampler = kwargs[:sampler]
+          configuration.sampler = sampler unless sampler.nil?
+
+          generator = kwargs[:span_id_generator]
+          configuration.span_id_generator = generator unless generator.nil?
 
           init_default_config
         end

--- a/google-cloud-translate/lib/google-cloud-translate.rb
+++ b/google-cloud-translate/lib/google-cloud-translate.rb
@@ -158,12 +158,13 @@ Google::Cloud.configure.add_config! :translate do |config|
     ENV["TRANSLATE_KEY"] || ENV["GOOGLE_CLOUD_KEY"]
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
-  config.add_field! :key, default_key, match: String
+  config.add_field! :key, default_key, match: String, allow_nil: true
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :retries, nil, match: Integer
   config.add_field! :timeout, nil, match: Integer

--- a/google-cloud-vision/lib/google-cloud-vision.rb
+++ b/google-cloud-vision/lib/google-cloud-vision.rb
@@ -124,10 +124,11 @@ Google::Cloud.configure.add_config! :vision do |config|
     )
   end
 
-  config.add_field! :project_id, default_project, match: String
+  config.add_field! :project_id, default_project, match: String, allow_nil: true
   config.add_alias! :project, :project_id
   config.add_field! :credentials, default_creds,
-                    match: [String, Hash, Google::Auth::Credentials]
+                    match: [String, Hash, Google::Auth::Credentials],
+                    allow_nil: true
   config.add_alias! :keyfile, :credentials
   config.add_field! :scope, nil, match: [String, Array]
   config.add_field! :timeout, nil, match: Integer


### PR DESCRIPTION
I noticed a bunch of warnings due to `nil`s being set in the configs where we switched to the deferred mechanism. This was because the config mechanism could no longer detect automatically whether `nil` was a valid value, so it defaulted to not allowing `nil`. These are nillable fields because the defaults could end up being `nil` if the environment variables are not set, so I went through and explicitly allowed `nil` for these fields.
