### PR TITLE
Policy Creation Fix

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -604,7 +604,7 @@ module Google
           policy = Policy.from_grpc grpc
           return policy unless block_given?
           yield policy
-          self.policy = policy
+          update_policy policy
         end
 
         ##
@@ -634,13 +634,14 @@ module Google
         #
         #   policy.add "roles/owner", "user:owner@example.com"
         #
-        #   sub.policy = policy # API call
+        #   sub.update_policy policy # API call
         #
-        def policy= new_policy
+        def update_policy new_policy
           ensure_service!
           grpc = service.set_subscription_policy name, new_policy.to_grpc
           Policy.from_grpc grpc
         end
+        alias policy= update_policy
 
         ##
         # Tests the specified permissions against the [Cloud

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -412,7 +412,7 @@ module Google
           policy = Policy.from_grpc grpc
           return policy unless block_given?
           yield policy
-          self.policy = policy
+          update_policy policy
         end
 
         ##
@@ -442,13 +442,14 @@ module Google
         #
         #   policy.add "roles/owner", "user:owner@example.com"
         #
-        #   topic.policy = policy # API call
+        #   topic.update_policy policy # API call
         #
-        def policy= new_policy
+        def update_policy new_policy
           ensure_service!
           grpc = service.set_topic_policy name, new_policy.to_grpc
           @policy = Policy.from_grpc grpc
         end
+        alias policy= update_policy
 
         ##
         # Tests the specified permissions against the [Cloud

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -367,6 +367,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Pubsub::Subscription#update_policy" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp("my-subscription"), ["projects/my-project/subscriptions/my-subscription", Hash]
+      mock_subscriber.expect :get_iam_policy, policy_resp, ["projects/my-project/subscriptions/my-subscription", Hash]
+      mock_subscriber.expect :set_iam_policy, policy_resp, ["projects/my-project/subscriptions/my-subscription", Google::Iam::V1::Policy, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Pubsub::Subscription#pull@A maximum number of messages returned can also be specified:" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", Hash]
@@ -464,11 +472,11 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Pubsub::Topic#policy@Use `force` to retrieve the latest policy from the service:" do
+  doctest.before "Google::Cloud::Pubsub::Topic#update_policy" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_publisher.expect :get_topic, topic_resp, ["projects/my-project/topics/my-topic", Hash]
       mock_publisher.expect :get_iam_policy, policy_resp, ["projects/my-project/topics/my-topic", Hash]
-      mock_publisher.expect :get_iam_policy, policy_resp, ["projects/my-project/topics/my-topic", Hash]
+      mock_publisher.expect :set_iam_policy, policy_resp, ["projects/my-project/topics/my-topic", Google::Iam::V1::Policy, Hash]
     end
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/policy_test.rb
@@ -40,6 +40,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Pubsub::Policy
+    policy.etag.must_equal "\b\x01"
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/viewer"].must_be_kind_of Array
@@ -63,7 +64,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
 
-    new_policy = {
+    updated_policy = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/owner",
@@ -73,10 +74,20 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
         ]
       }]
     }
+    new_policy = {
+      "etag"=>"CBD=",
+      "bindings" => [{
+        "role" => "roles/owner",
+        "members" => [
+          "serviceAccount:0987654321@developer.gserviceaccount.com",
+          "user:newowner@example.com"
+        ]
+      }]
+    }
 
-    policy = Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
+    set_req = Google::Iam::V1::Policy.decode_json(JSON.dump(updated_policy))
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
-    mock.expect :set_iam_policy, set_res, [topic_path(topic_name), policy, options: default_options]
+    mock.expect :set_iam_policy, set_res, [topic_path(topic_name), set_req, options: default_options]
     topic.service.mocked_publisher = mock
 
     policy = topic.policy
@@ -84,11 +95,12 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     policy.add "roles/owner", "user:newowner@example.com"
     policy.remove "roles/owner", "user:owner@example.com"
 
-    policy_2 = topic.policy = policy
+    policy_2 = topic.update_policy policy
 
     mock.verify
 
     policy_2.must_be_kind_of Google::Cloud::Pubsub::Policy
