### PR TITLE
 BigQuery: add customer managed encryption options to load jobs

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -141,7 +141,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     err.message.must_equal "conditionNotMet: Precondition Failed"
   end
 
-  it "create dataset returns valid etag equal to get dataset" do
+  it "create table returns valid etag equal to get table" do
     fresh_table_id = "#{rand 100}_kittens"
     fresh = dataset.create_table fresh_table_id do |schema|
       schema.integer   "id",    description: "id description",    mode: :required
@@ -154,6 +154,34 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     stale = dataset.table fresh_table_id
     stale.etag.wont_be :nil?
     stale.etag.must_equal fresh.etag
+  end
+
+  it "create table with cmek sets encryption_configuration" do
+    begin
+      encrypt_config = Google::Cloud::Bigquery::EncryptionConfiguration.new
+      encrypt_config.kms_key_name =  "projects/cloud-samples-tests/locations/us-central1" +
+                                     "/keyRings/test/cryptoKeys/test"
+      cmek_table = dataset.create_table "cmek_kittens",
+                                        encryption_configuration: encrypt_config
+
+      cmek_table.reload!
+      cmek_table.table_id.must_equal "cmek_kittens"
+      cmek_table.encryption_configuration.kms_key_name.must_equal "projects/cloud-samples-tests" +
+        "/locations/us-central1/keyRings/test/cryptoKeys/test"
+
+      new_encrypt_config = Google::Cloud::Bigquery::EncryptionConfiguration.new
+      new_encrypt_config.kms_key_name =  "projects/cloud-samples-tests/locations/us-central1" +
+                                         "/keyRings/test/cryptoKeys/otherkey"
+      cmek_table.encryption_configuration = new_encrypt_config
+
+      cmek_table.reload!
+      cmek_table.encryption_configuration.kms_key_name.must_equal "projects/cloud-samples-tests" +
+        "/locations/us-central1/keyRings/test/cryptoKeys/otherkey"
+
+    ensure
+      t2 = dataset.table "cmek_kittens"
+      t2.delete if t2
+    end
   end
 
   it "gets and sets time partitioning" do

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -432,7 +432,8 @@ module Google
         #   length is 1,024 characters.
         # @param [String] name A descriptive name for the table.
         # @param [String] description A user-friendly description of the table.
-        # @param [EncryptionConfiguration] encryption_configuration A configuration for custom table data encryption.
+        # @param [EncryptionConfiguration] encryption_configuration A
+        #   configuration for custom table data encryption.
         # @yield [table] a block for setting the table
         # @yieldparam [Table] table the table object to be updated
         #
@@ -490,18 +491,18 @@ module Google
         #
         # @!group Table
         #
-        def create_table table_id, name: nil, description: nil, encryption_configuration: nil
+        def create_table table_id, name: nil, description: nil,
+                         encryption_configuration: nil
           ensure_service!
-          unless encryption_configuration.nil?
-            encryption_configuration = encryption_configuration.to_gapi
-          end
           new_tb = Google::Apis::BigqueryV2::Table.new(
             table_reference: Google::Apis::BigqueryV2::TableReference.new(
               project_id: project_id, dataset_id: dataset_id,
               table_id: table_id
-            ),
-            encryption_configuration: encryption_configuration
+            )
           )
+          unless encryption_configuration.nil?
+            new_tb.encryption_configuration = encryption_configuration.to_gapi
+          end
           updater = Table::Updater.new(new_tb).tap do |tb|
             tb.name = name unless name.nil?
             tb.description = description unless description.nil?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -432,6 +432,7 @@ module Google
         #   length is 1,024 characters.
         # @param [String] name A descriptive name for the table.
         # @param [String] description A user-friendly description of the table.
+        # @param [EncryptionConfiguration] encryption_configuration A configuration for custom table data encryption.
         # @yield [table] a block for setting the table
         # @yieldparam [Table] table the table object to be updated
         #
@@ -489,13 +490,17 @@ module Google
         #
         # @!group Table
         #
-        def create_table table_id, name: nil, description: nil
+        def create_table table_id, name: nil, description: nil, encryption_configuration: nil
           ensure_service!
