### PR TITLE
BigQuery: Allow loading data from a list of URLs

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -159,6 +159,51 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
     result.must_equal true
   end
 
+  it "imports data from a list of files in your bucket with load_job" do
+    begin
+      more_data = rows.map { |row| JSON.generate row }.join("\n")
+      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      file1 = bucket.create_file local_file
+      file2 = bucket.create_file StringIO.new(more_data),
+                                 "more-kitten-test-data.json"
+      gs_url = "gs://#{file2.bucket}/#{file2.name}"
+
+      # Test both by file object and URL as string
+      job = dataset.load_job table_id, [file1, gs_url]
+      job.wait_until_done!
+      job.wont_be :failed?
+      job.input_files.must_equal 2
+      job.output_rows.must_equal 6
+    ensure
+      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
+      if post_bucket
+        post_bucket.files.map &:delete
+        post_bucket.delete
+      end
+    end
+  end
+
+  it "imports data from a list of files in your bucket with load" do
+    begin
+      more_data = rows.map { |row| JSON.generate row }.join("\n")
+      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      file1 = bucket.create_file local_file
+      file2 = bucket.create_file StringIO.new(more_data),
+                                 "more-kitten-test-data.json"
+      gs_url = "gs://#{file2.bucket}/#{file2.name}"
+
+      # Test both by file object and URL as string
+      result = dataset.load table_id, [file1, gs_url]
+      result.must_equal true
+    ensure
+      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
+      if post_bucket
+        post_bucket.files.map &:delete
+        post_bucket.delete
+      end
+    end
+  end
+
   it "adds an access entry with specifying user scope" do
     dataset.access do |acl|
       acl.add_reader_user user_val

--- a/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
@@ -245,9 +245,42 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
     job.output_rows.must_equal 3
   end
 
+  it "imports data from a file in your bucket with load_job" do
+    begin
+      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      file = bucket.create_file local_file
+
+      job = table.load_job file
+      job.wait_until_done!
+      job.wont_be :failed?
+    ensure
+      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
+      if post_bucket
+        post_bucket.files.map &:delete
+        post_bucket.delete
+      end
+    end
+  end
+
   it "imports data from a local file with load" do
     result = table.load local_file
     result.must_equal true
+  end
+
+  it "imports data from a file in your bucket with load" do
+    begin
+      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      file = bucket.create_file local_file
+
+      result = table.load file
+      result.must_equal true
+    ensure
+      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
+      if post_bucket
+        post_bucket.files.map &:delete
+        post_bucket.delete
+      end
+    end
   end
 
   it "copies itself to another table with copy_job" do

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -476,6 +476,30 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     end
   end
 
+  it "imports data from a list of files in your bucket with load_job" do
+    begin
+      more_data = rows.map { |row| JSON.generate row }.join("\n")
+      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      file1 = bucket.create_file local_file
+      file2 = bucket.create_file StringIO.new(more_data),
+                                 "more-kitten-test-data.json"
+      gs_url = "gs://#{file2.bucket}/#{file2.name}"
+
+      # Test both by file object and URL as string
+      job = table.load_job [file1, gs_url]
+      job.wait_until_done!
+      job.wont_be :failed?
+      job.input_files.must_equal 2
+      job.output_rows.must_equal 6
+    ensure
+      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
+      if post_bucket
+        post_bucket.files.map &:delete
+        post_bucket.delete
+      end
+    end
+  end
+
   it "imports data from a local file with load" do
     result = table.load local_file
     result.must_equal true
@@ -487,6 +511,27 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
       file = bucket.create_file local_file
 
       result = table.load file
+      result.must_equal true
+    ensure
+      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
+      if post_bucket
+        post_bucket.files.map &:delete
+        post_bucket.delete
+      end
+    end
+  end
+
+  it "imports data from a list of files in your bucket with load" do
+    begin
+      more_data = rows.map { |row| JSON.generate row }.join("\n")
+      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      file1 = bucket.create_file local_file
+      file2 = bucket.create_file StringIO.new(more_data),
+                                 "more-kitten-test-data.json"
+      gs_url = "gs://#{file2.bucket}/#{file2.name}"
+
+      # Test both by file object and URL as string
+      result = table.load [file1, gs_url]
       result.must_equal true
     ensure
       post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -270,6 +270,19 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Dataset#load_job@Pass a list of google-cloud-storage files:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name2.csv", Hash]
+    end
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::Dataset#load@Upload a file directly:" do
     skip "This creates a File object, which is difficult to mock with doctest."
   end
@@ -278,6 +291,19 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
       mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
