### PR TITLE
Update versioning info on documentation

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/overview.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Datastore API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Datastore API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Datastore API][Product Documentation]:
     # Accesses the schemaless NoSQL database to provide fully managed, robust,

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/overview.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Stackdriver Debugger API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Stackdriver Debugger API ([Beta](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Stackdriver Debugger API][Product Documentation]:
     # Examines the call stack and variables of a running application

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/overview.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Stackdriver Error Reporting API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Stackdriver Error Reporting API ([Beta](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Stackdriver Error Reporting API][Product Documentation]:
     # Stackdriver Error Reporting groups and counts similar errors from cloud

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/overview.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Stackdriver Logging API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Stackdriver Logging API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Stackdriver Logging API][Product Documentation]:
     # Writes log entries and manages your Stackdriver Logging configuration.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/overview.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Pub/Sub API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Pub/Sub API ([Beta](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Pub/Sub API][Product Documentation]:
     # Provides reliable, many-to-many, asynchronous messaging between applications.

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/overview.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Cloud Spanner API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Cloud Spanner API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Cloud Spanner API][Product Documentation]:
     # Cloud Spanner is a managed, mission-critical, globally consistent and

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/overview.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Stackdriver Trace API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Stackdriver Trace API ([Beta](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Stackdriver Trace API][Product Documentation]:
     # Sends application trace data to Stackdriver Trace for viewing. Trace data is


### PR DESCRIPTION
I compared versioning on [README.md](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md) with docs hosted on [googlecloudplatform.github.io](http://googlecloudplatform.github.io/google-cloud-ruby/#/docs/) and found some inconsistencies. I considered version information on README.md as the latest one and updated documentation on APIs where versioning were outdated.

While I was updating the version information, I also discovered that some GA APIs use "Product Name (GA)" as the title and other GA APIs use "Product Name" without (GA) suffix. I removed (GA) suffix everywhere on docs (except README.md) to be consistent, but feel free to re-add it if you want to.