+          unless encryption_configuration.nil?
+            encryption_configuration = encryption_configuration.to_gapi
+          end
           new_tb = Google::Apis::BigqueryV2::Table.new(
             table_reference: Google::Apis::BigqueryV2::TableReference.new(
               project_id: project_id, dataset_id: dataset_id,
               table_id: table_id
-            )
+            ),
+            encryption_configuration: encryption_configuration
           )
           updater = Table::Updater.new(new_tb).tap do |tb|
             tb.name = name unless name.nil?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1274,6 +1274,9 @@ module Google
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
         #   list must have a different key.
+        # @param [EncryptionConfiguration] destination_encryption_configuration
+        #   The custom encryption method used to protect the destination table.
+        #   If not set, default encryption is used.
         #
         # @yield [schema] A block for setting the schema for the destination
         #   table. The schema can be omitted if the destination table already
@@ -1350,7 +1353,9 @@ module Google
                      quoted_newlines: nil, encoding: nil, delimiter: nil,
                      ignore_unknown: nil, max_bad_records: nil, quote: nil,
                      skip_leading: nil, dryrun: nil, schema: nil, job_id: nil,
-                     prefix: nil, labels: nil, autodetect: nil, null_marker: nil
+                     prefix: nil, labels: nil, autodetect: nil,
+                     null_marker: nil,
+                     destination_encryption_configuration: nil
           ensure_service!
 
           if block_given?
@@ -1368,7 +1373,9 @@ module Google
                       skip_leading: skip_leading, dryrun: dryrun,
                       schema: schema_gapi, job_id: job_id, prefix: prefix,
                       labels: labels, autodetect: autodetect,
-                      null_marker: null_marker }
+                      null_marker: null_marker,
+                      destination_encryption_configuration:
+                        destination_encryption_configuration }
           return load_storage(table_id, file, options) if storage_url? file
           return load_local(table_id, file, options) if local_file? file
           raise Google::Cloud::Error, "Don't know how to load #{file}"
@@ -1484,6 +1491,9 @@ module Google
         #   See {Project#schema} for the creation of the schema for use with
         #   this option. Also note that for most use cases, the block yielded by
         #   this method is a more convenient way to configure the schema.
+        # @param [EncryptionConfiguration] destination_encryption_configuration
+        #   The custom encryption method used to protect the destination table.
+        #   If not set, default encryption is used.
         #
         # @yield [schema] A block for setting the schema for the destination
         #   table. The schema can be omitted if the destination table already
@@ -1559,7 +1569,8 @@ module Google
                  projection_fields: nil, jagged_rows: nil, quoted_newlines: nil,
                  encoding: nil, delimiter: nil, ignore_unknown: nil,
                  max_bad_records: nil, quote: nil, skip_leading: nil,
-                 schema: nil, autodetect: nil, null_marker: nil
+                 schema: nil, autodetect: nil, null_marker: nil,
+                 destination_encryption_configuration: nil
 
           yield (schema ||= Schema.from_gapi) if block_given?
 
@@ -1570,7 +1581,9 @@ module Google
                       delimiter: delimiter, ignore_unknown: ignore_unknown,
                       max_bad_records: max_bad_records, quote: quote,
                       skip_leading: skip_leading, schema: schema,
-                      autodetect: autodetect, null_marker: null_marker }
+                      autodetect: autodetect, null_marker: null_marker,
+                      destination_encryption_configuration:
+                        destination_encryption_configuration }
           job = load_job table_id, file, options
 
           job.wait_until_done!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/encryption.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/encryption.rb
