### PR TITLE
Add partitioning by field to BigQuery

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -43,7 +43,11 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     if t.nil?
       t = dataset.create_table time_partitioned_table_id do |updater|
         updater.time_partitioning_type = "DAY"
+        updater.time_partitioning_field = "dob"
         updater.time_partitioning_expiration = seven_days
+        updater.schema do |schema|
+          schema.timestamp "dob",   description: "dob description",   mode: :required
+        end
       end
     end
     t
@@ -85,6 +89,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     fresh.table?.must_equal true
     fresh.view?.must_equal false
     fresh.time_partitioning_type.must_be_nil
+    fresh.time_partitioning_field.must_be_nil
     fresh.time_partitioning_expiration.must_be_nil
     #fresh.location.must_equal "US"       TODO why nil? Set in dataset
 
@@ -170,6 +175,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     partitioned_table.reload!
     partitioned_table.table_id.must_equal "weekly_kittens"
     partitioned_table.time_partitioning_type.must_equal "DAY"
+    partitioned_table.time_partitioning_field.must_be_nil
     partitioned_table.time_partitioning_expiration.must_equal 1
   end
 
@@ -196,6 +202,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
   it "allows tables to be created with time_partioning enabled" do
     table = time_partitioned_table
     table.time_partitioning_type.must_equal "DAY"
+    table.time_partitioning_field.must_equal "dob"
     table.time_partitioning_expiration.must_equal seven_days
   end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -218,6 +218,64 @@ module Google
         end
 
         ###
+        # The field on which the table is partitioned, if any. See
+        # [Partitioned Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        #
+        # @return [String, nil] The partition field, if a field was configured.
+        #   `nil` if not partitioned, not set (partitioned by pseudo column
+        #   '_PARTITIONTIME') or the object is a reference (see {#reference?}).
+        #
+        # @!group Attributes
+        #
+        def time_partitioning_field
+          return nil if reference?
+          ensure_full_data!
+          @gapi.time_partitioning.field if time_partitioning?
+        end
+
+        ##
+        # Sets the field on which to partition the table. See [Partitioned
+        # Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+        # The table must also be partitioned.
+        #
+        # See {Table#time_partitioning_type=}.
+        #
+        # You can only set the partitioning field while creating a table as in
+        # the example below. BigQuery does not allow you to change partitioning
+        # on an existing table.
+        #
+        # If the table is not a full resource representation (see
+        # {#resource_full?}), the full representation will be retrieved before
+        # the update to comply with ETag-based optimistic concurrency control.
+        #
+        # @param [String] field The partition field. The field must be a
+        #   top-level TIMESTAMP or DATE field. Its mode must be NULLABLE or
+        #   REQUIRED.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.create_table "my_table" do |table|
+        #     table.time_partitioning_type  = "DAY"
+        #     table.time_partitioning_field = "dob"
+        #     table.schema do |schema|
+        #       schema.timestamp "dob", mode: :required
+        #     end
+        #   end
+        #
+        # @!group Attributes
+        #
+        def time_partitioning_field= field
+          reload! unless resource_full?
+          @gapi.time_partitioning ||= \
+            Google::Apis::BigqueryV2::TimePartitioning.new
+          @gapi.time_partitioning.field = field
+          patch_gapi! :time_partitioning
+        end
+
+        ###
         # The expiration for the table partitions, if any, in seconds. See
         # [Partitioned Tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
         #

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -66,6 +66,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
 
     table.time_partitioning?.must_be_nil
     table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
     table.id.must_be_nil
     table.name.must_be_nil

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
@@ -86,6 +86,28 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.verify
   end
 
+  it "updates time partitioning field" do
+    field = "dob"
+
+    mock = Minitest::Mock.new
+    table_hash = random_table_hash dataset_id, table_id, table_name, description
+    table_hash["timePartitioning"] = {
+        "field"  => field,
+    }
+    partitioning = Google::Apis::BigqueryV2::TimePartitioning.new field: field
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
+    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
+    mock.expect :patch_table, return_table(table_hash),
+                [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
+    table.service.mocked_service = mock
+
+    table.time_partitioning_field = field
+
+    table.time_partitioning_field.must_equal field
+    mock.verify
+  end
+
   it "updates time partitioning expiration" do
     expiration = 86_400
     expiration_ms = expiration * 1_000

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -43,6 +43,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
     table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
 
     table.name = new_table_name
@@ -51,6 +52,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
     table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
 
     mock.verify
@@ -71,6 +73,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
     table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
 
     table.description = new_description
@@ -79,6 +82,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.description.must_equal new_description
     table.schema.fields.count.must_equal schema.fields.count
     table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
 
     mock.verify
@@ -103,6 +107,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
     table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
 
     table.time_partitioning_type = type
@@ -111,6 +116,40 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
     table.time_partitioning_type.must_equal type
+    table.time_partitioning_expiration.must_be_nil
+
+    mock.verify
+  end
+
+  it "updates time partitioning field" do
+    field = "dob"
+
+    mock = Minitest::Mock.new
+    table_hash = random_table_hash dataset_id, table_id, table_name, description
+    table_hash["timePartitioning"] = {
+        "field"  => field,
+    }
+    partitioning = Google::Apis::BigqueryV2::TimePartitioning.new field: field
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
+    mock.expect :patch_table, return_table(table_hash),
+                [project, dataset_id, table_id, request_table_gapi, {options: {header: {"If-Match" => etag}}}]
+    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id]
+    table.service.mocked_service = mock
+
+    table.name.must_equal table_name
+    table.description.must_equal description
+    table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
+    table.time_partitioning_expiration.must_be_nil
+
+    table.time_partitioning_field = field
+
+    table.name.must_equal table_name
+    table.description.must_equal description
+    table.schema.fields.count.must_equal schema.fields.count
+    table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_equal field
     table.time_partitioning_expiration.must_be_nil
 
     mock.verify
@@ -136,6 +175,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
     table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_be_nil
 
     table.time_partitioning_expiration = expiration
@@ -144,6 +184,7 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     table.description.must_equal description
     table.schema.fields.count.must_equal schema.fields.count
     table.time_partitioning_type.must_be_nil
+    table.time_partitioning_field.must_be_nil
     table.time_partitioning_expiration.must_equal expiration
 
     mock.verify


### PR DESCRIPTION
In #1646 we added support for setting up partitioning when creating tables in BigQuery. About a month later Google released an update to support partitioning by field, rather than just partitioning on the ingestion date (or writing directly to a partition).

This updates `google-cloud-bigquery` gem to support setting that field.