### PR TITLE
fix links to enable api in constructor

### DIFF
--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
@@ -33,7 +33,7 @@ module Google
     #
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-    # 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/api/dialogflow)
+    # 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/library/dialogflow.googleapis.com)
     # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
     #
     # ### Next Steps

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
@@ -41,7 +41,7 @@ module Google
     #
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-    # 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/api/dialogflow)
+    # 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/library/dialogflow.googleapis.com)
     # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
     #
     # ### Next Steps

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/overview.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/overview.rb
@@ -30,7 +30,7 @@ module Google
     #
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
     # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-    # 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/api/dialogflow)
+    # 3. [Enable the Dialogflow API.](https://console.cloud.google.com/apis/library/dialogflow.googleapis.com)
     # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
     #
     # ### Installation


### PR DESCRIPTION
Addresses #2052 

@quartzmo - thanks for catching this. These were the only other bad links I could find. Did you notice any others?

Also, I noticed the `gem.homepage` is not correct for a number of the generated libs. I'll create another PR to make them consistent.