### PR TITLE
BigQuery Insert Performance Tuning

### DIFF
--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -115,12 +115,21 @@ namespace :acceptance do
   end
 end
 
-desc "Run benchmark script."
-task :benchmark, :queries do |t, args|
-  queries = args[:queries]
-  queries ||= "benchmark/queries.json"
+namespace :benchmark do
+  desc "Run queries benchmark script."
+  task :queries, :query_file do |t, args|
+    query_file = args[:query_file]
+    query_file ||= "benchmark/queries.json"
 
-  sh "bundle exec ruby benchmark/benchmark.rb #{queries}"
+    sh "bundle exec ruby benchmark/benchmark.rb #{query_file}"
+  end
+
+  desc "Run inserts benchmark script."
+  task :inserts, :insert_count do |t, args|
+    insert_count = args[:insert_count]
+
+    sh "bundle exec ruby benchmark/inserts.rb #{insert_count}"
+  end
 end
 
 desc "Run yard-doctest example tests."

--- a/google-cloud-bigquery/benchmark/README.md
+++ b/google-cloud-bigquery/benchmark/README.md
@@ -2,7 +2,16 @@
 This directory contains benchmarks for BigQuery client.
 
 ## Usage
+
+### Queries
+
 `BIGQUERY_PROJECT=<your project id> ruby benchmark/benchmark.rb benchmark/queries.json`
 
 BigQuery service caches requests so the benchmark should be run
 at least twice, disregarding the first result.
+
+### Inserts
+
+`BIGQUERY_PROJECT=<project-id> ruby benchmark/inserts.rb <insert-count>`
+
+Both synchronous and asynchronous inserts are performed and benchmarked.

--- a/google-cloud-bigquery/benchmark/inserts.rb
+++ b/google-cloud-bigquery/benchmark/inserts.rb
@@ -1,0 +1,85 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/bigquery"
+require "benchmark"
+require "securerandom"
+require "time"
+require "date"
+
+if ARGV.length < 1
+  puts "usage: BIGQUERY_PROJECT=<project-id> ruby benchmark/inserts.rb 2000"
+  exit 1
+end
+
+def ensure_dataset bigquery
+  dataset = bigquery.dataset "insert_bench"
+  dataset ||= bigquery.create_dataset "insert_bench"
+  dataset
+end
+
+def ensure_table dataset
+  table = dataset.table "insert_table"
+  table ||= dataset.create_table "insert_table" do |schema|
+    schema.string "name"
+    schema.integer "age"
+    schema.float "score"
+    schema.boolean "active"
+    schema.bytes "avatar"
+    schema.timestamp "started_at"
+    schema.time "duration"
+    schema.datetime "target_end"
+    schema.date "birthday"
+  end
+  table
+end
+
+def random_row bigquery
+  {
+    name: SecureRandom.hex(rand(20..40)),
+    age: rand(20..80),
+    score: rand(0.0..100.0),
+    active: rand(2).zero?,
+    avatar: StringIO.new(SecureRandom.hex(rand(200..400))),
+    started_at: Time.now - rand(1000),
+    duration: bigquery.time(rand(24), rand(60), rand(60)),
+    target_end: (Time.now - rand(1000)).to_datetime,
+    birthday: Date.today - rand(1000..10000)
+  }
+end
+
+bigquery = Google::Cloud::Bigquery.new
+insert_count = Integer(ARGV[0] || 1000)
+insert_rows = Array.new(insert_count) do |i|
+  random_row bigquery
+end
+dataset = ensure_dataset bigquery
+table = ensure_table dataset
+inserter = table.insert_async max_rows: insert_count
+
+puts "*"*56
+puts "  Insert benchmark for #{insert_count} rows:"
+puts "*"*56
+puts ""
+
+Benchmark.bm(10) do |x|
+  x.report "direct:" do
+    table.insert insert_rows
+  end
+
+  x.report "async:" do
+    inserter.insert insert_rows
+    inserter.stop.wait!
+  end
+end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -201,10 +201,17 @@ module Google
         end
 
         def insert_tabledata dataset_id, table_id, rows, options = {}