+    policy_2.etag.must_equal "\b\x10"
     policy_2.roles.must_be_kind_of Hash
     policy_2.roles.size.must_equal 1
     policy_2.roles["roles/viewer"].must_be :nil?
@@ -113,7 +125,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     mock = Minitest::Mock.new
     mock.expect :get_iam_policy, get_res, [topic_path(topic_name), options: default_options]
 
-    new_policy = {
+    updated_policy = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/owner",
@@ -123,10 +135,20 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
         ]
       }]
     }
+    new_policy = {
+      "etag"=>"CBD=",
+      "bindings" => [{
+        "role" => "roles/owner",
+        "members" => [
+          "serviceAccount:0987654321@developer.gserviceaccount.com",
+          "user:newowner@example.com"
+        ]
+      }]
+    }
 
-    policy = Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
+    set_req = Google::Iam::V1::Policy.decode_json(JSON.dump(updated_policy))
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
-    mock.expect :set_iam_policy, set_res, [topic_path(topic_name), policy, options: default_options]
+    mock.expect :set_iam_policy, set_res, [topic_path(topic_name), set_req, options: default_options]
     topic.service.mocked_publisher = mock
 
     policy = topic.policy do |p|
@@ -137,6 +159,7 @@ describe Google::Cloud::Pubsub::Topic, :policy, :mock_pubsub do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Pubsub::Policy
+    policy.etag.must_equal "\b\x10"
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/viewer"].must_be :nil?

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/policy.rb
@@ -179,7 +179,7 @@ module Google
         # @private New Policy from a
         # Google::Apis::CloudresourcemanagerV1::Policy object.
         def self.from_gapi gapi
-          roles = gapi.bindings.each_with_object({}) do |binding, memo|
+          roles = Array(gapi.bindings).each_with_object({}) do |binding, memo|
             memo[binding.role] = binding.members.to_a
           end
           new gapi.etag, roles

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/project.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/project.rb
@@ -361,7 +361,7 @@ module Google
           policy = Policy.from_gapi gapi
           return policy unless block_given?
           yield policy
-          self.policy = policy
+          update_policy policy
         end
 
         ##
@@ -393,13 +393,14 @@ module Google
         #
         #   policy.add "roles/owner", "user:owner@example.com"
         #
-        #   project.policy = policy # API call
+        #   project.update_policy policy # API call
         #
-        def policy= new_policy
+        def update_policy new_policy
           ensure_service!
           gapi = service.set_policy project_id, new_policy.to_gapi
           Policy.from_gapi gapi
         end
+        alias policy= update_policy
 
         ##
         # Tests the specified permissions against the [Cloud

--- a/google-cloud-resource_manager/support/doctest_helper.rb
+++ b/google-cloud-resource_manager/support/doctest_helper.rb
@@ -152,6 +152,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::ResourceManager::Project#update_policy" do
+    mock_translate do |mock|
+      mock.expect :get_project, project_gapi, ["tokyo-rain-123"]
+      mock.expect :get_policy, policy_gapi, ["tokyo-rain-123"]
+      mock.expect :set_policy, policy_gapi, ["tokyo-rain-123", Google::Apis::CloudresourcemanagerV1::Policy]
+    end
+  end
+
   doctest.before "Google::Cloud::ResourceManager::Project#test_permissions" do
     mock_translate do |mock|
       mock.expect :get_project, project_gapi, ["tokyo-rain-123"]

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/policy_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/policy_test.rb
@@ -1,4 +1,4 @@
- # Copyright 2016 Google LLC
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
 
 require "helper"
 
-describe Google::Cloud::ResourceManager::Policy, :mock_res_man do
+describe Google::Cloud::ResourceManager::Policy do
   let(:etag)       { "etag-1" }
   let(:roles) { { "roles/viewer" => ["allUsers"] } }
   let(:policy)    { Google::Cloud::ResourceManager::Policy.new etag, roles }
 
   it "knows its etag" do
-    policy.roles.must_equal roles
+    policy.etag.must_equal etag
   end
 
   it "knows its roles" do
