### PR TITLE
Updated generated unit tests for google-gax 1.1.x changes

### DIFF
--- a/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
+++ b/google-cloud-bigquery-data_transfer/test/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client_test.rb
@@ -107,7 +107,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::GetDataSourceRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_data_source, mock_method)
 
@@ -176,7 +176,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::ListDataSourcesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_data_sources, mock_method)
 
@@ -266,7 +266,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::CreateTransferConfigRequest, request)
         assert_equal(formatted_parent, request.parent)
         assert_equal(Google::Gax::to_proto(transfer_config, Google::Cloud::Bigquery::DataTransfer::V1::TransferConfig), request.transfer_config)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_transfer_config, mock_method)
 
@@ -355,7 +355,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::UpdateTransferConfigRequest, request)
         assert_equal(Google::Gax::to_proto(transfer_config, Google::Cloud::Bigquery::DataTransfer::V1::TransferConfig), request.transfer_config)
         assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_transfer_config, mock_method)
 
@@ -419,7 +419,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::DeleteTransferConfigRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_transfer_config, mock_method)
 
@@ -504,7 +504,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::GetTransferConfigRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_transfer_config, mock_method)
 
@@ -573,7 +573,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::ListTransferConfigsRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_transfer_configs, mock_method)
 
@@ -646,7 +646,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(Google::Gax::to_proto(start_time, Google::Protobuf::Timestamp), request.start_time)
         assert_equal(Google::Gax::to_proto(end_time, Google::Protobuf::Timestamp), request.end_time)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:schedule_transfer_runs, mock_method)
 
@@ -735,7 +735,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::GetTransferRunRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_transfer_run, mock_method)
 
@@ -797,7 +797,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::DeleteTransferRunRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_transfer_run, mock_method)
 
@@ -866,7 +866,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::ListTransferRunsRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_transfer_runs, mock_method)
 
@@ -938,7 +938,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::ListTransferLogsRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_transfer_logs, mock_method)
 
@@ -1008,7 +1008,7 @@ describe Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Bigquery::DataTransfer::V1::CheckValidCredsRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:check_valid_creds, mock_method)
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
@@ -98,7 +98,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
         assert_equal(clusters, request.clusters)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_instance, mock_method)
 
@@ -147,7 +147,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
         assert_equal(clusters, request.clusters)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_instance, mock_method)
 
@@ -232,7 +232,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::GetInstanceRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_instance, mock_method)
 
@@ -299,7 +299,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::ListInstancesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_instances, mock_method)
 
@@ -373,7 +373,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(display_name, request.display_name)
         assert_equal(type, request.type)
         assert_equal(labels, request.labels)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_instance, mock_method)
 
@@ -459,7 +459,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_instance_of(Google::Bigtable::Admin::V2::PartialUpdateInstanceRequest, request)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
         assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:partial_update_instance, mock_method)
 
@@ -523,7 +523,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::DeleteInstanceRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_instance, mock_method)
 
@@ -607,7 +607,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(Google::Gax::to_proto(cluster, Google::Bigtable::Admin::V2::Cluster), request.cluster)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_cluster, mock_method)
 
@@ -653,7 +653,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(Google::Gax::to_proto(cluster, Google::Bigtable::Admin::V2::Cluster), request.cluster)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_cluster, mock_method)
 
@@ -739,7 +739,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::GetClusterRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_cluster, mock_method)
 
@@ -806,7 +806,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::ListClustersRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_clusters, mock_method)
 
@@ -890,7 +890,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_name, request.name)
         assert_equal(location, request.location)
         assert_equal(serve_nodes, request.serve_nodes)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:update_cluster, mock_method)
 
@@ -936,7 +936,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_name, request.name)
         assert_equal(location, request.location)
         assert_equal(serve_nodes, request.serve_nodes)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:update_cluster, mock_method)
 
@@ -1011,7 +1011,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::DeleteClusterRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_cluster, mock_method)
 
@@ -1088,7 +1088,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(app_profile_id, request.app_profile_id)
         assert_equal(Google::Gax::to_proto(app_profile, Google::Bigtable::Admin::V2::AppProfile), request.app_profile)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_app_profile, mock_method)
 
@@ -1173,7 +1173,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::GetAppProfileRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_app_profile, mock_method)
 
@@ -1242,7 +1242,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::ListAppProfilesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_app_profiles, mock_method)
 
@@ -1315,7 +1315,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_instance_of(Google::Bigtable::Admin::V2::UpdateAppProfileRequest, request)
         assert_equal(Google::Gax::to_proto(app_profile, Google::Bigtable::Admin::V2::AppProfile), request.app_profile)
         assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_app_profile, mock_method)
 
@@ -1381,7 +1381,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_instance_of(Google::Bigtable::Admin::V2::DeleteAppProfileRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(ignore_warnings, request.ignore_warnings)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_app_profile, mock_method)
 
@@ -1451,7 +1451,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::GetIamPolicyRequest, request)
         assert_equal(formatted_resource, request.resource)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_iam_policy, mock_method)
 
@@ -1521,7 +1521,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_instance_of(Google::Iam::V1::SetIamPolicyRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(Google::Gax::to_proto(policy, Google::Iam::V1::Policy), request.policy)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_iam_policy, mock_method)
 
@@ -1591,7 +1591,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
         assert_instance_of(Google::Iam::V1::TestIamPermissionsRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(permissions, request.permissions)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:test_iam_permissions, mock_method)
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
@@ -88,7 +88,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(table_id, request.table_id)
         assert_equal(Google::Gax::to_proto(table, Google::Bigtable::Admin::V2::Table), request.table)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_table, mock_method)
 
