### PR TITLE
Pub/Sub: Recover from GRPC::Core::CallError

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -285,16 +285,20 @@ module Google
             @publisher = publisher
             @messages = []
             @callbacks = []
+            @total_message_bytes = publisher.topic_name.bytesize + 2
           end
 
           def add msg, callback
             @messages << msg
             @callbacks << callback
+            @total_message_bytes += msg.to_proto.bytesize + 2
           end
 
           def try_add msg, callback
-            if total_message_count + 1 > @publisher.max_messages ||
-               total_message_bytes + msg.to_proto.size >= @publisher.max_bytes
+            new_message_count = total_message_count + 1
+            new_message_bytes = total_message_bytes + msg.to_proto.bytesize + 2
+            if new_message_count > @publisher.max_messages ||
+               new_message_bytes >= @publisher.max_bytes
               return false
             end
             add msg, callback
@@ -311,7 +315,7 @@ module Google
           end
 
           def total_message_bytes
-            @messages.map(&:to_proto).map(&:size).inject(0, :+)
+            @total_message_bytes
           end
 
           def items

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_pusher.rb
@@ -197,7 +197,14 @@ module Google
             end
 
             def addl_delay_bytes deadline, ack_id
-              (deadline.bit_length / 8.0).ceil + ack_id.bytesize + 4
+              bytes_for_int(deadline) + ack_id.bytesize + 4
+            end
+
+            def bytes_for_int num
+              # Ruby 2.0 does not have Integer#bit_length
+              return [num].pack("s").bytesize unless num.respond_to? :bit_length
+
+              (num.bit_length / 8.0).ceil
             end
 
             def ready?

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_pusher.rb
@@ -162,31 +162,42 @@ module Google
             def initialize max_bytes: 10000000
               @max_bytes = max_bytes
               @request = Google::Pubsub::V1::StreamingPullRequest.new
+              @total_message_bytes = 0
             end
 
             def ack ack_id
               @request.ack_ids << ack_id
+              @total_message_bytes += addl_ack_bytes ack_id
             end
 
             def try_ack ack_id
-              addl_bytes = ack_id.size
+              addl_bytes = addl_ack_bytes ack_id
               return false if total_message_bytes + addl_bytes >= @max_bytes
 
               ack ack_id
               true
             end
 
+            def addl_ack_bytes ack_id
+              ack_id.bytesize + 2
+            end
+
             def delay deadline, ack_id
               @request.modify_deadline_seconds << deadline
               @request.modify_deadline_ack_ids << ack_id
+              @total_message_bytes += addl_delay_bytes deadline, ack_id
             end
 
             def try_delay deadline, ack_id
-              addl_bytes = deadline.to_s.size + ack_id.size
+              addl_bytes = addl_delay_bytes deadline, ack_id
               return false if total_message_bytes + addl_bytes >= @max_bytes
 
               delay deadline, ack_id
               true
+            end
+
+            def addl_delay_bytes deadline, ack_id
+              (deadline.bit_length / 8.0).ceil + ack_id.bytesize + 4
             end
 
             def ready?
@@ -194,7 +205,7 @@ module Google
             end
 
             def total_message_bytes
-              request.to_proto.size
+              @total_message_bytes
             end
           end
         end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
@@ -268,7 +268,7 @@ describe Google::Cloud::Pubsub::AsyncPublisher, :mock_pubsub do
     pubsub.service.mocked_publisher = mock
 
     # 190 is bigger than 10 messages, but less than 11.
-    publisher = Google::Cloud::Pubsub::AsyncPublisher.new topic_name, pubsub.service, max_bytes: 190, interval: 10
+    publisher = Google::Cloud::Pubsub::AsyncPublisher.new topic_name, pubsub.service, max_bytes: 250, interval: 10
 
     callbacks = 0
 

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -49,7 +49,9 @@ class StreamingPullStub
   attr_reader :request_enum, :responses
 
   def initialize responses
-    @responses = responses
+    # EnumeratorQueue will return an enum that blocks
+    @responses = Google::Cloud::Pubsub::Subscriber::EnumeratorQueue.new
+    responses.each { |response| @responses.push response }
   end
 
   def streaming_pull request_enum, options: nil


### PR DESCRIPTION
As first reported in #2010 and #2011 we are seeing `GRPC::Core::CallError` errors raised regularly on streaming connections under heavy load using the `grpc` gem version 1.7.0 and above. We have discussed this with the GRPC team and opened grpc/grpc#14853 to track this.

The problem adversely affects Google Cloud Pub/Sub Ruby gem because the error is being raised in a thread used by the GRPC library, and is not propagated to the Stream object used to manage the requests and responses to the stream. When the error is raised the stream connection is unexpectedly closed. This PR adds the ability for a Stream object to recover from the stream being closed unexpectedly.

This PR also enhances performance for the batch total byte size calculations.