### PR TITLE
BigQuery: Add QueryJob::Updater class

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -22,7 +22,7 @@ require "date"
 module Google
   module Cloud
     module Bigquery
-      # rubocop:disable all
+      # rubocop:disable Metrics/ModuleLength
 
       ##
       # @private
@@ -42,7 +42,6 @@ module Google
       # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
       # | `ARRAY` | `Array` | Nested arrays, `nil` values are not supported. |
       # | `STRUCT`    | `Hash`        | Hash keys may be strings or symbols. |
-
       module Convert
         ##
         # @private
@@ -61,6 +60,8 @@ module Google
           end
           Hash[row_pairs]
         end
+
+        # rubocop:disable all
 
         def self.format_value value, field
           if value.nil?
@@ -214,16 +215,6 @@ module Google
 
         ##
         # @private
-        def self.to_json_rows rows
-          rows.map { |row| to_json_row row }
-        end
-        ##
-        # @private
-        def self.to_json_row row
-          Hash[row.map { |k, v| [k.to_s, to_json_value(v)] }]
-        end
-        ##
-        # @private
         def self.to_json_value value
           if DateTime === value
             value.strftime "%Y-%m-%d %H:%M:%S.%6N"
@@ -245,14 +236,70 @@ module Google
           end
         end
 
+        # rubocop:enable all
+
+        ##
+        # @private
+        def self.to_json_rows rows
+          rows.map { |row| to_json_row row }
+        end
+
+        ##
+        # @private
+        def self.to_json_row row
+          Hash[row.map { |k, v| [k.to_s, to_json_value(v)] }]
+        end
+
         def self.resolve_legacy_sql standard_sql, legacy_sql
           return !standard_sql unless standard_sql.nil?
           return legacy_sql unless legacy_sql.nil?
           false
         end
 
-        # rubocop:enable all
+        ##
+        # @private
+        #
+        # Converts create disposition strings to API values.
+        #
+        # @return [String] API representation of create disposition.
+        def self.create_disposition str
+          val = {
+            "create_if_needed" => "CREATE_IF_NEEDED",
+            "createifneeded" => "CREATE_IF_NEEDED",
+            "if_needed" => "CREATE_IF_NEEDED",
+            "needed" => "CREATE_IF_NEEDED",
+            "create_never" => "CREATE_NEVER",
+            "createnever" => "CREATE_NEVER",
+            "never" => "CREATE_NEVER"
+          }[str.to_s.downcase]
+          return val unless val.nil?
+          str
+        end
+
+        ##
+        # @private
+        #
+        # Converts write disposition strings to API values.
+        #
+        # @return [String] API representation of write disposition.
+        def self.write_disposition str
+          val = {
+            "write_truncate" => "WRITE_TRUNCATE",
+            "writetruncate" => "WRITE_TRUNCATE",
+            "truncate" => "WRITE_TRUNCATE",
+            "write_append" => "WRITE_APPEND",
+            "writeappend" => "WRITE_APPEND",
+            "append" => "WRITE_APPEND",
+            "write_empty" => "WRITE_EMPTY",
+            "writeempty" => "WRITE_EMPTY",
+            "empty" => "WRITE_EMPTY"
+          }[str.to_s.downcase]
+          return val unless val.nil?
+          str
+        end
       end
+
+      # rubocop:enable Metrics/ModuleLength
     end
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -761,8 +761,6 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
-        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
-        #   tier to allow high-compute queries.
         # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
         #   job. Queries that will have bytes billed beyond this limit will fail
         #   (without incurring a charge). Optional. If unspecified, this will be
@@ -796,6 +794,8 @@ module Google
         #   inline code resource is equivalent to providing a URI for a file
         #   containing the same code. See [User-Defined
         #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
+        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
+        #   tier to allow high-compute queries.
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
         #   configuration object for setting additional options for the query.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -823,9 +823,8 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = dataset.query_job "SELECT name FROM my_table" do |query|