@@ -178,7 +178,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(table_id, request.table_id)
         assert_equal(source_snapshot, request.source_snapshot)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_table_from_snapshot, mock_method)
 
@@ -224,7 +224,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(table_id, request.table_id)
         assert_equal(source_snapshot, request.source_snapshot)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_table_from_snapshot, mock_method)
 
@@ -306,7 +306,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::ListTablesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_tables, mock_method)
 
@@ -376,7 +376,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::GetTableRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_table, mock_method)
 
@@ -438,7 +438,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::DeleteTableRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_table, mock_method)
 
@@ -510,7 +510,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           Google::Gax::to_proto(req, Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest::Modification)
         end
         assert_equal(modifications, request.modifications)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:modify_column_families, mock_method)
 
@@ -577,7 +577,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::DropRowRangeRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:drop_row_range, mock_method)
 
@@ -644,7 +644,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::GenerateConsistencyTokenRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:generate_consistency_token, mock_method)
 
@@ -713,7 +713,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
         assert_instance_of(Google::Bigtable::Admin::V2::CheckConsistencyRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(consistency_token, request.consistency_token)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:check_consistency, mock_method)
 
@@ -789,7 +789,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
         assert_equal(cluster, request.cluster)
         assert_equal(snapshot_id, request.snapshot_id)
         assert_equal(description, request.description)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:snapshot_table, mock_method)
 
@@ -878,7 +878,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::GetSnapshotRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_snapshot, mock_method)
 
@@ -947,7 +947,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::ListSnapshotsRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_snapshots, mock_method)
 
@@ -1012,7 +1012,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::DeleteSnapshotRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_snapshot, mock_method)
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance_admin_client_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
           location: cluster_location_path
         )
         assert_equal({ cluster.name => expected_cluster }, request.clusters)
-        operation
+        OpenStruct.new(execute: operation)
       end
 
       stub_instance_admin_grpc(:create_instance, mock_method) do
@@ -125,7 +125,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
           display_name: instance_attrs[:display_name]
         )
         assert_equal(clusters, request.clusters)
-        operation
+        OpenStruct.new(execute: operation)
       end
 
       stub_instance_admin_grpc(:create_instance, mock_method) do
@@ -146,7 +146,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::GetInstanceRequest, request)
         assert_equal(instance_path, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
 
       stub_instance_admin_grpc(:get_instance, mock_method) do
@@ -184,7 +184,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::ListInstancesRequest, request)
         assert_equal(project_path, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
 
       stub_instance_admin_grpc(:list_instances, mock_method) do
@@ -233,7 +233,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
         assert_equal(display_name, request.display_name)
         assert_equal(type, request.type)
         assert_equal(labels, request.labels)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
 
       stub_instance_admin_grpc(:update_instance, mock_method) do
@@ -286,7 +286,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::DeleteInstanceRequest, request)
         assert_equal(instance_path, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
 
       stub_instance_admin_grpc(:delete_instance, mock_method) do
@@ -335,7 +335,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
         }
 
         assert_equal(Google::Gax::to_proto(req_cluster, Google::Bigtable::Admin::V2::Cluster), request.cluster)
-        operation
+        OpenStruct.new(execute: operation)
       end
 
       stub_instance_admin_grpc(:create_cluster, mock_method) do
@@ -365,7 +365,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
           serve_nodes: cluster_attrs[:serve_nodes]
         }
         assert_equal(Google::Gax::to_proto(req_cluster, Google::Bigtable::Admin::V2::Cluster), request.cluster)
-        operation
+        OpenStruct.new(execute: operation)
       end
 
       stub_instance_admin_grpc(:create_cluster, mock_method) do
@@ -424,7 +424,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::GetClusterRequest, request)
         assert_equal(cluster_path, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
 
       stub_instance_admin_grpc(:get_cluster, mock_method) do
@@ -465,7 +465,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::ListClustersRequest, request)
         assert_equal(instance_path, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
 
       stub_instance_admin_grpc(:list_clusters, mock_method) do
@@ -514,7 +514,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
         assert_equal(cluster_path, request.name)
         assert_equal('', request.location)
         assert_equal(serve_nodes, request.serve_nodes)
-        operation
+        OpenStruct.new(execute: operation)
       end
 
       stub_instance_admin_grpc(:update_cluster, mock_method) do
@@ -543,7 +543,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
         assert_equal(cluster_path, request.name)
         assert_equal('', request.location)
         assert_equal(serve_nodes, request.serve_nodes)
-        operation
+        OpenStruct.new(execute: operation)
       end
 
       # Mock auth layer
@@ -593,7 +593,7 @@ describe Google::Cloud::Bigtable::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::DeleteClusterRequest, request)
         assert_equal(cluster_path, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
 
       stub_instance_admin_grpc(:delete_cluster, mock_method) do

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table_admin_client_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigtable::TableAdminClient do
         assert_equal(instance_path , request.parent)
         assert_equal(table_id, request.table_id)
         assert_equal(Google::Gax::to_proto(table, Google::Bigtable::Admin::V2::Table), request.table)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
 
       stub_table_admin_grpc(:create_table, mock_method) do
@@ -109,7 +109,7 @@ describe Google::Cloud::Bigtable::TableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::ListTablesRequest, request)
         assert_equal(instance_path , request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
 
       stub_table_admin_grpc(:list_tables, mock_method) do
@@ -149,7 +149,7 @@ describe Google::Cloud::Bigtable::TableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::GetTableRequest, request)
         assert_equal(table_path , request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
 
       stub_table_admin_grpc(:get_table, mock_method) do
@@ -182,7 +182,7 @@ describe Google::Cloud::Bigtable::TableAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::DeleteTableRequest, request)
         assert_equal(table_path , request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
 
       stub_table_admin_grpc(:delete_table, mock_method) do
@@ -229,7 +229,7 @@ describe Google::Cloud::Bigtable::TableAdminClient do
           Google::Gax::to_proto(req, Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest::Modification)
         end
         assert_equal(modifications, request.modifications)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
 
       stub_table_admin_grpc(:modify_column_families, mock_method) do
@@ -270,7 +270,7 @@ describe Google::Cloud::Bigtable::TableAdminClient do
         assert_instance_of(Google::Bigtable::Admin::V2::DropRowRangeRequest, request)
         assert_equal(table_path , request.name)
         assert_equal(row_key_prefix, request.row_key_prefix)
-        nil
+        OpenStruct.new(execute: nil)
       end
 
       stub_table_admin_grpc(:drop_row_range, mock_method) do

--- a/google-cloud-bigtable/test/google/cloud/bigtable/v2/bigtable_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/v2/bigtable_client_test.rb
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::V2::ReadRowsRequest, request)
         assert_equal(formatted_table_name, request.table_name)
