### PR TITLE
Fix Schema::Field type helpers

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -40,8 +40,8 @@ module Google
           MODES = %w[NULLABLE REQUIRED REPEATED].freeze
 
           # @private
-          TYPES = %w[STRING INTEGER FLOAT BOOLEAN BYTES TIMESTAMP TIME DATETIME
-                     DATE RECORD].freeze
+          TYPES = %w[STRING INTEGER INT64 FLOAT FLOAT64 BOOLEAN BOOL BYTES
+                     TIMESTAMP TIME DATETIME DATE RECORD STRUCT].freeze
 
           ##
           # The name of the field.
@@ -164,93 +164,93 @@ module Google
           end
 
           ##
-          # Checks if the mode of the field is `STRING`.
+          # Checks if the type of the field is `STRING`.
           #
           # @return [Boolean] `true` when `STRING`, `false` otherwise.
           #
           def string?
-            mode == "STRING"
+            type == "STRING"
           end
 
           ##
-          # Checks if the mode of the field is `INTEGER`.
+          # Checks if the type of the field is `INTEGER`.
           #
           # @return [Boolean] `true` when `INTEGER`, `false` otherwise.
           #
           def integer?
-            mode == "INTEGER"
+            type == "INTEGER" || type == "INT64"
           end
 
           ##
-          # Checks if the mode of the field is `FLOAT`.
+          # Checks if the type of the field is `FLOAT`.
           #
           # @return [Boolean] `true` when `FLOAT`, `false` otherwise.
           #
           def float?
-            mode == "FLOAT"
+            type == "FLOAT" || type == "FLOAT64"
           end
 
           ##
-          # Checks if the mode of the field is `BOOLEAN`.
+          # Checks if the type of the field is `BOOLEAN`.
           #
           # @return [Boolean] `true` when `BOOLEAN`, `false` otherwise.
           #
           def boolean?
-            mode == "BOOLEAN"
+            type == "BOOLEAN" || type == "BOOL"
           end
 
           ##
-          # Checks if the mode of the field is `BYTES`.
+          # Checks if the type of the field is `BYTES`.
           #
           # @return [Boolean] `true` when `BYTES`, `false` otherwise.
           #
           def bytes?
-            mode == "BYTES"
+            type == "BYTES"
           end
 
           ##
-          # Checks if the mode of the field is `TIMESTAMP`.
+          # Checks if the type of the field is `TIMESTAMP`.
           #
           # @return [Boolean] `true` when `TIMESTAMP`, `false` otherwise.
           #
           def timestamp?
-            mode == "TIMESTAMP"
+            type == "TIMESTAMP"
           end
 
           ##
-          # Checks if the mode of the field is `TIME`.
+          # Checks if the type of the field is `TIME`.
           #
           # @return [Boolean] `true` when `TIME`, `false` otherwise.
           #
           def time?
-            mode == "TIME"
+            type == "TIME"
           end
 
           ##
-          # Checks if the mode of the field is `DATETIME`.
+          # Checks if the type of the field is `DATETIME`.
           #
           # @return [Boolean] `true` when `DATETIME`, `false` otherwise.
           #
           def datetime?
-            mode == "DATETIME"
+            type == "DATETIME"
           end
 
           ##
-          # Checks if the mode of the field is `DATE`.
+          # Checks if the type of the field is `DATE`.
           #
           # @return [Boolean] `true` when `DATE`, `false` otherwise.
           #
           def date?
-            mode == "DATE"
+            type == "DATE"
           end
 
           ##
-          # Checks if the mode of the field is `RECORD`.
+          # Checks if the type of the field is `RECORD`.
           #
           # @return [Boolean] `true` when `RECORD`, `false` otherwise.
           #
           def record?
