### PR TITLE
BigQuery yield LoadJob::Updater for `dataset.load` and `table.load`

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -215,7 +215,9 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   end
 
   it "imports data from a local file and creates a new table without a schema with load" do
-    result = dataset.load table_with_schema.table_id, local_file, create: :never
+    result = dataset.load table_with_schema.table_id, local_file do |job|
+      job.create = :never
+    end
     result.must_equal true
   end
 

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -447,7 +447,9 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
 
   it "imports data from a local file with load_job" do
     job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
-    job = table.load_job local_file, job_id: job_id, labels: labels
+    job = table.load_job local_file, job_id: job_id do |j|
+      j.labels = labels
+    end
     job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
     job.job_id.must_equal job_id
     job.labels.must_equal labels

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1068,16 +1068,7 @@ module Google
 
           job = query_job query, options
           job.wait_until_done!
-
-          if job.failed?
-            begin
-              # raise to activate ruby exception cause handling
-              raise job.gapi_error
-            rescue StandardError => e
-              # wrap Google::Apis::Error with Google::Cloud::Error
-              raise Google::Cloud::Error.from_error(e)
-            end
-          end
+          ensure_job_succeeded! job
 
           job.data max: max
         end
@@ -1332,9 +1323,11 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   load_job = dataset.load_job "my_new_table",
-        #                           "gs://my-bucket/xxxx.kind_name.backup_info",
-        #                           format: "datastore_backup"
+        #   load_job = dataset.load_job(
+        #                "my_new_table",
+        #                "gs://my-bucket/xxxx.kind_name.backup_info") do |j|
+        #     j.format = "datastore_backup"
+        #   end
         #
         # @!group Data
         #
@@ -1363,9 +1356,7 @@ module Google
 
           yield updater if block_given?
 
-          job_gapi = updater.to_gapi
-          return load_local(job_id, prefix, file, job_gapi) if local_file? file
-          load_storage job_id, prefix, file, job_gapi
+          load_local_or_uri job_id, prefix, file, updater
         end
 
         ##
@@ -1479,13 +1470,12 @@ module Google
         #   this option. Also note that for most use cases, the block yielded by
         #   this method is a more convenient way to configure the schema.
         #
-        # @yield [schema] A block for setting the schema for the destination
-        #   table. The schema can be omitted if the destination table already
-        #   exists, or if you're loading data from a Google Cloud Datastore
-        #   backup.
-        # @yieldparam [Google::Cloud::Bigquery::Schema] schema The schema
-        #   instance provided using the `schema` option, or a new, empty schema
-        #   instance
+        # @yield [updater] A block for setting the schema of the destination
+        #   table and other options for the load job. The schema can be omitted
+        #   if the destination table already exists, or if you're loading data
+        #   from a Google Cloud Datastore backup.
+        # @yieldparam [Google::Cloud::Bigquery::LoadJob::Updater] updater An
+        #   updater to modify the load job and its schema.
         #
         # @return [Boolean] Returns `true` if the load job was successful.
         #
@@ -1544,8 +1534,9 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #
         #   dataset.load "my_new_table",
-        #                "gs://my-bucket/xxxx.kind_name.backup_info",
-        #                format: "datastore_backup"
+        #                "gs://my-bucket/xxxx.kind_name.backup_info" do |j|
+        #     j.format = "datastore_backup"
+        #   end
         #
         # @!group Data
         #
@@ -1554,31 +1545,28 @@ module Google
                  encoding: nil, delimiter: nil, ignore_unknown: nil,
                  max_bad_records: nil, quote: nil, skip_leading: nil,
                  schema: nil, autodetect: nil, null_marker: nil
+          ensure_service!
 
-          yield (schema ||= Schema.from_gapi) if block_given?
+          updater = load_job_updater table_id,
+                                     format: format, create: create,
+                                     write: write,
+                                     projection_fields: projection_fields,
+                                     jagged_rows: jagged_rows,
+                                     quoted_newlines: quoted_newlines,
+                                     encoding: encoding,
+                                     delimiter: delimiter,
+                                     ignore_unknown: ignore_unknown,
+                                     max_bad_records: max_bad_records,
+                                     quote: quote, skip_leading: skip_leading,
+                                     schema: schema,
+                                     autodetect: autodetect,
+                                     null_marker: null_marker
 
