### PR TITLE
Add google-cloud-firestore to google-cloud docs whitelist.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -294,6 +294,7 @@ namespace :jsondoc do
       "google-cloud-debugger",
       "google-cloud-dns",
       "google-cloud-error_reporting",
+      "google-cloud-firestore",
       "google-cloud-language",
       "google-cloud-logging",
       "google-cloud-monitoring",


### PR DESCRIPTION
Update Rakefile to add google-cloud-firestore to google-cloud docs whitelist.

I checked the Rakefile whitelist against the google-cloud left nav, and Firestore was the only package missing from the whitelist.

[fixes #1971]