-        #     query.legacy_sql = true
-        #   end
+        #   job = dataset.query_job "SELECT name FROM my_table",
+        #                           legacy_sql: true
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -840,10 +839,8 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = dataset.query_job(
-        #     "SELECT name FROM my_table WHERE id = ?") do |query|
-        #     query.params = [1]
-        #   end
+        #   job = dataset.query_job "SELECT name FROM my_table WHERE id = ?",
+        #                           params: [1]
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -858,10 +855,8 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = dataset.query_job(
-        #     "SELECT name FROM my_table WHERE id = @id") do |query|
-        #     query.params = { id: 1 }
-        #   end
+        #   job = dataset.query_job "SELECT name FROM my_table WHERE id = @id",
+        #                           params: { id: 1 }
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -870,7 +865,7 @@ module Google
         #     end
         #   end
         #
-        # @example Query using external data source:
+        # @example Query using external data source, set destination:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
@@ -882,8 +877,10 @@ module Google
         #     csv.skip_leading_rows = 1
         #   end
         #
-        #   job = dataset.query_job "SELECT * FROM my_ext_table",
-        #                           external: { my_ext_table: csv_table }
+        #   job = dataset.query_job "SELECT * FROM my_ext_table" do |query|
+        #     query.external = { my_ext_table: csv_table }
+        #     query.table = dataset.table "my_table", skip_lookup: true
+        #   end
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -1019,9 +1016,8 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   data = dataset.query "SELECT name FROM my_table" do |query|
-        #     query.legacy_sql = true
-        #   end
+        #   data = dataset.query "SELECT name FROM my_table",
+        #                        legacy_sql: true
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -1033,10 +1029,8 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   data = dataset.query(
-        #     "SELECT name FROM my_table WHERE id = ?") do |query|
-        #     query.params = [1]
-        #   end
+        #   data = dataset.query "SELECT name FROM my_table WHERE id = ?",
+        #                        params: [1]
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -1048,16 +1042,14 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   data = dataset.query(
-        #     "SELECT name FROM my_table WHERE id = @id") do |query|
-        #     query.params = { id: 1 }
-        #   end
+        #   data = dataset.query "SELECT name FROM my_table WHERE id = @id",
+        #                        params: { id: 1 }
         #
         #   data.each do |row|
         #     puts row[:name]
         #   end
         #
-        # @example Query using external data source:
+        # @example Query using external data source, set destination:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
@@ -1071,6 +1063,7 @@ module Google
         #
         #   data = dataset.query "SELECT * FROM my_ext_table" do |query|
         #     query.external = { my_ext_table: csv_table }
+        #     query.table = dataset.table "my_table", skip_lookup: true
         #   end
         #
         #   data.each do |row|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -761,11 +761,8 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
-        # @param [Integer] maximum_billing_tier Limits the billing tier for this
-        #   job. Queries that have resource usage beyond this tier will fail
-        #   (without incurring a charge). Optional. If unspecified, this will be
-        #   set to your project default. For more information, see [High-Compute
-        #   queries](https://cloud.google.com/bigquery/pricing#high-compute).
+        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
+        #   tier to allow high-compute queries.
         # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
         #   job. Queries that will have bytes billed beyond this limit will fail
         #   (without incurring a charge). Optional. If unspecified, this will be
@@ -826,8 +823,9 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = dataset.query_job "SELECT name FROM my_table",
-        #                           legacy_sql: true
+        #   job = dataset.query_job "SELECT name FROM my_table" do |query|
+        #     query.legacy_sql = true
+        #   end
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -842,8 +840,10 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = dataset.query_job "SELECT name FROM my_table WHERE id = ?",
-        #                           params: [1]
+        #   job = dataset.query_job(
+        #     "SELECT name FROM my_table WHERE id = ?") do |query|
+        #     query.params = [1]
+        #   end
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -858,8 +858,10 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = dataset.query_job "SELECT name FROM my_table WHERE id = @id",
-        #                           params: { id: 1 }
+        #   job = dataset.query_job(
+        #     "SELECT name FROM my_table WHERE id = @id") do |query|
+        #     query.params = { id: 1 }
+        #   end
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -907,10 +909,9 @@ module Google
                       maximum_bytes_billed: maximum_bytes_billed,
                       params: params, external: external, labels: labels,
                       udfs: udfs }
-          options[:dataset] ||= self
 
           updater = QueryJob::Updater.from_options query, options
-          updater.params = params unless params.nil?
+          updater.dataset = self
 
           yield updater if block_given?
 
@@ -1018,8 +1019,9 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   data = dataset.query "SELECT name FROM my_table",
-        #                        legacy_sql: true
+        #   data = dataset.query "SELECT name FROM my_table" do |query|
+        #     query.legacy_sql = true
+        #   end
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -1031,8 +1033,10 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   data = dataset.query "SELECT name FROM my_table WHERE id = ?",
-        #                        params: [1]
+        #   data = dataset.query(
+        #     "SELECT name FROM my_table WHERE id = ?") do |query|
+        #     query.params = [1]
+        #   end
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -1044,8 +1048,10 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   data = dataset.query "SELECT name FROM my_table WHERE id = @id",
-        #                        params: { id: 1 }
+        #   data = dataset.query(
+        #     "SELECT name FROM my_table WHERE id = @id") do |query|
+        #     query.params = { id: 1 }
+        #   end
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -1063,8 +1069,9 @@ module Google
         #     csv.skip_leading_rows = 1
         #   end
         #
-        #   data = dataset.query "SELECT * FROM my_ext_table",
-        #                        external: { my_ext_table: csv_table }
+        #   data = dataset.query "SELECT * FROM my_ext_table" do |query|
+        #     query.external = { my_ext_table: csv_table }
+        #   end
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -1076,10 +1083,10 @@ module Google
                   standard_sql: nil, legacy_sql: nil
           ensure_service!
           options = { priority: "INTERACTIVE", external: external, cache: cache,
-                      legacy_sql: legacy_sql, standard_sql: standard_sql }
+                      legacy_sql: legacy_sql, standard_sql: standard_sql,
+                      params: params }
           options[:dataset] ||= self
           updater = QueryJob::Updater.from_options query, options
-          updater.params = params unless params.nil?
 
           yield updater if block_given?
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -741,7 +741,7 @@ module Google
           #
           def create= new_create
             @gapi.configuration.load.update! create_disposition:
-              create_disposition(new_create)
+              Convert.create_disposition(new_create)
           end
 
           # Sets the write disposition.
@@ -762,7 +762,7 @@ module Google
           #
           def write= new_write
             @gapi.configuration.load.update! write_disposition:
-              write_disposition(new_write)
+              Convert.write_disposition(new_write)
           end
 
           # Sets the projection fields.
@@ -1014,36 +1014,6 @@ module Google
             return val unless val.nil?
             format
           end
-        end
-
-        def create_disposition str
-          val = {
-            "create_if_needed" => "CREATE_IF_NEEDED",
-            "createifneeded" => "CREATE_IF_NEEDED",
-            "if_needed" => "CREATE_IF_NEEDED",
-            "needed" => "CREATE_IF_NEEDED",
-            "create_never" => "CREATE_NEVER",
-            "createnever" => "CREATE_NEVER",
-            "never" => "CREATE_NEVER"
-          }[str.to_s.downcase]
-          return val unless val.nil?
-          str
-        end
-
-        def write_disposition str
-          val = {
-            "write_truncate" => "WRITE_TRUNCATE",
-            "writetruncate" => "WRITE_TRUNCATE",
-            "truncate" => "WRITE_TRUNCATE",
-            "write_append" => "WRITE_APPEND",
-            "writeappend" => "WRITE_APPEND",
-            "append" => "WRITE_APPEND",
-            "write_empty" => "WRITE_EMPTY",
-            "writeempty" => "WRITE_EMPTY",
-            "empty" => "WRITE_EMPTY"
-          }[str.to_s.downcase]
-          return val unless val.nil?
-          str
         end
       end
     end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -323,7 +323,7 @@ module Google
           attr_reader :updates
 
           ##
-          # Create an Updater object.
+          # @private Create an Updater object.
           def initialize gapi
             @updates = []
             @gapi = gapi
@@ -977,7 +977,7 @@ module Google
             @gapi.configuration.update! labels: val
           end
 
-          # Returns the Google API client library version of this load job.
+          # @private Returns the Google API client library version of this job.
           #
           # @return [<Google::Apis::BigqueryV2::Job>] (See
           #   {Google::Apis::BigqueryV2::Job})

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -178,11 +178,8 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
-        # @param [Integer] maximum_billing_tier Limits the billing tier for this
-        #   job. Queries that have resource usage beyond this tier will fail
-        #   (without incurring a charge). Optional. If unspecified, this will be
-        #   set to your project default. For more information, see [High-Compute
-        #   queries](https://cloud.google.com/bigquery/pricing#high-compute).
+        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
+        #   tier to allow high-compute queries.
         # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
         #   job. Queries that will have bytes billed beyond this limit will fail
         #   (without incurring a charge). Optional. If unspecified, this will be
@@ -245,9 +242,10 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "SELECT name FROM " \
-        #                            "[my_project:my_dataset.my_table]",
-        #                            legacy_sql: true
+        #   job = bigquery.query_job(
+        #     "SELECT name FROM [my_project:my_dataset.my_table]") do |query|
+        #     query.legacy_sql = true
+        #   end
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -263,8 +261,9 @@ module Google
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "`my_dataset.my_table`" \
-        #                            " WHERE id = ?",
-        #                            params: [1]
+        #                            " WHERE id = ?" do |query|
+        #     query.params = [1]
+        #   end
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -280,8 +279,9 @@ module Google
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "`my_dataset.my_table`" \
-        #                            " WHERE id = @id",
-        #                            params: { id: 1 }
+        #                            " WHERE id = @id" do |query|
+        #     query.params = { id: 1 }
+        #   end
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -301,8 +301,9 @@ module Google
         #     csv.skip_leading_rows = 1
         #   end
         #
-        #   job = bigquery.query_job "SELECT * FROM my_ext_table",
-        #                            external: { my_ext_table: csv_table }
+        #   job = bigquery.query_job "SELECT * FROM my_ext_table" do |query|
+        #     query.external = { my_ext_table: csv_table }
+        #   end
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -327,10 +328,9 @@ module Google
                       maximum_billing_tier: maximum_billing_tier,
                       maximum_bytes_billed: maximum_bytes_billed,
                       external: external, labels: labels,
-                      udfs: udfs }
+                      udfs: udfs, params: params }
 
           updater = QueryJob::Updater.from_options query, options
