### PR TITLE
google-api-client upgrades

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.1"
-  gem.add_dependency "google-api-client", "~> 0.17.0"
+  gem.add_dependency "google-api-client", "~> 0.19.8"
   gem.add_dependency "googleauth", "~> 0.6.2"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 

--- a/google-cloud-dns/acceptance/dns/dns_test.rb
+++ b/google-cloud-dns/acceptance/dns/dns_test.rb
@@ -18,7 +18,7 @@ require "tempfile"
 # This test is a ruby version of gcloud-node's dns test.
 describe Google::Cloud::Dns, :dns do
   let(:dns) { $dns }
-  let(:zone_dns) { $dns_domain }
+  let(:zone_dns) { $dns_domain + "." }
   let(:zone_name) { $dns_prefix }
   let(:zone) { $dns_zone ||= (dns.zone(zone_name) || dns.create_zone(zone_name, zone_dns)) }
 

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.1"
-  gem.add_dependency "google-api-client", "~> 0.17.0"
+  gem.add_dependency "google-api-client", "~> 0.19.0"
   gem.add_dependency "googleauth", "~> 0.6.2"
   gem.add_dependency "zonefile", "~> 1.04"
 

--- a/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
+++ b/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.1"
-  gem.add_dependency "google-api-client", "~> 0.17.0"
+  gem.add_dependency "google-api-client", "~> 0.19.8"
   gem.add_dependency "googleauth", "~> 0.6.2"
 
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.1"
-  gem.add_dependency "google-api-client", "~> 0.17.4"
+  gem.add_dependency "google-api-client", "~> 0.19.0"
   gem.add_dependency "googleauth", "~> 0.6.2"
   gem.add_dependency "digest-crc", "~> 0.4"
 


### PR DESCRIPTION
This PR upgrades the `google-api-client` dependency in each package to the lowest patch version of `0.19.x` that contains all API changes for the package (see [CHANGELOG](https://github.com/google/google-api-ruby-client/blob/master/CHANGELOG.md).)

I tested these upgrades with top-level `bundle update` and `bundle exec rake ci[yes]`, both passed.

I also ran BigQuery, Storage, and DNS acceptance tests. (ResourceManager does not have acceptance tests due to not having support for service accounts.)