@@ -33,5 +33,36 @@ describe Google::Cloud::ResourceManager::Policy, :mock_res_man do
     role.must_be_kind_of Array
     role.must_be :empty?
     role.frozen?.must_equal false
+  end
+
+  describe :from_gapi do
+    it "creates from a typical Google::Apis::CloudresourcemanagerV1::Policy object" do
+      gapi = Google::Apis::CloudresourcemanagerV1::Policy.new(
+        etag: etag,
+        bindings: roles.map do |key, val|
+          Google::Apis::CloudresourcemanagerV1::Binding.new(
+            role: key,
+            members: val
+          )
+        end
+      )
+
+      policy = Google::Cloud::ResourceManager::Policy.from_gapi gapi
+
+      policy.must_be_kind_of Google::Cloud::ResourceManager::Policy
+      policy.etag.must_equal etag
+      policy.roles.keys.sort.must_equal   roles.keys.sort
+      policy.roles.values.sort.must_equal roles.values.sort
+    end
+
+    it "creates from an empty Google::Apis::CloudresourcemanagerV1::Policy object" do
+      gapi = Google::Apis::CloudresourcemanagerV1::Policy.new
+
+      policy = Google::Cloud::ResourceManager::Policy.from_gapi gapi
+
+      policy.must_be_kind_of Google::Cloud::ResourceManager::Policy
+      policy.etag.must_be :nil?
+      policy.roles.must_be :empty?
+    end
   end
 end

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -264,7 +264,7 @@ module Google
           policy = Policy.from_grpc grpc
           return policy unless block_given?
           yield policy
-          self.policy = policy
+          update_policy policy
         end
 
         ##
@@ -294,14 +294,15 @@ module Google
         #
         #   policy.add "roles/owner", "user:owner@example.com"
         #
-        #   database.policy = policy # API call
+        #   database.update_policy policy # API call
         #
-        def policy= new_policy
+        def update_policy new_policy
           ensure_service!
           grpc = service.set_database_policy \
             instance_id, database_id, new_policy.to_grpc
           Policy.from_grpc grpc
         end
+        alias policy= update_policy
 
         ##
         # Tests the specified permissions against the [Cloud

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
@@ -374,7 +374,7 @@ module Google
           policy = Policy.from_grpc grpc
           return policy unless block_given?
           yield policy
-          self.policy = policy
+          update_policy policy
         end
 
         ##
@@ -404,13 +404,14 @@ module Google
         #
         #   policy.add "roles/owner", "user:owner@example.com"
         #
-        #   instance.policy = policy # API call
+        #   instance.update_policy policy # API call
         #
-        def policy= new_policy
+        def update_policy new_policy
           ensure_service!
           grpc = service.set_instance_policy path, new_policy.to_grpc
           Policy.from_grpc grpc
         end
+        alias policy= update_policy
 
         ##
         # Tests the specified permissions against the [Cloud

--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -150,6 +150,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Spanner::Instance#update_policy" do
+    mock_spanner do |mock, mock_instances, mock_databases|
+      mock_instances.expect :get_instance, OpenStruct.new(instance_hash), ["projects/my-project/instances/my-instance"]
+      mock_instances.expect :get_iam_policy, policy_resp, ["projects/my-project/instances/my-instance"]
+      mock_instances.expect :set_iam_policy, policy_resp, ["projects/my-project/instances/my-instance", Google::Iam::V1::Policy]
+    end
+  end
+
   doctest.before "Google::Cloud::Spanner::Instance#test_permissions" do
     mock_spanner do |mock, mock_instances, mock_databases|
       mock_instances.expect :get_instance, OpenStruct.new(instance_hash), ["projects/my-project/instances/my-instance"]