-          insert_rows = Array(rows).map do |row|
+          json_rows = Array(rows).map { |row| Convert.to_json_row row }
+
+          insert_tabledata_json_rows dataset_id, table_id, json_rows, options
+        end
+
+        def insert_tabledata_json_rows dataset_id, table_id, json_rows,
+                                       options = {}
+          insert_rows = Array(json_rows).map do |json_row|
             {
               insertId: SecureRandom.uuid,
-              json: Convert.to_json_row(row)
+              json: json_row
             }
           end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -202,21 +202,23 @@ module Google
 
         def insert_tabledata dataset_id, table_id, rows, options = {}
           insert_rows = Array(rows).map do |row|
-            Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
-              insert_id: SecureRandom.uuid,
+            {
+              insertId: SecureRandom.uuid,
               json: Convert.to_json_row(row)
-            )
+            }
           end
-          insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
+
+          insert_req = {
             rows: insert_rows,
-            ignore_unknown_values: options[:ignore_unknown],
-            skip_invalid_rows: options[:skip_invalid]
-          )
+            ignoreUnknownValues: options[:ignore_unknown],
+            skipInvalidRows: options[:skip_invalid]
+          }.to_json
 
           # The insertAll with insertId operation is considered idempotent
           execute backoff: true do
             service.insert_all_table_data(
-              @project, dataset_id, table_id, insert_req
+              @project, dataset_id, table_id, insert_req,
+              options: { skip_serialization: true }
             )
           end
         end

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -292,7 +292,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
       mock.expect :insert_all_table_data,
                   Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(insert_errors: []),