-          updater.params = params unless params.nil?
 
           yield updater if block_given?
 
@@ -442,7 +442,9 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   sql = "SELECT name FROM [my_project:my_dataset.my_table]"
-        #   data = bigquery.query sql, legacy_sql: true
+        #   data = bigquery.query sql do |query|
+        #     query.legacy_sql = true
+        #   end
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -466,8 +468,9 @@ module Google
         #
         #   data = bigquery.query "SELECT name " \
         #                         "FROM `my_dataset.my_table`" \
-        #                         "WHERE id = ?",
-        #                         params: [1]
+        #                         "WHERE id = ?" do |query|
+        #     query.params = [1]
+        #   end
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -480,8 +483,9 @@ module Google
         #
         #   data = bigquery.query "SELECT name " \
         #                         "FROM `my_dataset.my_table`" \
-        #                         "WHERE id = @id",
-        #                         params: { id: 1 }
+        #                         "WHERE id = @id" do |query|
+        #     query.params = { id: 1 }
+        #   end
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -498,8 +502,9 @@ module Google
         #     csv.skip_leading_rows = 1
         #   end
         #
-        #   data = bigquery.query "SELECT * FROM my_ext_table",
-        #                         external: { my_ext_table: csv_table }
+        #   data = bigquery.query "SELECT * FROM my_ext_table" do |query|
+        #     query.external = { my_ext_table: csv_table }
+        #   end
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -513,7 +518,6 @@ module Google
                       legacy_sql: legacy_sql, standard_sql: standard_sql,
                       params: params, external: external }
           updater = QueryJob::Updater.from_options query, options
