### PR TITLE
Add tests for BigQuery Job Updaters

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -135,6 +135,16 @@ describe Google::Cloud::Bigquery, :bigquery do
     job.udfs.must_equal udfs
   end
 
+  it "should run a query job with job labels and user defined function resources in a block updater" do
+    job = bigquery.query_job publicdata_query do |j|
+      j.labels = labels
+      j.udfs = udfs
+    end
+    job.must_be_kind_of Google::Cloud::Bigquery::Job
+    job.labels.must_equal labels
+    job.udfs.must_equal udfs
+  end
+
   it "should get a list of jobs" do
     jobs = bigquery.jobs.all request_limit: 3
     jobs.each { |job| job.must_be_kind_of Google::Cloud::Bigquery::Job }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_updater_test.rb
@@ -1,0 +1,151 @@
+# Copyright 2015 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Dataset, :query_job, :updater, :mock_bigquery do
+  let(:query) { "SELECT name, age, score, active FROM `some_project.some_dataset.users`" }
+  let(:dataset_id) { "my_dataset" }
+  let(:dataset_gapi) { random_dataset_gapi dataset_id }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
+                                                      bigquery.service }
+  let(:table_id) { "my_table" }
+  let(:table_gapi) { random_table_gapi dataset_id, table_id }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+                                                  bigquery.service }
+  let(:labels) { { "foo" => "bar" } }
+  let(:udfs) { [ "return x+1;", "gs://my-bucket/my-lib.js" ] }
+  let(:kms_key) { "path/to/encryption_key_name" }
+
+  it "queries the data with table options" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi(query)
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+      project_id: project,
+      dataset_id: dataset_id
+    )
+    job_gapi.configuration.query.destination_table = Google::Apis::BigqueryV2::TableReference.new(
+      project_id: project,
+      dataset_id: dataset_id,
+      table_id:   table_id
+    )
+    job_gapi.configuration.query.create_disposition = "CREATE_NEVER"
+    job_gapi.configuration.query.write_disposition = "WRITE_TRUNCATE"
+    job_gapi.configuration.query.allow_large_results = true
+    job_gapi.configuration.query.flatten_results = false
+    job_gapi.configuration.query.maximum_bytes_billed = 12345678901234
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = dataset.query_job query do |j|
+      j.table = table
+      j.create = :never
+      j.write = :truncate
+      j.large_results = true
+      j.flatten = false
+      j.maximum_bytes_billed = 12345678901234
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with the job labels option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query
+    job_gapi.configuration.labels = labels
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+      project_id: project,
+      dataset_id: dataset_id
+    )
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = dataset.query_job query do |j|
+      j.labels = labels
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.labels.must_equal labels
+  end
+
+  it "queries the data with an array for the udfs option" do
+    mock = Minitest::Mock.new
+    dataset.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query
+    job_gapi.configuration.query.user_defined_function_resources = udfs_gapi_array
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+      project_id: project,
+      dataset_id: dataset_id
+    )
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = dataset.query_job query do |j|
+      j.udfs = udfs
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.udfs.must_equal udfs
+  end
+
+  it "queries the data with a string for the udfs option" do
+    mock = Minitest::Mock.new
+    dataset.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query
+    job_gapi.configuration.query.user_defined_function_resources = [udfs_gapi_uri]
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+      project_id: project,
+      dataset_id: dataset_id
+    )
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = dataset.query_job query do |j|
+      j.udfs = "gs://my-bucket/my-lib.js"
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.udfs.must_equal ["gs://my-bucket/my-lib.js"]
+  end
+
+  it "queries the data with the encryption option" do
+    mock = Minitest::Mock.new
+    dataset.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query
+    job_gapi.configuration.query.destination_encryption_configuration = encryption_gapi(kms_key)
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+        project_id: project,
+        dataset_id: dataset_id
+    )
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    encrypt_config = bigquery.encryption kms_key: kms_key
+
+    job = dataset.query_job query do |j|
+      j.encryption = encrypt_config
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    job.encryption.kms_key.must_equal kms_key
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_updater_test.rb
@@ -1,0 +1,148 @@
+# Copyright 2015 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
+  let(:source_dataset) { "source_dataset" }
+  let(:source_table_id) { "source_table_id" }
+  let(:source_table_name) { "Source Table" }
+  let(:source_description) { "This is the source table" }
+  let(:source_table_gapi) { random_table_gapi source_dataset,
+                                              source_table_id,
+                                              source_table_name,
+                                              source_description }
+  let(:source_table) { Google::Cloud::Bigquery::Table.from_gapi source_table_gapi,
+                                                         bigquery.service }
+  let(:target_dataset) { "target_dataset" }
+  let(:target_table_id) { "target_table_id" }
+  let(:target_table_name) { "Target Table" }
+  let(:target_description) { "This is the target table" }
+  let(:target_table_gapi) { random_table_gapi target_dataset,
+                                              target_table_id,
+                                              target_table_name,
+                                              target_description }
+  let(:target_table) { Google::Cloud::Bigquery::Table.from_gapi target_table_gapi,
+                                                         bigquery.service }
+  let(:target_table_other_proj_gapi) { random_table_gapi target_dataset,
+                                              target_table_id,
+                                              target_table_name,
+                                              target_description,
+                                              "target-project" }
+  let(:target_table_other_proj) { Google::Cloud::Bigquery::Table.from_gapi target_table_other_proj_gapi,
+                                                         bigquery.service }
+  let(:labels) { { "foo" => "bar" } }
+  let(:kms_key) { "path/to/encryption_key_name" }
+
+  it "can copy itself with create disposition" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table)
+    job_gapi.configuration.copy.create_disposition = "CREATE_NEVER"
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = source_table.copy_job target_table do |j|
+      j.create = "CREATE_NEVER"
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+  it "can copy itself with create disposition symbol" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table)
+    job_gapi.configuration.copy.create_disposition = "CREATE_NEVER"
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = source_table.copy_job target_table do |j|
+      j.create = :never
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+
+  it "can copy itself with write disposition" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table)
+    job_gapi.configuration.copy.write_disposition = "WRITE_TRUNCATE"
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = source_table.copy_job target_table do |j|
+      j.write = "WRITE_TRUNCATE"
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+  it "can copy itself with write disposition symbol" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = copy_job_gapi(source_table, target_table)
+    job_gapi.configuration.copy.write_disposition = "WRITE_TRUNCATE"
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = source_table.copy_job target_table do |j|
+      j.write = :truncate
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+  end
+
+  it "can copy itself with the job labels option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = copy_job_gapi(source_table, target_table)
+    job_gapi.configuration.labels = labels
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = source_table.copy_job target_table do |j|
+      j.labels = labels
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.labels.must_equal labels
+  end
+
+  it "can copy itself with the encryption option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = copy_job_gapi(source_table, target_table)
+    job_gapi.configuration.copy.destination_encryption_configuration = encryption_gapi(kms_key)
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    encrypt_config = bigquery.encryption kms_key: kms_key
+
+    job = source_table.copy_job target_table do |j|
+      j.encryption = encrypt_config
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    job.encryption.kms_key.must_equal kms_key
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_updater_test.rb
@@ -1,0 +1,155 @@
+# Copyright 2015 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a extract of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Table, :extract_job, :updater, :mock_bigquery do
+  let(:credentials) { OpenStruct.new }
+  let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
+  let(:extract_bucket_gapi) {  Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
+  let(:extract_bucket) { Google::Cloud::Storage::Bucket.from_gapi extract_bucket_gapi,
+                                                           storage.service }
+  let(:extract_file_gapi) { Google::Apis::StorageV1::Object.from_json random_file_hash(extract_bucket.name).to_json }
+  let(:extract_file) { Google::Cloud::Storage::File.from_gapi extract_file_gapi,
+                                                       storage.service }
+  let(:extract_url) { extract_file.to_gs_url }
+
+  let(:dataset) { "dataset" }
+  let(:table_id) { "table_id" }
+  let(:table_name) { "Target Table" }
+  let(:description) { "This is the target table" }
+  let(:table_gapi) { random_table_gapi dataset,
+                                       table_id,
+                                       table_name,
+                                       description }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
+                                                  bigquery.service }
+  let(:labels) { { "foo" => "bar" } }
+
+  it "can extract itself and specify the csv format and options" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "CSV"
+    job_gapi.configuration.extract.compression = "GZIP"
+    job_gapi.configuration.extract.field_delimiter = "\t"
+    job_gapi.configuration.extract.print_header = false
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = table.extract_job extract_url do |j|
+      j.format = :csv
+      j.compression = "GZIP"
+      j.delimiter = "\t"
+      j.header = false
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract itself and specify the json format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "NEWLINE_DELIMITED_JSON"
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = table.extract_job extract_url do |j|
+      j.format = :json
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract itself and specify the avro format" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.extract.destination_format = "AVRO"
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = table.extract_job extract_url do |j|
+      j.format = :avro
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+  end
+
+  it "can extract itself with the job labels option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    job_gapi = extract_job_gapi(table, extract_file)
+    job_gapi.configuration.labels = labels
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = table.extract_job extract_file do |j|
+      j.labels = labels
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.labels.must_equal labels
+  end
+
+  # Borrowed from MockStorage, extract to a common module?
+
+  def random_bucket_hash name=random_bucket_name
+    {"kind"=>"storage#bucket",
+     "id"=>name,
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{name}",
+     "projectNumber"=>"1234567890",
+     "name"=>name,
+     "timeCreated"=>::Time.now,
+     "metageneration"=>"1",
+     "owner"=>{"entity"=>"project-owners-1234567890"},
+     "location"=>"US",
+     "storageClass"=>"STANDARD",
+     "etag"=>"CAE=" }
+  end
+
+  def random_file_hash bucket=random_bucket_name, name=random_file_path
+    {"kind"=>"storage#object",
+     "id"=>"#{bucket}/#{name}/1234567890",
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{bucket}/o/#{name}",
+     "name"=>"#{name}",
+     "bucket"=>"#{bucket}",
+     "generation"=>"1234567890",
+     "metageneration"=>"1",
+     "contentType"=>"text/plain",
+     "updated"=>::Time.now,
+     "storageClass"=>"STANDARD",
+     "size"=>rand(10_000),
+     "md5Hash"=>"HXB937GQDFxDFqUGi//weQ==",
+     "mediaLink"=>"https://www.googleapis.com/download/storage/v1/b/#{bucket}/o/#{name}?generation=1234567890&alt=media",
+     "owner"=>{"entity"=>"user-1234567890", "entityId"=>"abc123"},
+     "crc32c"=>"Lm1F3g==",
+     "etag"=>"CKih16GjycICEAE="}
+  end
+
+  def random_bucket_name
+    (0...50).map { ("a".."z").to_a[rand(26)] }.join
+  end
+
+  def random_file_path
+    [(0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join + ".txt"].join "/"
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_updater_storage_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_updater_storage_test.rb
@@ -1,0 +1,268 @@
+# Copyright 2015 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a load of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Table, :load_job, :updater, :storage, :mock_bigquery do
+  let(:credentials) { OpenStruct.new }
+  let(:storage) { Google::Cloud::Storage::Project.new(Google::Cloud::Storage::Service.new(project, credentials)) }
+  let(:load_bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
+  let(:load_bucket) { Google::Cloud::Storage::Bucket.from_gapi load_bucket_gapi, storage.service }
+  let(:load_file) { storage_file }
+  let(:load_url) { load_file.to_gs_url }
+
+  let(:dataset) { "dataset" }
+  let(:table_id) { "table_id" }
+  let(:table_name) { "Target Table" }
+  let(:description) { "This is the target table" }
+  let(:table_hash) { random_table_hash dataset, table_id, table_name, description }
+  let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:labels) { { "foo" => "bar" } }
+  let(:kms_key) { "path/to/encryption_key_name" }
+
+  def storage_file path = nil
+    gapi = Google::Apis::StorageV1::Object.from_json random_file_hash(load_bucket.name, path).to_json
+    Google::Cloud::Storage::File.from_gapi gapi, storage.service
+  end
+
+  it "can specify a storage file with format" do
+    special_file = storage_file "data.json"
+    special_url = special_file.to_gs_url
+
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, special_url
+    job_gapi.configuration.load.source_format = "CSV"
+    mock.expect :insert_job, load_job_resp_gapi(table, special_url),
+      [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job special_file do |j|
+      j.format = :csv
+    end
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
+  it "can specify a storage file and derive CSV format with CSV options" do
+    special_file = storage_file "data.csv"
+    special_url = special_file.to_gs_url
+
+    mock = Minitest::Mock.new
+    job_gapi = load_job_csv_options_gapi table_gapi.table_reference
+    job_gapi.configuration.load.source_uris = [special_url]
+    mock.expect :insert_job, load_job_resp_gapi(table, special_url),
+      [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job special_file do |j|
+      j.jagged_rows = true
+      j.quoted_newlines = true
+      j.autodetect = true
+      j.encoding = "ISO-8859-1"
+      j.delimiter = "\t"
+      j.ignore_unknown = true
+      j.max_bad_records = 42
+      j.null_marker = "\N"
+      j.quote = "'"
+      j.skip_leading = 1
+    end
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
+  it "can load a Datastore backup file and specify projection fields" do
+    special_file = storage_file "data.backup_info"
+    special_url = special_file.to_gs_url
+    projection_fields = ["first_name"]
+
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, special_url
+    job_gapi.configuration.load.source_format = "DATASTORE_BACKUP"
+    job_gapi.configuration.load.projection_fields = projection_fields
+    mock.expect :insert_job, load_job_resp_gapi(table, special_url),
+      [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job special_file do |j|
+      j.projection_fields = projection_fields
+    end
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
+  it "can load itself with create disposition" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
+    job_gapi.configuration.load.create_disposition = "CREATE_NEVER"
+    mock.expect :insert_job, load_job_resp_gapi(table, load_url),
+      [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job load_url do |j|
+      j.create = "CREATE_NEVER"
+    end
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
+  it "can load itself with create disposition symbol" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
+    job_gapi.configuration.load.create_disposition = "CREATE_NEVER"
+    mock.expect :insert_job, load_job_resp_gapi(table, load_url),
+      [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job load_url do |j|
+      j.create = :never
+    end
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
+  it "can load itself with write disposition" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
+    job_gapi.configuration.load.write_disposition = "WRITE_TRUNCATE"
+    mock.expect :insert_job, load_job_resp_gapi(table, load_url),
+      [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job load_url do |j|
+      j.write = "WRITE_TRUNCATE"
+    end
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
+  it "can load itself with write disposition symbol" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
+    job_gapi.configuration.load.write_disposition = "WRITE_TRUNCATE"
+    mock.expect :insert_job, load_job_resp_gapi(table, load_url),
+      [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job load_url do |j|
+      j.write = :truncate
+    end
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+
+    mock.verify
+  end
+
+  it "can load a storage file with the job labels option" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
+    job_gapi.configuration.labels = labels
+    mock.expect :insert_job, load_job_resp_gapi(table, load_url, labels: labels),
+      [project, job_gapi]
+    table.service.mocked_service = mock
+
+    job = table.load_job load_file do |j|
+      j.labels = labels
+    end
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.labels.must_equal labels
+
+    mock.verify
+  end
+
+  it "can load a storage file with the encryption option" do
+    mock = Minitest::Mock.new
+    job_gapi = load_job_url_gapi table_gapi.table_reference, load_url
+    job_gapi.configuration.load.destination_encryption_configuration = encryption_gapi(kms_key)
+    mock.expect :insert_job, job_gapi,
+                [project, job_gapi]
+    table.service.mocked_service = mock
+
+    encrypt_config = bigquery.encryption kms_key: kms_key
+
+    job = table.load_job load_file do |j|
+      j.encryption = encrypt_config
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
+    job.encryption.must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
+    job.encryption.kms_key.must_equal kms_key
+  end
+
+  def load_job_resp_gapi table, load_url, job_id: "job_9876543210", labels: nil
+    hash = random_job_hash job_id
+    hash["configuration"]["load"] = {
+      "sourceUris" => [load_url],
+      "destinationTable" => {
+        "projectId" => table.project_id,
+        "datasetId" => table.dataset_id,
+        "tableId" => table.table_id
+      },
+    }
+    resp = Google::Apis::BigqueryV2::Job.from_json hash.to_json
+    resp.configuration.labels = labels if labels
+    resp
+  end
+
+  # Borrowed from MockStorage, load to a common module?
+
+  def random_bucket_hash name=random_bucket_name
+    {"kind"=>"storage#bucket",
+     "id"=>name,
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{name}",
+     "projectNumber"=>"1234567890",
+     "name"=>name,
+     "timeCreated"=>::Time.now,
+     "metageneration"=>"1",
+     "owner"=>{"entity"=>"project-owners-1234567890"},
+     "location"=>"US",
+     "storageClass"=>"STANDARD",
+     "etag"=>"CAE=" }
+  end
+
+  def random_file_hash bucket=random_bucket_name, name=random_file_path
+    {"kind"=>"storage#object",
+     "id"=>"#{bucket}/#{name}/1234567890",
+     "selfLink"=>"https://www.googleapis.com/storage/v1/b/#{bucket}/o/#{name}",
+     "name"=>"#{name}",
+     "bucket"=>"#{bucket}",
+     "generation"=>"1234567890",
+     "metageneration"=>"1",
+     "contentType"=>"text/plain",
+     "updated"=>::Time.now,
+     "storageClass"=>"STANDARD",
+     "size"=>rand(10_000),
+     "md5Hash"=>"HXB937GQDFxDFqUGi//weQ==",
+     "mediaLink"=>"https://www.googleapis.com/download/storage/v1/b/#{bucket}/o/#{name}?generation=1234567890&alt=media",
+     "owner"=>{"entity"=>"user-1234567890", "entityId"=>"abc123"},
+     "crc32c"=>"Lm1F3g==",
+     "etag"=>"CKih16GjycICEAE="}
+  end
+
+  def random_bucket_name
+    (0...50).map { ("a".."z").to_a[rand(26)] }.join
+  end
+
+  def random_file_path
+    [(0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join,
+     (0...10).map { ("a".."z").to_a[rand(26)] }.join + ".txt"].join "/"
+  end
+end

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -725,4 +725,8 @@ class MockBigquery < Minitest::Spec
       yield tmpfile
     end
   end
+
+  def encryption_gapi key_name
+    Google::Apis::BigqueryV2::EncryptionConfiguration.new kms_key_name: key_name
+  end
 end


### PR DESCRIPTION
Add both unit and acceptance tests to improve coverage.

refs  #1973, #2003, #2014, #2015, #2016, and #2022