-                  ["my-project", "my_dataset", "my_table", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+                  ["my-project", "my_dataset", "my_table", String, Hash]
     end
   end
 
@@ -374,7 +374,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
       mock.expect :insert_all_table_data,
                   Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(insert_errors: []),
-                  ["my-project", "my_dataset", "my_table", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+                  ["my-project", "my_dataset", "my_table", String, Hash]
     end
   end
 
@@ -585,7 +585,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project", "my_dataset", "my_table", Hash]
       mock.expect :insert_all_table_data,
                   Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(insert_errors: []),
-                  ["my-project", "my_dataset", "my_table", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+                  ["my-project", "my_dataset", "my_table", String, Hash]
     end
   end
 
@@ -647,7 +647,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
       mock.expect :insert_all_table_data,
                   Google::Apis::BigqueryV2::InsertAllTableDataResponse.new(insert_errors: []),
-                  ["my-project", "my_dataset", "my_table", Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+                  ["my-project", "my_dataset", "my_table", String, Hash]
     end
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_async_test.rb
@@ -31,20 +31,21 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
                 {"name"=>"Sally", "age"=>nil, "score"=>nil, "active"=>nil}] }
   let(:insert_id) { "abc123" }
   let(:insert_rows) { rows.map do |row|
-                        Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
-                          insert_id: insert_id,
+                        {
+                          insertId: insert_id,
                           json: row
-                        )
+                        }
                       end }
   let(:success_table_insert_gapi) { Google::Apis::BigqueryV2::InsertAllTableDataResponse.new insert_errors: [] }
 
   it "inserts one row" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: [insert_rows.first], ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: [insert_rows.first], ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [project, dataset_id, table_id, insert_req]
+      [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     inserter = dataset.insert_async table_id
@@ -75,11 +76,12 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
     it "inserts one row" do
       mock = Minitest::Mock.new
-      insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-        rows: [insert_rows.first], ignore_unknown_values: nil, skip_invalid_rows: nil)
+      insert_req = {
+        rows: [insert_rows.first], ignoreUnknownValues: nil, skipInvalidRows: nil
+      }.to_json
       mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
       mock.expect :insert_all_table_data, success_table_insert_gapi,
-        [project, dataset_id, table_id, insert_req]
+        [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
       dataset.service.mocked_service = mock
 
       inserter = dataset.insert_async table_id
@@ -108,11 +110,12 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
   it "inserts three rows at the same time" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [project, dataset_id, table_id, insert_req]
+      [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     inserter = dataset.insert_async table_id
@@ -140,11 +143,12 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
   it "inserts three rows one at a time" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [project, dataset_id, table_id, insert_req]
+      [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     inserter = dataset.insert_async table_id
@@ -174,11 +178,12 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
 
   it "inserts rows with a callback" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [project, dataset_id, table_id, insert_req]
+      [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     callback_called = false
@@ -228,11 +233,11 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
     mock = Minitest::Mock.new
     mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
     # It makes two requests, but we can't control what order they occur.
-    # So only specify that two InsertAllTableDataRequests are made.
+    # So only specify that two requests are made.
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [project, dataset_id, table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+      [project, dataset_id, table_id, String, Hash]
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [project, dataset_id, table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+      [project, dataset_id, table_id, String, Hash]
     dataset.service.mocked_service = mock
 
     callbacks = 0
@@ -267,11 +272,11 @@ describe Google::Cloud::Bigquery::Dataset, :insert_async, :mock_bigquery do
     mock = Minitest::Mock.new
     mock.expect :get_table, table_gapi, [project, dataset_id, table_id]
     # It makes two requests, but we can't control what order they occur.
-    # So only specify that two InsertAllTableDataRequests are made.
+    # So only specify that two requests are made.
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [project, dataset_id, table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+      [project, dataset_id, table_id, String, Hash]
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [project, dataset_id, table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+      [project, dataset_id, table_id, String, Hash]
     dataset.service.mocked_service = mock
 
     callbacks = 0

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
@@ -25,10 +25,10 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
                 {"name"=>"Sally", "age"=>nil, "score"=>nil, "active"=>nil}] }
   let(:insert_id) { "abc123" }
   let(:insert_rows) { rows.map do |row|
-                        Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
-                          insert_id: insert_id,
+                        {
+                          insertId: insert_id,
                           json: row
-                        )
+                        }
                       end }
 
   let(:table_id) { "table_id" }
@@ -42,10 +42,11 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
   it "can insert one row" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: [insert_rows.first], ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: [insert_rows.first], ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-                [project, dataset_id, table_id, insert_req]
+                [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     result = nil
@@ -65,10 +66,11 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
     it "can insert one row" do
       mock = Minitest::Mock.new
-      insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-        rows: [insert_rows.first], ignore_unknown_values: nil, skip_invalid_rows: nil)
+      insert_req = {
+        rows: [insert_rows.first], ignoreUnknownValues: nil, skipInvalidRows: nil
+      }.to_json
       mock.expect :insert_all_table_data, success_table_insert_gapi,
-                  [project, dataset_id, table_id, insert_req]
+                  [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
       dataset.service.mocked_service = mock
 
       result = nil
@@ -86,10 +88,11 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
   it "can insert multiple rows" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-                [project, dataset_id, table_id, insert_req]
+                [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     result = nil
@@ -106,10 +109,11 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
   it "will indicate there was a problem with the data" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, failure_table_insert_gapi,
-                [project, dataset_id, table_id, insert_req]
+                [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     result = nil
@@ -163,10 +167,11 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
   it "can specify skipping invalid rows" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: true)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: true
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-                [project, dataset_id, table_id, insert_req]
+                [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     result = nil
@@ -183,10 +188,11 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
 
   it "can specify ignoring unknown values" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: true, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: true, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-                [project, dataset_id, table_id, insert_req]
+                [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     result = nil
@@ -225,15 +231,16 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
       next_vacation: Date.parse("2666-06-06"),
       favorite_time: Time.parse("2001-12-19T23:59:59 UTC").utc.to_datetime
     }
-    inserted_row_gapi = Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
-      insert_id: insert_id,
+    inserted_row_hash = {
+      insertId: insert_id,
       json: {"id"=>2, "name"=>"Gandalf", "age"=>1000, "weight"=>198.6, "is_magic"=>true, "scores"=>[100.0, 99.0, 0.001], "spells"=>[{"name"=>"Skydragon", "discovered_by"=>"Firebreather", "properties"=>[{"name"=>"Flying", "power"=>1.0}, {"name"=>"Creature", "power"=>1.0}, {"name"=>"Explodey", "power"=>11.0}], "icon"=>"eyJuYW1lIjoibWlrZSIsImJyZWVkIjoidGhlY2F0a2luZCIsImlkIjoxLCJkb2IiOjE0ODg0NzgzNjIuMjA5MDM0fQp7Im5hbWUiOiJjaHJpcyIsImJyZWVkIjoiZ29sZGVucmV0cmlldmVyPyIsImlkIjoyLCJkb2IiOjE0ODg0NzgzNjIuMjA5MDM0fQp7Im5hbWUiOiJqaiIsImJyZWVkIjoiaWRrYW55Y2F0YnJlZWRzIiwiaWQiOjMsImRvYiI6MTQ4ODQ3ODM2Mi4yMDkwMzR9Cg==", "last_used"=>"2015-10-31 23:59:56.000000+00:00"}], "tea_time"=>"15:00:00", "next_vacation"=>"2666-06-06", "favorite_time"=>"2001-12-19 23:59:59.000000"}
-    )
+    }
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: [inserted_row_gapi], ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: [inserted_row_hash], ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-                [project, dataset_id, table_id, insert_req]
+                [project, dataset_id, table_id, insert_req, options: { skip_serialization: true }]
     dataset.service.mocked_service = mock
 
     result = nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
@@ -187,7 +187,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
   it "returns error in callback result when inserting rows with a callback" do
     mock = Minitest::Mock.new
-    def mock.insert_tabledata dataset_id, table_id, rows, options = {}
+    def mock.insert_tabledata_json_rows dataset_id, table_id, json_rows, options = {}
       raise Google::Cloud::UnavailableError.new
     end
     table.service = mock

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
@@ -28,19 +28,20 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
                 {"name"=>"Sally", "age"=>nil, "score"=>nil, "active"=>nil}] }
   let(:insert_id) { "abc123" }
   let(:insert_rows) { rows.map do |row|
-                        Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
-                          insert_id: insert_id,
+                        {
+                          insertId: insert_id,
                           json: row
-                        )
+                        }
                       end }
   let(:success_table_insert_gapi) { Google::Apis::BigqueryV2::InsertAllTableDataResponse.new insert_errors: [] }
 
   it "inserts one row" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: [insert_rows.first], ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: [insert_rows.first], ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     inserter = table.insert_async
@@ -68,10 +69,11 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
   it "inserts three rows at the same time" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     inserter = table.insert_async
@@ -99,10 +101,11 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
   it "inserts three rows one at a time" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     inserter = table.insert_async
@@ -132,10 +135,11 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
 
   it "inserts rows with a callback" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     callback_called = false
@@ -230,11 +234,11 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
   it "inserts multiple batches when row byte size limit is reached" do
     mock = Minitest::Mock.new
     # It makes two requests, but we can't control what order they occur.
-    # So only specify that two InsertAllTableDataRequests are made.
+    # So only specify that two requests are made.
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+      [table.project_id, table.dataset_id, table.table_id, String, Hash]
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+      [table.project_id, table.dataset_id, table.table_id, String, Hash]
     table.service.mocked_service = mock
 
     callbacks = 0
@@ -268,11 +272,11 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
   it "inserts multiple batches when row count limit is reached" do
     mock = Minitest::Mock.new
     # It makes two requests, but we can't control what order they occur.
-    # So only specify that two InsertAllTableDataRequests are made.
+    # So only specify that two requests are made.
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+      [table.project_id, table.dataset_id, table.table_id, String, Hash]
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, Google::Apis::BigqueryV2::InsertAllTableDataRequest]
+      [table.project_id, table.dataset_id, table.table_id, String, Hash]
     table.service.mocked_service = mock
 
     callbacks = 0

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_insert_test.rb
@@ -20,10 +20,10 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
                 {"name"=>"Sally", "age"=>nil, "score"=>nil, "active"=>nil}] }
   let(:insert_id) { "abc123" }
   let(:insert_rows) { rows.map do |row|
-                        Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
-                          insert_id: insert_id,
+                        {
+                          insertId: insert_id,
                           json: row
-                        )
+                        }
                       end }
   let(:dataset_id) { "dataset" }
   let(:table_hash) { random_table_hash dataset_id }
@@ -36,10 +36,11 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
   it "can insert one row" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: [insert_rows.first], ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: [insert_rows.first], ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     result = nil
@@ -56,10 +57,11 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
   it "can insert multiple rows" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     result = nil
@@ -76,10 +78,11 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
   it "will indicate there was a problem with the data" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, failure_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     result = nil
@@ -133,10 +136,11 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
   it "can specify skipping invalid rows" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: true)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: true
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     result = nil
@@ -153,10 +157,11 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
 
   it "can specify ignoring unknown values" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: true, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: true, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     result = nil