-          updater.params = params unless params.nil?
 
           yield updater if block_given?
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -322,12 +322,13 @@ module Google
           options = { priority: priority, cache: cache, table: table,
                       create: create, write: write,
                       large_results: large_results, flatten: flatten,
-                      dataset: dataset, project: project,
+                      dataset: dataset, project: project || self.project,
                       legacy_sql: legacy_sql, standard_sql: standard_sql,
                       maximum_billing_tier: maximum_billing_tier,
                       maximum_bytes_billed: maximum_bytes_billed,
                       external: external, labels: labels,
                       udfs: udfs }
+
           updater = QueryJob::Updater.from_options query, options
           updater.params = params unless params.nil?
 
@@ -417,6 +418,9 @@ module Google
         #   When set to false, the values of `large_results` and `flatten` are
         #   ignored; the query will be run as if `large_results` is true and
         #   `flatten` is false. Optional. The default value is false.
+        # @yield [job] a job configuration object
+        # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
+        #   configuration object for setting additional options for the query.
         #
         # @return [Google::Cloud::Bigquery::Data]
         #
@@ -504,11 +508,17 @@ module Google
         def query query, params: nil, external: nil, max: nil, cache: true,
                   dataset: nil, project: nil, standard_sql: nil, legacy_sql: nil
           ensure_service!