+    end
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::Dataset#load@Pass a list of google-cloud-storage files:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name2.csv", Hash]
     end
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
@@ -684,6 +710,19 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Table#load_job@Pass a list of google-cloud-storage files:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name2.csv", Hash]
+    end
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::Table#load@Upload a file directly:" do
     skip "This creates a File object, which is difficult to mock with doctest."
   end
@@ -692,6 +731,19 @@ YARD::Doctest.configure do |doctest|
     mock_storage do |mock|
       mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
       mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
+    end
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::Table#load@Pass a list of google-cloud-storage files:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket,  OpenStruct.new(name: "my-bucket"), ["my-bucket", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name.csv", Hash]
+      mock.expect :get_object,  OpenStruct.new(bucket: "my-bucket", name: "path/to/audio.raw"), ["my-bucket", "file-name2.csv", Hash]
     end
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_storage_test.rb
@@ -200,6 +200,20 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :storage, :mock_bigquery d
     mock.verify
   end
 
+  it "can specify an Array of storage urls as strings or URIs" do
+    load_url2 = storage_file("more-kittens").to_gs_url
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_reference, [load_url, load_url2]
+    mock.expect :insert_job, load_job_resp_gapi([load_url, load_url2]),
+                [project, job_gapi]
+    dataset.service.mocked_service = mock
+
+    job = dataset.load_job table_id, [URI(load_url), load_url2]
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
   it "can load itself as a dryrun" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_reference, load_url

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_storage_test.rb
@@ -200,6 +200,20 @@ describe Google::Cloud::Bigquery::Dataset, :load, :storage, :mock_bigquery do
     mock.verify
   end
 
+  it "can specify an Array of storage urls as strings or URIs" do
+    load_url2 = storage_file("more-kittens").to_gs_url
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_reference, [load_url, load_url2]
+    mock.expect :insert_job, load_job_resp_gapi([load_url, load_url2]),
+                [project, job_gapi]
+    dataset.service.mocked_service = mock
+
+    result = dataset.load table_id, [URI(load_url), load_url2]
+    result.must_equal true
+
+    mock.verify
+  end
+
   it "can load itself with create disposition" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_reference, load_url

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_storage_test.rb
@@ -181,6 +181,20 @@ describe Google::Cloud::Bigquery::Table, :load_job, :storage, :mock_bigquery do
     mock.verify
   end
 
+  it "can specify an Array of storage urls as strings or URIs" do
+    load_url2 = storage_file("more-kittens").to_gs_url
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, [load_url, load_url2]
+    mock.expect :insert_job, load_job_resp_gapi(table, [load_url, load_url2]),
+                [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job [URI(load_url), load_url2]
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
   it "can load itself as a dryrun" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_gapi.table_reference, load_url

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_storage_test.rb
@@ -181,6 +181,20 @@ describe Google::Cloud::Bigquery::Table, :load, :storage, :mock_bigquery do
     mock.verify
   end
 
+  it "can specify an Array of storage urls as strings or URIs" do
+    load_url2 = storage_file("more-kittens").to_gs_url
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, [load_url, load_url2]
+    mock.expect :insert_job, load_job_resp_gapi(table, [load_url, load_url2]),
+                [project, job_gapi]
+    table.service.mocked_service = mock
+
+    result = table.load [URI(load_url), load_url2]
+    result.must_equal true
+
+    mock.verify
+  end
+
   it "can load itself with create disposition" do
     mock = Minitest::Mock.new
     job_gapi = load_job_url_gapi table_gapi.table_reference, load_url

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -675,13 +675,13 @@ class MockBigquery < Minitest::Spec
     )
   end
 
-  def load_job_url_gapi table_reference, url, job_id: "job_9876543210"
+  def load_job_url_gapi table_reference, urls, job_id: "job_9876543210"
     Google::Apis::BigqueryV2::Job.new(
       job_reference: job_reference_gapi(project, job_id),
       configuration: Google::Apis::BigqueryV2::JobConfiguration.new(
         load: Google::Apis::BigqueryV2::JobConfigurationLoad.new(
           destination_table: table_reference,
-          source_uris: [url],
+          source_uris: [urls].flatten,
         ),
         dry_run: nil
       )


### PR DESCRIPTION
In the BigQuery API documentation, a load job can be given a list or source URIs. This PR updates the client to allow you to send an array of `Storage` objects, or URLs (and `String` or `URI`), when loading data into a table or dataset.

The initial commit adds some table-reference acceptance tests that were missing, but make it complete with the table acceptance tests.

I noticed that there are very few load/load_job acceptance tests for the dataset. Would you like me to also fill that in to cover all the various cases we have for table and table-reference?