-        [expected_response]
+        OpenStruct.new(execute: [expected_response])
       end
       mock_stub = MockGrpcClientStub.new(:read_rows, mock_method)
 
@@ -153,7 +153,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::V2::SampleRowKeysRequest, request)
         assert_equal(formatted_table_name, request.table_name)
-        [expected_response]
+        OpenStruct.new(execute: [expected_response])
       end
       mock_stub = MockGrpcClientStub.new(:sample_row_keys, mock_method)
 
@@ -227,7 +227,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
           Google::Gax::to_proto(req, Google::Bigtable::V2::Mutation)
         end
         assert_equal(mutations, request.mutations)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:mutate_row, mock_method)
 
@@ -313,7 +313,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
           Google::Gax::to_proto(req, Google::Bigtable::V2::MutateRowsRequest::Entry)
         end
         assert_equal(entries, request.entries)
-        [expected_response]
+        OpenStruct.new(execute: [expected_response])
       end
       mock_stub = MockGrpcClientStub.new(:mutate_rows, mock_method)
 
@@ -388,7 +388,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
         assert_instance_of(Google::Bigtable::V2::CheckAndMutateRowRequest, request)
         assert_equal(formatted_table_name, request.table_name)
         assert_equal(row_key, request.row_key)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:check_and_mutate_row, mock_method)
 
@@ -463,7 +463,7 @@ describe Google::Cloud::Bigtable::V2::BigtableClient do
           Google::Gax::to_proto(req, Google::Bigtable::V2::ReadModifyWriteRule)
         end
         assert_equal(rules, request.rules)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:read_modify_write_row, mock_method)
 

--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.0.1"
+  gem.add_dependency "google-gax", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rubocop", "~> 0.50.0"

--- a/google-cloud-container/test/google/cloud/container/v1/cluster_manager_client_test.rb
+++ b/google-cloud-container/test/google/cloud/container/v1/cluster_manager_client_test.rb
@@ -84,7 +84,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_instance_of(Google::Container::V1::ListClustersRequest, request)
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_clusters, mock_method)
 
@@ -201,7 +201,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_cluster, mock_method)
 
@@ -300,7 +300,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(Google::Gax::to_proto(cluster, Google::Container::V1::Cluster), request.cluster)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_cluster, mock_method)
 
@@ -401,7 +401,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(Google::Gax::to_proto(update, Google::Container::V1::ClusterUpdate), request.update)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_cluster, mock_method)
 
@@ -510,7 +510,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(node_pool_id, request.node_pool_id)
         assert_equal(node_version, request.node_version)
         assert_equal(image_type, request.image_type)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_node_pool, mock_method)
 
@@ -625,7 +625,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(node_pool_id, request.node_pool_id)
         assert_equal(Google::Gax::to_proto(autoscaling, Google::Container::V1::NodePoolAutoscaling), request.autoscaling)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_node_pool_autoscaling, mock_method)
 
@@ -734,7 +734,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(logging_service, request.logging_service)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_logging_service, mock_method)
 
@@ -839,7 +839,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(monitoring_service, request.monitoring_service)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_monitoring_service, mock_method)
 
@@ -944,7 +944,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(Google::Gax::to_proto(addons_config, Google::Container::V1::AddonsConfig), request.addons_config)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_addons_config, mock_method)
 
@@ -1049,7 +1049,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(locations, request.locations)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_locations, mock_method)
 
@@ -1154,7 +1154,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(master_version, request.master_version)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_master, mock_method)
 
@@ -1261,7 +1261,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(action, request.action)
         assert_equal(Google::Gax::to_proto(update, Google::Container::V1::MasterAuth), request.update)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_master_auth, mock_method)
 
@@ -1368,7 +1368,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:delete_cluster, mock_method)
 
@@ -1448,7 +1448,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_instance_of(Google::Container::V1::ListOperationsRequest, request)
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_operations, mock_method)
 
@@ -1537,7 +1537,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(operation_id, request.operation_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_operation, mock_method)
 
@@ -1615,7 +1615,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(operation_id, request.operation_id)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:cancel_operation, mock_method)
 
@@ -1697,7 +1697,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_instance_of(Google::Container::V1::GetServerConfigRequest, request)
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_server_config, mock_method)
 
@@ -1769,7 +1769,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_node_pools, mock_method)
 
@@ -1864,7 +1864,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(node_pool_id, request.node_pool_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_node_pool, mock_method)
 
@@ -1969,7 +1969,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(Google::Gax::to_proto(node_pool, Google::Container::V1::NodePool), request.node_pool)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_node_pool, mock_method)
 
@@ -2074,7 +2074,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(node_pool_id, request.node_pool_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:delete_node_pool, mock_method)
 
