### PR TITLE
BigQuery: Refactor Job methods

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -514,18 +514,12 @@ module Google
         #   end
         #
         def query query, params: nil, external: nil, max: nil, cache: true,
-                  dataset: nil, project: nil, standard_sql: nil, legacy_sql: nil
-          ensure_service!
-          options = { priority: "INTERACTIVE", cache: cache, dataset: dataset,
-                      project: project || self.project,
-                      legacy_sql: legacy_sql, standard_sql: standard_sql,
-                      params: params, external: external }
-          updater = QueryJob::Updater.from_options service, query, options
-
-          yield updater if block_given?
-
-          gapi = service.query_job updater.to_gapi
-          job = Job.from_gapi gapi, service
+                  dataset: nil, project: nil, standard_sql: nil,
+                  legacy_sql: nil, &block
+          job = query_job query, params: params, external: external,
+                                 cache: cache, dataset: dataset,
+                                 project: project, standard_sql: standard_sql,
+                                 legacy_sql: legacy_sql, &block
           job.wait_until_done!
 
           if job.failed?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1836,26 +1836,18 @@ module Google
                  projection_fields: nil, jagged_rows: nil, quoted_newlines: nil,
                  encoding: nil, delimiter: nil, ignore_unknown: nil,
                  max_bad_records: nil, quote: nil, skip_leading: nil,
-                 autodetect: nil, null_marker: nil
-          ensure_service!
+                 autodetect: nil, null_marker: nil, &block
+          job = load_job files, format: format, create: create, write: write,
+                                projection_fields: projection_fields,
+                                jagged_rows: jagged_rows,
+                                quoted_newlines: quoted_newlines,
+                                encoding: encoding, delimiter: delimiter,
+                                ignore_unknown: ignore_unknown,
+                                max_bad_records: max_bad_records,
+                                quote: quote, skip_leading: skip_leading,
+                                autodetect: autodetect,
+                                null_marker: null_marker, &block
 
-          updater = load_job_updater format: format, create: create,
-                                     write: write,
-                                     projection_fields: projection_fields,
-                                     jagged_rows: jagged_rows,
-                                     quoted_newlines: quoted_newlines,
-                                     encoding: encoding,
-                                     delimiter: delimiter,
-                                     ignore_unknown: ignore_unknown,
-                                     max_bad_records: max_bad_records,
-                                     quote: quote, skip_leading: skip_leading,
-                                     schema: schema,
-                                     autodetect: autodetect,
-                                     null_marker: null_marker
-
-          yield updater if block_given?
-
-          job = load_local_or_uri files, updater
           job.wait_until_done!
           ensure_job_succeeded! job
           true


### PR DESCRIPTION
Make all non-job methods call job methods, to reduce code duplication.