### PR TITLE
Document and check for unsupported Ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,7 +788,14 @@ $ gem install google-cloud-video_intelligence
 
 ## Supported Ruby Versions
 
-google-cloud-ruby is supported on Ruby 2.0+.
+These libraries are currently supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
 
 ## Versioning
 

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -35,6 +35,13 @@ end
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -51,6 +51,13 @@ end
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -20,6 +20,17 @@ steps:
 $ gem install google-cloud-bigtable
 ```
 
+### Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ### Next Steps
 - Read the [Client Library Documentation][] for Cloud Bigtable API
   to see other available methods on the client.

--- a/google-cloud-container/README.md
+++ b/google-cloud-container/README.md
@@ -31,6 +31,17 @@ zone = "us-central1-a"
 response = cluster_manager_client.list_clusters(project_id_2, zone)
 ```
 
+### Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ### Next Steps
 - Read the [Client Library Documentation][] for Google Container Engine API
   to see other available methods on the client.

--- a/google-cloud-core/README.md
+++ b/google-cloud-core/README.md
@@ -8,11 +8,11 @@ This library contains shared types, such as error classes, for the google-cloud 
 
 This library is currently supported on Ruby 2.0+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases are
-or are nearing end-of-life. After June 1, 2018, Google will provide official
-support only for Ruby versions that are considered current and supported by
-Ruby-core (that is, Ruby versions that are either in normal maintenance or in
-security maintenance).
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
 See https://www.ruby-lang.org/en/downloads/branches/ for further details.
 
 ## Versioning