@@ -195,15 +200,16 @@ describe Google::Cloud::Bigquery::Table, :insert, :mock_bigquery do
       next_vacation: Date.parse("2666-06-06"),
       favorite_time: Time.parse("2001-12-19T23:59:59 UTC").utc.to_datetime
     }
-    inserted_row_gapi = Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
-      insert_id: insert_id,
+    inserted_row_hash = {
+      insertId: insert_id,
       json: {"id"=>2, "name"=>"Gandalf", "age"=>1000, "weight"=>198.6, "is_magic"=>true, "scores"=>[100.0, 99.0, 0.001], "spells"=>[{"name"=>"Skydragon", "discovered_by"=>"Firebreather", "properties"=>[{"name"=>"Flying", "power"=>1.0}, {"name"=>"Creature", "power"=>1.0}, {"name"=>"Explodey", "power"=>11.0}], "icon"=>"eyJuYW1lIjoibWlrZSIsImJyZWVkIjoidGhlY2F0a2luZCIsImlkIjoxLCJkb2IiOjE0ODg0NzgzNjIuMjA5MDM0fQp7Im5hbWUiOiJjaHJpcyIsImJyZWVkIjoiZ29sZGVucmV0cmlldmVyPyIsImlkIjoyLCJkb2IiOjE0ODg0NzgzNjIuMjA5MDM0fQp7Im5hbWUiOiJqaiIsImJyZWVkIjoiaWRrYW55Y2F0YnJlZWRzIiwiaWQiOjMsImRvYiI6MTQ4ODQ3ODM2Mi4yMDkwMzR9Cg==", "last_used"=>"2015-10-31 23:59:56.000000+00:00"}], "tea_time"=>"15:00:00", "next_vacation"=>"2666-06-06", "favorite_time"=>"2001-12-19 23:59:59.000000"}
-    )
+    }
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: [inserted_row_gapi], ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: [inserted_row_hash], ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     result = nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -49,10 +49,10 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
                 {"name"=>"Sally", "age"=>nil, "score"=>nil, "active"=>nil}] }
   let(:insert_id) { "abc123" }
   let(:insert_rows) { rows.map do |row|
-                        Google::Apis::BigqueryV2::InsertAllTableDataRequest::Row.new(
-                          insert_id: insert_id,
+                        {
+                          insertId: insert_id,
                           json: row
-                        )
+                        }
                       end }
 
   it "knows its attributes" do
@@ -296,10 +296,11 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
 
   it "can insert multiple rows" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     result = nil
@@ -316,10 +317,11 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
 
   it "inserts three rows one at a time with insert_async" do
     mock = Minitest::Mock.new
-    insert_req = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new(
-      rows: insert_rows, ignore_unknown_values: nil, skip_invalid_rows: nil)
+    insert_req = {
+      rows: insert_rows, ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
     mock.expect :insert_all_table_data, success_table_insert_gapi,
-      [table.project_id, table.dataset_id, table.table_id, insert_req]
+      [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
     inserter = table.insert_async


### PR DESCRIPTION
This PR addresses some performance issues when inserting data. It skips the serialization to Google API Client classes as an optimization. It also fixes a performance issue when using the AsyncInserter with a high number of rows.

[refs #1943]