@@ -2179,7 +2179,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(node_pool_id, request.node_pool_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:rollback_node_pool_upgrade, mock_method)
 
@@ -2286,7 +2286,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(node_pool_id, request.node_pool_id)
         assert_equal(Google::Gax::to_proto(management, Google::Container::V1::NodeManagement), request.management)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_node_pool_management, mock_method)
 
@@ -2397,7 +2397,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(cluster_id, request.cluster_id)
         # assert_equal(Google::Gax::to_proto(resource_labels, Google::Container::V1::SetLabelsRequest::ResourceLabelsEntry), request.resource_labels)
         assert_equal(label_fingerprint, request.label_fingerprint)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_labels, mock_method)
 
@@ -2506,7 +2506,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(enabled, request.enabled)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_legacy_abac, mock_method)
 
@@ -2609,7 +2609,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:start_ip_rotation, mock_method)
 
@@ -2708,7 +2708,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:complete_ip_rotation, mock_method)
 
@@ -2811,7 +2811,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(node_pool_id, request.node_pool_id)
         assert_equal(node_count, request.node_count)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_node_pool_size, mock_method)
 
@@ -2920,7 +2920,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(Google::Gax::to_proto(network_policy, Google::Container::V1::NetworkPolicy), request.network_policy)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_network_policy, mock_method)
 
@@ -3025,7 +3025,7 @@ describe Google::Cloud::Container::V1::ClusterManagerClient do
         assert_equal(zone, request.zone)
         assert_equal(cluster_id, request.cluster_id)
         assert_equal(Google::Gax::to_proto(maintenance_policy, Google::Container::V1::MaintenancePolicy), request.maintenance_policy)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_maintenance_policy, mock_method)
 

--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.0.0"
+  gem.add_dependency "google-gax", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rubocop", "~> 0.50.0"

--- a/google-cloud-dataproc/test/google/cloud/dataproc/v1/cluster_controller_client_test.rb
+++ b/google-cloud-dataproc/test/google/cloud/dataproc/v1/cluster_controller_client_test.rb
@@ -101,7 +101,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(Google::Gax::to_proto(cluster, Google::Cloud::Dataproc::V1::Cluster), request.cluster)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_cluster, mock_method)
 
@@ -147,7 +147,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(Google::Gax::to_proto(cluster, Google::Cloud::Dataproc::V1::Cluster), request.cluster)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_cluster, mock_method)
 
@@ -248,7 +248,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_equal(cluster_name, request.cluster_name)
         assert_equal(Google::Gax::to_proto(cluster, Google::Cloud::Dataproc::V1::Cluster), request.cluster)
         assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:update_cluster, mock_method)
 
@@ -300,7 +300,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_equal(cluster_name, request.cluster_name)
         assert_equal(Google::Gax::to_proto(cluster, Google::Cloud::Dataproc::V1::Cluster), request.cluster)
         assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:update_cluster, mock_method)
 
@@ -398,7 +398,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(cluster_name, request.cluster_name)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:delete_cluster, mock_method)
 
@@ -444,7 +444,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(cluster_name, request.cluster_name)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:delete_cluster, mock_method)
 
@@ -534,7 +534,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(cluster_name, request.cluster_name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_cluster, mock_method)
 
@@ -617,7 +617,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_instance_of(Google::Cloud::Dataproc::V1::ListClustersRequest, request)
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_clusters, mock_method)
 
@@ -699,7 +699,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(cluster_name, request.cluster_name)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:diagnose_cluster, mock_method)
 
@@ -745,7 +745,7 @@ describe Google::Cloud::Dataproc::V1::ClusterControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(cluster_name, request.cluster_name)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:diagnose_cluster, mock_method)
 

--- a/google-cloud-dataproc/test/google/cloud/dataproc/v1/job_controller_client_test.rb
+++ b/google-cloud-dataproc/test/google/cloud/dataproc/v1/job_controller_client_test.rb
@@ -88,7 +88,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(Google::Gax::to_proto(job, Google::Cloud::Dataproc::V1::Job), request.job)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:submit_job, mock_method)
 
@@ -172,7 +172,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(job_id, request.job_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_job, mock_method)
 
@@ -255,7 +255,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
         assert_instance_of(Google::Cloud::Dataproc::V1::ListJobsRequest, request)
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_jobs, mock_method)
 
@@ -336,7 +336,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
         assert_equal(job_id, request.job_id)
         assert_equal(Google::Gax::to_proto(job, Google::Cloud::Dataproc::V1::Job), request.job)
         assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_job, mock_method)
 
@@ -428,7 +428,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(job_id, request.job_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:cancel_job, mock_method)
 
@@ -506,7 +506,7 @@ describe Google::Cloud::Dataproc::V1::JobControllerClient do
         assert_equal(project_id, request.project_id)
         assert_equal(region, request.region)
         assert_equal(job_id, request.job_id)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_job, mock_method)
 

--- a/google-cloud-dlp/test/google/cloud/dlp/v2/dlp_service_client_test.rb
+++ b/google-cloud-dlp/test/google/cloud/dlp/v2/dlp_service_client_test.rb
@@ -82,7 +82,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::InspectContentRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:inspect_content, mock_method)
 
@@ -150,7 +150,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::RedactImageRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:redact_image, mock_method)
 
@@ -216,7 +216,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::DeidentifyContentRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:deidentify_content, mock_method)
 
@@ -282,7 +282,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::ReidentifyContentRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:reidentify_content, mock_method)
 
@@ -343,7 +343,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_info_types, mock_method)
 
@@ -411,7 +411,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::CreateInspectTemplateRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_inspect_template, mock_method)
 
@@ -484,7 +484,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::UpdateInspectTemplateRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_inspect_template, mock_method)
 