@@ -462,6 +470,14 @@ YARD::Doctest.configure do |doctest|
     mock_spanner do |mock, mock_instances, mock_databases|
       mock_databases.expect :get_database, database_resp, ["projects/my-project/instances/my-instance/databases/my-database"]
       mock_databases.expect :update_database_ddl, nil, ["projects/my-project/instances/my-instance/databases/my-database", Array, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Spanner::Database#update_policy" do
+    mock_spanner do |mock, mock_instances, mock_databases|
+      mock_databases.expect :get_database, database_resp, ["projects/my-project/instances/my-instance/databases/my-database"]
+      mock_databases.expect :get_iam_policy, policy_resp, ["projects/my-project/instances/my-instance/databases/my-database"]
+      mock_databases.expect :set_iam_policy, policy_resp, ["projects/my-project/instances/my-instance/databases/my-database", Google::Iam::V1::Policy]
     end
   end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
@@ -56,6 +56,7 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Spanner::Policy
+    policy.etag.must_equal "\b\x01"
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/viewer"].must_be_kind_of Array
@@ -73,9 +74,9 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
     updated_policy_hash["bindings"].first["members"].shift
     updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
 
-    policy = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    mock.expect :set_iam_policy, set_res, [database.path, policy]
+    set_req = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
+    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.merge(etag: "CBD=").to_json
+    mock.expect :set_iam_policy, set_res, [database.path, set_req]
     database.service.mocked_databases = mock
 
     policy = database.policy
@@ -83,11 +84,12 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
     policy.add "roles/owner", "user:newowner@example.com"
     policy.remove "roles/owner", "user:owner@example.com"
 
-    policy = database.policy = policy
+    policy = database.update_policy policy
 
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Spanner::Policy
+    policy.etag.must_equal "\b\x10"
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/viewer"].must_be :nil?
@@ -107,9 +109,9 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
     updated_policy_hash["bindings"].first["members"].shift
     updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
 
-    policy = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    mock.expect :set_iam_policy, set_res, [database.path, policy]
+    set_req = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
+    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.merge(etag: "CBD=").to_json
+    mock.expect :set_iam_policy, set_res, [database.path, set_req]
     database.service.mocked_databases = mock
 
     policy = database.policy do |p|
@@ -120,6 +122,7 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Spanner::Policy
+    policy.etag.must_equal "\b\x10"
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/viewer"].must_be :nil?

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
@@ -55,6 +55,7 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Spanner::Policy
+    policy.etag.must_equal "\b\x01"
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/viewer"].must_be_kind_of Array
@@ -72,9 +73,9 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
     updated_policy_hash["bindings"].first["members"].shift
     updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
 
-    policy = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    mock.expect :set_iam_policy, set_res, [instance.path, policy]
+    set_req = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
+    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.merge(etag: "CBD=").to_json
+    mock.expect :set_iam_policy, set_res, [instance.path, set_req]
     instance.service.mocked_instances = mock
 
     policy = instance.policy
@@ -82,11 +83,12 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
     policy.add "roles/owner", "user:newowner@example.com"
     policy.remove "roles/owner", "user:owner@example.com"
 
-    policy = instance.policy = policy
+    policy = instance.update_policy policy
 
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Spanner::Policy
+    policy.etag.must_equal "\b\x10"
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/viewer"].must_be :nil?
@@ -106,9 +108,9 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
     updated_policy_hash["bindings"].first["members"].shift
     updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
 
-    policy = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
-    mock.expect :set_iam_policy, set_res, [instance.path, policy]
+    set_req = Google::Iam::V1::Policy.decode_json updated_policy_hash.to_json
+    set_res = Google::Iam::V1::Policy.decode_json updated_policy_hash.merge(etag: "CBD=").to_json
+    mock.expect :set_iam_policy, set_res, [instance.path, set_req]
     instance.service.mocked_instances = mock
 
     policy = instance.policy do |p|
@@ -119,6 +121,7 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Spanner::Policy
+    policy.etag.must_equal "\b\x10"
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/viewer"].must_be :nil?

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1197,7 +1197,7 @@ module Google
           policy = Policy.from_gapi gapi
           return policy unless block_given?
           yield policy
-          self.policy = policy
+          update_policy policy
         end
 
         ##
@@ -1230,14 +1230,15 @@ module Google
         #
         #   policy.add "roles/owner", "user:owner@example.com"
         #
-        #   bucket.policy = policy # API call
+        #   bucket.update_policy policy # API call
         #
-        def policy= new_policy
+        def update_policy new_policy
           ensure_service!
           gapi = service.set_bucket_policy name, new_policy.to_gapi,
                                            user_project: user_project
           Policy.from_gapi gapi
         end
+        alias policy= update_policy
 
         ##
         # Tests the specified permissions against the [Cloud

--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -199,7 +199,7 @@ module Google
         # @private New Policy from a
         # Google::Apis::StorageV1::Policy object.
         def self.from_gapi gapi
-          roles = gapi.bindings.each_with_object({}) do |binding, memo|
+          roles = Array(gapi.bindings).each_with_object({}) do |binding, memo|
             memo[binding.role] = binding.members.to_a
           end
           new gapi.etag, roles

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -324,13 +324,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::Storage::Bucket#policy=" do
+  doctest.before "Google::Cloud::Storage::Bucket#update_policy" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi("my-todo-app"), ["my-todo-app", Hash]
       mock.expect :get_bucket_iam_policy, policy_gapi, ["my-todo-app", Hash]
       mock.expect :set_bucket_iam_policy, new_policy_gapi, ["my-todo-app", Google::Apis::StorageV1::Policy, Hash]
     end
   end
+  doctest.skip "Google::Cloud::Storage::Bucket#policy="
 
   doctest.before "Google::Cloud::Storage::Bucket#requester_pays" do
     mock_storage do |mock|

--- a/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_iam_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       ]
     )
   }