-            mode == "RECORD"
+            type == "RECORD" || type == "STRUCT"
           end
 
           ##

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
@@ -1,0 +1,312 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
+  let(:schema_hash) do
+    {
+      "fields" => [
+        {
+          "name" => "name",
+          "type" => "STRING",
+          "mode" => "REQUIRED"
+        },
+        {
+          "name" => "age",
+          "type" => "INTEGER",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "score",
+          "type" => "FLOAT",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "active",
+          "type" => "BOOLEAN",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "avatar",
+          "type" => "BYTES",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "started_at",
+          "type" => "TIMESTAMP",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "duration",
+          "type" => "TIME",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "target_end",
+          "type" => "DATETIME",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "birthday",
+          "type" => "DATE",
+          "mode" => "NULLABLE"
+        },
+        {
+          "name" => "alts",
+          "type" => "RECORD",
+          "mode" => "REPEATED",
+          "fields" => [
+            {
+              "name" => "age",
+              "type" => "INT64"
+            },
+            {
+              "name" => "score",
+              "type" => "FLOAT64"
+            },
+            {
+              "name" => "active",
+              "type" => "BOOL"
+            },
+            {
+              "name" => "alt",
+              "type" => "STRUCT",
+              "fields" => [
+                {
+                  "name" => "name",
+                  "type" => "STRING"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  end
+  let(:schema_json) { schema_hash.to_json }
+  let(:schema_gapi) { Google::Apis::BigqueryV2::TableSchema.from_json schema_json }
+  let(:schema) { Google::Cloud::Bigquery::Schema.from_gapi schema_gapi }
+  let(:empty_schema) { Google::Cloud::Bigquery::Schema.from_gapi }
+
+  it "has basic values" do
+    schema.must_be_kind_of Google::Cloud::Bigquery::Schema
+    schema.fields.wont_be :empty?
+    schema.fields.map(&:name).must_equal ["name", "age", "score", "active", "avatar", "started_at", "duration", "target_end", "birthday", "alts"]
+  end
+
+  it "can access fields with a symbol" do
+    schema.field(:name).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:name).name.must_equal "name"
+    schema.field(:name).type.must_equal "STRING"
+    schema.field(:name).mode.must_equal "REQUIRED"
+    schema.field(:name).must_be :string?
+    schema.field(:name).must_be :required?
+
+    schema.field(:age).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:age).name.must_equal "age"
+    schema.field(:age).type.must_equal "INTEGER"
+    schema.field(:age).mode.must_equal "NULLABLE"
+    schema.field(:age).must_be :integer?
+    schema.field(:age).must_be :nullable?
+
+    schema.field(:score).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:score).name.must_equal "score"
+    schema.field(:score).type.must_equal "FLOAT"
+    schema.field(:score).mode.must_equal "NULLABLE"
+    schema.field(:score).must_be :float?
+    schema.field(:score).must_be :nullable?
+
+    schema.field(:active).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:active).name.must_equal "active"
+    schema.field(:active).type.must_equal "BOOLEAN"
+    schema.field(:active).mode.must_equal "NULLABLE"
+    schema.field(:active).must_be :boolean?
+    schema.field(:active).must_be :nullable?
+
+    schema.field(:avatar).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:avatar).name.must_equal "avatar"
+    schema.field(:avatar).type.must_equal "BYTES"
+    schema.field(:avatar).mode.must_equal "NULLABLE"
+    schema.field(:avatar).must_be :bytes?
+    schema.field(:avatar).must_be :nullable?
+
+    schema.field(:started_at).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:started_at).name.must_equal "started_at"
+    schema.field(:started_at).type.must_equal "TIMESTAMP"
+    schema.field(:started_at).mode.must_equal "NULLABLE"
+    schema.field(:started_at).must_be :timestamp?
+    schema.field(:started_at).must_be :nullable?
+
+    schema.field(:duration).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:duration).name.must_equal "duration"
+    schema.field(:duration).type.must_equal "TIME"
+    schema.field(:duration).mode.must_equal "NULLABLE"
+    schema.field(:duration).must_be :time?
+    schema.field(:duration).must_be :nullable?
+
+    schema.field(:target_end).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:target_end).name.must_equal "target_end"
+    schema.field(:target_end).type.must_equal "DATETIME"
+    schema.field(:target_end).mode.must_equal "NULLABLE"
+    schema.field(:target_end).must_be :datetime?
+    schema.field(:target_end).must_be :nullable?
+
+    schema.field(:birthday).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:birthday).name.must_equal "birthday"
+    schema.field(:birthday).type.must_equal "DATE"
+    schema.field(:birthday).mode.must_equal "NULLABLE"
+    schema.field(:birthday).must_be :date?
+    schema.field(:birthday).must_be :nullable?
+
+    schema.field(:alts).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:alts).name.must_equal "alts"
+    schema.field(:alts).type.must_equal "RECORD"
+    schema.field(:alts).mode.must_equal "REPEATED"
+    schema.field(:alts).must_be :record?
+    schema.field(:alts).must_be :repeated?
+
+    schema.field(:alts).field(:age).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:alts).field(:age).name.must_equal "age"
+    schema.field(:alts).field(:age).type.must_equal "INT64"
+    schema.field(:alts).field(:age).mode.must_be :nil?
+    schema.field(:alts).field(:age).must_be :integer?
+
+    schema.field(:alts).field(:score).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:alts).field(:score).name.must_equal "score"
+    schema.field(:alts).field(:score).type.must_equal "FLOAT64"
+    schema.field(:alts).field(:score).mode.must_be :nil?
+    schema.field(:alts).field(:score).must_be :float?
+
+    schema.field(:alts).field(:active).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:alts).field(:active).name.must_equal "active"
+    schema.field(:alts).field(:active).type.must_equal "BOOL"
+    schema.field(:alts).field(:active).mode.must_be :nil?
+    schema.field(:alts).field(:active).must_be :boolean?
+
+    schema.field(:alts).field(:alt).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:alts).field(:alt).name.must_equal "alt"
+    schema.field(:alts).field(:alt).type.must_equal "STRUCT"
+    schema.field(:alts).field(:alt).mode.must_be :nil?
+    schema.field(:alts).field(:alt).must_be :record?
+
+    schema.field(:alts).field(:alt).field(:name).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field(:alts).field(:alt).field(:name).name.must_equal "name"
+    schema.field(:alts).field(:alt).field(:name).type.must_equal "STRING"
+    schema.field(:alts).field(:alt).field(:name).mode.must_be :nil?
+    schema.field(:alts).field(:alt).field(:name).must_be :string?
+  end
+
+  it "can access fields with a string" do
+    schema.field("name").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("name").name.must_equal "name"
+    schema.field("name").type.must_equal "STRING"
+    schema.field("name").mode.must_equal "REQUIRED"
+    schema.field("name").must_be :string?
+    schema.field("name").must_be :required?
+
+    schema.field("age").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("age").name.must_equal "age"
+    schema.field("age").type.must_equal "INTEGER"
+    schema.field("age").mode.must_equal "NULLABLE"
+    schema.field("age").must_be :integer?
+    schema.field("age").must_be :nullable?
+
+    schema.field("score").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("score").name.must_equal "score"
+    schema.field("score").type.must_equal "FLOAT"
+    schema.field("score").mode.must_equal "NULLABLE"
+    schema.field("score").must_be :float?
+    schema.field("score").must_be :nullable?
+
+    schema.field("active").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("active").name.must_equal "active"
+    schema.field("active").type.must_equal "BOOLEAN"
+    schema.field("active").mode.must_equal "NULLABLE"
+    schema.field("active").must_be :boolean?
+    schema.field("active").must_be :nullable?
+
+    schema.field("avatar").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("avatar").name.must_equal "avatar"
+    schema.field("avatar").type.must_equal "BYTES"
+    schema.field("avatar").mode.must_equal "NULLABLE"
+    schema.field("avatar").must_be :bytes?
+    schema.field("avatar").must_be :nullable?
+
+    schema.field("started_at").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("started_at").name.must_equal "started_at"
+    schema.field("started_at").type.must_equal "TIMESTAMP"
+    schema.field("started_at").mode.must_equal "NULLABLE"
+    schema.field("started_at").must_be :timestamp?
+    schema.field("started_at").must_be :nullable?
+
+    schema.field("duration").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("duration").name.must_equal "duration"
+    schema.field("duration").type.must_equal "TIME"
+    schema.field("duration").mode.must_equal "NULLABLE"
+    schema.field("duration").must_be :time?
+    schema.field("duration").must_be :nullable?
+
+    schema.field("target_end").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("target_end").name.must_equal "target_end"
+    schema.field("target_end").type.must_equal "DATETIME"
+    schema.field("target_end").mode.must_equal "NULLABLE"
+    schema.field("target_end").must_be :datetime?
+    schema.field("target_end").must_be :nullable?
+
+    schema.field("birthday").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("birthday").name.must_equal "birthday"
+    schema.field("birthday").type.must_equal "DATE"
+    schema.field("birthday").mode.must_equal "NULLABLE"
+    schema.field("birthday").must_be :date?
+    schema.field("birthday").must_be :nullable?
+
+    schema.field("alts").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("alts").name.must_equal "alts"
+    schema.field("alts").type.must_equal "RECORD"
+    schema.field("alts").mode.must_equal "REPEATED"
+    schema.field("alts").must_be :record?
+    schema.field("alts").must_be :repeated?
+
+    schema.field("alts").field("age").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("alts").field("age").name.must_equal "age"
+    schema.field("alts").field("age").type.must_equal "INT64"
+    schema.field("alts").field("age").mode.must_be :nil?
+    schema.field("alts").field("age").must_be :integer?
+
+    schema.field("alts").field("score").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("alts").field("score").name.must_equal "score"
+    schema.field("alts").field("score").type.must_equal "FLOAT64"
+    schema.field("alts").field("score").mode.must_be :nil?
+    schema.field("alts").field("score").must_be :float?
+
+    schema.field("alts").field("active").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("alts").field("active").name.must_equal "active"
+    schema.field("alts").field("active").type.must_equal "BOOL"
+    schema.field("alts").field("active").mode.must_be :nil?
+    schema.field("alts").field("active").must_be :boolean?
+
+    schema.field("alts").field("alt").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("alts").field("alt").name.must_equal "alt"
+    schema.field("alts").field("alt").type.must_equal "STRUCT"
+    schema.field("alts").field("alt").mode.must_be :nil?
+    schema.field("alts").field("alt").must_be :record?
+
+    schema.field("alts").field("alt").field("name").must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    schema.field("alts").field("alt").field("name").name.must_equal "name"
+    schema.field("alts").field("alt").field("name").type.must_equal "STRING"
+    schema.field("alts").field("alt").field("name").mode.must_be :nil?
+    schema.field("alts").field("alt").field("name").must_be :string?
+  end
+end


### PR DESCRIPTION
`Scheme` and `Schema::Field` were missing test coverage. `Schema::Field` had silly bugs in the type helpers.

[fixes #2029]