@@ -552,7 +552,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_inspect_template, mock_method)
 
@@ -616,7 +616,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::ListInspectTemplatesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_inspect_templates, mock_method)
 
@@ -681,7 +681,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::DeleteInspectTemplateRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_inspect_template, mock_method)
 
@@ -754,7 +754,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::CreateDeidentifyTemplateRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_deidentify_template, mock_method)
 
@@ -827,7 +827,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::UpdateDeidentifyTemplateRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_deidentify_template, mock_method)
 
@@ -900,7 +900,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::GetDeidentifyTemplateRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_deidentify_template, mock_method)
 
@@ -969,7 +969,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::ListDeidentifyTemplatesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_deidentify_templates, mock_method)
 
@@ -1034,7 +1034,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::DeleteDeidentifyTemplateRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_deidentify_template, mock_method)
 
@@ -1102,7 +1102,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::CreateDlpJobRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_dlp_job, mock_method)
 
@@ -1171,7 +1171,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::ListDlpJobsRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_dlp_jobs, mock_method)
 
@@ -1242,7 +1242,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::GetDlpJobRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_dlp_job, mock_method)
 
@@ -1304,7 +1304,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::DeleteDlpJobRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_dlp_job, mock_method)
 
@@ -1366,7 +1366,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::CancelDlpJobRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:cancel_dlp_job, mock_method)
 
@@ -1435,7 +1435,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::ListJobTriggersRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_job_triggers, mock_method)
 
@@ -1511,7 +1511,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::GetJobTriggerRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_job_trigger, mock_method)
 
@@ -1573,7 +1573,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::DeleteJobTriggerRequest, request)
         assert_equal(name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_job_trigger, mock_method)
 
@@ -1646,7 +1646,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::UpdateJobTriggerRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_job_trigger, mock_method)
 
@@ -1719,7 +1719,7 @@ describe Google::Cloud::Dlp::V2::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2::CreateJobTriggerRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_job_trigger, mock_method)
 

--- a/google-cloud-dlp/test/google/cloud/dlp/v2beta1/dlp_service_client_test.rb
+++ b/google-cloud-dlp/test/google/cloud/dlp/v2beta1/dlp_service_client_test.rb
@@ -94,7 +94,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
           Google::Gax::to_proto(req, Google::Privacy::Dlp::V2beta1::ContentItem)
         end
         assert_equal(items, request.items)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:inspect_content, mock_method)
 
@@ -182,7 +182,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
           Google::Gax::to_proto(req, Google::Privacy::Dlp::V2beta1::ContentItem)
         end
         assert_equal(items, request.items)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:redact_content, mock_method)
 
@@ -266,7 +266,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
           Google::Gax::to_proto(req, Google::Privacy::Dlp::V2beta1::ContentItem)
         end
         assert_equal(items, request.items)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:deidentify_content, mock_method)
 
@@ -356,7 +356,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
         assert_instance_of(Google::Privacy::Dlp::V2beta1::AnalyzeDataSourceRiskRequest, request)
         assert_equal(Google::Gax::to_proto(privacy_metric, Google::Privacy::Dlp::V2beta1::PrivacyMetric), request.privacy_metric)
         assert_equal(Google::Gax::to_proto(source_table, Google::Privacy::Dlp::V2beta1::BigQueryTable), request.source_table)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_data_source_risk, mock_method)
 
@@ -396,7 +396,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
         assert_instance_of(Google::Privacy::Dlp::V2beta1::AnalyzeDataSourceRiskRequest, request)
         assert_equal(Google::Gax::to_proto(privacy_metric, Google::Privacy::Dlp::V2beta1::PrivacyMetric), request.privacy_metric)
         assert_equal(Google::Gax::to_proto(source_table, Google::Privacy::Dlp::V2beta1::BigQueryTable), request.source_table)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_data_source_risk, mock_method)
 
@@ -483,7 +483,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
         assert_equal(Google::Gax::to_proto(inspect_config, Google::Privacy::Dlp::V2beta1::InspectConfig), request.inspect_config)
         assert_equal(Google::Gax::to_proto(storage_config, Google::Privacy::Dlp::V2beta1::StorageConfig), request.storage_config)
         assert_equal(Google::Gax::to_proto(output_config, Google::Privacy::Dlp::V2beta1::OutputStorageConfig), request.output_config)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_inspect_operation, mock_method)
 
@@ -535,7 +535,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
         assert_equal(Google::Gax::to_proto(inspect_config, Google::Privacy::Dlp::V2beta1::InspectConfig), request.inspect_config)
         assert_equal(Google::Gax::to_proto(storage_config, Google::Privacy::Dlp::V2beta1::StorageConfig), request.storage_config)
         assert_equal(Google::Gax::to_proto(output_config, Google::Privacy::Dlp::V2beta1::OutputStorageConfig), request.output_config)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_inspect_operation, mock_method)
 
@@ -621,7 +621,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2beta1::ListInspectFindingsRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_inspect_findings, mock_method)
 
@@ -689,7 +689,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
         assert_instance_of(Google::Privacy::Dlp::V2beta1::ListInfoTypesRequest, request)
         assert_equal(category, request.category)
         assert_equal(language_code, request.language_code)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_info_types, mock_method)
 
@@ -757,7 +757,7 @@ describe Google::Cloud::Dlp::V2beta1::DlpServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Privacy::Dlp::V2beta1::ListRootCategoriesRequest, request)
         assert_equal(language_code, request.language_code)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_root_categories, mock_method)
 

--- a/google-cloud-firestore/test/google/cloud/firestore/v1beta1/firestore_client_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/v1beta1/firestore_client_test.rb
@@ -83,7 +83,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Firestore::V1beta1::GetDocumentRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_document, mock_method)
 
