### PR TITLE
Firestore Documentation Updates

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore.rb
@@ -212,9 +212,7 @@ module Google
     #
     # user_snap = firestore.doc("users/frank").get
     #
-    # nested_field_path = Google::Cloud::Firestore::FieldPath.new(
-    #   :favorites, :food
-    # )
+    # nested_field_path = firestore.field_path :favorites, :food
     # user_snap.get(nested_field_path) #=> "Pizza"
     # ```
     #
@@ -355,9 +353,7 @@ module Google
     #
     # user_ref = firestore.doc "users/frank"
     #
-    # nested_field_path = Google::Cloud::Firestore::FieldPath.new(
-    #   :favorites, :food
-    # )
+    # nested_field_path = firestore.field_path :favorites, :food
     # user_ref.update({ nested_field_path => "Pasta" })
     # ```
     #

--- a/google-cloud-firestore/lib/google/cloud/firestore.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore.rb
@@ -358,7 +358,7 @@ module Google
     # nested_field_path = Google::Cloud::Firestore::FieldPath.new(
     #   :favorites, :food
     # )
-    # user_ref.update({ nested_field_path: "Pasta" })
+    # user_ref.update({ nested_field_path => "Pasta" })
     # ```
     #
     # ## Using transactions and batched writes

--- a/google-cloud-firestore/lib/google/cloud/firestore/batch.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/batch.rb
@@ -262,7 +262,7 @@ module Google
         #   )
         #
         #   firestore.batch do |b|
-        #     b.update("users/frank", { nested_field_path: "Pasta" })
+        #     b.update("users/frank", { nested_field_path => "Pasta" })
         #   end
         #
         # @example Update a document using a document reference:

--- a/google-cloud-firestore/lib/google/cloud/firestore/batch.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/batch.rb
@@ -257,9 +257,7 @@ module Google
         #
         #   firestore = Google::Cloud::Firestore.new
         #
-        #   nested_field_path = Google::Cloud::Firestore::FieldPath.new(
-        #     :favorites, :food
-        #   )
+        #   nested_field_path = firestore.field_path :favorites, :food
         #
         #   firestore.batch do |b|
         #     b.update("users/frank", { nested_field_path => "Pasta" })

--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -238,10 +238,10 @@ module Google
         end
 
         ##
-        # Creates a field path object representing the nested fields for
+        # Creates a field path object representing a nested field for
         # document data.
         #
-        # @return [Array<String>] The fields.
+        # @return [FieldPath] The field path object.
         #
         # @example
         #   require "google/cloud/firestore"

--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -170,9 +170,9 @@ module Google
         ##
         # Retrieves a list of document snapshots.
         #
-        # @param [String, DocumentReference] docs One or more strings
-        #   representing the path of the document, or document reference
-        #   objects.
+        # @param [String, DocumentReference, Array<String|DocumentReference>]
+        #   docs One or more strings representing the path of the document, or
+        #   document reference objects.
         #
         # @yield [documents] The block for accessing the document snapshots.
         # @yieldparam [DocumentSnapshot] document A document snapshot.
@@ -241,8 +241,9 @@ module Google
         # Creates a field path object representing a nested field for
         # document data.
         #
-        # @param [String, Symbol] fields One or more strings representing the
-        #   path of the data to select. Each field must be provided separately.
+        # @param [String, Symbol, Array<String|Symbol>] fields One or more
+        #   strings representing the path of the data to select. Each field must
+        #   be provided separately.
         #
         # @return [FieldPath] The field path object.
         #

--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -241,6 +241,9 @@ module Google
         # Creates a field path object representing a nested field for
         # document data.
         #
+        # @param [String, Symbol] fields One or more strings representing the
+        #   path of the data to select. Each field must be provided separately.
+        #
         # @return [FieldPath] The field path object.
         #
         # @example

--- a/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
@@ -128,13 +128,13 @@ module Google
 
         ##
         # The document reference or database the collection reference belongs
