### PR TITLE
Add BigQuery Project#service_account_email

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -61,6 +61,14 @@ describe Google::Cloud::Bigquery, :bigquery do
     view
   end
 
+  it "should get its project service account email" do
+    email = bigquery.service_account_email
+    email.wont_be :nil?
+    email.must_be_kind_of String
+    # https://stackoverflow.com/questions/22993545/ruby-email-validation-with-regex
+    email.must_match /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+  end
+
   it "should get a list of datasets" do
     datasets = bigquery.datasets max: 1
     # The code in before ensures we have at least one dataset

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -85,6 +85,17 @@ module Google
         alias project project_id
 
         ##
+        # The email address of the service account for the project used to
+        # connect to BigQuery. (See also {#project_id}.)
+        #
+        # @return [String] The service account email address.
+        #
+        def service_account_email
+          @service_account_email ||= \
+            service.project_service_account.email
+        end
+
+        ##
         # Queries data by creating a [query
         # job](https://cloud.google.com/bigquery/docs/query-overview#query_jobs).
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -70,6 +70,10 @@ module Google
         end
         attr_accessor :mocked_service
 
+        def project_service_account
+          service.get_project_service_account project
+        end
+
         ##
         # Lists all datasets in the specified project to which you have
         # been granted the READER dataset role.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_test.rb
@@ -16,8 +16,21 @@ require "helper"
 require "json"
 
 describe Google::Cloud::Bigquery::Project, :mock_bigquery do
+  let(:email) { "my_service_account@bigquery-encryption.iam.gserviceaccount.com" }
+  let(:service_account_resp) { OpenStruct.new email: email }
   let(:dataset_id) { "my_dataset" }
   let(:filter) { "labels.foo:bar" }
+
+  it "gets and memoizes its service_account_email" do
+    mock = Minitest::Mock.new
+    mock.expect :get_project_service_account, service_account_resp, [project]
+    bigquery.service.mocked_service = mock
+
+    bigquery.service_account_email.must_equal email
+    bigquery.service_account_email.must_equal email # memoized, no request
+
+    mock.verify
+  end
 
   it "creates an empty dataset" do
     mock = Minitest::Mock.new


### PR DESCRIPTION
[closes #1960]

@tswast @choenden:

* Can we safely just return the email string (current solution), or should the new method return an object that can be given more attributes later?
* Is memoization of the value (current solution) OK?