-  let(:new_policy_gapi) {
+  let(:updated_policy_gapi) {
     Google::Apis::StorageV1::Policy.new(
       etag: "CAE=",
       bindings: [
@@ -49,7 +49,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
       ]
     )
   }
+  let(:new_policy_gapi) {
+    Google::Apis::StorageV1::Policy.new(
+      etag: "CAF=",
+      bindings: [
+        Google::Apis::StorageV1::Policy::Binding.new(
+          role: "roles/storage.objectViewer",
+          members: [
+            "user:viewer@example.com",
+            "serviceAccount:1234567890@developer.gserviceaccount.com"
+          ]
+        )
+      ]
+    )
+  }
   let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
+  let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
   let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
 
   it "gets the policy" do
@@ -61,6 +76,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAE="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -77,6 +93,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAE="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -86,13 +103,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
   it "sets the policy" do
     mock = Minitest::Mock.new
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: nil]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
 
     storage.service.mocked_service = mock
-    policy = bucket.policy = new_policy
+    policy = bucket.update_policy updated_policy
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAF="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -103,13 +121,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
 
   it "sets the policy with user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: "test"]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
 
     storage.service.mocked_service = mock
-    policy = bucket_user_project.policy = new_policy
+    policy = bucket_user_project.update_policy updated_policy
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAF="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -122,7 +141,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     mock = Minitest::Mock.new
     mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: nil]
 
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: nil]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
 
     storage.service.mocked_service = mock
     policy = bucket.policy do |p|
@@ -131,6 +150,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAF="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -143,7 +163,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     mock = Minitest::Mock.new
     mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
 
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: "test"]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
 
     storage.service.mocked_service = mock
     policy = bucket_user_project.policy do |p|
@@ -152,6 +172,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :mock_storage do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAF="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_iam_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       ]
     )
   }
-  let(:new_policy_gapi) {
+  let(:updated_policy_gapi) {
     Google::Apis::StorageV1::Policy.new(
       etag: "CAE=",
       bindings: [
@@ -46,7 +46,22 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
       ]
     )
   }
+  let(:new_policy_gapi) {
+    Google::Apis::StorageV1::Policy.new(
+      etag: "CAF=",
+      bindings: [
+        Google::Apis::StorageV1::Policy::Binding.new(
+          role: "roles/storage.objectViewer",
+          members: [
+            "user:viewer@example.com",
+            "serviceAccount:1234567890@developer.gserviceaccount.com"
+          ]
+        )
+      ]
+    )
+  }
   let(:old_policy) { Google::Cloud::Storage::Policy.from_gapi old_policy_gapi }
+  let(:updated_policy) { Google::Cloud::Storage::Policy.from_gapi updated_policy_gapi }
   let(:new_policy) { Google::Cloud::Storage::Policy.from_gapi new_policy_gapi }
 
   it "gets the policy" do
@@ -58,6 +73,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAE="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -74,6 +90,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAE="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -83,13 +100,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
 
   it "sets the policy" do
     mock = Minitest::Mock.new
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: nil]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
 
     storage.service.mocked_service = mock