@@ -1,0 +1,122 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/apis/bigquery_v2"
+
+module Google
+  module Cloud
+    module Bigquery
+      ##
+      # # Encryption Configuration
+      #
+      # A builder for BigQuery table encryption configurations, passed to block arguments to
+      # {Dataset#create_table} and {Table#encryption_configuration}.
+      #
+      # @see https://cloud.google.com/bigquery/docs/customer-managed-encryption
+      #   Protecting Data with Cloud KMS Keys
+      #
+      # @example
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #   dataset = bigquery.dataset "my_dataset"
+      #   encrypt_config = Google::Cloud::Bigquery::EncryptionConfiguration.new
+      #   encrypt_config.kms_key_name = "my_key_name"
+      #   table = dataset.create_table(
+      #       "my_table", encryption_configuration: encrypt_config)
+      #
+      class EncryptionConfiguration
+        ##
+        # @private The Google API Client object.
+        attr_accessor :gapi
+
+        ##
+        # @private Create an empty EncryptionConfiguration object.
+        def initialize
+          @gapi = Google::Apis::BigqueryV2::EncryptionConfiguration.new
+        end
+
+        ##
+        # The Cloud KMS encryption key that will be used to protect the table.
+        # For example: `projects/a/locations/b/keyRings/c/cryptoKeys/d`
+        # The default value is `nil`, which means default encryption is used.
+        #
+        # @return [String]
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   config = Google::Cloud::Bigquery::EncryptionConfiguration.new
+        #   key_name = "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+        #   config.kms_key_name = key_name
+        #
+        def kms_key_name
+          @gapi.kms_key_name
+        end
+
+        ##
+        # Set the Cloud KMS encryption key that will be used to protect the
+        # table. For example: `projects/a/locations/b/keyRings/c/cryptoKeys/d`
+        # The default value is `nil`, which means default encryption is used.
+        #
+        # @param [String] new_kms_key_name New Cloud KMS key name
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   config = Google::Cloud::Bigquery::EncryptionConfiguration.new
+        #   key_name = "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+        #   config.kms_key_name = key_name
+        #
+        def kms_key_name= new_kms_key_name
+          frozen_check!
+          @gapi.kms_key_name = new_kms_key_name
+        end
+
+        # @private
+        def changed?
+          return false if frozen?
+          @original_json != @gapi.to_json
+        end
+
+        ##
+        # @private Google API Client object.
+        def to_gapi
+          @gapi
+        end
+
+        ##
+        # @private Google API Client object.
+        def self.from_gapi gapi
+          new_config = new
+          new_config.instance_variable_set :@gapi, gapi
+          new_config
+        end
+
+        # @private
+        def == other
+          return false unless other.is_a? Schema
+          to_gapi.to_json == other.to_gapi.to_json
+        end
+
+        protected
+
+        def frozen_check!
+          return unless frozen?
+          raise ArgumentError, "Cannot modify a frozen encryption configuration"
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/encryption.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/encryption.rb
@@ -20,8 +20,9 @@ module Google
       ##
       # # Encryption Configuration
       #
-      # A builder for BigQuery table encryption configurations, passed to block arguments to
-      # {Dataset#create_table} and {Table#encryption_configuration}.
+      # A builder for BigQuery table encryption configurations, passed to block
+      # arguments to {Dataset#create_table} and
+      # {Table#encryption_configuration}.
       #
       # @see https://cloud.google.com/bigquery/docs/customer-managed-encryption
       #   Protecting Data with Cloud KMS Keys
@@ -33,8 +34,8 @@ module Google
       #   dataset = bigquery.dataset "my_dataset"
       #   encrypt_config = Google::Cloud::Bigquery::EncryptionConfiguration.new
       #   encrypt_config.kms_key_name = "my_key_name"
-      #   table = dataset.create_table(
-      #       "my_table", encryption_configuration: encrypt_config)
+      #   table = dataset.create_table "my_table",
+      #                                encryption_configuration: encrypt_config
       #
       class EncryptionConfiguration
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -72,6 +72,19 @@ module Google
         end
 
         ##
+        # The custom encryption method used to protect the destination table.
+        # If not set, default encryption is used.
+        #
+        # @return [EncryptionConfiguration] A custom encryption configuration.
+        #
+        def destination_encryption_configuration
+          encrypt_config =
+            @gapi.configuration.load.destination_encryption_configuration
+          return nil unless encrypt_config
+          EncryptionConfiguration.from_gapi encrypt_config
+        end
+
+        ##
         # The delimiter used between fields in the source data. The default is a
         # comma (,).
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -430,6 +430,10 @@ module Google
             )
           )
           req.configuration.labels = options[:labels] if options[:labels]
