### PR TITLE
labels should be instance_of?(::String) as per Protobuf expectation

### DIFF
--- a/google-cloud-trace/lib/google/cloud/trace/notifications.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/notifications.rb
@@ -105,7 +105,7 @@ module Google
           event.payload.each do |k, v|
             if v.is_a? ::String
               v = v[0, maxlen - 3] + "..." if maxlen && v.size > maxlen
-              labels["#{label_namespace}#{k}"] = v
+              labels["#{label_namespace}#{k}"] = v.to_s
             end
           end
           labels

--- a/google-cloud-trace/test/helper.rb
+++ b/google-cloud-trace/test/helper.rb
@@ -79,3 +79,5 @@ def wait_until_true timeout = 5
 
   :completed
 end
+
+class StringChild < ::String; end;


### PR DESCRIPTION
@quartzmo, Please refer to my [comment](https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/2049#issuecomment-382660831) on #2049 for more details.

This should fix a major problem with using Google Stacktrace with Rails as any `ActiveSupport::Notifications::Event` that has a value in the `event.payload` which is not a `::String` but a child of `::String` will raise an exception as `Protobuf` expects a `::String`.
