### PR TITLE
Fix unit tests when running on a GCE VM

### DIFF
--- a/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
@@ -73,7 +73,8 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
       config.sampler = sampler
       config.span_id_generator = mock_span_id_generator
     end
-    Google::Cloud::Trace::Middleware.new base_app
+    tracer.service.mocked_lowlevel_client = Minitest::Mock.new
+    Google::Cloud::Trace::Middleware.new base_app, service: tracer.service
   }
 
   before do
@@ -120,7 +121,8 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
     it "creates a default AsyncReporter if service isn't passed in" do
       Google::Cloud::Trace.configure.project_id = "test"
       Google::Cloud::Trace.stub :new, OpenStruct.new(service: nil) do
-        base_middleware.instance_variable_get(:@service).must_be_kind_of Google::Cloud::Trace::AsyncReporter
+        middleware = Google::Cloud::Trace::Middleware.new base_app, credentials: credentials
+        middleware.instance_variable_get(:@service).must_be_kind_of Google::Cloud::Trace::AsyncReporter
       end
     end
   end

--- a/google-cloud-translate/test/google/cloud/translate_test.rb
+++ b/google-cloud-translate/test/google/cloud/translate_test.rb
@@ -539,7 +539,6 @@ describe Google::Cloud do
       }
       stubbed_service = ->(project, credentials, scope: nil, key: nil, retries: nil, timeout: nil) {
         key.must_equal "this-is-the-api-key"
-        project.must_be :empty?
         credentials.must_be :nil?
         scope.must_be :nil?
         retries.must_be :nil?
@@ -560,7 +559,6 @@ describe Google::Cloud do
               Google::Cloud::Translate::Service.stub :new, stubbed_service do
                 translate = Google::Cloud::Translate.new
                 translate.must_be_kind_of Google::Cloud::Translate::Api
-                translate.project.must_be :empty?
                 translate.service.must_be_kind_of OpenStruct
               end
             end


### PR DESCRIPTION
If your dev environment is a GCE VM (as mine is as of a couple days ago), the credentials environment is a bit different because a GCE metadata server exists. This PR insulates a few unit tests that were broken in that environment. Specifically:
* Several trace tests were actually getting default credentials when they didn't need to. This was failing on a GCE VM. Stubbed out those credentials.
* A translate test was checking for an empty project when it didn't need to. This was failing on a GCE VM because there exists an ambient project. Removed those checks.