-          options = { cache: cache, dataset: dataset, project: project,
+          options = { priority: "INTERACTIVE", cache: cache, dataset: dataset,
+                      project: project || self.project,
                       legacy_sql: legacy_sql, standard_sql: standard_sql,
                       params: params, external: external }
+          updater = QueryJob::Updater.from_options query, options
+          updater.params = params unless params.nil?
 
-          job = query_job query, options
+          yield updater if block_given?
+
+          gapi = service.query_job nil, nil, updater.to_gapi
+          job = Job.from_gapi gapi, service
           job.wait_until_done!
 
           if job.failed?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -219,6 +219,9 @@ module Google
         #   inline code resource is equivalent to providing a URI for a file
         #   containing the same code. See [User-Defined
         #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
+        # @yield [job] a job configuration object
+        # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
+        #   configuration object for setting query options.
         #
         # @return [Google::Cloud::Bigquery::QueryJob]
         #
@@ -323,9 +326,14 @@ module Google
                       legacy_sql: legacy_sql, standard_sql: standard_sql,
                       maximum_billing_tier: maximum_billing_tier,
                       maximum_bytes_billed: maximum_bytes_billed,
-                      params: params, external: external, labels: labels,
-                      job_id: job_id, prefix: prefix, udfs: udfs }
-          gapi = service.query_job query, options
+                      external: external, labels: labels,
+                      udfs: udfs }
+          updater = QueryJob::Updater.from_options query, options
+          updater.params = params unless params.nil?
+
+          yield updater if block_given?
+
+          gapi = service.query_job job_id, prefix, updater.to_gapi
           Job.from_gapi gapi, service
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -242,10 +242,9 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job(
-        #     "SELECT name FROM [my_project:my_dataset.my_table]") do |query|
-        #     query.legacy_sql = true
-        #   end
+        #   job = bigquery.query_job "SELECT name FROM " \
+        #                            " [my_project:my_dataset.my_table]",
+        #                            legacy_sql: true
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -261,9 +260,8 @@ module Google
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "`my_dataset.my_table`" \
-        #                            " WHERE id = ?" do |query|
-        #     query.params = [1]
-        #   end
+        #                            " WHERE id = ?",
+        #                            params: [1]
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -279,9 +277,8 @@ module Google
         #
         #   job = bigquery.query_job "SELECT name FROM " \
         #                            "`my_dataset.my_table`" \
-        #                            " WHERE id = @id" do |query|
-        #     query.params = { id: 1 }
-        #   end
+        #                            " WHERE id = @id",
+        #                            params: { id: 1 }
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -290,7 +287,7 @@ module Google
         #     end
         #   end
         #
-        # @example Query using external data source:
+        # @example Query using external data source, set destination:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
@@ -303,6 +300,8 @@ module Google
         #
         #   job = bigquery.query_job "SELECT * FROM my_ext_table" do |query|
         #     query.external = { my_ext_table: csv_table }
+        #     dataset = bigquery.dataset "my_dataset", skip_lookup: true
+        #     query.table = dataset.table "my_table", skip_lookup: true
         #   end
         #
         #   job.wait_until_done!
@@ -442,9 +441,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   sql = "SELECT name FROM [my_project:my_dataset.my_table]"
-        #   data = bigquery.query sql do |query|
-        #     query.legacy_sql = true
-        #   end
+        #   data = bigquery.query sql, legacy_sql: true
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -468,9 +465,8 @@ module Google
         #
         #   data = bigquery.query "SELECT name " \
         #                         "FROM `my_dataset.my_table`" \
-        #                         "WHERE id = ?" do |query|
-        #     query.params = [1]
-        #   end
+        #                         "WHERE id = ?",
+        #                         params: [1]
         #
         #   data.each do |row|
         #     puts row[:name]
@@ -483,15 +479,14 @@ module Google
         #
         #   data = bigquery.query "SELECT name " \
         #                         "FROM `my_dataset.my_table`" \
-        #                         "WHERE id = @id" do |query|
-        #     query.params = { id: 1 }
-        #   end
+        #                         "WHERE id = @id",
+        #                         params: { id: 1 }
         #
         #   data.each do |row|
         #     puts row[:name]
         #   end
         #
-        # @example Query using external data source:
+        # @example Query using external data source, set destination:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
@@ -504,6 +499,8 @@ module Google
         #
         #   data = bigquery.query "SELECT * FROM my_ext_table" do |query|
         #     query.external = { my_ext_table: csv_table }
+        #     dataset = bigquery.dataset "my_dataset", skip_lookup: true
+        #     query.table = dataset.table "my_table", skip_lookup: true
         #   end
         #
         #   data.each do |row|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -178,8 +178,6 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
-        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
-        #   tier to allow high-compute queries.
         # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
         #   job. Queries that will have bytes billed beyond this limit will fail
         #   (without incurring a charge). Optional. If unspecified, this will be
@@ -216,6 +214,8 @@ module Google
         #   inline code resource is equivalent to providing a URI for a file
         #   containing the same code. See [User-Defined
         #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
+        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
+        #   tier to allow high-compute queries.
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
         #   configuration object for setting query options.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -318,9 +318,9 @@ module Google
         # Yielded to a block to accumulate changes for a patch request.
         class Updater < QueryJob
           class << self
-            # If no job_id or prefix is given, always generate a client-side
-            # job ID anyway, for idempotent retry in the google-api-client
-            # layer. See
+            # @private If no job_id or prefix is given, always generate a
+            # client-side job ID anyway, for idempotent retry in the
+            # google-api-client layer. See
             # https://cloud.google.com/bigquery/docs/managing-jobs#generate-jobid
             def job_ref_from job_id, prefix
               prefix ||= "job_"
@@ -331,6 +331,7 @@ module Google
               )
             end
 
