### PR TITLE
BigQuery: Updates public dataset project name used in docs

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery.rb
@@ -48,13 +48,13 @@ module Google
     #
     # A BigQuery project contains datasets, which in turn contain tables.
     # Assuming that you have not yet created datasets or tables in your own
-    # project, let's connect to Google's `publicdata` project, and see what we
-    # find.
+    # project, let's connect to Google's `bigquery-public-data` project, and see
+    # what we find.
     #
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new project: "publicdata"
+    # bigquery = Google::Cloud::Bigquery.new project: "bigquery-public-data"
     #
     # bigquery.datasets.count #=> 1
     # bigquery.datasets.first.dataset_id #=> "samples"
@@ -74,7 +74,7 @@ module Google
     # ```ruby
     # require "google/cloud/bigquery"
     #
-    # bigquery = Google::Cloud::Bigquery.new project: "publicdata"
+    # bigquery = Google::Cloud::Bigquery.new project: "bigquery-public-data"
     #
     # dataset = bigquery.dataset "samples"
     # table = dataset.table "shakespeare"
@@ -147,7 +147,7 @@ module Google
     # bigquery = Google::Cloud::Bigquery.new
     #
     # sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " \
-    #       "FROM [publicdata:samples.shakespeare]"
+    #       "FROM [bigquery-public-data:samples.shakespeare]"
     # data = bigquery.query sql, legacy_sql: true
     # ```
     #
@@ -212,7 +212,7 @@ module Google
     #
     # sql = "SELECT APPROX_TOP_COUNT(corpus, 10) as title, " \
     #       "COUNT(*) as unique_words " \
-    #       "FROM publicdata.samples.shakespeare"
+    #       "FROM `bigquery-public-data.samples.shakespeare`"
     # data = bigquery.query sql
     #
     # data.next? #=> false
@@ -239,7 +239,7 @@ module Google
     #
     # sql = "SELECT APPROX_TOP_COUNT(corpus, 10) as title, " \
     #       "COUNT(*) as unique_words " \
-    #       "FROM publicdata.samples.shakespeare"
+    #       "FROM `bigquery-public-data.samples.shakespeare`"
     # job = bigquery.query_job sql
     #
     # job.wait_until_done!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -33,7 +33,7 @@ module Google
       #
       #   bigquery = Google::Cloud::Bigquery.new
       #
-      #   sql = "SELECT word FROM publicdata.samples.shakespeare"
+      #   sql = "SELECT word FROM `bigquery-public-data.samples.shakespeare`"
       #   job = bigquery.query_job sql
       #
       #   job.wait_until_done!
@@ -105,7 +105,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   sql = "SELECT word FROM publicdata.samples.shakespeare"
+        #   sql = "SELECT word FROM `bigquery-public-data.samples.shakespeare`"
         #   job = bigquery.query_job sql
         #
         #   job.wait_until_done!
@@ -205,7 +205,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   sql = "SELECT word FROM publicdata.samples.shakespeare"
+        #   sql = "SELECT word FROM `bigquery-public-data.samples.shakespeare`"
         #   job = bigquery.query_job sql
         #
         #   job.wait_until_done!
@@ -232,7 +232,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   sql = "SELECT word FROM publicdata.samples.shakespeare"
+        #   sql = "SELECT word FROM `bigquery-public-data.samples.shakespeare`"
         #   job = bigquery.query_job sql
         #
         #   job.wait_until_done!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -44,7 +44,7 @@ module Google
       #   bigquery = Google::Cloud::Bigquery.new
       #
       #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
-      #                            "publicdata.samples.shakespeare"
+      #                            "`bigquery-public-data.samples.shakespeare`"
       #
       #   job.wait_until_done!
       #
@@ -236,7 +236,7 @@ module Google
         #
         #   {
         #     "reason"=>"notFound",
-        #     "message"=>"Not found: Table publicdata:samples.BAD_ID"
+        #     "message"=>"Not found: Table bigquery-public-data:samples.BAD_ID"
         #   }
         #
         def error
@@ -252,7 +252,7 @@ module Google
         #
         #   {
         #     "reason"=>"notFound",
-        #     "message"=>"Not found: Table publicdata:samples.BAD_ID"
+        #     "message"=>"Not found: Table bigquery-public-data:samples.BAD_ID"
         #   }
         #
         def errors
@@ -284,8 +284,10 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
-        #                            "publicdata.samples.shakespeare"
+        #   query = "SELECT COUNT(word) as count FROM " \
+        #           "`bigquery-public-data.samples.shakespeare`"
+        #
+        #   job = bigquery.query_job query
         #
         #   job.cancel
         #
@@ -304,8 +306,10 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
-        #                            "publicdata.samples.shakespeare"
+        #   query = "SELECT COUNT(word) as count FROM " \
+        #           "`bigquery-public-data.samples.shakespeare`"
+        #
+        #   job = bigquery.query_job query
         #
         #   job.wait_until_done!
         #   job.rerun!
@@ -324,8 +328,10 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
-        #                            "publicdata.samples.shakespeare"
+        #   query = "SELECT COUNT(word) as count FROM " \
+        #           "`bigquery-public-data.samples.shakespeare`"
+        #
+        #   job = bigquery.query_job query
         #
         #   job.done?
         #   job.reload!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -36,7 +36,7 @@ module Google
       #   bigquery = Google::Cloud::Bigquery.new
       #
       #   job = bigquery.query_job "SELECT COUNT(word) as count FROM " \
-      #                            "publicdata.samples.shakespeare"
+      #                            "`bigquery-public-data.samples.shakespeare`"
       #
       #   job.wait_until_done!
       #
@@ -171,7 +171,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   sql = "SELECT word FROM publicdata.samples.shakespeare"
+        #   sql = "SELECT word FROM `bigquery-public-data.samples.shakespeare`"
         #   job = bigquery.query_job sql
         #
         #   job.wait_until_done!
@@ -253,7 +253,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   sql = "SELECT word FROM publicdata.samples.shakespeare"
+        #   sql = "SELECT word FROM `bigquery-public-data.samples.shakespeare`"
         #   job = bigquery.query_job sql
         #
         #   job.wait_until_done!
@@ -289,7 +289,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   sql = "SELECT word FROM publicdata.samples.shakespeare"
+        #   sql = "SELECT word FROM `bigquery-public-data.samples.shakespeare`"
         #   job = bigquery.query_job sql
         #
         #   job.wait_until_done!
@@ -347,7 +347,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   sql = "SELECT word FROM publicdata.samples.shakespeare"
+        #   sql = "SELECT word FROM `bigquery-public-data.samples.shakespeare`"
         #   job = bigquery.query_job sql
         #
         #   job.wait_until_done!
@@ -416,7 +416,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   sql = "SELECT word FROM publicdata.samples.shakespeare"
+        #   sql = "SELECT word FROM `bigquery-public-data.samples.shakespeare`"
         #   job = bigquery.query_job sql
         #
         #   job.wait_until_done!


### PR DESCRIPTION
Currently, the code samples in the docs use both `publicdata` and `bigquery-public-data` projects. 

This PR:
+ Updates all uses in the docs (not the tests) to `bigquery-public-data` for better consistency across samples and languages
+ Adds backticks around table names where they were missing in order to avoid confusion about when they are required