### PR TITLE
BigQuery: Add LoadJob::Updater to allow for additional properties on load jobs

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1269,13 +1269,12 @@ module Google
         #   optional. Label keys must start with a letter and each label in the
         #   list must have a different key.
         #
-        # @yield [schema] A block for setting the schema for the destination
-        #   table. The schema can be omitted if the destination table already
-        #   exists, or if you're loading data from a Google Cloud Datastore
-        #   backup.
-        # @yieldparam [Google::Cloud::Bigquery::Schema] schema The schema
-        #   instance provided using the `schema` option, or a new, empty schema
-        #   instance
+        # @yield [updater] A block for setting the schema and other
+        #   options for the destination table. The schema can be omitted if the
+        #   destination table already exists, or if you're loading data from a
+        #   Google Cloud Datastore backup.
+        # @yieldparam [Google::Cloud::Bigquery::LoadJob::Updater] updater An
+        #   updater to modify the load job and its schema.
         #
         # @return [Google::Cloud::Bigquery::LoadJob] A new load job object.
         #
@@ -1347,25 +1346,26 @@ module Google
                      prefix: nil, labels: nil, autodetect: nil, null_marker: nil
           ensure_service!
 
-          if block_given?
-            schema ||= Schema.from_gapi
-            yield schema
-          end
-          schema_gapi = schema.to_gapi if schema
+          updater = load_job_updater table_id,
+                                     format: format, create: create,
+                                     write: write,
+                                     projection_fields: projection_fields,
+                                     jagged_rows: jagged_rows,
+                                     quoted_newlines: quoted_newlines,
+                                     encoding: encoding,
+                                     delimiter: delimiter,
+                                     ignore_unknown: ignore_unknown,
+                                     max_bad_records: max_bad_records,
+                                     quote: quote, skip_leading: skip_leading,
+                                     dryrun: dryrun, schema: schema,
+                                     labels: labels, autodetect: autodetect,
+                                     null_marker: null_marker
 
-          options = { format: format, create: create, write: write,
-                      projection_fields: projection_fields,
-                      jagged_rows: jagged_rows,
-                      quoted_newlines: quoted_newlines, encoding: encoding,
-                      delimiter: delimiter, ignore_unknown: ignore_unknown,
-                      max_bad_records: max_bad_records, quote: quote,
-                      skip_leading: skip_leading, dryrun: dryrun,
-                      schema: schema_gapi, job_id: job_id, prefix: prefix,
-                      labels: labels, autodetect: autodetect,
-                      null_marker: null_marker }
-          return load_storage(table_id, file, options) if storage_url? file
-          return load_local(table_id, file, options) if local_file? file
-          raise Google::Cloud::Error, "Don't know how to load #{file}"
+          yield updater if block_given?
+
+          job_gapi = updater.to_gapi
+          return load_local(job_id, prefix, file, job_gapi) if local_file? file
+          load_storage job_id, prefix, file, job_gapi
         end
 
         ##
@@ -1946,20 +1946,122 @@ module Google
           reload! if resource_partial?
         end
 