+            # @private API object for dataset.
             def dataset_ref_from dts, pjt = nil
               return nil if dts.nil?
               if dts.respond_to? :dataset_id
@@ -348,7 +349,7 @@ module Google
           end
 
           ##
-          # Create an Updater object.
+          # @private Create an Updater object.
           def initialize gapi
             @gapi = gapi
           end
@@ -620,7 +621,7 @@ module Google
               udfs_gapi_from value
           end
 
-          # Returns the Google API client library version of this query job.
+          # @private Returns the Google API client library version of this job.
           #
           # @return [<Google::Apis::BigqueryV2::Job>] (See
           #   {Google::Apis::BigqueryV2::Job})

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -360,28 +360,6 @@ module Google
                 "interactive" => "INTERACTIVE" }[str.to_s.downcase]
             end
 
-            def create_disposition str
-              { "create_if_needed" => "CREATE_IF_NEEDED",
-                "createifneeded" => "CREATE_IF_NEEDED",
-                "if_needed" => "CREATE_IF_NEEDED",
-                "needed" => "CREATE_IF_NEEDED",
-                "create_never" => "CREATE_NEVER",
-                "createnever" => "CREATE_NEVER",
-                "never" => "CREATE_NEVER" }[str.to_s.downcase]
-            end
-
-            def write_disposition str
-              { "write_truncate" => "WRITE_TRUNCATE",
-                "writetruncate" => "WRITE_TRUNCATE",
-                "truncate" => "WRITE_TRUNCATE",
-                "write_append" => "WRITE_APPEND",
-                "writeappend" => "WRITE_APPEND",
-                "append" => "WRITE_APPEND",
-                "write_empty" => "WRITE_EMPTY",
-                "writeempty" => "WRITE_EMPTY",
-                "empty" => "WRITE_EMPTY" }[str.to_s.downcase]
-            end
-
             def udfs array_or_str
               Array(array_or_str).map do |uri_or_code|
                 resource =