--- a/google-cloud-core/README.md
+++ b/google-cloud-core/README.md
@@ -6,7 +6,14 @@ This library contains shared types, such as error classes, for the google-cloud 
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is currently supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases are
+or are nearing end-of-life. After June 1, 2018, Google will provide official
+support only for Ruby versions that are considered current and supported by
+Ruby-core (that is, Ruby versions that are either in normal maintenance or in
+security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
 
 ## Versioning
 

--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -113,7 +113,8 @@ module Google
             "GCLOUD_KEYFILE", "GCLOUD_KEYFILE_JSON"
         end
 
-        config.add_field! :project_id, default_project, match: String, allow_nil: true
+        config.add_field! :project_id, default_project,
+                          match: String, allow_nil: true
         config.add_alias! :project, :project_id
         config.add_field! :credentials, default_creds, match: Object
         config.add_alias! :keyfile, :credentials
@@ -129,13 +130,13 @@ module Google
     # Minimum "supported" Ruby version (non-EOL)
     # @private
     #
-    SUPPORTED_VERSION_THRESHOLD = "2.0"
+    SUPPORTED_VERSION_THRESHOLD = "2.0".freeze
 
     ##
     # Minimum "recommended" Ruby version (normal maintenance)
     # @private
     #
-    RECOMMENDED_VERSION_THRESHOLD = "2.3"
+    RECOMMENDED_VERSION_THRESHOLD = "2.3".freeze
 
     ##
     # Check Ruby version and emit a warning if it is old

--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -148,7 +148,7 @@ module Google
       cur_version = Gem::Version.new RUBY_VERSION
       if cur_version < Gem::Version.new(supported_version)
         warn "WARNING: You are running Ruby #{cur_version}, which has reached" \
-          " end-of-life and is no longer supported by Ruby-core."
+          " end-of-life and is no longer supported by Ruby Core."
         warn "It is strongly recommended that you upgrade to Ruby" \
           " #{recommended_version} or later."
         warn "See https://www.ruby-lang.org/en/downloads/branches/ for more" \

--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -96,26 +96,80 @@ module Google
 
       @config
     end
+
+    ##
+    # Initialize toplevel configuration
+    # @private
+    #
+    def self.init_configuration
+      configure do |config|
+        default_project = Google::Cloud::Config.deferred do
+          ENV["GOOGLE_CLOUD_PROJECT"] || ENV["GCLOUD_PROJECT"]
+        end
+        default_creds = Google::Cloud::Config.deferred do
+          Google::Cloud::Config.credentials_from_env \
+            "GOOGLE_CLOUD_CREDENTIALS", "GOOGLE_CLOUD_CREDENTIALS_JSON",
+            "GOOGLE_CLOUD_KEYFILE", "GOOGLE_CLOUD_KEYFILE_JSON",
+            "GCLOUD_KEYFILE", "GCLOUD_KEYFILE_JSON"
+        end
+
+        config.add_field! :project_id, default_project, match: String, allow_nil: true
+        config.add_alias! :project, :project_id
+        config.add_field! :credentials, default_creds, match: Object
+        config.add_alias! :keyfile, :credentials
+      end
+    end
+
+    # In June, 2018, set supported version to 2.3 and recommended to 2.4.
+    # Thereafter, follow the MRI support schedule: supported means non-EOL,
+    # and recommended means in normal (rather than security) maintenance.
+    # See https://www.ruby-lang.org/en/downloads/branches/
+
+    ##
+    # Minimum "supported" Ruby version (non-EOL)
+    # @private
+    #
+    SUPPORTED_VERSION_THRESHOLD = "2.0"
+
+    ##
+    # Minimum "recommended" Ruby version (normal maintenance)
+    # @private
+    #
+    RECOMMENDED_VERSION_THRESHOLD = "2.3"
+
+    ##
+    # Check Ruby version and emit a warning if it is old
+    # @private
+    #
+    def self.warn_on_old_ruby_version \
+        supported_version: SUPPORTED_VERSION_THRESHOLD,
+        recommended_version: RECOMMENDED_VERSION_THRESHOLD
+      cur_version = Gem::Version.new RUBY_VERSION
+      if cur_version < Gem::Version.new(supported_version)
+        warn "WARNING: You are running Ruby #{cur_version}, which has reached" \
+          " end-of-life and is no longer supported by Ruby-core."
+        warn "It is strongly recommended that you upgrade to Ruby" \
+          " #{recommended_version} or later."
+        warn "See https://www.ruby-lang.org/en/downloads/branches/ for more" \
+          " info on the Ruby maintenance schedule."
+      elsif cur_version < Gem::Version.new(recommended_version)
+        warn "WARNING: You are running Ruby #{cur_version}, which is nearing" \
+          " end-of-life."
+        warn "Consider upgrading to Ruby #{recommended_version} or later."
+        warn "See https://www.ruby-lang.org/en/downloads/branches/ for more" \
+          " info on the Ruby maintenance schedule."
+      end
+    rescue ArgumentError
+      warn "Unable to determine current Ruby version."
+    end
   end
 end
 
 # Set the default top-level configuration
-Google::Cloud.configure do |config|
-  default_project = Google::Cloud::Config.deferred do
-    ENV["GOOGLE_CLOUD_PROJECT"] || ENV["GCLOUD_PROJECT"]
-  end
-  default_creds = Google::Cloud::Config.deferred do
-    Google::Cloud::Config.credentials_from_env \
-      "GOOGLE_CLOUD_CREDENTIALS", "GOOGLE_CLOUD_CREDENTIALS_JSON",
-      "GOOGLE_CLOUD_KEYFILE", "GOOGLE_CLOUD_KEYFILE_JSON",
-      "GCLOUD_KEYFILE", "GCLOUD_KEYFILE_JSON"
-  end
+Google::Cloud.init_configuration
 
-  config.add_field! :project_id, default_project, match: String, allow_nil: true
-  config.add_alias! :project, :project_id
-  config.add_field! :credentials, default_creds, match: Object
-  config.add_alias! :keyfile, :credentials
-end
+# Emit a warning if current Ruby is at or nearing end-of-life
+Google::Cloud.warn_on_old_ruby_version
 
 # Auto-load all Google Cloud service gems.
 Gem.find_files("google-cloud-*.rb").each do |google_cloud_service|

--- a/google-cloud-dataproc/README.md
+++ b/google-cloud-dataproc/README.md
@@ -42,6 +42,17 @@ cluster_controller_client.list_clusters(project_id_2, region).each_page do |page
 end
 ```
 
+### Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ### Next Steps
 - Read the [Client Library Documentation][] for Google Cloud Dataproc API
   to see other available methods on the client.

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -51,6 +51,13 @@ tasks = datastore.run query
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -226,6 +226,13 @@ for a list of possible configuration options.
 
 This library is supported on Ruby 2.2 or later.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 This library follows [Semantic Versioning](http://semver.org/). It is currently
 in major version zero (0.y.z), which means that anything may change at any time
 and the public API should not be considered stable.

--- a/google-cloud-dlp/README.md
+++ b/google-cloud-dlp/README.md
@@ -21,6 +21,17 @@ steps:
 $ gem install google-cloud-dlp
 ```
 
+### Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ### Preview
 #### DlpServiceClient
 ```rb

--- a/google-cloud-dns/README.md
+++ b/google-cloud-dns/README.md
@@ -44,6 +44,13 @@ end
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-env/README.md
+++ b/google-cloud-env/README.md
@@ -8,6 +8,13 @@ This library provides information on the application hosting environment for app
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -182,6 +182,13 @@ in the [Authentication Guide](https://googlecloudplatform.github.io/google-cloud
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-firestore/README.md
+++ b/google-cloud-firestore/README.md
@@ -18,6 +18,17 @@ steps:
 $ gem install google-cloud-firestore
 ```
 
+### Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ### Next Steps
 - Read the [Client Library Documentation][] for Google Cloud Firestore API
   to see other available methods on the client.

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -33,6 +33,17 @@ document = { content: content, type: type }
 response = language_service_client.analyze_sentiment(document)
 ```
 
+### Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ### Next Steps
 - Read the [Client Library Documentation][] for Google Cloud Natural Language API
   to see other available methods on the client.

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -160,6 +160,13 @@ for more ways to authenticate the client library.
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-monitoring/README.md
+++ b/google-cloud-monitoring/README.md
@@ -42,6 +42,17 @@ metric_service_client.list_monitored_resource_descriptors(formatted_name).each_p
 end
 ```
 
+### Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ### Next Steps
 - Read the [Client Library Documentation][] for Stackdriver Monitoring API
   to see other available methods on the client.

--- a/google-cloud-os_login/README.md
+++ b/google-cloud-os_login/README.md
@@ -19,6 +19,17 @@ steps:
 $ gem install google-cloud-os_login
 ```
 
+### Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ### Next Steps
 - Read the [Client Library Documentation][] for Google Cloud OS Login API
   to see other available methods on the client.

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -54,6 +54,13 @@ subscriber.stop.wait!
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -64,6 +64,13 @@ projects = resource_manager.projects filter: "labels.env:production"
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-spanner/README.md
+++ b/google-cloud-spanner/README.md
@@ -40,6 +40,13 @@ end
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-speech/README.md
+++ b/google-cloud-speech/README.md
@@ -40,6 +40,13 @@ result.confidence #=> 0.9826789498329163
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -44,6 +44,13 @@ file.copy backup, file.name
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-trace/README.md
+++ b/google-cloud-trace/README.md
@@ -187,6 +187,13 @@ in the [Authentication Guide](https://googlecloudplatform.github.io/google-cloud
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -44,6 +44,13 @@ translation.text #=> "Salve mundi!"
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud-video_intelligence/README.md
+++ b/google-cloud-video_intelligence/README.md
@@ -57,6 +57,17 @@ operation.reload!
 operation.wait_until_done!
 ```
 
+### Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.
+
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ### Next Steps
 - Read the [Client Library Documentation][] for Cloud Video Intelligence API
   to see other available methods on the client.

--- a/google-cloud-vision/README.md
+++ b/google-cloud-vision/README.md
@@ -35,6 +35,13 @@ landmark.description #=> "Mount Rushmore"
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -6,6 +6,13 @@ This gem is a convenience package for loading all gems in the google-cloud proje
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/stackdriver-core/README.md
+++ b/stackdriver-core/README.md
@@ -8,6 +8,13 @@ This library contains shared types and utilities for Stackdriver-related librari
 
 This library is supported on Ruby 2.0+.
 
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -110,8 +110,14 @@ See the gem documentation for each individual gem for more information.
 
 This library is supported on Ruby 2.2+.
 
-This library follows [Semantic Versioning](http://semver.org/).
+However, Ruby 2.3 or later is strongly recommended, as earlier releases have
+reached or are nearing end-of-life. After June 1, 2018, Google will provide
+official support only for Ruby versions that are considered current and
+supported by Ruby Core (that is, Ruby versions that are either in normal
+maintenance or in security maintenance).
+See https://www.ruby-lang.org/en/downloads/branches/ for further details.
 
+This library follows [Semantic Versioning](http://semver.org/).
 It is currently in major version zero (0.y.z), which means that anything may change at any time and the public API should not be considered stable.
 
 ## Contributing


### PR DESCRIPTION
I added code that will check for the current `RUBY_VERSION` at `google-cloud-core` load time, and print warnings if an old version is detected.

Also proposed some language in the README (just edited google-cloud-core's readme for now). If this looks good, I'll replicate it over the other readmes.