### PR TITLE
Storage: Add File Rewrite

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -311,26 +311,6 @@ module Google
           end
         end
 
-        ## Copy a file from source bucket/object to a
-        # destination bucket/object.
-        def copy_file source_bucket_name, source_file_path,
-                      destination_bucket_name, destination_file_path,
-                      file_gapi = nil, key: nil, acl: nil, generation: nil,
-                      token: nil, user_project: nil
-          key_options = rewrite_key_options key, key
-          execute do
-            service.rewrite_object \
-              source_bucket_name, source_file_path,
-              destination_bucket_name, destination_file_path,
-              file_gapi,
-              destination_predefined_acl: acl,
-              source_generation: generation,
-              rewrite_token: token,
-              user_project: user_project(user_project),
-              options: key_options
-          end
-        end
-
         ## Rewrite a file from source bucket/object to a
         # destination bucket/object.
         def rewrite_file source_bucket_name, source_file_path,

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -637,6 +637,46 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Storage::File#rewrite" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", nil, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::File#rewrite@The file can be rewritten to a new path in the bucket:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "path/to/destination/file.ext", nil, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::File#rewrite@The file can also be rewritten by specifying a generation:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "my-bucket", "copy/of/previous/generation/file.ext", nil, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::File#rewrite@The file can be modified during rewriting:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", Google::Apis::StorageV1::Object, Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Storage::File#rewrite@The file can be rewritten with a new encryption key:" do
+    mock_storage do |mock|
+      mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_object, file_gapi, ["my-bucket", "path/to/my-file.ext", Hash]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), ["my-bucket", "path/to/my-file.ext", "new-destination-bucket", "path/to/destination/file.ext", Google::Apis::StorageV1::Object, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Storage::File#rotate" do
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]


### PR DESCRIPTION
The existing `File#copy` method supports an encryption key for reads/writes, but it does not allow different encryption keys for both the file being read and the file being written. `File#rotate` allows users to replace encryption keys, but not in a single API call that can give the new file a different name or store in a different bucket. Add `File#rewrite` to support all the existing behavior of `File#copy`, while allowing users to specify both the source and destination encryption keys.

[refs #2002]