### PR TITLE
Fix bug using Time object as key

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
@@ -327,14 +327,14 @@ module Google
           keys = [keys] unless keys.is_a? Array
           return Google::Spanner::V1::KeySet.new(all: true) if keys.empty?
           if keys_are_ranges? keys
-            keys = [keys] unless keys.is_a? Array
             key_ranges = keys.map do |r|
               Convert.to_key_range(r)
             end
             return Google::Spanner::V1::KeySet.new(ranges: key_ranges)
           end
-          key_list = Array(keys).map do |i|
-            Convert.raw_to_value(Array(i)).list_value
+          key_list = keys.map do |key|
+            key = [key] unless key.is_a? Array
+            Convert.raw_to_value(key).list_value
           end
           Google::Spanner::V1::KeySet.new keys: key_list
         end

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -351,14 +351,14 @@ module Google
           keys = [keys] unless keys.is_a? Array
           return Google::Spanner::V1::KeySet.new(all: true) if keys.empty?
           if keys_are_ranges? keys
-            keys = [keys] unless keys.is_a? Array
             key_ranges = keys.map do |r|
               Convert.to_key_range(r)
             end
             return Google::Spanner::V1::KeySet.new(ranges: key_ranges)
           end
-          key_list = Array(keys).map do |i|
-            Convert.raw_to_value(Array(i)).list_value
+          key_list = keys.map do |key|
+            key = [key] unless key.is_a? Array
+            Convert.raw_to_value(key).list_value
           end
           Google::Spanner::V1::KeySet.new keys: key_list
         end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -223,6 +223,37 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     mock.verify
   end
 
+  it "deletes multiple rows of keys (timestamp keys) directly" do
+    time1 = Time.now - 5*60*60
+    time2 = Time.now - 5*60*60
+    time3 = Time.now - 5*60*60
+    time4 = Time.now - 5*60*60
+
+    mutations = [
+      Google::Spanner::V1::Mutation.new(
+        delete: Google::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Spanner::V1::KeySet.new(
+            keys: [time1, time2, time3, time4].map do |i|
+              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+            end
+          )
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client.delete "users", [time1, time2, time3, time4]
+    timestamp.must_equal commit_time
+
+    shutdown_client! client
+
+    mock.verify
+  end
+
   it "deletes multiple rows of key rangess directly" do
     mutations = [
       Google::Spanner::V1::Mutation.new(
@@ -266,6 +297,34 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     spanner.service.mocked_service = mock
 
     timestamp = client.delete "users", 5
+    timestamp.must_equal commit_time
+
+    shutdown_client! client
+
+    mock.verify
+  end
+
+  it "deletes a single rows (timestamp key) directly" do
+    time5 = Time.now - 5*60*60
+
+    mutations = [
+      Google::Spanner::V1::Mutation.new(
+        delete: Google::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Spanner::V1::KeySet.new(
+            keys: [time5].map do |i|
+              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+            end
+          )
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client.delete "users", time5
     timestamp.must_equal commit_time
 
     shutdown_client! client


### PR DESCRIPTION
Reading and deleting take key values. If the value is a `Time` object (for a `TIMESTAMP` value) then the API request was not formatted correctly.

Add test coverage to ensure that Time keys are formatted properly.