-        def load_storage table_id, url, options = {}
+        def load_job_gapi table_id, dryrun
+          Google::Apis::BigqueryV2::Job.new(
+            configuration: Google::Apis::BigqueryV2::JobConfiguration.new(
+              load: Google::Apis::BigqueryV2::JobConfigurationLoad.new(
+                destination_table: Google::Apis::BigqueryV2::TableReference.new(
+                  project_id: @service.project,
+                  dataset_id: dataset_id,
+                  table_id: table_id
+                )
+              ),
+              dry_run: dryrun
+            )
+          )
+        end
+
+        def load_job_csv_options! job, jagged_rows: nil,
+                                  quoted_newlines: nil,
+                                  delimiter: nil,
+                                  quote: nil, skip_leading: nil,
+                                  null_marker: nil
+          job.jagged_rows = jagged_rows unless jagged_rows.nil?
+          job.quoted_newlines = quoted_newlines unless quoted_newlines.nil?
+          job.delimiter = delimiter unless delimiter.nil?
+          job.null_marker = null_marker unless null_marker.nil?
+          job.quote = quote unless quote.nil?
+          job.skip_leading = skip_leading unless skip_leading.nil?
+        end
+
+        def load_job_file_options! job, format: nil,
+                                   projection_fields: nil,
+                                   jagged_rows: nil, quoted_newlines: nil,
+                                   encoding: nil, delimiter: nil,
+                                   ignore_unknown: nil, max_bad_records: nil,
+                                   quote: nil, skip_leading: nil,
+                                   null_marker: nil
+          job.format = format unless format.nil?
+          unless projection_fields.nil?
+            job.projection_fields = projection_fields
+          end
+          job.encoding = encoding unless encoding.nil?
+          job.ignore_unknown = ignore_unknown unless ignore_unknown.nil?
+          job.max_bad_records = max_bad_records unless max_bad_records.nil?
+          load_job_csv_options! job, jagged_rows: jagged_rows,
+                                     quoted_newlines: quoted_newlines,
+                                     delimiter: delimiter,
+                                     quote: quote,
+                                     skip_leading: skip_leading,
+                                     null_marker: null_marker
+        end
+
+        def load_job_updater table_id, format: nil, create: nil,
+                             write: nil, projection_fields: nil,
+                             jagged_rows: nil, quoted_newlines: nil,
+                             encoding: nil, delimiter: nil,
+                             ignore_unknown: nil, max_bad_records: nil,
+                             quote: nil, skip_leading: nil, dryrun: nil,
+                             schema: nil, labels: nil, autodetect: nil,
+                             null_marker: nil
+          new_job = load_job_gapi table_id, dryrun
+          LoadJob::Updater.new(new_job).tap do |job|
+            job.create = create unless create.nil?
+            job.write = write unless write.nil?
+            job.schema = schema unless schema.nil?
+            job.autodetect = autodetect unless autodetect.nil?
+            job.labels = labels unless labels.nil?
+            load_job_file_options! job, format: format,
+                                        projection_fields: projection_fields,
+                                        jagged_rows: jagged_rows,
+                                        quoted_newlines: quoted_newlines,
+                                        encoding: encoding,
+                                        delimiter: delimiter,
+                                        ignore_unknown: ignore_unknown,
+                                        max_bad_records: max_bad_records,
+                                        quote: quote,
+                                        skip_leading: skip_leading,
+                                        null_marker: null_marker
+          end
+        end
+
+        def derive_source_format path
+          return "CSV" if path.end_with? ".csv"
+          return "NEWLINE_DELIMITED_JSON" if path.end_with? ".json"
+          return "AVRO" if path.end_with? ".avro"
+          return "DATASTORE_BACKUP" if path.end_with? ".backup_info"
+          nil
+        end
+
+        def load_storage job_id, prefix, url, job_gapi
           # Convert to storage URL
           url = url.to_gs_url if url.respond_to? :to_gs_url
           url = url.to_s if url.is_a? URI
 
-          gapi = service.load_table_gs_url dataset_id, table_id, url, options
+          unless url.nil?
+            job_gapi.configuration.load.update! source_uris: Array(url)
+            if job_gapi.configuration.load.source_format.nil?
+              source_format = derive_source_format url
+              unless source_format.nil?
+                job_gapi.configuration.load.source_format = source_format
+              end
+            end
+          end
+
+          gapi = service.load_table_gs_url job_id, prefix, job_gapi
           Job.from_gapi gapi, service
         end
 
-        def load_local table_id, file, options = {}
-          # Convert to storage URL
-          file = file.to_gs_url if file.respond_to? :to_gs_url
+        def load_local job_id, prefix, file, job_gapi
+          path = Pathname(file).to_path
+          if job_gapi.configuration.load.source_format.nil?
+            source_format = derive_source_format path
+            unless source_format.nil?
+              job_gapi.configuration.load.source_format = source_format
+            end
+          end
 
