### PR TITLE
Firestore: Fix DocumentSnapshot bug

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -553,7 +553,7 @@ module Google
           results = service.run_query parent_path, @query
           results.each do |result|
             next if result.document.nil?
-            yield DocumentSnapshot.from_query_result(result, self)
+            yield DocumentSnapshot.from_query_result(result, client)
           end
         end
         alias run get

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -117,7 +117,7 @@ module Google
           results.each do |result|
             extract_transaction_from_result! result
             next if result.result.nil?
-            yield DocumentSnapshot.from_batch_result(result, self)
+            yield DocumentSnapshot.from_batch_result(result, client)
           end
         end
         alias get_docs get_all
@@ -230,7 +230,7 @@ module Google
           results.each do |result|
             extract_transaction_from_result! result
             next if result.document.nil?
-            yield DocumentSnapshot.from_query_result(result, self)
+            yield DocumentSnapshot.from_query_result(result, client)
           end
         end
         alias run get

--- a/google-cloud-firestore/test/google/cloud/firestore/client/get_all_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/get_all_test.rb
@@ -134,10 +134,14 @@ describe Google::Cloud::Firestore::Client, :get_all, :mock_firestore do
     docs.each do |doc|
       doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      doc.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      doc.ref.client.must_equal firestore
+
       doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       doc.parent.collection_id.must_equal "users"
       doc.parent.collection_path.must_equal "users"
       doc.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      doc.parent.client.must_equal firestore
     end
 
     docs[0].must_be :exists?

--- a/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/client/transaction_test.rb
@@ -484,10 +484,14 @@ describe Google::Cloud::Firestore::Client, :transaction, :mock_firestore do
     results.each do |result|
       result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      result.ref.client.must_equal firestore
+
       result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       result.parent.collection_id.must_equal "users"
       result.parent.collection_path.must_equal "users"
       result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      result.parent.client.must_equal firestore
     end
 
     results.first.data.must_be_kind_of Hash

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/get_test.rb
@@ -72,10 +72,14 @@ describe Google::Cloud::Firestore::CollectionReference, :get, :mock_firestore do
     docs.each do |doc|
       doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      doc.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      doc.ref.client.must_equal firestore
+
       doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-      doc.parent.collection_id.must_equal collection.collection_id
-      doc.parent.collection_path.must_equal collection.collection_path
-      doc.parent.path.must_equal collection.path
+      doc.parent.collection_id.must_equal "messages"
+      doc.parent.collection_path.must_equal "users/mike/messages"
+      doc.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
+      doc.parent.client.must_equal firestore
     end
 
     docs.first.data.must_be_kind_of Hash

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/query_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/query_test.rb
@@ -315,10 +315,14 @@ describe Google::Cloud::Firestore::CollectionReference, :query, :mock_firestore 
       results.each do |result|
         result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+        result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+        result.ref.client.must_equal firestore
+
         result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
-        result.parent.collection_id.must_equal collection.collection_id
-        result.parent.collection_path.must_equal collection.collection_path
-        result.parent.path.must_equal collection.path
+        result.parent.collection_id.must_equal "messages"
+        result.parent.collection_path.must_equal "users/mike/messages"
+        result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users/mike/messages"
+        result.parent.client.must_equal firestore
       end
 
       results.first.data.must_be_kind_of Hash
@@ -344,9 +348,14 @@ describe Google::Cloud::Firestore::CollectionReference, :query, :mock_firestore 
     results.each do |result|
       result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      result.ref.client.must_equal firestore
+
       result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       result.parent.collection_id.must_equal "users"
       result.parent.collection_path.must_equal "users"
+      result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      result.parent.client.must_equal firestore
     end
 
     results.first.data.must_be_kind_of Hash

--- a/google-cloud-firestore/test/google/cloud/firestore/query_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query_test.rb
@@ -252,9 +252,13 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     results.each do |result|
       result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      result.ref.client.must_equal firestore
+
       result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       result.parent.collection_id.must_equal "users"
       result.parent.collection_path.must_equal "users"
+      result.parent.client.must_equal firestore
     end
 
     results.first.data.must_be_kind_of Hash

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/get_all_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/get_all_test.rb
@@ -142,10 +142,14 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :empty, :mock_firestor
     docs.each do |doc|
       doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      doc.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      doc.ref.client.must_equal firestore
+
       doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       doc.parent.collection_id.must_equal "users"
       doc.parent.collection_path.must_equal "users"
       doc.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      doc.parent.client.must_equal firestore
     end
 
     docs[0].must_be :exists?

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/get_test.rb
@@ -212,10 +212,14 @@ describe Google::Cloud::Firestore::Transaction, :get, :empty, :mock_firestore do
     results.each do |result|
       result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      result.ref.client.must_equal firestore
+
       result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       result.parent.collection_id.must_equal "users"
       result.parent.collection_path.must_equal "users"
       result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      result.parent.client.must_equal firestore
     end
 
     results.first.data.must_be_kind_of Hash

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/query_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/empty/query_test.rb
@@ -103,10 +103,14 @@ describe Google::Cloud::Firestore::Transaction, :query, :empty, :mock_firestore 
     results.each do |result|
       result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      result.ref.client.must_equal firestore
+
       result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       result.parent.collection_id.must_equal "users"
       result.parent.collection_path.must_equal "users"
       result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      result.parent.client.must_equal firestore
     end
 
     results.first.data.must_be_kind_of Hash

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/get_all_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/get_all_test.rb
@@ -140,10 +140,14 @@ describe Google::Cloud::Firestore::Transaction, :get_all, :mock_firestore do
     docs.each do |doc|
       doc.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      doc.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      doc.ref.client.must_equal firestore
+
       doc.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       doc.parent.collection_id.must_equal "users"
       doc.parent.collection_path.must_equal "users"
       doc.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      doc.parent.client.must_equal firestore
     end
 
     docs[0].must_be :exists?

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/get_test.rb
@@ -200,10 +200,14 @@ describe Google::Cloud::Firestore::Transaction, :get, :mock_firestore do
     results.each do |result|
       result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      result.ref.client.must_equal firestore
+
       result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       result.parent.collection_id.must_equal "users"
       result.parent.collection_path.must_equal "users"
       result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      result.parent.client.must_equal firestore
     end
 
     results.first.data.must_be_kind_of Hash

--- a/google-cloud-firestore/test/google/cloud/firestore/transaction/query_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/transaction/query_test.rb
@@ -89,10 +89,14 @@ describe Google::Cloud::Firestore::Transaction, :query, :mock_firestore do
     results.each do |result|
       result.must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
 
+      result.ref.must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      result.ref.client.must_equal firestore
+
       result.parent.must_be_kind_of Google::Cloud::Firestore::CollectionReference
       result.parent.collection_id.must_equal "users"
       result.parent.collection_path.must_equal "users"
       result.parent.path.must_equal "projects/projectID/databases/(default)/documents/users"
+      result.parent.client.must_equal firestore
     end
 
     results.first.data.must_be_kind_of Hash


### PR DESCRIPTION
The reference to `Client` was being set to the `Query` or `Transaction`, this PR fixes this. We didn't see this as we generally create a new `Batch` object to make changes, but test coverage was added to ensure that the object was assigned properly.

[fixes #2051]