@@ -154,7 +154,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
         assert_instance_of(Google::Firestore::V1beta1::ListDocumentsRequest, request)
         assert_equal(formatted_parent, request.parent)
         assert_equal(collection_id, request.collection_id)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_documents, mock_method)
 
@@ -232,7 +232,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
         assert_equal(collection_id, request.collection_id)
         assert_equal(document_id, request.document_id)
         assert_equal(Google::Gax::to_proto(document, Google::Firestore::V1beta1::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_document, mock_method)
 
@@ -317,7 +317,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
         assert_instance_of(Google::Firestore::V1beta1::UpdateDocumentRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Firestore::V1beta1::Document), request.document)
         assert_equal(Google::Gax::to_proto(update_mask, Google::Firestore::V1beta1::DocumentMask), request.update_mask)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_document, mock_method)
 
@@ -381,7 +381,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Firestore::V1beta1::DeleteDocumentRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_document, mock_method)
 
@@ -451,7 +451,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
         assert_instance_of(Google::Firestore::V1beta1::BatchGetDocumentsRequest, request)
         assert_equal(formatted_database, request.database)
         assert_equal(documents, request.documents)
-        [expected_response]
+        OpenStruct.new(execute: [expected_response])
       end
       mock_stub = MockGrpcClientStub.new(:batch_get_documents, mock_method)
 
@@ -521,7 +521,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Firestore::V1beta1::BeginTransactionRequest, request)
         assert_equal(formatted_database, request.database)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:begin_transaction, mock_method)
 
@@ -592,7 +592,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
           Google::Gax::to_proto(req, Google::Firestore::V1beta1::Write)
         end
         assert_equal(writes, request.writes)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:commit, mock_method)
 
@@ -661,7 +661,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
         assert_instance_of(Google::Firestore::V1beta1::RollbackRequest, request)
         assert_equal(formatted_database, request.database)
         assert_equal(transaction, request.transaction)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:rollback, mock_method)
 
@@ -731,7 +731,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Firestore::V1beta1::RunQueryRequest, request)
         assert_equal(formatted_parent, request.parent)
-        [expected_response]
+        OpenStruct.new(execute: [expected_response])
       end
       mock_stub = MockGrpcClientStub.new(:run_query, mock_method)
 
@@ -802,7 +802,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
         request = requests.first
         assert_instance_of(Google::Firestore::V1beta1::WriteRequest, request)
         assert_equal(formatted_database, request.database)
-        [expected_response]
+        OpenStruct.new(execute: [expected_response])
       end
       mock_stub = MockGrpcClientStub.new(:write, mock_method)
 
@@ -873,7 +873,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
         request = requests.first
         assert_instance_of(Google::Firestore::V1beta1::ListenRequest, request)
         assert_equal(formatted_database, request.database)
-        [expected_response]
+        OpenStruct.new(execute: [expected_response])
       end
       mock_stub = MockGrpcClientStub.new(:listen, mock_method)
 
@@ -945,7 +945,7 @@ describe Google::Cloud::Firestore::V1beta1::FirestoreClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Firestore::V1beta1::ListCollectionIdsRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_collection_ids, mock_method)
 

--- a/google-cloud-language/test/google/cloud/language/v1/language_service_client_test.rb
+++ b/google-cloud-language/test/google/cloud/language/v1/language_service_client_test.rb
@@ -83,7 +83,7 @@ describe Google::Cloud::Language::V1::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1::AnalyzeSentimentRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_sentiment, mock_method)
 
@@ -150,7 +150,7 @@ describe Google::Cloud::Language::V1::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1::AnalyzeEntitiesRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_entities, mock_method)
 
@@ -217,7 +217,7 @@ describe Google::Cloud::Language::V1::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_entity_sentiment, mock_method)
 
@@ -284,7 +284,7 @@ describe Google::Cloud::Language::V1::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1::AnalyzeSyntaxRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_syntax, mock_method)
 
@@ -350,7 +350,7 @@ describe Google::Cloud::Language::V1::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1::ClassifyTextRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:classify_text, mock_method)
 
@@ -419,7 +419,7 @@ describe Google::Cloud::Language::V1::LanguageServiceClient do
         assert_instance_of(Google::Cloud::Language::V1::AnnotateTextRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1::Document), request.document)
         assert_equal(Google::Gax::to_proto(features, Google::Cloud::Language::V1::AnnotateTextRequest::Features), request.features)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:annotate_text, mock_method)
 

--- a/google-cloud-language/test/google/cloud/language/v1beta2/language_service_client_test.rb
+++ b/google-cloud-language/test/google/cloud/language/v1beta2/language_service_client_test.rb
@@ -83,7 +83,7 @@ describe Google::Cloud::Language::V1beta2::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1beta2::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_sentiment, mock_method)
 
@@ -150,7 +150,7 @@ describe Google::Cloud::Language::V1beta2::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1beta2::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_entities, mock_method)
 
@@ -217,7 +217,7 @@ describe Google::Cloud::Language::V1beta2::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1beta2::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_entity_sentiment, mock_method)
 
@@ -284,7 +284,7 @@ describe Google::Cloud::Language::V1beta2::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1beta2::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:analyze_syntax, mock_method)
 
@@ -350,7 +350,7 @@ describe Google::Cloud::Language::V1beta2::LanguageServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Language::V1beta2::ClassifyTextRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1beta2::Document), request.document)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:classify_text, mock_method)
 