+          unless options[:destination_encryption_configuration].nil?
+            req.configuration.load.destination_encryption_configuration =
+              options[:destination_encryption_configuration].to_gapi
+          end
           req
         end
 
@@ -464,6 +468,10 @@ module Google
             )
           )
           req.configuration.labels = options[:labels] if options[:labels]
+          unless options[:destination_encryption_configuration].nil?
+            req.configuration.load.destination_encryption_configuration =
+              options[:destination_encryption_configuration].to_gapi
+          end
           req
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -743,7 +743,8 @@ module Google
           return nil if reference?
           ensure_full_data!
           return nil if @gapi.encryption_configuration.nil?
-          External.from_gapi(@gapi.encryption_configuration).freeze
+          EncryptionConfiguration.from_gapi(@gapi.encryption_configuration)
+                                 .freeze
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -18,6 +18,7 @@ require "google/cloud/bigquery/service"
 require "google/cloud/bigquery/data"
 require "google/cloud/bigquery/table/list"
 require "google/cloud/bigquery/schema"
+require "google/cloud/bigquery/encryption"
 require "google/cloud/bigquery/external"
 require "google/cloud/bigquery/insert_response"
 require "google/cloud/bigquery/table/async_inserter"
@@ -722,6 +723,53 @@ module Google
         def headers
           return nil if reference?
           schema.headers
+        end
+
+        ##
+        # The {EncryptionConfiguration} object that represents the custom
+        # encryption method used to protect the table. If not set, default
+        # encryption is used.
+        #
+        # Present only if the table is using custom encryption.
+        #
+        # @see https://cloud.google.com/bigquery/docs/customer-managed-encryption
+        #   Protecting Data with Cloud KMS Keys
+        #
+        # @return [EncryptionConfiguration, nil] The encryption configuration.
+        #
+        #   @!group Attributes
+        #
+        def encryption_configuration
+          return nil if reference?
+          ensure_full_data!
+          return nil if @gapi.encryption_configuration.nil?
+          External.from_gapi(@gapi.encryption_configuration).freeze
+        end
+
+        ##
+
+        # Set the {EncryptionConfiguration} object that represents the custom
+        # encryption method used to protect the table. If not set, default
+        # encryption is used.
+        #
+        # Present only if the table is using custom encryption.
+        #
+        # If the table is not a full resource representation (see
+        # {#resource_full?}), the full representation will be retrieved before
+        # the update to comply with ETag-based optimistic concurrency control.
+        #
+        #
+        # @see https://cloud.google.com/bigquery/docs/customer-managed-encryption
+        #   Protecting Data with Cloud KMS Keys
+        #
+        # @return [EncryptionConfiguration] The encryption configuration.
+        #
+        # @!group Attributes
+        #
+        def encryption_configuration= encryption_configuration
+          reload! unless resource_full?
+          @gapi.encryption_configuration = encryption_configuration.to_gapi
+          patch_gapi! :encryption_configuration
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1479,6 +1479,9 @@ module Google
         #   dashes. International characters are allowed. Label values are
         #   optional. Label keys must start with a letter and each label in the
         #   list must have a different key.
+        # @param [EncryptionConfiguration] destination_encryption_configuration
+        #   The custom encryption method used to protect the destination table.
+        #   If not set, default encryption is used.
         #
         # @return [Google::Cloud::Bigquery::LoadJob]
         #
@@ -1521,7 +1524,8 @@ module Google
                      quoted_newlines: nil, encoding: nil, delimiter: nil,
                      ignore_unknown: nil, max_bad_records: nil, quote: nil,
                      skip_leading: nil, dryrun: nil, job_id: nil, prefix: nil,