-        # to. If the collection is a root collection, it will return the
-        # database object. If the collection is nested under a document, it
-        # will return the document reference object.
+        # to. If the collection is a root collection, it will return the client
+        # object. If the collection is nested under a document, it will return
+        # the document reference object.
         #
         # @return [Client, DocumentReference] parent object.
         #
-        # @example Returns database object for root collections:
+        # @example Returns client object for root collections:
         #   require "google/cloud/firestore"
         #
         #   firestore = Google::Cloud::Firestore.new

--- a/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/collection_reference.rb
@@ -132,7 +132,7 @@ module Google
         # database object. If the collection is nested under a document, it
         # will return the document reference object.
         #
-        # @return [Database, DocumentReference] parent object.
+        # @return [Client, DocumentReference] parent object.
         #
         # @example Returns database object for root collections:
         #   require "google/cloud/firestore"

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
@@ -326,7 +326,7 @@ module Google
         #   nested_field_path = Google::Cloud::Firestore::FieldPath.new(
         #     :favorites, :food
         #   )
-        #   user_ref.update({ nested_field_path: "Pasta" })
+        #   user_ref.update({ nested_field_path => "Pasta" })
         #
         # @example Update a document using the `update_time` precondition:
         #   require "google/cloud/firestore"

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
@@ -323,9 +323,7 @@ module Google
         #
         #   user_ref = firestore.doc "users/frank"
         #
-        #   nested_field_path = Google::Cloud::Firestore::FieldPath.new(
-        #     :favorites, :food
-        #   )
+        #   nested_field_path = firestore.field_path :favorites, :food
         #   user_ref.update({ nested_field_path => "Pasta" })
         #
         # @example Update a document using the `update_time` precondition:

--- a/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
@@ -42,6 +42,9 @@ module Google
         # Creates a field path object representing a nested field for
         # document data.
         #
+        # @param [String, Symbol] fields One or more strings representing the
+        #   path of the data to select. Each field must be provided separately.
+        #
         # @return [FieldPath] The field path object.
         #
         # @example

--- a/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
@@ -42,8 +42,9 @@ module Google
         # Creates a field path object representing a nested field for
         # document data.
         #
-        # @param [String, Symbol] fields One or more strings representing the
-        #   path of the data to select. Each field must be provided separately.
+        # @param [String, Symbol, Array<String|Symbol>] fields One or more
+        #   strings representing the path of the data to select. Each field must
+        #   be provided separately.
         #
         # @return [FieldPath] The field path object.
         #

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -526,7 +526,7 @@ module Google
         # Retrieves document snapshots for the query.
         #
         # @yield [documents] The block for accessing the document snapshots.
-        # @yieldparam [DocumentReference] document A document snapshot.
+        # @yieldparam [DocumentSnapshot] document A document snapshot.
         #
         # @return [Enumerator<DocumentSnapshot>] A list of document snapshots.
         #

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -528,7 +528,7 @@ module Google
         # @yield [documents] The block for accessing the document snapshots.
         # @yieldparam [DocumentReference] document A document snapshot.
         #
-        # @return [Enumerator<DocumentReference>] A list of document snapshots.
+        # @return [Enumerator<DocumentSnapshot>] A list of document snapshots.
         #
         # @example
         #   require "google/cloud/firestore"

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -57,9 +57,9 @@ module Google
         # Restricts documents matching the query to return only data for the
         # provided fields.
         #
-        # @param [FieldPath, String, Symbol] fields A field path to
-        #   filter results with and return only the specified fields. One or
-        #   more field paths can be specified.
+        # @param [FieldPath, String, Symbol, Array<FieldPath|String|Symbol>]
+        #   fields A field path to filter results with and return only the
+        #   specified fields. One or more field paths can be specified.
         #
         #   If a {FieldPath} object is not provided then the field will be
         #   treated as a dotted string, meaning the string represents individual
@@ -365,7 +365,8 @@ module Google
         # Values provided to `start_at` without an associated field path
         # provided to `order` will result in an error.
         #
