### PR TITLE
Pub/Sub Subscriber Thread Fix

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/enumerator_queue.rb
@@ -30,9 +30,11 @@ module Google
             @queue.push obj
           end
 
-          def dump_queue
+          def quit_and_dump_queue
             objs = []
             objs << @queue.pop until @queue.empty?
+            # Signal that the enumerator is ready to end
+            @queue.push @sentinel
             objs
           end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -256,7 +256,7 @@ module Google
 
             # signal to the previous queue to shut down
             old_queue = []
-            old_queue = @request_queue.dump_queue if @request_queue
+            old_queue = @request_queue.quit_and_dump_queue if @request_queue
 
             @request_queue = EnumeratorQueue.new self
             @request_queue.push initial_input_request


### PR DESCRIPTION
This PR addresses a slow load of threads when using a Subscriber. A GRPC streaming response does not stay open indefinitely, and will need to be restarted when it fails. As part of the restart we need to ensure that the streaming request thread in GRPC is also closed. See #1994 for further discussion.