### PR TITLE
BigQuery: Unset Job Location

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
@@ -203,6 +203,11 @@ module Google
           # @!group Attributes
           def location= value
             @gapi.job_reference.location = value
+            return unless value.nil?
+
+            # Treat assigning value of nil the same as unsetting the value.
+            unset = @gapi.job_reference.instance_variables.include? :@location
+            @gapi.job_reference.remove_instance_variable :@location if unset
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
@@ -224,6 +224,11 @@ module Google
           # @!group Attributes
           def location= value
             @gapi.job_reference.location = value
+            return unless value.nil?
+
+            # Treat assigning value of nil the same as unsetting the value.
+            unset = @gapi.job_reference.instance_variables.include? :@location
+            @gapi.job_reference.remove_instance_variable :@location if unset
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -745,6 +745,11 @@ module Google
           # @!group Attributes
           def location= value
             @gapi.job_reference.location = value
+            return unless value.nil?
+
+            # Treat assigning value of nil the same as unsetting the value.
+            unset = @gapi.job_reference.instance_variables.include? :@location
+            @gapi.job_reference.remove_instance_variable :@location if unset
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -402,6 +402,11 @@ module Google
           # @!group Attributes
           def location= value
             @gapi.job_reference.location = value
+            return unless value.nil?
+
+            # Treat assigning value of nil the same as unsetting the value.
+            unset = @gapi.job_reference.instance_variables.include? :@location
+            @gapi.job_reference.remove_instance_variable :@location if unset
           end
 
           ##

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_updater_test.rb
@@ -206,16 +206,35 @@ describe Google::Cloud::Bigquery::Project, :query_job, :updater, :mock_bigquery 
     mock = Minitest::Mock.new
     dataset.service.mocked_service = mock
 
-    job_gapi = query_job_gapi query, location: nil
-    job_gapi.job_reference.location = region
-    mock.expect :insert_job, job_gapi, [project, job_gapi]
+    insert_job_gapi = query_job_gapi query, location: region
+    return_job_gapi = query_job_gapi query, location: region
+    mock.expect :insert_job, return_job_gapi, [project, insert_job_gapi]
 
     job = bigquery.query_job query do |j|
+      j.location.must_be :nil?
       j.location = region
     end
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
     job.location.must_equal region
+  end
+
+  it "queries the data with setting location to nil" do
+    mock = Minitest::Mock.new
+    dataset.service.mocked_service = mock
+
+    insert_job_gapi = query_job_gapi query, location: nil
+    return_job_gapi = query_job_gapi query, location: "US"
+    mock.expect :insert_job, return_job_gapi, [project, insert_job_gapi]
+
+    job = bigquery.query_job query do |j|
+      j.location.must_be :nil?
+      j.location = nil
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    job.location.must_equal "US"
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_job_updater_test.rb
@@ -171,17 +171,36 @@ describe Google::Cloud::Bigquery::Table, :copy_job, :updater, :mock_bigquery do
   it "can copy itself with the location option" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = copy_job_gapi(source_table, target_table)
+    job_gapi = copy_job_gapi(source_table, target_table, location: "US")
     job_gapi.job_reference.location = region
 
     mock.expect :insert_job, job_gapi, [project, job_gapi]
 
     job = source_table.copy_job target_table do |j|
+      j.location.must_equal "US" # default
       j.location = region
     end
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
     job.location.must_equal region
+  end
+
+  it "can copy itself with unsetting the location option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    # Setting location: nil is the same as unsetting it in the gapic object
+    job_gapi = copy_job_gapi(source_table, target_table, location: nil)
+
+    mock.expect :insert_job, job_gapi, [project, job_gapi]
+
+    job = source_table.copy_job target_table do |j|
+      j.location.must_equal "US" # default
+      j.location = nil
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::CopyJob
+    job.location.must_be :nil?
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_job_updater_test.rb
@@ -132,18 +132,41 @@ describe Google::Cloud::Bigquery::Table, :extract_job, :updater, :mock_bigquery 
   it "can extract itself with the location option" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
-    job_gapi = extract_job_gapi(table, extract_file)
-    job_gapi.job_reference.location = region
+    insert_job_gapi = extract_job_gapi(table, extract_file)
+    return_job_gapi = extract_job_gapi(table, extract_file)
+    insert_job_gapi.job_reference.location = region
+    return_job_gapi.job_reference.location = region
 
-    mock.expect :insert_job, job_gapi, [project, job_gapi]
+    mock.expect :insert_job, return_job_gapi, [project, insert_job_gapi]
 
     job = table.extract_job extract_file do |j|
+      j.location.must_equal "US"
       j.location = region
     end
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
     job.location.must_equal region
+  end
+
+  it "can extract itself and unset the location" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    insert_job_gapi = extract_job_gapi(table, extract_file)
+    return_job_gapi = extract_job_gapi(table, extract_file)
+    insert_job_gapi.job_reference.remove_instance_variable :@location
+    return_job_gapi.job_reference.location = "US"
+
+    mock.expect :insert_job, return_job_gapi, [project, insert_job_gapi]
+
+    job = table.extract_job extract_file do |j|
+      j.location.must_equal "US"
+      j.location = nil
+    end
+    mock.verify
+
+    job.must_be_kind_of Google::Cloud::Bigquery::ExtractJob
+    job.location.must_equal "US"
   end
 
   # Borrowed from MockStorage, extract to a common module?


### PR DESCRIPTION
Users may decide to set location to nil in order to unset the value and make the BigQuery service use the default location. Currently, this sends the JSON value null to the BigQuery service, but that will raise the following error:

`invalid: Invalid value for: null is not a valid value`

Treat setting location to nil the same as unsetting the value, this will not send any value for location to the BigQuery service.