@@ -419,7 +419,7 @@ describe Google::Cloud::Language::V1beta2::LanguageServiceClient do
         assert_instance_of(Google::Cloud::Language::V1beta2::AnnotateTextRequest, request)
         assert_equal(Google::Gax::to_proto(document, Google::Cloud::Language::V1beta2::Document), request.document)
         assert_equal(Google::Gax::to_proto(features, Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features), request.features)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:annotate_text, mock_method)
 

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/group_service_client_test.rb
@@ -85,7 +85,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::ListGroupsRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_groups, mock_method)
 
@@ -165,7 +165,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::GetGroupRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_group, mock_method)
 
@@ -244,7 +244,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
         assert_instance_of(Google::Monitoring::V3::CreateGroupRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(Google::Gax::to_proto(group, Google::Monitoring::V3::Group), request.group)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_group, mock_method)
 
@@ -323,7 +323,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::UpdateGroupRequest, request)
         assert_equal(Google::Gax::to_proto(group, Google::Monitoring::V3::Group), request.group)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_group, mock_method)
 
@@ -385,7 +385,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::DeleteGroupRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_group, mock_method)
 
@@ -459,7 +459,7 @@ describe Google::Cloud::Monitoring::V3::GroupServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::ListGroupMembersRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_group_members, mock_method)
 

--- a/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
+++ b/google-cloud-monitoring/test/google/cloud/monitoring/v3/metric_service_client_test.rb
@@ -85,7 +85,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::ListMonitoredResourceDescriptorsRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_monitored_resource_descriptors, mock_method)
 
@@ -163,7 +163,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::GetMonitoredResourceDescriptorRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_monitored_resource_descriptor, mock_method)
 
@@ -232,7 +232,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::ListMetricDescriptorsRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_metric_descriptors, mock_method)
 
@@ -312,7 +312,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::GetMetricDescriptorRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_metric_descriptor, mock_method)
 
@@ -391,7 +391,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
         assert_instance_of(Google::Monitoring::V3::CreateMetricDescriptorRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(Google::Gax::to_proto(metric_descriptor, Google::Api::MetricDescriptor), request.metric_descriptor)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:create_metric_descriptor, mock_method)
 
@@ -455,7 +455,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Monitoring::V3::DeleteMetricDescriptorRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_metric_descriptor, mock_method)
 
@@ -530,7 +530,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
         assert_equal(filter, request.filter)
         assert_equal(Google::Gax::to_proto(interval, Google::Monitoring::V3::TimeInterval), request.interval)
         assert_equal(view, request.view)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_time_series, mock_method)
 
@@ -616,7 +616,7 @@ describe Google::Cloud::Monitoring::V3::MetricServiceClient do
           Google::Gax::to_proto(req, Google::Monitoring::V3::TimeSeries)
         end
         assert_equal(time_series, request.time_series)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:create_time_series, mock_method)
 

--- a/google-cloud-os_login/google-cloud-os_login.gemspec
+++ b/google-cloud-os_login/google-cloud-os_login.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.0.0"
+  gem.add_dependency "google-gax", "~> 1.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rubocop", "~> 0.50.0"

--- a/google-cloud-os_login/test/google/cloud/os_login/v1beta/os_login_service_client_test.rb
+++ b/google-cloud-os_login/test/google/cloud/os_login/v1beta/os_login_service_client_test.rb
@@ -78,7 +78,7 @@ describe Google::Cloud::OsLogin::V1beta::OsLoginServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Oslogin::V1beta::DeletePosixAccountRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_posix_account, mock_method)
 
@@ -140,7 +140,7 @@ describe Google::Cloud::OsLogin::V1beta::OsLoginServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Oslogin::V1beta::DeleteSshPublicKeyRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_ssh_public_key, mock_method)
 
@@ -208,7 +208,7 @@ describe Google::Cloud::OsLogin::V1beta::OsLoginServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Oslogin::V1beta::GetLoginProfileRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_login_profile, mock_method)
 
@@ -281,7 +281,7 @@ describe Google::Cloud::OsLogin::V1beta::OsLoginServiceClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Cloud::Oslogin::V1beta::GetSshPublicKeyRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_ssh_public_key, mock_method)
 
@@ -349,7 +349,7 @@ describe Google::Cloud::OsLogin::V1beta::OsLoginServiceClient do
         assert_instance_of(Google::Cloud::Oslogin::V1beta::ImportSshPublicKeyRequest, request)
         assert_equal(formatted_parent, request.parent)
         assert_equal(Google::Gax::to_proto(ssh_public_key, Google::Cloud::Oslogin::Common::SshPublicKey), request.ssh_public_key)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:import_ssh_public_key, mock_method)
 
@@ -426,7 +426,7 @@ describe Google::Cloud::OsLogin::V1beta::OsLoginServiceClient do
         assert_instance_of(Google::Cloud::Oslogin::V1beta::UpdateSshPublicKeyRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(Google::Gax::to_proto(ssh_public_key, Google::Cloud::Oslogin::Common::SshPublicKey), request.ssh_public_key)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:update_ssh_public_key, mock_method)
 

--- a/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/database/v1/database_admin_client_test.rb
@@ -86,7 +86,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::Admin::Database::V1::ListDatabasesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_databases, mock_method)
 
@@ -165,7 +165,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
         assert_instance_of(Google::Spanner::Admin::Database::V1::CreateDatabaseRequest, request)
         assert_equal(formatted_parent, request.parent)
         assert_equal(create_statement, request.create_statement)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_database, mock_method)
 
@@ -205,7 +205,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
         assert_instance_of(Google::Spanner::Admin::Database::V1::CreateDatabaseRequest, request)
         assert_equal(formatted_parent, request.parent)
         assert_equal(create_statement, request.create_statement)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_database, mock_method)
 
@@ -275,7 +275,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::Admin::Database::V1::GetDatabaseRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_database, mock_method)
 
