### PR TITLE
Add missing libraries to top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This client supports the following Google Cloud Platform services at a [Beta](#v
 This client supports the following Google Cloud Platform services at an [Alpha](#versioning) quality level:
 
 * [Container Engine](#container-engine-alpha) (Alpha)
+* [Cloud Dataproc](#cloud-dataproc-alpha) (Alpha)
 * [Cloud DNS](#cloud-dns-alpha) (Alpha)
 * [Cloud Natural Language API](#cloud-natural-language-api-alpha) (Alpha)
 * [Cloud Resource Manager](#cloud-resource-manager-alpha) (Alpha)
@@ -223,6 +224,42 @@ cluster_manager_client = Google::Cloud::Container.new
 project_id_2 = project_id
 zone = "us-central1-a"
 response = cluster_manager_client.list_clusters(project_id_2, zone)
+```
+
+### Cloud Dataproc (Alpha)
+
+- [google-cloud-dataproc README](google-cloud-dataproc/README.md)
+- [google-cloud-dataproc API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-dataproc/latest)
+- [google-cloud-dataproc on RubyGems](https://rubygems.org/gems/google-cloud-dataproc)
+- [Google Cloud Dataproc documentation](https://cloud.google.com/dataproc/docs)
+
+#### Quick Start
+
+```sh
+$ gem install google-cloud-dataproc
+```
+
+#### Preview
+
+```ruby
+require "google/cloud/dataproc"
+
+cluster_controller_client = Google::Cloud::Dataproc::ClusterController.new
+project_id_2 = project_id
+region = "global"
+
+# Iterate over all results.
+cluster_controller_client.list_clusters(project_id_2, region).each do |element|
+  # Process element.
+end
+
+# Or iterate over results one page at a time.
+cluster_controller_client.list_clusters(project_id_2, region).each_page do |page|
+  # Process each page at a time.
+  page.each do |element|
+    # Process element.
+  end
+end
 ```
 
 ### Stackdriver Error Reporting (Beta)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This client supports the following Google Cloud Platform services at an [Alpha](
 * [Data Loss Prevention](#data-loss-prevention-alpha) (Alpha)
 * [Cloud DNS](#cloud-dns-alpha) (Alpha)
 * [Cloud Natural Language API](#cloud-natural-language-api-alpha) (Alpha)
+* [Cloud OS Login](#cloud-os-login-alpha) (Alpha)
 * [Cloud Resource Manager](#cloud-resource-manager-alpha) (Alpha)
 * [Cloud Speech API](#cloud-speech-api-alpha) (Alpha)
 * [Cloud Vision API](#cloud-vision-api-alpha) (Alpha)
@@ -424,6 +425,19 @@ annotation.sentiment.score #=> 0.10000000149011612
 annotation.sentiment.magnitude #=> 1.100000023841858
 annotation.sentences.count #=> 2
 annotation.tokens.count #=> 13
+```
+
+### Cloud OS Login (Alpha)
+
+- [google-cloud-os_login README](google-cloud-os_login/README.md)
+- [google-cloud-os_login API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-os_login/latest)
+- [google-cloud-os_login on RubyGems](https://rubygems.org/gems/google-cloud-os_login)
+- [Google Cloud DNS documentation](https://cloud.google.com/compute/docs/oslogin/rest/)
+
+#### Quick Start
+
+```sh
+$ gem install google-cloud-os_login
 ```
 
 ### Cloud Pub/Sub (Beta)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This client supports the following Google Cloud Platform services at a [Beta](#v
 
 This client supports the following Google Cloud Platform services at an [Alpha](#versioning) quality level:
 
+* [Container Engine](#container-engine-alpha) (Alpha)
 * [Cloud DNS](#cloud-dns-alpha) (Alpha)
 * [Cloud Natural Language API](#cloud-natural-language-api-alpha) (Alpha)
 * [Cloud Resource Manager](#cloud-resource-manager-alpha) (Alpha)
@@ -198,6 +199,30 @@ change = zone.update do |tx|
   end
 end
 
+```
+
+### Container Engine (Alpha)
+
+- [google-cloud-container README](google-cloud-container/README.md)
+- [google-cloud-container API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-container/latest)
+- [google-cloud-container on RubyGems](https://rubygems.org/gems/google-cloud-container)
+- [Container Engine documentation](https://cloud.google.com/kubernetes-engine/docs/)
+
+#### Quick Start
+
+```sh
+$ gem install google-cloud-container
+```
+
+#### Preview
+
+```ruby
+require "google/cloud/container"
+
+cluster_manager_client = Google::Cloud::Container.new
+project_id_2 = project_id
+zone = "us-central1-a"
+response = cluster_manager_client.list_clusters(project_id_2, zone)
 ```
 
 ### Stackdriver Error Reporting (Beta)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This client supports the following Google Cloud Platform services at an [Alpha](
 
 * [Container Engine](#container-engine-alpha) (Alpha)
 * [Cloud Dataproc](#cloud-dataproc-alpha) (Alpha)
+* [Data Loss Prevention](#data-loss-prevention-alpha) (Alpha)
 * [Cloud DNS](#cloud-dns-alpha) (Alpha)
 * [Cloud Natural Language API](#cloud-natural-language-api-alpha) (Alpha)
 * [Cloud Resource Manager](#cloud-resource-manager-alpha) (Alpha)
@@ -260,6 +261,34 @@ cluster_controller_client.list_clusters(project_id_2, region).each_page do |page
     # Process element.
   end
 end
+```
+
+### Data Loss Prevention (Alpha)
+
+- [google-cloud-dlp README](google-cloud-dlp/README.md)
+- [google-cloud-dlp API documentation](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-dlp/latest)
+- [google-cloud-dlp on RubyGems](https://rubygems.org/gems/google-cloud-dlp)
+- [Data Loss Prevention documentation](https://cloud.google.com/dlp/docs)
+
+#### Quick Start
+
+```sh
+$ gem install google-cloud-dlp
+```
+
+#### Preview
+
+```ruby
+require "google/cloud/dlp"
+
+dlp_service_client = Google::Cloud::Dlp.new
+min_likelihood = :POSSIBLE
+inspect_config = { min_likelihood: min_likelihood }
+type = "text/plain"
+value = "my phone number is 215-512-1212"
+items_element = { type: type, value: value }
+items = [items_element]
+response = dlp_service_client.inspect_content(inspect_config, items)
 ```
 
 ### Stackdriver Error Reporting (Beta)


### PR DESCRIPTION
This PR adds the following libraries to the top-level README:

* Container Engine - Alpha
* Dataproc - Alpha
* DLP - Alpha
* OS Login - Alpha

[closes #1947]