-    policy = bucket.policy = new_policy
+    policy = bucket.update_policy updated_policy
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAF="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -100,13 +118,14 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
 
   it "sets the policy with user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: "test"]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
 
     storage.service.mocked_service = mock
-    policy = bucket_user_project.policy = new_policy
+    policy = bucket_user_project.update_policy updated_policy
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAF="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -119,7 +138,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: nil]
 
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: nil]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: nil]
 
     storage.service.mocked_service = mock
     policy = bucket.policy do |p|
@@ -128,6 +147,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAF="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array
@@ -140,7 +160,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     mock.expect :get_bucket_iam_policy, old_policy_gapi, [bucket_name, user_project: "test"]
 
-    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, new_policy_gapi, user_project: "test"]
+    mock.expect :set_bucket_iam_policy, new_policy_gapi, [bucket_name, updated_policy_gapi, user_project: "test"]
 
     storage.service.mocked_service = mock
     policy = bucket_user_project.policy do |p|
@@ -149,6 +169,7 @@ describe Google::Cloud::Storage::Bucket, :iam, :lazy, :mock_storage do
     mock.verify
 
     policy.must_be_kind_of Google::Cloud::Storage::Policy
+    policy.etag.must_equal "CAF="
     policy.roles.must_be_kind_of Hash
     policy.roles.size.must_equal 1
     policy.roles["roles/storage.objectViewer"].must_be_kind_of Array

--- a/google-cloud-storage/test/google/cloud/storage/policy_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_test.rb
@@ -1,0 +1,68 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Storage::Policy do
+  let(:etag)       { "etag-1" }
+  let(:roles) { { "roles/viewer" => ["allUsers"] } }
+  let(:policy)    { Google::Cloud::Storage::Policy.new etag, roles }
+
+  it "knows its etag" do
+    policy.etag.must_equal etag
+  end
+
+  it "knows its roles" do
+    policy.roles.keys.sort.must_equal   roles.keys.sort
+    policy.roles.values.sort.must_equal roles.values.sort
+  end
+
+  it "returns an empty array for missing role" do
+    role = policy.role "roles/does-not-exist"
+    role.must_be_kind_of Array
+    role.must_be :empty?
+    role.frozen?.must_equal false
+  end
+
+  describe :from_gapi do
+    it "creates from a typical Google::Apis::StorageV1::Policy object" do
+      gapi = Google::Apis::StorageV1::Policy.new(
+        etag: etag,
+        bindings: roles.map do |key, val|
+          Google::Apis::StorageV1::Policy::Binding.new(
+            role: key,
+            members: val
+          )
+        end
+      )
+
+      policy = Google::Cloud::Storage::Policy.from_gapi gapi
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_equal etag
+      policy.roles.keys.sort.must_equal   roles.keys.sort
+      policy.roles.values.sort.must_equal roles.values.sort
+    end
+
+    it "creates from an empty Google::Apis::StorageV1::Policy object" do
+      gapi = Google::Apis::StorageV1::Policy.new
+
+      policy = Google::Cloud::Storage::Policy.from_gapi gapi
+
+      policy.must_be_kind_of Google::Cloud::Storage::Policy
+      policy.etag.must_be :nil?
+      policy.roles.must_be :empty?
+    end
+  end
+end


### PR DESCRIPTION
`Policy` objects returned from the Google API Client may have `bindings` as a `nil` object instead of an empty array. This is because the RESTful resource uses JSON to format the data, and looks like it may omit the bindings data entirely when empty. (I say "may" because I haven't been able to reproduce this from calling the API yet.) We do not see this behavior GRPC endpoints, because of Protobuf's use of default values.

[fixes #1965]