### PR TITLE
Remove references to unused source-contexts.json file

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/debuggee.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/debuggee.rb
@@ -134,12 +134,8 @@ module Google
           debuggee_args[:id] = id if id
 
           source_context = read_app_json_file "source-context.json"
-          debuggee_args[:source_contexts] = [source_context] if source_context
-
-          source_contexts = read_app_json_file "source-contexts.json"
-          if source_contexts
-            debuggee_args[:ext_source_contexts] = source_contexts
-          elsif source_context
+          if source_context
+            debuggee_args[:source_contexts] = [source_context]
             debuggee_args[:ext_source_contexts] = [{ context: source_context }]
           end
 


### PR DESCRIPTION
This is a request from the cloud debugger team. The "source-contexts.json" (plural) file was never actually needed, and is no longer generated by the gcloud SDK, and was never documented by the cloud debugger team either. They'd like us not to reference it, to avoid future confusion.