-        # @param [Object] values The field value to start the query at.
+        # @param [Object, Array<Object>] values The field value to start the
+        #   query at.
         #
         # @return [Query] New query with `start_at` called on it.
         #
@@ -407,7 +408,8 @@ module Google
         # Values provided to `start_after` without an associated field path
         # provided to `order` will result in an error.
         #
-        # @param [Object] values The field value to start the query after.
+        # @param [Object, Array<Object>] values The field value to start the
+        #   query after.
         #
         # @return [Query] New query with `start_after` called on it.
         #
@@ -449,7 +451,8 @@ module Google
         # Values provided to `end_before` without an associated field path
         # provided to `order` will result in an error.
         #
-        # @param [Object] values The field value to end the query before.
+        # @param [Object, Array<Object>] values The field value to end the query
+        #   before.
         #
         # @return [Query] New query with `end_before` called on it.
         #
@@ -491,7 +494,8 @@ module Google
         # Values provided to `end_at` without an associated field path provided
         # to `order` will result in an error.
         #
-        # @param [Object] values The field value to end the query at.
+        # @param [Object, Array<Object>] values The field value to end the query
+        #   at.
         #
         # @return [Query] New query with `end_at` called on it.
         #

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -427,9 +427,7 @@ module Google
         #
         #   firestore = Google::Cloud::Firestore.new
         #
-        #   nested_field_path = Google::Cloud::Firestore::FieldPath.new(
-        #     :favorites, :food
-        #   )
+        #   nested_field_path = firestore.field_path :favorites, :food
         #
         #   firestore.transaction do |tx|
         #     tx.update("users/frank", { nested_field_path => "Pasta" })

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -432,7 +432,7 @@ module Google
         #   )
         #
         #   firestore.transaction do |tx|
-        #     tx.update("users/frank", { nested_field_path: "Pasta" })
+        #     tx.update("users/frank", { nested_field_path => "Pasta" })
         #   end
         #
         # @example Update a document using a document reference:

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -136,7 +136,7 @@ module Google
         #   to run.
         #
         # @yield [documents] The block for accessing the document snapshots.
-        # @yieldparam [DocumentReference] document A document snapshot.
+        # @yieldparam [DocumentSnapshot] document A document snapshot.
         #
         # @return [DocumentSnapshot, Enumerator<DocumentSnapshot>] A
         #   single document snapshot when passed a document path or a document

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -81,9 +81,9 @@ module Google
         ##
         # Retrieves a list of document snapshots.
         #
-        # @param [String, DocumentReference] docs One or more strings
-        #   representing the path of the document, or document reference
-        #   objects.
+        # @param [String, DocumentReference, Array<String|DocumentReference>]
+        #   docs One or more strings representing the path of the document, or
+        #   document reference objects.
         #
         # @yield [documents] The block for accessing the document snapshots.
         # @yieldparam [DocumentSnapshot] document A document snapshot.

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -138,10 +138,10 @@ module Google
         # @yield [documents] The block for accessing the document snapshots.
         # @yieldparam [DocumentReference] document A document snapshot.
         #
-        # @return [DocumentReference, Enumerator<DocumentReference>] A
-        #   single document snapshot when passed a document path a document
-        #   reference, or a list of document snapshots when passed other valid
-        #   values.
+        # @return [DocumentSnapshot, Enumerator<DocumentSnapshot>] A
+        #   single document snapshot when passed a document path or a document
+        #   reference object, or a list of document snapshots when passed other
+        #   valid values.
         #
         # @example Get a document snapshot given a document path:
         #   require "google/cloud/firestore"


### PR DESCRIPTION
This PR makes some documentation changes and corrections for Firestore.

* FieldPath changes
  * Code example documentation fix, use FieldPath object variable instead of creating a Symbol
  * Prefer `Client#field_path` convenience method to `FieldPath.new` constructor, less typing and smaller code examples
  * Add missing `fields` argument documentation
  * Update `Client#field_path` documentation description to match `FieldPath.new`
* Fix CollectionReference#parent return type
* Fix Query#get and Transaction#get return types

[fixes #2050]