### PR TITLE
better error message when transaction failed

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -545,14 +545,14 @@ module Google
             # Create new transaction and retry the block
             tx = Transaction.new service, previous_transaction: tx.id
             retry
-          rescue StandardError
+          rescue StandardError => e
             begin
               tx.rollback
-            rescue StandardError
+            rescue StandardError => e
               raise TransactionError,
-                    "Transaction failed to commit and rollback."
+                    "Transaction failed to commit and rollback: #{e}"
             end
-            raise TransactionError, "Transaction failed to commit."
+            raise TransactionError, "Transaction failed to commit: #{e}"
           end
         end
 
@@ -602,14 +602,14 @@ module Google
           begin
             yield tx
             tx.commit
-          rescue StandardError
+          rescue StandardError => e
             begin
               tx.rollback
-            rescue StandardError
+            rescue StandardError => e
               raise TransactionError,
-                    "Transaction failed to commit and rollback."
+                    "Transaction failed to commit and rollback: #{e}"
             end
-            raise TransactionError, "Transaction failed to commit."
+            raise TransactionError, "Transaction failed to commit: #{e}"
           end
         end
         alias snapshot read_only_transaction

--- a/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/dataset_test.rb
@@ -1206,7 +1206,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
     end
 
     error.wont_be :nil?
-    error.message.must_equal "Transaction failed to commit."
+    error.message.must_equal "Transaction failed to commit: This error should be wrapped by TransactionError."
     error.cause.wont_be :nil?
     error.cause.message.must_equal "This error should be wrapped by TransactionError."
   end
@@ -1245,7 +1245,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
 
       error.wont_be :nil?
       error.must_be_kind_of Google::Cloud::Datastore::TransactionError
-      error.message.must_equal "Transaction failed to commit and rollback."
+      error.message.must_equal "Transaction failed to commit and rollback: rollback error"
       error.cause.wont_be :nil?
       error.cause.must_be_kind_of RuntimeError
       error.cause.message.must_equal "rollback error"
@@ -1321,7 +1321,7 @@ describe Google::Cloud::Datastore::Dataset, :mock_datastore do
           tx.save entity
         end
       end.must_raise Google::Cloud::Datastore::TransactionError
-      error.message.must_equal "Transaction failed to commit."
+      error.message.must_equal "Transaction failed to commit: unsupported"
       error.cause.must_be_kind_of StandardError
       error.cause.message.must_equal "unsupported"
     end


### PR DESCRIPTION
It was hiding the real details of the exception within the transaction block.

Now in my case the
```plain
Transaction failed to commit. (Google::Cloud::Datastore::TransactionError)
```
became
```plain
Transaction failed to commit: undefined method `query' for #<Google::Cloud::Datastore::ReadOnlyTransaction:0x007fd3ee304d90> (Google::Cloud::Datastore::TransactionError)
```