-          gapi = service.load_table_file dataset_id, table_id, file, options
+          gapi = service.load_table_file job_id, prefix, file, job_gapi
           Job.from_gapi gapi, service
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -314,6 +314,737 @@ module Google
         rescue StandardError
           nil
         end
+
+        ##
+        # Yielded to a block to accumulate changes for a patch request.
+        class Updater < LoadJob
+          ##
+          # A list of attributes that were updated.
+          attr_reader :updates
+
+          ##
+          # Create an Updater object.
+          def initialize gapi
+            @updates = []
+            @gapi = gapi
+            @schema = nil
+          end
+
+          ##
+          # Returns the table's schema. This method can also be used to set,
+          # replace, or add to the schema by passing a block. See {Schema} for
+          # available methods.
+          #
+          # @param [Boolean] replace Whether to replace the existing schema with
+          #   the new schema. If `true`, the fields will replace the existing
+          #   schema. If `false`, the fields will be added to the existing
+          #   schema. When a table already contains data, schema changes must be
+          #   additive. Thus, the default value is `false`.
+          # @yield [schema] a block for setting the schema
+          # @yieldparam [Schema] schema the object accepting the schema
+          #
+          # @return [Google::Cloud::Bigquery::Schema]
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |j|
+          #     j.schema do |s|
+          #       s.string "first_name", mode: :required
+          #       s.record "cities_lived", mode: :repeated do |r|
+          #         r.string "place", mode: :required
+          #         r.integer "number_of_years", mode: :required
+          #       end
+          #     end
+          #   end
+          #
+          # @!group Schema
+          #
+          def schema replace: false
+            # Same as Table#schema, but not frozen
+            # TODO: make sure to call ensure_full_data! on Dataset#update
+            @schema ||= Schema.from_gapi @gapi.configuration.load.schema
+            if block_given?
+              @schema = Schema.from_gapi if replace
+              yield @schema
+              check_for_mutated_schema!
+            end
+            # Do not freeze on updater, allow modifications
+            @schema
+          end
+
+          ##
+          # Sets the schema of the destination table.
+          #
+          # @param [Google::Cloud::Bigquery::Schema] new_schema The schema for
+          #   the destination table. Optional. The schema can be omitted if the
+          #   destination table already exists, or if you're loading data from a
+          #   source that includes a schema, such as Avro or a Google Cloud
+          #   Datastore backup.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   schema = bigquery.schema do |s|
+          #     s.string "first_name", mode: :required
+          #     s.record "cities_lived", mode: :repeated do |nested_schema|
+          #       nested_schema.string "place", mode: :required
+          #       nested_schema.integer "number_of_years", mode: :required
+          #     end
+          #   end
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |j|
+          #     j.schema = schema
+          #   end
+          #
+          # @!group Schema
+          #
+          def schema= new_schema
+            @schema = new_schema
+          end
+
+          ##
+          # Adds a string field to the schema.
+          #
+          # See {Schema#string}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.string "first_name", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def string name, description: nil, mode: :nullable
+            schema.string name, description: description, mode: mode
+          end
+
+          ##
+          # Adds an integer field to the schema.
+          #
+          # See {Schema#integer}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.integer "age", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def integer name, description: nil, mode: :nullable
+            schema.integer name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a floating-point number field to the schema.
+          #
+          # See {Schema#float}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.float "price", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def float name, description: nil, mode: :nullable
+            schema.float name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a boolean field to the schema.
+          #
+          # See {Schema#boolean}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.boolean "active", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def boolean name, description: nil, mode: :nullable
+            schema.boolean name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a bytes field to the schema.
+          #
+          # See {Schema#bytes}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.bytes "avatar", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def bytes name, description: nil, mode: :nullable
+            schema.bytes name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a timestamp field to the schema.
+          #
+          # See {Schema#timestamp}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.timestamp "creation_date", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def timestamp name, description: nil, mode: :nullable
+            schema.timestamp name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a time field to the schema.
+          #
+          # See {Schema#time}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.time "duration", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def time name, description: nil, mode: :nullable
+            schema.time name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a datetime field to the schema.
+          #
+          # See {Schema#datetime}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.datetime "target_end", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def datetime name, description: nil, mode: :nullable
+            schema.datetime name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a date field to the schema.
+          #
+          # See {Schema#date}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.date "birthday", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def date name, description: nil, mode: :nullable
+            schema.date name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a record field to the schema. A block must be passed describing
+          # the nested fields of the record. For more information about nested
+          # and repeated records, see [Preparing Data for BigQuery
+          # ](https://cloud.google.com/bigquery/preparing-data-for-bigquery).
+          #
+          # See {Schema#record}.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          # @yield [nested_schema] a block for setting the nested schema
+          # @yieldparam [Schema] nested_schema the object accepting the
+          #   nested schema
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.record "cities_lived", mode: :repeated do |cities_lived|
+          #       cities_lived.string "place", mode: :required
+          #       cities_lived.integer "number_of_years", mode: :required
+          #     end
+          #   end
+          #
+          # @!group Schema
+          #
+          def record name, description: nil, mode: nil, &block
+            schema.record name, description: description, mode: mode, &block
+          end
+
+          ##
+          # Make sure any access changes are saved
+          def check_for_mutated_schema!
+            return if @schema.nil?
+            return unless @schema.changed?
+            @gapi.configuration.load.schema = @schema.to_gapi
+            patch_gapi! :schema
+          end
+
+          ##
+          # Sets the source file format. The default value is `csv`.
+          #
+          # The following values are supported:
+          #
+          # * `csv` - CSV
+          # * `json` - [Newline-delimited JSON](http://jsonlines.org/)
+          # * `avro` - [Avro](http://avro.apache.org/)
+          # * `datastore_backup` - Cloud Datastore backup
+          #
+          # @param [String] new_format The new source format.
+          #
+          # @!group Attributes
+          #
+          def format= new_format
+            @gapi.configuration.load.update! source_format:
+              source_format(new_format)
+          end
+
+          # Sets the create disposition.
+          #
+          # This specifies whether the job is allowed to create new tables. The
+          # default value is `needed`.
+          #
+          # The following values are supported:
+          #
+          # * `needed` - Create the table if it does not exist.
+          # * `never` - The table must already exist. A 'notFound' error is
+          #             raised if the table does not exist.
+          #
+          # @param [String] new_create The new create disposition.
+          #
+          # @!group Attributes
+          #
+          def create= new_create
+            @gapi.configuration.load.update! create_disposition:
+              create_disposition(new_create)
+          end
+
+          # Sets the write disposition.
+          #
+          # This specifies how to handle data already present in the table. The
+          # default value is `append`.
+          #
+          # The following values are supported:
+          #
+          # * `truncate` - BigQuery overwrites the table data.
+          # * `append` - BigQuery appends the data to the table.
+          # * `empty` - An error will be returned if the table already contains
+          #   data.
+          #
+          # @param [String] new_write The new write disposition.
+          #
+          # @!group Attributes
+          #
+          def write= new_write
+            @gapi.configuration.load.update! write_disposition:
+              write_disposition(new_write)
+          end
+
+          # Sets the projection fields.
+          #
+          # If the `format` option is set to `datastore_backup`, indicates
+          # which entity properties to load from a Cloud Datastore backup.
+          # Property names are case sensitive and must be top-level properties.
+          # If not set, BigQuery loads all properties. If any named property
+          # isn't found in the Cloud Datastore backup, an invalid error is
+          # returned.
+          #
+          # @param [Array<String>] new_fields The new projection fields.
+          #
+          # @!group Attributes
+          #
+          def projection_fields= new_fields
+            if new_fields.nil?
+              @gapi.configuration.load.update! projection_fields: nil
+            else
+              @gapi.configuration.load.update! projection_fields:
+                Array(new_fields)
+            end
+          end
+
+          # Sets the source URIs to load.
+          #
+          # The fully-qualified URIs that point to your data in Google Cloud.
+          #
+          # * For Google Cloud Storage URIs: Each URI can contain one '*'
+          #   wildcard character and it must come after the 'bucket' name. Size
+          #   limits related to load jobs apply to external data sources. For
+          # * Google Cloud Bigtable URIs: Exactly one URI can be specified and
+          #   it has be a fully specified and valid HTTPS URL for a Google Cloud
+          #   Bigtable table.
+          # * For Google Cloud Datastore backups: Exactly one URI can be
+          #   specified. Also, the '*' wildcard character is not allowed.
+          #
+          # @param [Array<String>] new_uris The new source URIs to load.
+          #
+          # @!group Attributes
+          #
+          def source_uris= new_uris
+            if new_uris.nil?
+              @gapi.configuration.load.update! source_uris: nil
+            else
+              @gapi.configuration.load.update! source_uris: Array(new_uris)
+            end
+          end
+
+          # Sets flag for allowing jagged rows.
+          #
+          # Accept rows that are missing trailing optional columns. The missing
+          # values are treated as nulls. If `false`, records with missing
+          # trailing columns are treated as bad records, and if there are too
+          # many bad records, an invalid error is returned in the job result.
+          # The default value is `false`. Only applicable to CSV, ignored for
+          # other formats.
+          #
+          # @param [Boolean] val Accept rows that are missing trailing optional
+          #   columns.
+          #
+          # @!group Attributes
+          #
+          def jagged_rows= val
+            @gapi.configuration.load.update! allow_jagged_rows: val
+          end
+
+          # Allows quoted data sections to contain newline characters in CSV.
+          #
+          # @param [Boolean] val Indicates if BigQuery should allow quoted data
+          #   sections that contain newline characters in a CSV file. The
+          #   default value is `false`.
+          #
+          # @!group Attributes
+          #
+          def quoted_newlines= val
+            @gapi.configuration.load.update! allow_quoted_newlines: val
+          end
+
+          # Allows BigQuery to autodetect the schema.
+          #
+          # @param [Boolean] val Indicates if BigQuery should automatically
+          #   infer the options and schema for CSV and JSON sources. The default
+          #   value is `false`.
+          #
+          # @!group Attributes
+          #
+          def autodetect= val
+            @gapi.configuration.load.update! autodetect: val
+          end
+
+          # Sets the character encoding of the data.
+          #
+          # @param [String] val The character encoding of the data. The
+          #   supported values are `UTF-8` or `ISO-8859-1`. The default value
+          #   is `UTF-8`.
+          #
+          # @!group Attributes
+          #
+          def encoding= val
+            @gapi.configuration.load.update! encoding: val
+          end
+
+          # Sets the separator for fields in a CSV file.
+          #
+          # @param [String] val Specifices the separator for fields in a CSV
+          #   file. BigQuery converts the string to `ISO-8859-1` encoding, and
+          #   then uses the first byte of the encoded string to split the data
+          #   in its raw, binary state. Default is <code>,</code>.
+          #
+          # @!group Attributes
+          #
+          def delimiter= val
+            @gapi.configuration.load.update! field_delimiter: val
+          end
+
+          # Allows unknown columns to be ignored.
+          #
+          # @param [Boolean] val Indicates if BigQuery should allow extra
+          #   values that are not represented in the table schema. If true, the
+          #   extra values are ignored. If false, records with extra columns are
+          #   treated as bad records, and if there are too many bad records, an
+          #   invalid error is returned in the job result. The default value is
+          #   `false`.
+          #
+          #   The `format` property determines what BigQuery treats as an extra
+          #   value:
+          #
+          #   * `CSV`: Trailing columns
+          #   * `JSON`: Named values that don't match any column names
+          #
+          # @!group Attributes
+          #
+          def ignore_unknown= val
+            @gapi.configuration.load.update! ignore_unknown_values: val
+          end
+
+          # Sets the maximum number of bad records that can be ignored.
+          #
+          # @param [Integer] val The maximum number of bad records that
+          #   BigQuery can ignore when running the job. If the number of bad
+          #   records exceeds this value, an invalid error is returned in the
+          #   job result. The default value is `0`, which requires that all
+          #   records are valid.
+          #
+          # @!group Attributes
+          #
+          def max_bad_records= val
+            @gapi.configuration.load.update! max_bad_records: val
+          end
+
+          # Sets the string that represents a null value in a CSV file.
+          #
+          # @param [String] val Specifies a string that represents a null value
+          #   in a CSV file. For example, if you specify `\N`, BigQuery
+          #   interprets `\N` as a null value when loading a CSV file. The
+          #   default value is the empty string. If you set this property to a
+          #   custom value, BigQuery throws an error if an empty string is
+          #   present for all data types except for STRING and BYTE. For STRING
+          #   and BYTE columns, BigQuery interprets the empty string as an empty
+          #   value.
+          #
+          # @!group Attributes
+          #
+          def null_marker= val
+            @gapi.configuration.load.update! null_marker: val
+          end
+
+          # Sets the character to use to quote string values in CSVs.
+          #
+          # @param [String] val The value that is used to quote data sections
+          #   in a CSV file. BigQuery converts the string to ISO-8859-1
+          #   encoding, and then uses the first byte of the encoded string to
+          #   split the data in its raw, binary state. The default value is a
+          #   double-quote <code>"</code>. If your data does not contain quoted
+          #   sections, set the property value to an empty string. If your data
+          #   contains quoted newline characters, you must also set the
+          #   allowQuotedNewlines property to true.
+          #
+          # @!group Attributes
+          #
+          def quote= val
+            @gapi.configuration.load.update! quote: val
+          end
+
+          # Sets the number of leading rows to skip in the file.
+          #
+          # @param [Integer] val The number of rows at the top of a CSV file
+          #   that BigQuery will skip when loading the data. The default
+          #   value is `0`. This property is useful if you have header rows in
+          #   the file that should be skipped.
+          #
+          # @!group Attributes
+          #
+          def skip_leading= val
+            @gapi.configuration.load.update! skip_leading_rows: val
+          end
+
+          # Sets the labels to use for the load job.
+          #
+          # @param [Hash] val A hash of user-provided labels associated with
+          #   the job. You can use these to organize and group your jobs. Label
+          #   keys and values can be no longer than 63 characters, can only
+          #   contain lowercase letters, numeric characters, underscores and
+          #   dashes. International characters are allowed. Label values are
+          #   optional. Label keys must start with a letter and each label in
+          #   the list must have a different key.
+          #
+          # @!group Attributes
+          #
+          def labels= val
+            @gapi.configuration.update! labels: val
+          end
+
+          # Returns the Google API client library version of this load job.
+          #
+          # @return [<Google::Apis::BigqueryV2::Job>] (See
+          #   {Google::Apis::BigqueryV2::Job})
+          def to_gapi
+            check_for_mutated_schema!
+            @gapi
+          end
+
+          protected
+
+          ##
+          # Change to a NOOP
+          def ensure_full_data!
+            # Do nothing because we trust the gapi is full before we get here.
+          end
+
+          ##
+          # Queue up all the updates instead of making them.
+          def patch_gapi! attribute
+            @updates << attribute
+            @updates.uniq!
+          end
+
+          def source_format format
+            val = {
+              "csv" => "CSV",
+              "json" => "NEWLINE_DELIMITED_JSON",
+              "newline_delimited_json" => "NEWLINE_DELIMITED_JSON",
+              "avro" => "AVRO",
+              "datastore" => "DATASTORE_BACKUP",
+              "backup" => "DATASTORE_BACKUP",
+              "datastore_backup" => "DATASTORE_BACKUP"
+            }[format.to_s.downcase]
+            return val unless val.nil?
+            format
+          end
+        end
+
+        def create_disposition str
+          val = {
+            "create_if_needed" => "CREATE_IF_NEEDED",
+            "createifneeded" => "CREATE_IF_NEEDED",
+            "if_needed" => "CREATE_IF_NEEDED",
+            "needed" => "CREATE_IF_NEEDED",
+            "create_never" => "CREATE_NEVER",
+            "createnever" => "CREATE_NEVER",
+            "never" => "CREATE_NEVER"
+          }[str.to_s.downcase]
+          return val unless val.nil?
+          str
+        end
+
+        def write_disposition str
+          val = {
+            "write_truncate" => "WRITE_TRUNCATE",
+            "writetruncate" => "WRITE_TRUNCATE",
+            "truncate" => "WRITE_TRUNCATE",
+            "write_append" => "WRITE_APPEND",
+            "writeappend" => "WRITE_APPEND",
+            "append" => "WRITE_APPEND",
+            "write_empty" => "WRITE_EMPTY",
+            "writeempty" => "WRITE_EMPTY",
+            "empty" => "WRITE_EMPTY"
+          }[str.to_s.downcase]
+          return val unless val.nil?
+          str
+        end
       end
     end
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_updater_test.rb
@@ -1,0 +1,81 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+require "google/apis/bigquery_v2"
+
+describe Google::Cloud::Bigquery::LoadJob::Updater do
+  def new_updater
+    new_job = Google::Apis::BigqueryV2::Job.new(
+      configuration: Google::Apis::BigqueryV2::JobConfiguration.new(
+        load: Google::Apis::BigqueryV2::JobConfigurationLoad.new
+      )
+    )
+    Google::Cloud::Bigquery::LoadJob::Updater.new new_job
+  end
+
+  it "can set the source format" do
+    updater = new_updater
+    updater.format = "csv"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.source_format.must_equal "CSV"
+
+    updater.format = "json"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.source_format.must_equal "NEWLINE_DELIMITED_JSON"
+
+    updater.format = "avro"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.source_format.must_equal "AVRO"
+
+    updater.format = "SOME_NEW_UNSUPPORTED_FORMAT"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.source_format.must_equal "SOME_NEW_UNSUPPORTED_FORMAT"
+  end
+
+  it "can set the create disposition" do
+    updater = new_updater
+    updater.create = "needed"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.create_disposition.must_equal "CREATE_IF_NEEDED"
+
+    updater.create = "never"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.create_disposition.must_equal "CREATE_NEVER"
+
+    updater.create = "SOME_NEW_UNSUPPORTED_DISPOSITION"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.create_disposition.must_equal "SOME_NEW_UNSUPPORTED_DISPOSITION"
+  end
+
+  it "can set the write disposition" do
+    updater = new_updater
+    updater.write = "append"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.write_disposition.must_equal "WRITE_APPEND"
+
+    updater.write = "truncate"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.write_disposition.must_equal "WRITE_TRUNCATE"
+
+    updater.write = "empty"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.write_disposition.must_equal "WRITE_EMPTY"
+
+    updater.write = "SOME_NEW_UNSUPPORTED_DISPOSITION"
+    job_gapi = updater.to_gapi
+    job_gapi.configuration.load.write_disposition.must_equal "SOME_NEW_UNSUPPORTED_DISPOSITION"
+  end
+end


### PR DESCRIPTION
As discussed in https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/1963, this adds a block to `load_job` so that new properties can be added to LoadJob without needing to add arguments to the `load_job` function.

Notes:

- This does not touch the `load` methods which start and wait for a load job. (I wasn't sure how to pass the block on to the `load_job` method.
- There's quite a bit of copy-pasted code here. I wasn't sure where to put shared private helper methods.