### PR TITLE
Update Bigquery README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,26 +81,27 @@ $ gem install google-cloud-bigquery
 ```ruby
 require "google/cloud/bigquery"
 
-bigquery = Google::Cloud::Bigquery.new(
-  project_id: "my-todo-project",
-  credentials: "/path/to/keyfile.json"
-)
+bigquery = Google::Cloud::Bigquery.new
+dataset = bigquery.create_dataset "my_dataset"
 
-# Create a new table to archive todos
-dataset = bigquery.dataset "my-todo-archive"
-table = dataset.create_table "todos",
-          name: "Todos Archive",
-          description: "Archive for completed TODO records"
+table = dataset.create_table "my_table" do |t|
+  t.name = "My Table",
+  t.description = "A description of my table."
+  t.schema do |s|
+    s.string "first_name", mode: :required
+    s.string "last_name", mode: :required
+    s.integer "age", mode: :required
+  end
+end
 
-# Load data into the table
-file = File.open "/archive/todos/completed-todos.csv"
-load_job = table.load file
+# Load data into the table from Google Cloud Storage
+table.load "gs://my-bucket/file-name.csv"
 
-# Run a query for the number of completed todos by owner
-count_sql = "SELECT owner, COUNT(*) AS complete_count FROM todos GROUP BY owner"
-data = bigquery.query count_sql
+# Run a query
+data = dataset.query "SELECT first_name FROM my_table"
+
 data.each do |row|
-  puts row[:name]
+  puts row[:first_name]
 end
 ```
 

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -23,26 +23,27 @@ Instructions and configuration options are covered in the [Authentication Guide]
 ```ruby
 require "google/cloud/bigquery"
 
-bigquery = Google::Cloud::Bigquery.new(
-  project_id: "my-todo-project",
-  credentials: "/path/to/keyfile.json"
-)
+bigquery = Google::Cloud::Bigquery.new
+dataset = bigquery.create_dataset "my_dataset"
 
-# Create a new table to archive todos
-dataset = bigquery.dataset "my-todo-archive"
-table = dataset.create_table "todos",
-          name: "Todos Archive",
-          description: "Archive for completed TODO records"
+table = dataset.create_table "my_table" do |t|
+  t.name = "My Table",
+  t.description = "A description of my table."
+  t.schema do |s|
+    s.string "first_name", mode: :required
+    s.string "last_name", mode: :required
+    s.integer "age", mode: :required
+  end
+end
 
-# Load data into the table
-file = File.open "/archive/todos/completed-todos.csv"
-table.load file
+# Load data into the table from Google Cloud Storage
+table.load "gs://my-bucket/file-name.csv"
 
-# Run a query for the number of completed todos by owner
-count_sql = "SELECT owner, COUNT(*) AS complete_count FROM todos GROUP BY owner"
-data = bigquery.query count_sql
+# Run a query
+data = dataset.query "SELECT first_name FROM my_table"
+
 data.each do |row|
-  puts row[:name]
+  puts row[:first_name]
 end
 ```
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1643,7 +1643,7 @@ module Google
         #   value is `0`. This property is useful if you have header rows in the
         #   file that should be skipped.
         #
-        # @return [Google::Cloud::Bigquery::LoadJob]
+        # @return [Boolean] Returns `true` if the load job was successful.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -1652,7 +1652,7 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
-        #   load_job = table.load_job "gs://my-bucket/file-name.csv"
+        #   table.load "gs://my-bucket/file-name.csv"
         #
         # @example Pass a google-cloud-storage `File` instance:
         #   require "google/cloud/bigquery"
@@ -1665,7 +1665,7 @@ module Google
         #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-bucket"
         #   file = bucket.file "file-name.csv"
-        #   load_job = table.load_job file
+        #   table.load file
         #
         # @example Upload a file directly:
         #   require "google/cloud/bigquery"
@@ -1675,7 +1675,7 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   file = File.open "my_data.csv"
-        #   load_job = table.load_job file
+        #   table.load file
         #
         # @!group Data
         #


### PR DESCRIPTION
This PR also fixes `BigQuery::Table#load` documentation:

* Fix return type.
* Replace `#load_job` examples with `#load` examples.

[fixes #1935]