@@ -420,8 +398,8 @@ module Google
                   priority: priority_value(options[:priority]),
                   use_query_cache: options[:cache],
                   destination_table: dest_table,
-                  create_disposition: create_disposition(options[:create]),
-                  write_disposition: write_disposition(options[:write]),
+                  create_disposition: Convert.create_disposition(options[:create]),
+                  write_disposition: Convert.write_disposition(options[:write]),
                   allow_large_results: options[:large_results],
                   flatten_results: options[:flatten],
                   default_dataset: dataset_config,

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -385,7 +385,8 @@ module Google
               copy: API::JobConfigurationTableCopy.new(
                 source_table: source,
                 destination_table: target,
-                create_disposition: Convert.create_disposition(options[:create]),
+                create_disposition:
+                  Convert.create_disposition(options[:create]),
                 write_disposition: Convert.write_disposition(options[:write])
               ),
               dry_run: options[:dryrun]

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -385,8 +385,8 @@ module Google
               copy: API::JobConfigurationTableCopy.new(
                 source_table: source,
                 destination_table: target,
-                create_disposition: create_disposition(options[:create]),
-                write_disposition: write_disposition(options[:write])
+                create_disposition: Convert.create_disposition(options[:create]),
+                write_disposition: Convert.write_disposition(options[:write])
               ),
               dry_run: options[:dryrun]
             )
@@ -416,28 +416,6 @@ module Google
           )
           req.configuration.labels = options[:labels] if options[:labels]
           req
-        end
-
-        def create_disposition str
-          { "create_if_needed" => "CREATE_IF_NEEDED",
-            "createifneeded" => "CREATE_IF_NEEDED",
-            "if_needed" => "CREATE_IF_NEEDED",
-            "needed" => "CREATE_IF_NEEDED",
-            "create_never" => "CREATE_NEVER",
-            "createnever" => "CREATE_NEVER",
-            "never" => "CREATE_NEVER" }[str.to_s.downcase]
-        end
-
-        def write_disposition str
-          { "write_truncate" => "WRITE_TRUNCATE",
-            "writetruncate" => "WRITE_TRUNCATE",
-            "truncate" => "WRITE_TRUNCATE",
-            "write_append" => "WRITE_APPEND",
-            "writeappend" => "WRITE_APPEND",
-            "append" => "WRITE_APPEND",
-            "write_empty" => "WRITE_EMPTY",
-            "writeempty" => "WRITE_EMPTY",
-            "empty" => "WRITE_EMPTY" }[str.to_s.downcase]
         end
 
         def source_format path, format


### PR DESCRIPTION
As with LoadJob::Updater, the new class QueryJob::Updater will make it easier to add new properties to query jobs without having to get way too many keyword arguments to the `query` and `query_job` functions.

Note: I do not make an attribute for `maximum_billing_tier` as this property is deprecated. According to the BigQuery team, this property is no longer used, as "high-compute" queries are no longer supported.