### PR TITLE
Update google-cloud docs TOC

### DIFF
--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -315,18 +315,6 @@
       "patterns": ["\/language"],
       "nav": [
         {
-          "title": "Project",
-          "type": "google/cloud/language/project"
-        },
-        {
-          "title": "Document",
-          "type": "google/cloud/language/document"
-        },
-        {
-          "title": "Annotation",
-          "type": "google/cloud/language/annotation"
-        },
-        {
           "title": "V1",
           "type": "google/cloud/language/v1",
           "patterns": ["\/language\/v1$", "\/language\/v1\/"],


### PR DESCRIPTION
Remove links to outdated content by copying latest nav from `google-cloud-language` to `google-cloud` `toc.json`.

[fixes #1969]