@@ -350,7 +350,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
         assert_instance_of(Google::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest, request)
         assert_equal(formatted_database, request.database)
         assert_equal(statements, request.statements)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:update_database_ddl, mock_method)
 
@@ -390,7 +390,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
         assert_instance_of(Google::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest, request)
         assert_equal(formatted_database, request.database)
         assert_equal(statements, request.statements)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:update_database_ddl, mock_method)
 
@@ -455,7 +455,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::Admin::Database::V1::DropDatabaseRequest, request)
         assert_equal(formatted_database, request.database)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:drop_database, mock_method)
 
@@ -521,7 +521,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::Admin::Database::V1::GetDatabaseDdlRequest, request)
         assert_equal(formatted_database, request.database)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_database_ddl, mock_method)
 
@@ -591,7 +591,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
         assert_instance_of(Google::Iam::V1::SetIamPolicyRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(Google::Gax::to_proto(policy, Google::Iam::V1::Policy), request.policy)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_iam_policy, mock_method)
 
@@ -661,7 +661,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::GetIamPolicyRequest, request)
         assert_equal(formatted_resource, request.resource)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_iam_policy, mock_method)
 
@@ -729,7 +729,7 @@ describe Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient do
         assert_instance_of(Google::Iam::V1::TestIamPermissionsRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(permissions, request.permissions)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:test_iam_permissions, mock_method)
 

--- a/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/admin/instance/v1/instance_admin_client_test.rb
@@ -86,7 +86,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::Admin::Instance::V1::ListInstanceConfigsRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_instance_configs, mock_method)
 
@@ -157,7 +157,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::Admin::Instance::V1::GetInstanceConfigRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_instance_config, mock_method)
 
@@ -226,7 +226,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::Admin::Instance::V1::ListInstancesRequest, request)
         assert_equal(formatted_parent, request.parent)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:list_instances, mock_method)
 
@@ -304,7 +304,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::Admin::Instance::V1::GetInstanceRequest, request)
         assert_equal(formatted_name, request.name)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_instance, mock_method)
 
@@ -390,7 +390,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Spanner::Admin::Instance::V1::Instance), request.instance)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_instance, mock_method)
 
@@ -436,7 +436,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
         assert_equal(formatted_parent, request.parent)
         assert_equal(instance_id, request.instance_id)
         assert_equal(Google::Gax::to_proto(instance, Google::Spanner::Admin::Instance::V1::Instance), request.instance)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:create_instance, mock_method)
 
@@ -533,7 +533,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
         assert_instance_of(Google::Spanner::Admin::Instance::V1::UpdateInstanceRequest, request)
         assert_equal(Google::Gax::to_proto(instance, Google::Spanner::Admin::Instance::V1::Instance), request.instance)
         assert_equal(Google::Gax::to_proto(field_mask, Google::Protobuf::FieldMask), request.field_mask)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:update_instance, mock_method)
 
@@ -573,7 +573,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
         assert_instance_of(Google::Spanner::Admin::Instance::V1::UpdateInstanceRequest, request)
         assert_equal(Google::Gax::to_proto(instance, Google::Spanner::Admin::Instance::V1::Instance), request.instance)
         assert_equal(Google::Gax::to_proto(field_mask, Google::Protobuf::FieldMask), request.field_mask)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:update_instance, mock_method)
 
@@ -638,7 +638,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Spanner::Admin::Instance::V1::DeleteInstanceRequest, request)
         assert_equal(formatted_name, request.name)
-        nil
+        OpenStruct.new(execute: nil)
       end
       mock_stub = MockGrpcClientStub.new(:delete_instance, mock_method)
 
@@ -708,7 +708,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
         assert_instance_of(Google::Iam::V1::SetIamPolicyRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(Google::Gax::to_proto(policy, Google::Iam::V1::Policy), request.policy)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:set_iam_policy, mock_method)
 
@@ -778,7 +778,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
       mock_method = proc do |request|
         assert_instance_of(Google::Iam::V1::GetIamPolicyRequest, request)
         assert_equal(formatted_resource, request.resource)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:get_iam_policy, mock_method)
 
@@ -846,7 +846,7 @@ describe Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient do
         assert_instance_of(Google::Iam::V1::TestIamPermissionsRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(permissions, request.permissions)
-        expected_response
+        OpenStruct.new(execute: expected_response)
       end
       mock_stub = MockGrpcClientStub.new(:test_iam_permissions, mock_method)
 

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb
@@ -85,7 +85,7 @@ describe Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
 
@@ -118,7 +118,7 @@ describe Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
 

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb
@@ -93,7 +93,7 @@ describe Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceServiceClie
         assert_instance_of(Google::Cloud::Videointelligence::V1beta1::AnnotateVideoRequest, request)
         assert_equal(input_uri, request.input_uri)
         assert_equal(features, request.features)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
 
@@ -134,7 +134,7 @@ describe Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceServiceClie
         assert_instance_of(Google::Cloud::Videointelligence::V1beta1::AnnotateVideoRequest, request)
         assert_equal(input_uri, request.input_uri)
         assert_equal(features, request.features)
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
 

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb
@@ -85,7 +85,7 @@ describe Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClie
 
       # Mock Grpc layer
       mock_method = proc do
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
 
@@ -118,7 +118,7 @@ describe Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClie
 
       # Mock Grpc layer
       mock_method = proc do
-        operation
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
 


### PR DESCRIPTION
Updated the generated unit tests to be compatible with the gRPC mocks for an upcoming gax 1.1.1 release (currently on master).

When doing this, I also noticed that a couple of the gapic modules were pinned to version numbers like 1.0.1 instead of 1.0. I can't think of any reason why we'd want to do that so I updated them as well in this change, but if there's a reason let me know.