### PR TITLE
Regenerate v1 to pickup timeout config changes

### DIFF
--- a/google-cloud-speech/lib/google/cloud/speech/v1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/cloud_speech_services_pb.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/cloud_speech_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ module Google
       #
       # | Class | Description |
       # | ----- | ----------- |
-      # | [SpeechClient][] | Google Cloud Speech API. |
+      # | [SpeechClient][] | Service that implements Google Cloud Speech API. |
       # | [Data Types][] | Data types for Google::Cloud::Speech::V1 |
       #
       # [SpeechClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-speech/latest/google/cloud/speech/v1/speechclient

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/rpc/status.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/overview.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client_config.json
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client_config.json
@@ -13,15 +13,15 @@
           "initial_retry_delay_millis": 100,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 190000,
+          "initial_rpc_timeout_millis": 1000000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 190000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 1000000,
+          "total_timeout_millis": 5000000
         }
       },
       "methods": {
         "Recognize": {
-          "timeout_millis": 190000,
+          "timeout_millis": 1000000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
@@ -31,7 +31,7 @@
           "retry_params_name": "default"
         },
         "StreamingRecognize": {
-          "timeout_millis": 600000,
+          "timeout_millis": 1000000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         }


### PR DESCRIPTION
We are regenerating this due to some configuration changes.

I left the doc changes from the generated code in but I'm not sure if that makes sense since nothing else has changed.