### PR TITLE
Add table acceptance test for BigQuery partitioning by field

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
@@ -107,7 +107,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
   it "gets and sets time partitioning" do
     partitioned_table = dataset.table partitioned_table_id
     if partitioned_table.nil?
-      partitioned_table = dataset.create_table partitioned_table_id do |updater|
+      dataset.create_table partitioned_table_id do |updater|
         updater.time_partitioning_type = "DAY"
         updater.time_partitioning_expiration = seven_days
       end
@@ -126,7 +126,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
   it "gets and sets time partitioning by field" do
     partitioned_table = dataset.table partitioned_field_table_id
     if partitioned_table.nil?
-      partitioned_table = dataset.create_table partitioned_field_table_id do |updater|
+      dataset.create_table partitioned_field_table_id do |updater|
         updater.time_partitioning_type = "DAY"
         updater.time_partitioning_field = "dob"
         updater.time_partitioning_expiration = seven_days

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -179,6 +179,28 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     partitioned_table.time_partitioning_expiration.must_equal 1
   end
 
+  it "gets and sets time partitioning by field" do
+    partitioned_table = dataset.table "kittens_field_reference"
+    if partitioned_table.nil?
+      partitioned_table = dataset.create_table "kittens_field_reference" do |updater|
+        updater.time_partitioning_type = "DAY"
+        updater.time_partitioning_field = "dob"
+        updater.time_partitioning_expiration = seven_days
+        updater.schema do |schema|
+          schema.timestamp "dob",   description: "dob description",   mode: :required
+        end
+      end
+    end
+
+    partitioned_table.time_partitioning_expiration = 1
+
+    partitioned_table.reload!
+    partitioned_table.table_id.must_equal "kittens_field_reference"
+    partitioned_table.time_partitioning_type.must_equal "DAY"
+    partitioned_table.time_partitioning_field.must_equal "dob"
+    partitioned_table.time_partitioning_expiration.must_equal 1
+  end
+
   it "updates its schema" do
     begin
       t = dataset.create_table "table_schema_test"


### PR DESCRIPTION
I realized I missed a test in #1978.

I also removed unused variables in the BigQuery `table_reference_test` (because the variable is re-assigned to the local reference object).

I'm getting a failure in acceptance tests on this:
> Google::Cloud::Bigquery::bigquery#test_0011_should get a list of projects
But I get that on master as well, so I don't think it's related to this change.