-                     labels: nil, autodetect: nil, null_marker: nil
+                     labels: nil, autodetect: nil, null_marker: nil,
+                     destination_encryption_configuration: nil
           ensure_service!
           options = { format: format, create: create, write: write,
                       projection_fields: projection_fields,
@@ -1531,7 +1535,9 @@ module Google
                       max_bad_records: max_bad_records, quote: quote,
                       skip_leading: skip_leading, dryrun: dryrun,
                       job_id: job_id, prefix: prefix, labels: labels,
-                      autodetect: autodetect, null_marker: null_marker }
+                      autodetect: autodetect, null_marker: null_marker,
+                      destination_encryption_configuration:
+                        destination_encryption_configuration }
           return load_storage(file, options) if storage_url? file
           return load_local(file, options) if local_file? file
           raise Google::Cloud::Error, "Don't know how to load #{file}"
@@ -1633,6 +1639,11 @@ module Google
         #   file that BigQuery will skip when loading the data. The default
         #   value is `0`. This property is useful if you have header rows in the
         #   file that should be skipped.
+        # @param [EncryptionConfiguration] destination_encryption_configuration
+        #   The custom encryption method used to protect the destination table.
+        #   If not set, default encryption is used.
+        #
+        # Present only if the table is using custom encryption.
         #
         # @return [Google::Cloud::Bigquery::LoadJob]
         #
@@ -1674,7 +1685,8 @@ module Google
                  projection_fields: nil, jagged_rows: nil, quoted_newlines: nil,
                  encoding: nil, delimiter: nil, ignore_unknown: nil,
                  max_bad_records: nil, quote: nil, skip_leading: nil,
-                 autodetect: nil, null_marker: nil
+                 autodetect: nil, null_marker: nil,
+                 destination_encryption_configuration: nil
           job = load_job file, format: format, create: create, write: write,
                                projection_fields: projection_fields,
                                jagged_rows: jagged_rows,
@@ -1683,7 +1695,9 @@ module Google
                                ignore_unknown: ignore_unknown,
                                max_bad_records: max_bad_records, quote: quote,
                                skip_leading: skip_leading,
-                               autodetect: autodetect, null_marker: null_marker
+                               autodetect: autodetect, null_marker: null_marker,
+                               destination_encryption_configuration:
+                                 destination_encryption_configuration
 
           job.wait_until_done!
 

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -360,6 +360,13 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::EncryptionConfiguration" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :insert_table, table_full_gapi, ["my-project", "my_dataset", Google::Apis::BigqueryV2::Table]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::ExtractJob" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/encryption_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/encryption_test.rb
@@ -1,0 +1,31 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::EncryptionConfiguration do
+  it "can be used for KMS keys" do
+    config = Google::Cloud::Bigquery::EncryptionConfiguration.new.tap do |e|
+      e.gapi.kms_key_name = "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+    end
+    config_gapi = Google::Apis::BigqueryV2::EncryptionConfiguration.new(
+      kms_key_name: "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+    )
+
+    config.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    config.kms_key_name.must_equal "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+
+    config.to_gapi.to_h.must_equal config_gapi.to_h
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/encryption_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/encryption_test.rb
@@ -28,4 +28,27 @@ describe Google::Cloud::Bigquery::EncryptionConfiguration do
 
     config.to_gapi.to_h.must_equal config_gapi.to_h
   end
+
+  it "can set KMS keys" do
+    config = Google::Cloud::Bigquery::EncryptionConfiguration.new
+    config.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+
+    config.kms_key_name =  "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+    config.kms_key_name.must_equal "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+
+    config.kms_key_name =  "projects/1/locations/2/keyRings/3/cryptoKeys/4"
+    config.kms_key_name.must_equal "projects/1/locations/2/keyRings/3/cryptoKeys/4"
+  end
+
+  it "can be converted from gapi" do
+    config_gapi = Google::Apis::BigqueryV2::EncryptionConfiguration.new(
+      kms_key_name: "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+    )
+    config = Google::Cloud::Bigquery::EncryptionConfiguration.from_gapi config_gapi
+
+    config.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    config.kms_key_name.must_equal "projects/a/locations/b/keyRings/c/cryptoKeys/d"
+
+    config.to_gapi.to_h.must_equal config_gapi.to_h
+  end
 end


### PR DESCRIPTION
Another step towards resolving #1960. Still missing copy jobs and query jobs.

Based on #1962