### PR TITLE
Update Spanner Acceptance Test Setup

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/database_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/database_test.rb
@@ -15,10 +15,10 @@
 require "spanner_helper"
 
 describe "Spanner Databases", :spanner do
-  let(:instance_id) { $spanner_prefix }
+  let(:instance_id) { "google-cloud-ruby-tests" }
 
   it "creates, updates, and drops a database" do
-    database_id = "crud"
+    database_id = "#{$spanner_prefix}-crud"
 
     spanner.database(instance_id, database_id).must_be :nil?
 

--- a/google-cloud-spanner/acceptance/spanner/instance_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/instance_test.rb
@@ -15,46 +15,6 @@
 require "spanner_helper"
 
 describe "Spanner Instances", :spanner do
-  it "creates, updates, and deletes an instance" do
-    instance_id = "#{$spanner_prefix}-empty"
-    name = "#{$spanner_prefix} Empty"
-    config = "regional-us-central1"
-
-    spanner.instance(instance_id).must_be :nil?
-
-    job = spanner.create_instance instance_id, name: name, config: config, nodes: 1, labels: { env: :development }
-
-    job.must_be_kind_of Google::Cloud::Spanner::Instance::Job
-    job.wont_be :done?
-    job.wait_until_done!
-
-    job.must_be :done?
-    raise Google::Cloud::Error.from_error(job.error) if job.error?
-    instance = job.instance
-    instance.wont_be :nil?
-    instance.must_be_kind_of Google::Cloud::Spanner::Instance
-    instance.instance_id.must_equal instance_id
-    instance.name.must_equal name
-    instance.config.instance_config_id.must_equal config
-    instance.nodes.must_equal 1
-    map_to_hash(instance.labels).must_equal({ "env" => "development" })
-
-    spanner.instance(instance_id).wont_be :nil?
-
-    new_name = instance.name.reverse
-    instance.name = new_name
-    instance.nodes = 2
-    instance.labels["env"] = "production"
-    instance.save
-
-    instance.name.must_equal new_name
-    instance.nodes.must_equal 2
-    map_to_hash(instance.labels).must_equal({ "env" => "production" })
-
-    instance.delete
-    spanner.instance(instance_id).must_be :nil?
-  end
-
   it "lists and gets instances" do
     all_instances = spanner.instances.all.to_a
     all_instances.wont_be :empty?
@@ -64,14 +24,5 @@ describe "Spanner Instances", :spanner do
 
     first_instance = spanner.instance all_instances.first.instance_id
     first_instance.must_be_kind_of Google::Cloud::Spanner::Instance
-  end
-
-  def map_to_hash map
-    if map.respond_to? :to_h
-      map.to_h
-    else
-      # Enumerable doesn't have to_h on ruby 2.0...
-      Hash[map.to_a]
-    end
   end
 end

--- a/google-cloud-spanner/acceptance/spanner_helper.rb
+++ b/google-cloud-spanner/acceptance/spanner_helper.rb
@@ -246,16 +246,20 @@ $spanner_prefix = "gcruby-#{Date.today.strftime "%y%m%d"}-#{SecureRandom.hex(4)}
 fixture = Object.new
 fixture.extend Acceptance::SpannerTest::Fixtures
 
-job = $spanner.create_instance $spanner_prefix, name: $spanner_prefix, config: "regional-us-central1", nodes: 1
-job.wait_until_done!
-fail GRPC::BadStatus.new(job.error.code, job.error.message) if job.error?
+instance = $spanner.instance "google-cloud-ruby-tests"
+instance ||= begin
+  inst_job = $spanner.create_instance "google-cloud-ruby-tests", name: "google-cloud-ruby-tests", config: "regional-us-central1", nodes: 1
+  inst_job.wait_until_done!
+  fail GRPC::BadStatus.new(inst_job.error.code, inst_job.error.message) if inst_job.error?
+  inst_job.instance
+end
 
-job2 = job.instance.create_database "main", statements: fixture.schema_ddl_statements
-job2.wait_until_done!
-fail GRPC::BadStatus.new(job.error.code, job.error.message) if job.error?
+db_job = instance.create_database $spanner_prefix, statements: fixture.schema_ddl_statements
+db_job.wait_until_done!
+fail GRPC::BadStatus.new(db_job.error.code, db_job.error.message) if db_job.error?
 
 # Create one client for all tests, to minimize resource usage
-$spanner_client = $spanner.client $spanner_prefix, "main"
+$spanner_client = $spanner.client "google-cloud-ruby-tests", $spanner_prefix
 
 def clean_up_spanner_objects
   puts "Cleaning up instances and databases after spanner tests."


### PR DESCRIPTION
We have a limited number of instances available for running tests.
The Spanner team has asked that we reuse a instance instead of
creating and deleting an instance for each test run.
Create a shared instance and use a new database per test run.
Remove the acceptance test that creates instances.