-          options = { format: format, create: create, write: write,
-                      projection_fields: projection_fields,
-                      jagged_rows: jagged_rows,
-                      quoted_newlines: quoted_newlines, encoding: encoding,
-                      delimiter: delimiter, ignore_unknown: ignore_unknown,
-                      max_bad_records: max_bad_records, quote: quote,
-                      skip_leading: skip_leading, schema: schema,
-                      autodetect: autodetect, null_marker: null_marker }
-          job = load_job table_id, file, options
+          yield updater if block_given?
 
+          job = load_local_or_uri nil, nil, file, updater
           job.wait_until_done!
-
-          if job.failed?
-            begin
-              # raise to activate ruby exception cause handling
-              raise job.gapi_error
-            rescue StandardError => e
-              # wrap Google::Apis::Error with Google::Cloud::Error
-              raise Google::Cloud::Error.from_error(e)
-            end
-          end
-
+          ensure_job_succeeded! job
           true
         end
 
@@ -1946,6 +1934,17 @@ module Google
           reload! if resource_partial?
         end
 
+        def ensure_job_succeeded! job
+          return unless job.failed?
+          begin
+            # raise to activate ruby exception cause handling
+            raise job.gapi_error
+          rescue StandardError => e
+            # wrap Google::Apis::Error with Google::Cloud::Error
+            raise Google::Cloud::Error.from_error(e)
+          end
+        end
+
         def load_job_gapi table_id, dryrun
           Google::Apis::BigqueryV2::Job.new(
             configuration: Google::Apis::BigqueryV2::JobConfiguration.new(
@@ -2063,6 +2062,16 @@ module Google
 
           gapi = service.load_table_file job_id, prefix, file, job_gapi
           Job.from_gapi gapi, service
+        end
+
+        def load_local_or_uri job_id, prefix, file, updater
+          job_gapi = updater.to_gapi
+          job = if local_file? file
+                  load_local job_id, prefix, file, job_gapi
+                else
+                  load_storage job_id, prefix, file, job_gapi
+                end
+          job
         end
 
         def storage_url? file

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1207,17 +1207,7 @@ module Google
         def copy destination_table, create: nil, write: nil
           job = copy_job destination_table, create: create, write: write
           job.wait_until_done!
-
-          if job.failed?
-            begin
-              # raise to activate ruby exception cause handling
-              raise job.gapi_error
-            rescue StandardError => e
-              # wrap Google::Apis::Error with Google::Cloud::Error
-              raise Google::Cloud::Error.from_error(e)
-            end
-          end
-
+          ensure_job_succeeded! job
           true
         end
 
@@ -1347,17 +1337,7 @@ module Google
                                          compression: compression,
                                          delimiter: delimiter, header: header
           job.wait_until_done!
-
-          if job.failed?
-            begin
-              # raise to activate ruby exception cause handling
-              raise job.gapi_error
-            rescue StandardError => e
-              # wrap Google::Apis::Error with Google::Cloud::Error
-              raise Google::Cloud::Error.from_error(e)
-            end
-          end
-
+          ensure_job_succeeded! job
           true
         end
 
@@ -1644,6 +1624,13 @@ module Google
         #   value is `0`. This property is useful if you have header rows in the
         #   file that should be skipped.
         #
+        # @yield [updater] A block for setting the schema of the destination
+        #   table and other options for the load job. The schema can be omitted
+        #   if the destination table already exists, or if you're loading data
+        #   from a Google Cloud Datastore backup.
+        # @yieldparam [Google::Cloud::Bigquery::LoadJob::Updater] updater An
+        #   updater to modify the load job and its schema.
+        #
         # @return [Google::Cloud::Bigquery::LoadJob]
         #
         # @example
@@ -1653,7 +1640,7 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
-        #   load_job = table.load_job "gs://my-bucket/file-name.csv"
+        #   success = table.load "gs://my-bucket/file-name.csv"
         #
         # @example Pass a google-cloud-storage `File` instance:
         #   require "google/cloud/bigquery"
@@ -1666,7 +1653,7 @@ module Google
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-bucket"
         #   file = bucket.file "file-name.csv"
-        #   load_job = table.load_job file
+        #   success = table.load file
         #
         # @example Upload a file directly:
         #   require "google/cloud/bigquery"
@@ -1675,8 +1662,10 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
-        #   file = File.open "my_data.csv"
-        #   load_job = table.load_job file
+        #   file = File.open "my_data.json"
+        #   success = table.load file do |j|
+        #     j.format = "newline_delimited_json"
+        #   end
         #
         # @!group Data
         #
@@ -1685,28 +1674,27 @@ module Google
                  encoding: nil, delimiter: nil, ignore_unknown: nil,
                  max_bad_records: nil, quote: nil, skip_leading: nil,
                  autodetect: nil, null_marker: nil
-          job = load_job file, format: format, create: create, write: write,
-                               projection_fields: projection_fields,
-                               jagged_rows: jagged_rows,
-                               quoted_newlines: quoted_newlines,
-                               encoding: encoding, delimiter: delimiter,
-                               ignore_unknown: ignore_unknown,
-                               max_bad_records: max_bad_records, quote: quote,
-                               skip_leading: skip_leading,
-                               autodetect: autodetect, null_marker: null_marker
+          ensure_service!
 
+          updater = load_job_updater format: format, create: create,
+                                     write: write,
+                                     projection_fields: projection_fields,
+                                     jagged_rows: jagged_rows,
+                                     quoted_newlines: quoted_newlines,
+                                     encoding: encoding,
+                                     delimiter: delimiter,
+                                     ignore_unknown: ignore_unknown,
+                                     max_bad_records: max_bad_records,
+                                     quote: quote, skip_leading: skip_leading,
+                                     schema: schema,
+                                     autodetect: autodetect,
+                                     null_marker: null_marker
+
+          yield updater if block_given?
+
+          job = load_local_or_uri nil, nil, file, updater
           job.wait_until_done!
-
-          if job.failed?
-            begin
-              # raise to activate ruby exception cause handling
-              raise job.gapi_error
-            rescue StandardError => e
-              # wrap Google::Apis::Error with Google::Cloud::Error
-              raise Google::Cloud::Error.from_error(e)
-            end
-          end
-
+          ensure_job_succeeded! job
           true
         end
 
@@ -2050,6 +2038,17 @@ module Google
           reload!
         end
 
+        def ensure_job_succeeded! job
+          return unless job.failed?
+          begin
+            # raise to activate ruby exception cause handling
+            raise job.gapi_error
+          rescue StandardError => e
+            # wrap Google::Apis::Error with Google::Cloud::Error
+            raise Google::Cloud::Error.from_error(e)
+          end
+        end
+
         def load_job_gapi table_id, dryrun
           Google::Apis::BigqueryV2::Job.new(
             configuration: Google::Apis::BigqueryV2::JobConfiguration.new(
@@ -2167,6 +2166,16 @@ module Google
 
           gapi = service.load_table_file job_id, prefix, file, job_gapi
           Job.from_gapi gapi, service
+        end
+
+        def load_local_or_uri job_id, prefix, file, updater
+          job_gapi = updater.to_gapi
+          job = if local_file? file
+                  load_local job_id, prefix, file, job_gapi
+                else
+                  load_storage job_id, prefix, file, job_gapi
+                end
+          job
         end
 
         def storage_url? file


### PR DESCRIPTION
This will allow additional properties to be added to LoadJob without
needing to add additional arguments to the `dataset.load` and
`table.load` methods.

Also added a `ensure_job_succeeded! job` method to get the line counts
down enough to make rubocop happy with the change.

This is the follow-up to https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/1973 and another step towards adding the encryption configuration properties in https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1960.