### PR TITLE
Spanner STRUCT in Query Parameters

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/batch_client/execute_partition_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/batch_client/execute_partition_test.rb
@@ -16,7 +16,7 @@ require "spanner_helper"
 
 describe "Spanner Batch Client", :execute_partition, :spanner do
   let(:db) { spanner_client }
-  let(:batch_client) { $spanner.batch_client $spanner_instance_id, $spanner_prefix }
+  let(:batch_client) { $spanner.batch_client $spanner_instance_id, $spanner_database_id }
   let(:table_name) { "stuffs" }
   let(:table_index) { "IsStuffsIdPrime" }
   let(:batch_snapshot) { batch_client.batch_snapshot }

--- a/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
@@ -17,19 +17,164 @@ require "spanner_helper"
 describe "Spanner Client", :params, :struct, :spanner do
   let(:db) { spanner_client }
 
-  it "queries and returns a struct parameter" do
-    skip "Sending a STRUCT was working, but now returns an error"
+  describe "Struct Parameters Query Examples" do
+    # Simple field access.
+    # [parameters=STRUCT<threadf INT64, userf STRING>(1,"bob") AS struct_param, 10 as p4]
+    # SELECT @struct_param.userf, @p4;
+    it "Simple field access" do
+      results = db.execute "SELECT @struct_param.userf, @p4",
+                           params: { struct_param: { threadf: 1, userf: "bob" }, p4: 10 }
 
-    results = db.execute "SELECT ARRAY(@value) AS value", params: { value: { message: "hello", repeat: 1 } }
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ userf: :STRING, 1 => :INT64 })
+      results.rows.first.to_h.must_equal({ userf: "bob", 1 => 10 })
+    end
+
+    # # Simple field access on NULL struct value.
+    # [parameters=CAST(NULL AS STRUCT<threadf INT64, userf STRING>) AS struct_param]
+    # SELECT @struct_param.userf;
+    it "Simple field access on NULL struct value" do
+      struct_type = db.fields(threadf: :INT64, userf: :STRING)
+      results = db.execute "SELECT @struct_param.userf",
+                           params: { struct_param: nil },
+                           types:  { struct_param: struct_type }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ userf: :STRING })
+      results.rows.first.to_h.must_equal({ userf: nil })
+    end
+
+    # # Nested struct field access.
+    # [parameters=STRUCT<structf STRUCT<nestedf STRING>> (STRUCT<nestedf STRING>("bob")) AS struct_param]
+    # SELECT @struct_param.structf.nestedf;
+    it "Nested struct field access" do
+      results = db.execute "SELECT @struct_param.structf.nestedf",
+                           params: { struct_param: { structf: { nestedf: "bob" } } }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ nestedf: :STRING })
+      results.rows.first.to_h.must_equal({ nestedf: "bob" })
+    end
+
+    # # Nested struct field access on NULL struct value.
+    # [parameters=CAST(STRUCT(null) AS STRUCT<structf STRUCT<nestedf STRING>>) AS  struct_param]
+    # SELECT @struct_param.structf.nestedf;
+    it "Nested struct field access on NULL struct value" do
+      struct_type = db.fields(structf: db.fields(nestedf: :STRING))
+      results = db.execute "SELECT @struct_param.structf.nestedf",
+                           params: { struct_param: nil },
+                           types:  { struct_param: struct_type }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ nestedf: :STRING })
+      results.rows.first.to_h.must_equal({ nestedf: nil })
+    end
+
+    # # Non-NULL struct with no fields (empty struct).
+    # [parameters=CAST(STRUCT() AS STRUCT<>) AS struct_param]
+    # SELECT @struct_param IS NULL;
+    it "Non-NULL struct with no fields (empty struct)" do
+      struct_type = db.fields({})
+      results = db.execute "SELECT @struct_param IS NULL",
+                           params: { struct_param: {} }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ 0 => :BOOL })
+      results.rows.first.to_h.must_equal({ 0 => false })
+    end
+
+    # # NULL struct with no fields.
+    # [parameters=CAST(NULL AS STRUCT<>) AS struct_param]
+    # SELECT @struct_param IS NULL
+    it "NULL struct with no fields" do
+      struct_type = db.fields({})
+      results = db.execute "SELECT @struct_param IS NULL",
+                           params: { struct_param: nil },
+                           types:  { struct_param: struct_type }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ 0 => :BOOL })
+      results.rows.first.to_h.must_equal({ 0 => true })
+    end
+
+    # # Struct with single NULL field.
+    # [parameters=STRUCT<f1 INT64>(NULL) AS struct_param]
+    # SELECT @struct_param.f1;
+    it "Struct with single NULL field" do
+      struct_type = db.fields(f1: :INT64)
+      results = db.execute "SELECT @struct_param.f1",
+                           params: { struct_param: { f1: nil } },
+                           types:  { struct_param: struct_type }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ f1: :INT64 })
+      results.rows.first.to_h.must_equal({ f1: nil })
+    end
+
+    # # Equality check.
+    # [parameters=STRUCT<threadf INT64, userf STRING>(1,"bob") AS struct_param]
+    # SELECT @struct_param=STRUCT<threadf INT64, userf STRING>(1,"bob");
+    it "Equality check" do
+      struct_value = db.fields(threadf: :INT64, userf: :STRING).struct([1, "bob"])
+      results = db.execute "SELECT @struct_param=STRUCT<threadf INT64, userf STRING>(1,\"bob\")",
+                           params: { struct_param: struct_value }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ 0 => :BOOL })
+      results.rows.first.to_h.must_equal({ 0 => true })
+    end
+
+    # # Nullness check.
+    # [parameters=ARRAY<STRUCT<threadf INT64, userf STRING>> [(1,"bob")] AS struct_arr_param]
+    # SELECT @struct_arr_param IS NULL;
+    it "Nullness check" do
+      struct_value = db.fields(threadf: :INT64, userf: :STRING).struct([1, "bob"])
+      results = db.execute "SELECT @struct_arr_param IS NULL",
+                           params: { struct_arr_param: [struct_value] }
+                           # params: { struct_arr_param: [{ threadf: 1, userf: "bob" }] }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ 0 => :BOOL })
+      results.rows.first.to_h.must_equal({ 0 => false })
+    end
+
+    # # Null array of struct field.
+    # [parameters=STRUCT<intf INT64, arraysf ARRAY<STRUCT<threadid INT64>>> (10,CAST(NULL AS ARRAY<STRUCT<threadid INT64>>)) AS struct_param]
+    # SELECT a.threadid FROM UNNEST(@struct_param.arraysf) a;
+    it "Null array of struct field" do
+      struct_value = db.fields(intf: :INT64, arraysf: [db.fields(threadid: :INT64)]).struct([10, nil])
+      results = db.execute "SELECT a.threadid FROM UNNEST(@struct_param.arraysf) a",
+                           params: { struct_param: struct_value }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ threadid: :INT64 })
+      results.rows.count.must_equal 0
+    end
+
+    # # Null array of struct.
+    # [parameters=CAST(NULL AS ARRAY<STRUCT<threadid INT64>>) as struct_arr_param]
+    # SELECT a.threadid FROM UNNEST(@struct_arr_param) a;
+    it "Null array of struct" do
+      struct_type = db.fields(threadid: :INT64)
+      results = db.execute "SELECT a.threadid FROM UNNEST(@struct_arr_param) a",
+                           params: { struct_arr_param: nil },
+                           types:  { struct_arr_param: [struct_type] }
+
+      results.must_be_kind_of Google::Cloud::Spanner::Results
+      results.fields.to_h.must_equal({ threadid: :INT64 })
+      results.rows.count.must_equal 0
+    end
+  end
+
+  it "queries and returns a struct parameter" do
+    results = db.execute "SELECT ARRAY(SELECT AS STRUCT message, repeat FROM (SELECT @value.message AS message, @value.repeat AS repeat)) AS value", params: { value: { message: "hello", repeat: 1 } }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ value: [{ message: :STRING, repeat: :INT64 }] })
+    results.fields.to_h.must_equal({ value: [db.fields(message: :STRING, repeat: :INT64)] })
     results.rows.first.to_h.must_equal({ value: [{ message: "hello", repeat: 1 }] })
   end
 
   it "queries a struct parameter and returns string and integer" do
-    skip "Sending a STRUCT was working, but now returns an error"
-
     results = db.execute "SELECT @value.message AS message, @value.repeat AS repeat", params: { value: { message: "hello", repeat: 1 } }
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
@@ -42,7 +187,7 @@ describe "Spanner Client", :params, :struct, :spanner do
     results = db.execute struct_sql
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ 0 => [{ message: :STRING, repeat: :INT64 }] })
+    results.fields.to_h.must_equal({ 0 => [db.fields(message: :STRING, repeat: :INT64)] })
     results.rows.first.to_h.must_equal({ 0 => [{ message: "hello", repeat: 1 }, { message: "hola", repeat: 2 }] })
   end
 
@@ -51,7 +196,7 @@ describe "Spanner Client", :params, :struct, :spanner do
     results = db.execute struct_sql
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ 0 => [{ 0 => :STRING, 1 => :INT64 }] })
+    results.fields.to_h.must_equal({ 0 => [db.fields(0 => :STRING, 1 => :INT64)] })
     results.rows.first.to_h.must_equal({ 0 => [] })
   end
 

--- a/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
@@ -74,7 +74,6 @@ describe "Spanner Client", :params, :struct, :spanner do
     # [parameters=CAST(STRUCT() AS STRUCT<>) AS struct_param]
     # SELECT @struct_param IS NULL;
     it "Non-NULL struct with no fields (empty struct)" do
-      struct_type = db.fields({})
       results = db.execute "SELECT @struct_param IS NULL",
                            params: { struct_param: {} }
 

--- a/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/types/struct_test.rb
@@ -24,7 +24,7 @@ describe "Spanner Client", :types, :struct, :spanner do
     results = db.execute nested_sql
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ 0 => [{ C1: :STRING, C2: :INT64 }] })
+    results.fields.to_h.must_equal({ 0 => [db.fields(C1: :STRING, C2: :INT64)] })
     results.rows.first.to_h.must_equal({ 0 => [{ C1: "a", C2: 1 }, { C1: "b", C2: 2 }] })
   end
 
@@ -33,7 +33,7 @@ describe "Spanner Client", :types, :struct, :spanner do
     results = db.execute empty_sql
 
     results.must_be_kind_of Google::Cloud::Spanner::Results
-    results.fields.to_h.must_equal({ 0 => [{ 0 => :STRING, 1 => :INT64 }] })
+    results.fields.to_h.must_equal({ 0 => [db.fields(0 => :STRING, 1 => :INT64)] })
     results.rows.first.to_h.must_equal({ 0 => [] })
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/database_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/database_test.rb
@@ -15,11 +15,10 @@
 require "spanner_helper"
 
 describe "Spanner Databases", :spanner do
-  let(:instance_id) { "google-cloud-ruby-tests" }
+  let(:instance_id) { $spanner_instance_id }
+  let(:database_id) { "#{$spanner_database_id}-crud" }
 
   it "creates, updates, and drops a database" do
-    database_id = "#{$spanner_prefix}-crud"
-
     spanner.database(instance_id, database_id).must_be :nil?
 
     job = spanner.create_database instance_id, database_id

--- a/google-cloud-spanner/acceptance/spanner_helper.rb
+++ b/google-cloud-spanner/acceptance/spanner_helper.rb
@@ -246,9 +246,9 @@ end
 # Create buckets to be shared with all the tests
 require "date"
 require "securerandom"
-# prefix is already 22 characters, can only add 7 additional characters
-$spanner_prefix = "gcruby-#{Date.today.strftime "%y%m%d"}-#{SecureRandom.hex(4)}"
 $spanner_instance_id = "google-cloud-ruby-tests"
+# $spanner_database_id is already 22 characters, can only add 7 additional characters
+$spanner_database_id = "gcruby-#{Date.today.strftime "%y%m%d"}-#{SecureRandom.hex(4)}"
 
 # Setup main instance and database for the tests
 fixture = Object.new
@@ -262,16 +262,16 @@ instance ||= begin
   inst_job.instance
 end
 
-db_job = instance.create_database $spanner_prefix, statements: fixture.schema_ddl_statements
+db_job = instance.create_database $spanner_database_id, statements: fixture.schema_ddl_statements
 db_job.wait_until_done!
 fail GRPC::BadStatus.new(db_job.error.code, db_job.error.message) if db_job.error?
 
 # Create one client for all tests, to minimize resource usage
-$spanner_client = $spanner.client $spanner_instance_id, $spanner_prefix
+$spanner_client = $spanner.client $spanner_instance_id, $spanner_database_id
 
 def clean_up_spanner_objects
   puts "Cleaning up instances and databases after spanner tests."
-  $spanner.instance($spanner_instance_id).database($spanner_prefix).drop
+  $spanner.instance($spanner_instance_id).database($spanner_database_id).drop
   puts "Closing the Spanner Client."
   $spanner_client.close
 rescue => e

--- a/google-cloud-spanner/lib/google/cloud/spanner/batch_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/batch_client.rb
@@ -273,6 +273,80 @@ module Google
         end
 
         ##
+        # Creates a configuration object ({Fields}) that may be provided to
+        # queries or used to create STRUCT objects. (The STRUCT will be
+        # represented by the {Data} class.) See {Client#execute} and/or
+        # {Fields#struct}.
+        #
+        # For more information, see [Data Types - Constructing a
+        # STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
+        #
+        # @param [Array, Hash] types Accepts an array or hash types.
+        #
+        #   Arrays can contain just the type value, or a sub-array of the
+        #   field's name and type value. Hash keys must contain the field name
+        #   as a `Symbol` or `String`, or the field position as an `Integer`.
+        #   Hash values must contain the type value. If a Hash is used the
+        #   fields will be created using the same order as the Hash keys.
+        #
+        #   Supported type values incude:
+        #
+        #   * `:BOOL`
+        #   * `:BYTES`
+        #   * `:DATE`
+        #   * `:FLOAT64`
+        #   * `:INT64`
+        #   * `:STRING`
+        #   * `:TIMESTAMP`
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Nested Structs are specified by providing a Fields
+        #     object.
+        #
+        # @return [Fields] The fields of the given types.
+        #
+        # @example Create a STRUCT value with named fields using Fields object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   batch_client = spanner.batch_client "my-instance", "my-database"
+        #
+        #   named_type = batch_client.fields(
+        #     { id: :INT64, name: :STRING, active: :BOOL }
+        #   )
+        #   named_data = named_type.struct(
+        #     { id: 42, name: nil, active: false }
+        #   )
+        #
+        # @example Create a STRUCT value with anonymous field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   batch_client = spanner.batch_client "my-instance", "my-database"
+        #
+        #   anon_type = batch_client.fields [:INT64, :STRING, :BOOL]
+        #   anon_data = anon_type.struct [42, nil, false]
+        #
+        # @example Create a STRUCT value with duplicate field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   batch_client = spanner.batch_client "my-instance", "my-database"
+        #
+        #   dup_type = batch_client.fields(
+        #     [[:x, :INT64], [:x, :STRING], [:x, :BOOL]]
+        #   )
+        #   dup_data = dup_type.struct [42, nil, false]
+        #
+        def fields types
+          Fields.new types
+        end
+
+        ##
         # Creates a Spanner Range. This can be used in place of a Ruby Range
         # when needing to exclude the beginning value.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/batch_snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/batch_snapshot.rb
@@ -112,23 +112,35 @@ module Google
         #   placeholder consists of "@" followed by the parameter name.
         #   Parameter names consist of any combination of letters, numbers, and
         #   underscores.
-        # @param [Integer] partition_size_bytes The desired data size for each
-        #   partition generated. This is only a hint. The actual size of each
-        #   partition may be smaller or larger than this size request.
-        # @param [Integer] max_partitions The desired maximum number of
-        #   partitions to return. For example, this may be set to the number of
-        #   workers available. This is only a hint and may provide different
-        #   results based on the request.
         # @param [Hash] params SQL parameters for the query string. The
         #   parameter placeholders, minus the "@", are the the hash keys, and
         #   the literal values are the hash values. If the query string contains
         #   something like "WHERE id > @msg_id", then the params must contain
         #   something like `:msg_id => 1`.
+        #
+        #   Ruby types are mapped to Spanner types as follows:
+        #
+        #   | Spanner     | Ruby           | Notes  |
+        #   |-------------|----------------|---|
+        #   | `BOOL`      | `true`/`false` | |
+        #   | `INT64`     | `Integer`      | |
+        #   | `FLOAT64`   | `Float`        | |
+        #   | `STRING`    | `String`       | |
+        #   | `DATE`      | `Date`         | |
+        #   | `TIMESTAMP` | `Time`, `DateTime` | |
+        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
+        #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #   | `STRUCT`    | `Hash`, {Data} | |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
+        #   See [Data Types - Constructing a
+        #   STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
         # @param [Hash] types Types of the SQL parameters in `params`. It is not
         #   always possible for Cloud Spanner to infer the right SQL type from a
-        #   value in `params`. In these cases, the `types` hash can be used to
-        #   specify the exact SQL type for some or all of the SQL query
-        #   parameters.
+        #   value in `params`. In these cases, the `types` hash must be used to
+        #   specify the SQL type for these values.
         #
         #   The keys of the hash should be query string parameter placeholders,
         #   minus the "@". The values of the hash should be Cloud Spanner type
@@ -141,13 +153,20 @@ module Google
         #   * `:INT64`
         #   * `:STRING`
         #   * `:TIMESTAMP`
-        #
-        #   Arrays are specified by providing the type code in an array. For
-        #   example, an array of integers are specified as `[:INT64]`.
-        #
-        #   Structs are not yet supported in query parameters.
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Types for STRUCT values (`Hash`/{Data} objects) are
+        #     specified using a {Fields} object.
         #
         #   Types are optional.
+        # @param [Integer] partition_size_bytes The desired data size for each
+        #   partition generated. This is only a hint. The actual size of each
+        #   partition may be smaller or larger than this size request.
+        # @param [Integer] max_partitions The desired maximum number of
+        #   partitions to return. For example, this may be set to the number of
+        #   workers available. This is only a hint and may provide different
+        #   results based on the request.
         #
         # @return [Array<Google::Cloud::Spanner::Partition>] The partitions
         #   created by the query partition.
@@ -342,23 +361,6 @@ module Google
         ##
         # Executes a SQL query.
         #
-        # Arguments can be passed using `params`, Ruby types are mapped to
-        # Spanner types as follows:
-        #
-        # | Spanner     | Ruby           | Notes  |
-        # |-------------|----------------|---|
-        # | `BOOL`      | `true`/`false` | |
-        # | `INT64`     | `Integer`      | |
-        # | `FLOAT64`   | `Float`        | |
-        # | `STRING`    | `String`       | |
-        # | `DATE`      | `Date`         | |
-        # | `TIMESTAMP` | `Time`, `DateTime` | |
-        # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-        # | `ARRAY`     | `Array` | Nested arrays are not supported. |
-        #
-        # See [Data
-        # types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
-        #
         # @param [String] sql The SQL query string. See [Query
         #   syntax](https://cloud.google.com/spanner/docs/query-syntax).
         #
@@ -371,11 +373,30 @@ module Google
         #   the literal values are the hash values. If the query string contains
         #   something like "WHERE id > @msg_id", then the params must contain
         #   something like `:msg_id => 1`.
+        #
+        #   Ruby types are mapped to Spanner types as follows:
+        #
+        #   | Spanner     | Ruby           | Notes  |
+        #   |-------------|----------------|---|
+        #   | `BOOL`      | `true`/`false` | |
+        #   | `INT64`     | `Integer`      | |
+        #   | `FLOAT64`   | `Float`        | |
+        #   | `STRING`    | `String`       | |
+        #   | `DATE`      | `Date`         | |
+        #   | `TIMESTAMP` | `Time`, `DateTime` | |
+        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
+        #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #   | `STRUCT`    | `Hash`, {Data} | |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
+        #   See [Data Types - Constructing a
+        #   STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
         # @param [Hash] types Types of the SQL parameters in `params`. It is not
         #   always possible for Cloud Spanner to infer the right SQL type from a
-        #   value in `params`. In these cases, the `types` hash can be used to
-        #   specify the exact SQL type for some or all of the SQL query
-        #   parameters.
+        #   value in `params`. In these cases, the `types` hash must be used to
+        #   specify the SQL type for these values.
         #
         #   The keys of the hash should be query string parameter placeholders,
         #   minus the "@". The values of the hash should be Cloud Spanner type
@@ -388,11 +409,11 @@ module Google
         #   * `:INT64`
         #   * `:STRING`
         #   * `:TIMESTAMP`
-        #
-        #   Arrays are specified by providing the type code in an array. For
-        #   example, an array of integers are specified as `[:INT64]`.
-        #
-        #   Structs are not yet supported in query parameters.
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Types for STRUCT values (`Hash`/{Data} objects) are
+        #     specified using a {Fields} object.
         #
         #   Types are optional.
         # @return [Google::Cloud::Spanner::Results] The results of the query
@@ -419,8 +440,72 @@ module Google
         #   batch_snapshot = batch_client.batch_snapshot
         #
         #   results = batch_snapshot.execute "SELECT * FROM users " \
-        #                         "WHERE active = @active",
-        #                         params: { active: true }
+        #                                    "WHERE active = @active",
+        #                                    params: { active: true }
+        #
+        #   results.rows.each do |row|
+        #     puts "User #{row[:id]} is #{row[:name]}"
+        #   end
+        #
+        # @example Query with a SQL STRUCT query parameter as a Hash:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   batch_client = spanner.batch_client "my-instance", "my-database"
+        #   batch_snapshot = batch_client.batch_snapshot
+        #
+        #   user_hash = { id: 1, name: "Charlie", active: false }
+        #
+        #   results = batch_snapshot.execute "SELECT * FROM users WHERE " \
+        #                                    "ID = @user_struct.id " \
+        #                                    "AND name = @user_struct.name " \
+        #                                    "AND active = @user_struct.active",
+        #                                    params: { user_struct: user_hash }
+        #
+        #   results.rows.each do |row|
+        #     puts "User #{row[:id]} is #{row[:name]}"
+        #   end
+        #
+        # @example Specify the SQL STRUCT type using Fields object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   batch_client = spanner.batch_client "my-instance", "my-database"
+        #   batch_snapshot = batch_client.batch_snapshot
+        #
+        #   user_type = batch_client.fields(
+        #     { id: :INT64, name: :STRING, active: :BOOL }
+        #   )
+        #   user_hash = { id: 1, name: nil, active: false }
+        #
+        #   results = batch_snapshot.execute "SELECT * FROM users WHERE " \
+        #                                    "ID = @user_struct.id " \
+        #                                    "AND name = @user_struct.name " \
+        #                                    "AND active = @user_struct.active",
+        #                                    params: { user_struct: user_hash },
+        #                                    types: { user_struct: user_type }
+        #
+        #   results.rows.each do |row|
+        #     puts "User #{row[:id]} is #{row[:name]}"
+        #   end
+        #
+        # @example Or, query with a SQL STRUCT as a typed Data object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   batch_client = spanner.batch_client "my-instance", "my-database"
+        #   batch_snapshot = batch_client.batch_snapshot
+        #
+        #   user_type = batch_client.fields(
+        #     { id: :INT64, name: :STRING, active: :BOOL }
+        #   )
+        #   user_data = user_type.struct id: 1, name: nil, active: false
+        #
+        #   results = batch_snapshot.execute "SELECT * FROM users WHERE " \
+        #                                    "ID = @user_struct.id " \
+        #                                    "AND name = @user_struct.name " \
+        #                                    "AND active = @user_struct.active",
+        #                                    params: { user_struct: user_data }
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -98,23 +98,6 @@ module Google
         ##
         # Executes a SQL query.
         #
-        # Arguments can be passed using `params`, Ruby types are mapped to
-        # Spanner types as follows:
-        #
-        # | Spanner     | Ruby           | Notes  |
-        # |-------------|----------------|---|
-        # | `BOOL`      | `true`/`false` | |
-        # | `INT64`     | `Integer`      | |
-        # | `FLOAT64`   | `Float`        | |
-        # | `STRING`    | `String`       | |
-        # | `DATE`      | `Date`         | |
-        # | `TIMESTAMP` | `Time`, `DateTime` | |
-        # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-        # | `ARRAY`     | `Array` | Nested arrays are not supported. |
-        #
-        # See [Data
-        # types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
-        #
         # @param [String] sql The SQL query string. See [Query
         #   syntax](https://cloud.google.com/spanner/docs/query-syntax).
         #
@@ -127,11 +110,30 @@ module Google
         #   the literal values are the hash values. If the query string contains
         #   something like "WHERE id > @msg_id", then the params must contain
         #   something like `:msg_id => 1`.
+        #
+        #   Ruby types are mapped to Spanner types as follows:
+        #
+        #   | Spanner     | Ruby           | Notes  |
+        #   |-------------|----------------|---|
+        #   | `BOOL`      | `true`/`false` | |
+        #   | `INT64`     | `Integer`      | |
+        #   | `FLOAT64`   | `Float`        | |
+        #   | `STRING`    | `String`       | |
+        #   | `DATE`      | `Date`         | |
+        #   | `TIMESTAMP` | `Time`, `DateTime` | |
+        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
+        #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #   | `STRUCT`    | `Hash`, {Data} | |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
+        #   See [Data Types - Constructing a
+        #   STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
         # @param [Hash] types Types of the SQL parameters in `params`. It is not
         #   always possible for Cloud Spanner to infer the right SQL type from a
-        #   value in `params`. In these cases, the `types` hash can be used to
-        #   specify the exact SQL type for some or all of the SQL query
-        #   parameters.
+        #   value in `params`. In these cases, the `types` hash must be used to
+        #   specify the SQL type for these values.
         #
         #   The keys of the hash should be query string parameter placeholders,
         #   minus the "@". The values of the hash should be Cloud Spanner type
@@ -144,11 +146,11 @@ module Google
         #   * `:INT64`
         #   * `:STRING`
         #   * `:TIMESTAMP`
-        #
-        #   Arrays are specified by providing the type code in an array. For
-        #   example, an array of integers are specified as `[:INT64]`.
-        #
-        #   Structs are not yet supported in query parameters.
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Types for STRUCT values (`Hash`/{Data} objects) are
+        #     specified using a {Fields} object.
         #
         #   Types are optional.
         # @param [Hash] single_use Perform the read with a single-use snapshot
@@ -229,6 +231,66 @@ module Google
         #
         #   results = db.execute "SELECT * FROM users WHERE active = @active",
         #                        params: { active: true }
+        #
+        #   results.rows.each do |row|
+        #     puts "User #{row[:id]} is #{row[:name]}"
+        #   end
+        #
+        # @example Query with a SQL STRUCT query parameter as a Hash:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   user_hash = { id: 1, name: "Charlie", active: false }
+        #
+        #   results = db.execute "SELECT * FROM users WHERE " \
+        #                        "ID = @user_struct.id " \
+        #                        "AND name = @user_struct.name " \
+        #                        "AND active = @user_struct.active",
+        #                        params: { user_struct: user_hash }
+        #
+        #   results.rows.each do |row|
+        #     puts "User #{row[:id]} is #{row[:name]}"
+        #   end
+        #
+        # @example Specify the SQL STRUCT type using Fields object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   user_type = db.fields id: :INT64, name: :STRING, active: :BOOL
+        #   user_hash = { id: 1, name: nil, active: false }
+        #
+        #   results = db.execute "SELECT * FROM users WHERE " \
+        #                        "ID = @user_struct.id " \
+        #                        "AND name = @user_struct.name " \
+        #                        "AND active = @user_struct.active",
+        #                        params: { user_struct: user_hash },
+        #                        types: { user_struct: user_type }
+        #
+        #   results.rows.each do |row|
+        #     puts "User #{row[:id]} is #{row[:name]}"
+        #   end
+        #
+        # @example Or, query with a SQL STRUCT as a typed Data object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   user_type = db.fields id: :INT64, name: :STRING, active: :BOOL
+        #   user_data = user_type.struct id: 1, name: nil, active: false
+        #
+        #   results = db.execute "SELECT * FROM users WHERE " \
+        #                        "ID = @user_struct.id " \
+        #                        "AND name = @user_struct.name " \
+        #                        "AND active = @user_struct.active",
+        #                        params: { user_struct: user_data }
         #
         #   results.rows.each do |row|
         #     puts "User #{row[:id]} is #{row[:name]}"
@@ -855,24 +917,72 @@ module Google
         end
 
         ##
-        # @private
-        # Creates fields object from types.
+        # Creates a configuration object ({Fields}) that may be provided to
+        # queries or used to create STRUCT objects. (The STRUCT will be
+        # represented by the {Data} class.) See {Client#execute} and/or
+        # {Fields#struct}.
         #
-        # @param [Array, Hash] types Accepts an array of types, array of type
-        #   pairs, hash of positional types, hash of named types.
+        # For more information, see [Data Types - Constructing a
+        # STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
+        #
+        # @param [Array, Hash] types Accepts an array or hash types.
+        #
+        #   Arrays can contain just the type value, or a sub-array of the
+        #   field's name and type value. Hash keys must contain the field name
+        #   as a `Symbol` or `String`, or the field position as an `Integer`.
+        #   Hash values must contain the type value. If a Hash is used the
+        #   fields will be created using the same order as the Hash keys.
+        #
+        #   Supported type values incude:
+        #
+        #   * `:BOOL`
+        #   * `:BYTES`
+        #   * `:DATE`
+        #   * `:FLOAT64`
+        #   * `:INT64`
+        #   * `:STRING`
+        #   * `:TIMESTAMP`
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Nested Structs are specified by providing a Fields
+        #     object.
         #
         # @return [Fields] The fields of the given types.
         #
-        # @example
+        # @example Create a STRUCT value with named fields using Fields object:
         #   require "google/cloud/spanner"
         #
         #   spanner = Google::Cloud::Spanner.new
         #
         #   db = spanner.client "my-instance", "my-database"
-        #   user_fields = db.fields id: :INT64, name: :STRING, active: :BOOL
         #
-        #   db.update "users", [user_fields.data(1, "Charlie", false),
-        #                       user_fields.data(2, "Harvey", true)]
+        #   named_type = db.fields(
+        #     { id: :INT64, name: :STRING, active: :BOOL }
+        #   )
+        #   named_data = named_type.struct(
+        #     { id: 42, name: nil, active: false }
+        #   )
+        #
+        # @example Create a STRUCT value with anonymous field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   anon_type = db.fields [:INT64, :STRING, :BOOL]
+        #   anon_data = anon_type.struct [42, nil, false]
+        #
+        # @example Create a STRUCT value with duplicate field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   dup_type = db.fields [[:x, :INT64], [:x, :STRING], [:x, :BOOL]]
+        #   dup_data = dup_type.struct [42, nil, false]
         #
         def fields types
           Fields.new types

--- a/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/commit.rb
@@ -99,7 +99,7 @@ module Google
             Google::Spanner::V1::Mutation.new(
               insert_or_update: Google::Spanner::V1::Mutation::Write.new(
                 table: table, columns: row.keys.map(&:to_s),
-                values: [Convert.raw_to_value(row.values).list_value]
+                values: [Convert.object_to_grpc_value(row.values).list_value]
               )
             )
           end
@@ -157,7 +157,7 @@ module Google
             Google::Spanner::V1::Mutation.new(
               insert: Google::Spanner::V1::Mutation::Write.new(
                 table: table, columns: row.keys.map(&:to_s),
-                values: [Convert.raw_to_value(row.values).list_value]
+                values: [Convert.object_to_grpc_value(row.values).list_value]
               )
             )
           end
@@ -214,7 +214,7 @@ module Google
             Google::Spanner::V1::Mutation.new(
               update: Google::Spanner::V1::Mutation::Write.new(
                 table: table, columns: row.keys.map(&:to_s),
-                values: [Convert.raw_to_value(row.values).list_value]
+                values: [Convert.object_to_grpc_value(row.values).list_value]
               )
             )
           end
@@ -273,7 +273,7 @@ module Google
             Google::Spanner::V1::Mutation.new(
               replace: Google::Spanner::V1::Mutation::Write.new(
                 table: table, columns: row.keys.map(&:to_s),
-                values: [Convert.raw_to_value(row.values).list_value]
+                values: [Convert.object_to_grpc_value(row.values).list_value]
               )
             )
           end
@@ -334,7 +334,7 @@ module Google
           end
           key_list = keys.map do |key|
             key = [key] unless key.is_a? Array
-            Convert.raw_to_value(key).list_value
+            Convert.object_to_grpc_value(key).list_value
           end
           Google::Spanner::V1::KeySet.new keys: key_list
         end

--- a/google-cloud-spanner/lib/google/cloud/spanner/data.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/data.rb
@@ -110,14 +110,15 @@ module Google
         #
         def [] key
           if key.is_a? Integer
-            return Convert.value_to_raw(@grpc_values[key],
-                                        @grpc_fields[key].type)
+            return Convert.grpc_value_to_object(@grpc_values[key],
+                                                @grpc_fields[key].type)
           end
           name_count = @grpc_fields.find_all { |f| f.name == String(key) }.count
           return nil if name_count.zero?
           raise DuplicateNameError if name_count > 1
           index = @grpc_fields.find_index { |f| f.name == String(key) }
-          Convert.value_to_raw(@grpc_values[index], @grpc_fields[index].type)
+          Convert.grpc_value_to_object(@grpc_values[index],
+                                       @grpc_fields[index].type)
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/data.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/data.rb
@@ -185,12 +185,43 @@ module Google
         end
 
         ##
+        # @private
+        def to_grpc_value
+          if @grpc_values.nil?
+            return Google::Protobuf::Value.new null_value: :NULL_VALUE
+          end
+
+          Google::Protobuf::Value.new(
+            list_value: Google::Protobuf::ListValue.new(
+              values: @grpc_values
+            )
+          )
+        end
+
+        ##
+        # @private
+        def to_grpc_type
+          Google::Spanner::V1::Type.new(
+            code: :STRUCT,
+            struct_type: Google::Spanner::V1::StructType.new(
+              fields: @grpc_fields
+            )
+          )
+        end
+
+        ##
+        # @private
+        def to_grpc_value_and_type
+          [to_grpc_value, to_grpc_type]
+        end
+
+        ##
         # @private Creates a new Data instance from
         # Spanner values and fields.
         def self.from_grpc grpc_values, grpc_fields
           new.tap do |d|
-            d.instance_variable_set :@grpc_values, grpc_values
-            d.instance_variable_set :@grpc_fields, grpc_fields
+            d.instance_variable_set :@grpc_values, Array(grpc_values)
+            d.instance_variable_set :@grpc_fields, Array(grpc_fields)
           end
         end
       end

--- a/google-cloud-spanner/lib/google/cloud/spanner/data.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/data.rb
@@ -42,7 +42,8 @@ module Google
       #
       class Data
         ##
-        # Returns the names and values of the data as an array of field objects.
+        # Returns the configuration object ({Fields}) of the names and types of
+        # the data.
         #
         # @return [Array<Array>] An array containing name and value pairs.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
@@ -343,6 +343,14 @@ module Google
           return false unless other.is_a? Fields
           pairs == other.pairs
         end
+        alias eql? ==
+
+        # @private
+        def hash
+          # The Protobuf object looks to maintain consistent hash values
+          # for objects with the same configuration.
+          to_grpc_type.hash
+        end
 
         # @private
         def to_s

--- a/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
@@ -41,7 +41,65 @@ module Google
       #
       class Fields
         ##
-        # @private
+        # Creates {Fields} object from types. See {Client#fields}.
+        #
+        # This object can be used to create {Data} objects by providing values
+        # that match the field types. See {Fields#struct}.
+        #
+        # See [Data Types - Constructing a
+        # STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
+        #
+        # @param [Array, Hash] types Accepts an array or hash types.
+        #
+        #   Arrays can contain just the type value, or a sub-array of the
+        #   field's name and type value. Hash keys must contain the field name
+        #   as a `Symbol` or `String`, or the field position as an `Integer`.
+        #   Hash values must contain the type value. If a Hash is used the
+        #   fields will be created using the same order as the Hash keys.
+        #
+        #   Supported type values incude:
+        #
+        #   * `:BOOL`
+        #   * `:BYTES`
+        #   * `:DATE`
+        #   * `:FLOAT64`
+        #   * `:INT64`
+        #   * `:STRING`
+        #   * `:TIMESTAMP`
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Nested Structs are specified by providing a Fields
+        #     object.
+        #
+        # @return [Fields] The fields of the given types.
+        #
+        # @example Create a STRUCT value with named fields using Fields object:
+        #   require "google/cloud/spanner"
+        #
+        #   named_type = Google::Cloud::Spanner::Fields.new(
+        #     { id: :INT64, name: :STRING, active: :BOOL }
+        #   )
+        #   named_data = named_type.struct(
+        #     { id: 42, name: nil, active: false }
+        #   )
+        #
+        # @example Create a STRUCT value with anonymous field names:
+        #   require "google/cloud/spanner"
+        #
+        #   anon_type = Google::Cloud::Spanner::Fields.new(
+        #     [:INT64, :STRING, :BOOL]
+        #   )
+        #   anon_data = anon_type.struct [42, nil, false]
+        #
+        # @example Create a STRUCT value with duplicate field names:
+        #   require "google/cloud/spanner"
+        #
+        #   dup_type = Google::Cloud::Spanner::Fields.new(
+        #     [[:x, :INT64], [:x, :STRING], [:x, :BOOL]]
+        #   )
+        #   dup_data = dup_type.struct [42, nil, false]
+        #
         def initialize types
           types = types.to_a if types.is_a? Hash
 
@@ -146,11 +204,60 @@ module Google
         # rubocop:disable all
 
         ##
-        # Creates a new Data object given the data values matching the fields.
+        # Creates a new {Data} object given the data values matching the fields.
         # Can be provided as either an Array of values, or a Hash where the hash
         # keys match the field name or match the index position of the field.
         #
+        # For more information, see [Data Types - Constructing a
+        # STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
+        #
+        # @param [Array, Hash] data Accepts an array or hash data values.
+        #
+        #   Arrays can contain just the data value, nested arrays will be
+        #   treated as lists of values. Values must be provided in the same
+        #   order as the fields, and there is no way to associate values to the
+        #   field names.
+        #
+        #   Hash keys must contain the field name as a `Symbol` or `String`, or
+        #   the field position as an `Integer`. Hash values must contain the
+        #   data value. Hash values will be matched to the fields, so they don't
+        #   need to match the same order as the fields.
+        #
         # @return [Data] A new Data object.
+        #
+        # @example Create a STRUCT value with named fields using Fields object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   named_type = db.fields(
+        #     { id: :INT64, name: :STRING, active: :BOOL }
+        #   )
+        #   named_data = named_type.struct(
+        #     { id: 42, name: nil, active: false }
+        #   )
+        #
+        # @example Create a STRUCT value with anonymous field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   anon_type = db.fields [:INT64, :STRING, :BOOL]
+        #   anon_data = anon_type.struct [42, nil, false]
+        #
+        # @example Create a STRUCT value with duplicate field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   dup_type = db.fields [[:x, :INT64], [:x, :STRING], [:x, :BOOL]]
+        #   dup_data = dup_type.struct [42, nil, false]
         #
         def struct data
           # create local copy of types so they are parsed just once.

--- a/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
@@ -111,9 +111,7 @@ module Google
             type.is_a?(Array) && type.count == 2 && type.first.is_a?(Integer)
           end
 
-          if sorted_types.count != sorted_types.map(&:first).uniq.count
-            raise ArgumentError, "cannot specify position more than once"
-          end
+          verify_sorted_types! sorted_types, types.count
 
           @grpc_fields = Array.new(types.count) do |index|
             sorted_type = sorted_types.assoc index
@@ -386,6 +384,21 @@ module Google
         protected
 
         # rubocop:disable all
+
+        def verify_sorted_types! sorted_types, total_count
+          sorted_unique_positions = sorted_types.map(&:first).uniq.sort
+          return if sorted_unique_positions.empty?
+
+          if sorted_unique_positions.first < 0
+            raise ArgumentError, "cannot specify position less than 0"
+          end
+          if sorted_unique_positions.last >= total_count
+            raise ArgumentError, "cannot specify position more than field count"
+          end
+          if sorted_types.count != sorted_unique_positions.count
+            raise ArgumentError, "cannot specify position more than once"
+          end
+        end
 
         def to_grpc_field pair
           if pair.is_a?(Array)

--- a/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/fields.rb
@@ -267,7 +267,7 @@ module Google
           elsif data.is_a? Array
             # Convert data in the order it was recieved
             values = data.map.with_index do |datum, index|
-              Convert.raw_to_value_and_type(datum, cached_types[index]).first
+              Convert.object_to_grpc_value_and_type(datum, cached_types[index]).first
             end
             return Data.from_grpc values, @grpc_fields
           elsif data.is_a? Hash
@@ -275,14 +275,14 @@ module Google
             # we can't always trust the Hash to be in order.
             values = @grpc_fields.map.with_index do |field, index|
               if data.key? index
-                Convert.raw_to_value_and_type(data[index],
+                Convert.object_to_grpc_value_and_type(data[index],
                                               cached_types[index]).first
               elsif !field.name.to_s.empty?
                 if data.key? field.name.to_s
-                  Convert.raw_to_value_and_type(data[field.name.to_s],
+                  Convert.object_to_grpc_value_and_type(data[field.name.to_s],
                                                 cached_types[index]).first
                 elsif data.key? field.name.to_s.to_sym
-                  Convert.raw_to_value_and_type(data[field.name.to_s.to_sym],
+                  Convert.object_to_grpc_value_and_type(data[field.name.to_s.to_sym],
                                                 cached_types[index]).first
                 else
                   raise "data value for field #{field.name} missing"
@@ -384,19 +384,19 @@ module Google
             if pair.count == 2
               if pair.first.is_a?(Integer)
                 Google::Spanner::V1::StructType::Field.new(
-                  type: Convert.type_for_field(pair.last)
+                  type: Convert.grpc_type_for_field(pair.last)
                 )
               else
                 Google::Spanner::V1::StructType::Field.new(
                   name: String(pair.first),
-                  type: Convert.type_for_field(pair.last)
+                  type: Convert.grpc_type_for_field(pair.last)
                 )
               end
             else
               Google::Spanner::V1::StructType::Field.new(
                 type: Google::Spanner::V1::Type.new(
                   code: :ARRAY,
-                  array_element_type: Convert.type_for_field(pair.last)
+                  array_element_type: Convert.grpc_type_for_field(pair.last)
                 )
               )
             end
@@ -407,7 +407,7 @@ module Google
               raise ArgumentError, "type must be a symbol"
             end
             Google::Spanner::V1::StructType::Field.new(
-              type: Convert.type_for_field(pair)
+              type: Convert.grpc_type_for_field(pair)
             )
           end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -51,7 +51,8 @@ module Google
         end
 
         ##
-        # Returns the field names and types for the rows in the returned data.
+        # Returns the configuration object ({Fields}) of the names and types of
+        # the rows in the returned data.
         #
         # @return [Fields] The fields of the returned data.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/snapshot.rb
@@ -63,23 +63,6 @@ module Google
         ##
         # Executes a SQL query.
         #
-        # Arguments can be passed using `params`, Ruby types are mapped to
-        # Spanner types as follows:
-        #
-        # | Spanner     | Ruby           | Notes  |
-        # |-------------|----------------|---|
-        # | `BOOL`      | `true`/`false` | |
-        # | `INT64`     | `Integer`      | |
-        # | `FLOAT64`   | `Float`        | |
-        # | `STRING`    | `String`       | |
-        # | `DATE`      | `Date`         | |
-        # | `TIMESTAMP` | `Time`, `DateTime` | |
-        # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-        # | `ARRAY`     | `Array` | Nested arrays are not supported. |
-        #
-        # See [Data
-        # types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
-        #
         # @param [String] sql The SQL query string. See [Query
         #   syntax](https://cloud.google.com/spanner/docs/query-syntax).
         #
@@ -92,11 +75,30 @@ module Google
         #   the literal values are the hash values. If the query string contains
         #   something like "WHERE id > @msg_id", then the params must contain
         #   something like `:msg_id => 1`.
+        #
+        #   Ruby types are mapped to Spanner types as follows:
+        #
+        #   | Spanner     | Ruby           | Notes  |
+        #   |-------------|----------------|---|
+        #   | `BOOL`      | `true`/`false` | |
+        #   | `INT64`     | `Integer`      | |
+        #   | `FLOAT64`   | `Float`        | |
+        #   | `STRING`    | `String`       | |
+        #   | `DATE`      | `Date`         | |
+        #   | `TIMESTAMP` | `Time`, `DateTime` | |
+        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
+        #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #   | `STRUCT`    | `Hash`, {Data} | |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
+        #   See [Data Types - Constructing a
+        #   STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
         # @param [Hash] types Types of the SQL parameters in `params`. It is not
         #   always possible for Cloud Spanner to infer the right SQL type from a
-        #   value in `params`. In these cases, the `types` hash can be used to
-        #   specify the exact SQL type for some or all of the SQL query
-        #   parameters.
+        #   value in `params`. In these cases, the `types` hash must be used to
+        #   specify the SQL type for these values.
         #
         #   The keys of the hash should be query string parameter placeholders,
         #   minus the "@". The values of the hash should be Cloud Spanner type
@@ -109,11 +111,11 @@ module Google
         #   * `:INT64`
         #   * `:STRING`
         #   * `:TIMESTAMP`
-        #
-        #   Arrays are specified by providing the type code in an array. For
-        #   example, an array of integers are specified as `[:INT64]`.
-        #
-        #   Structs are not yet supported in query parameters.
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Types for STRUCT values (`Hash`/{Data} objects) are
+        #     specified using a {Fields} object.
         #
         #   Types are optional.
         # @return [Google::Cloud::Spanner::Results] The results of the query
@@ -143,6 +145,69 @@ module Google
         #     results = snp.execute "SELECT * FROM users " \
         #                           "WHERE active = @active",
         #                           params: { active: true }
+        #
+        #     results.rows.each do |row|
+        #       puts "User #{row[:id]} is #{row[:name]}"
+        #     end
+        #   end
+        #
+        # @example Query with a SQL STRUCT query parameter as a Hash:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.snapshot do |snp|
+        #      user_hash = { id: 1, name: "Charlie", active: false }
+        #
+        #     results = snp.execute "SELECT * FROM users WHERE " \
+        #                           "ID = @user_struct.id " \
+        #                           "AND name = @user_struct.name " \
+        #                           "AND active = @user_struct.active",
+        #                           params: { user_struct: user_hash }
+        #
+        #     results.rows.each do |row|
+        #       puts "User #{row[:id]} is #{row[:name]}"
+        #     end
+        #   end
+        #
+        # @example Specify the SQL STRUCT type using Fields object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.snapshot do |snp|
+        #      user_type = snp.fields id: :INT64, name: :STRING, active: :BOOL
+        #      user_hash = { id: 1, name: nil, active: false }
+        #
+        #     results = snp.execute "SELECT * FROM users WHERE " \
+        #                           "ID = @user_struct.id " \
+        #                           "AND name = @user_struct.name " \
+        #                           "AND active = @user_struct.active",
+        #                           params: { user_struct: user_hash },
+        #                           types: { user_struct: user_type }
+        #
+        #     results.rows.each do |row|
+        #       puts "User #{row[:id]} is #{row[:name]}"
+        #     end
+        #   end
+        #
+        # @example Or, query with a SQL STRUCT as a typed Data object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.snapshot do |snp|
+        #      user_type = snp.fields id: :INT64, name: :STRING, active: :BOOL
+        #   user_data = user_type.struct id: 1, name: nil, active: false
+        #
+        #     results = snp.execute "SELECT * FROM users WHERE " \
+        #                           "ID = @user_struct.id " \
+        #                           "AND name = @user_struct.name " \
+        #                           "AND active = @user_struct.active",
+        #                           params: { user_struct: user_data }
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}"
@@ -201,6 +266,84 @@ module Google
 
           session.read table, columns, keys: keys, index: index, limit: limit,
                                        transaction: tx_selector
+        end
+
+        ##
+        # Creates a configuration object ({Fields}) that may be provided to
+        # queries or used to create STRUCT objects. (The STRUCT will be
+        # represented by the {Data} class.) See {Client#execute} and/or
+        # {Fields#struct}.
+        #
+        # For more information, see [Data Types - Constructing a
+        # STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
+        #
+        # See [Data Types - Constructing a
+        # STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
+        #
+        # @param [Array, Hash] types Accepts an array or hash types.
+        #
+        #   Arrays can contain just the type value, or a sub-array of the
+        #   field's name and type value. Hash keys must contain the field name
+        #   as a `Symbol` or `String`, or the field position as an `Integer`.
+        #   Hash values must contain the type value. If a Hash is used the
+        #   fields will be created using the same order as the Hash keys.
+        #
+        #   Supported type values incude:
+        #
+        #   * `:BOOL`
+        #   * `:BYTES`
+        #   * `:DATE`
+        #   * `:FLOAT64`
+        #   * `:INT64`
+        #   * `:STRING`
+        #   * `:TIMESTAMP`
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Nested Structs are specified by providing a Fields
+        #     object.
+        #
+        # @return [Fields] The fields of the given types.
+        #
+        # @example Create a STRUCT value with named fields using Fields object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.snapshot do |snp|
+        #     named_type = snp.fields(
+        #       { id: :INT64, name: :STRING, active: :BOOL }
+        #     )
+        #     named_data = named_type.struct(
+        #       { id: 42, name: nil, active: false }
+        #     )
+        #   end
+        #
+        # @example Create a STRUCT value with anonymous field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.snapshot do |snp|
+        #     anon_type = snp.fields [:INT64, :STRING, :BOOL]
+        #     anon_data = anon_type.struct [42, nil, false]
+        #   end
+        #
+        # @example Create a STRUCT value with duplicate field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.snapshot do |snp|
+        #     dup_type = snp.fields [[:x, :INT64], [:x, :STRING], [:x, :BOOL]]
+        #     dup_data = dup_type.struct [42, nil, false]
+        #   end
+        #
+        def fields types
+          Fields.new types
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -92,23 +92,6 @@ module Google
         ##
         # Executes a SQL query.
         #
-        # Arguments can be passed using `params`, Ruby types are mapped to
-        # Spanner types as follows:
-        #
-        # | Spanner     | Ruby           | Notes  |
-        # |-------------|----------------|---|
-        # | `BOOL`      | `true`/`false` | |
-        # | `INT64`     | `Integer`      | |
-        # | `FLOAT64`   | `Float`        | |
-        # | `STRING`    | `String`       | |
-        # | `DATE`      | `Date`         | |
-        # | `TIMESTAMP` | `Time`, `DateTime` | |
-        # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-        # | `ARRAY`     | `Array` | Nested arrays are not supported. |
-        #
-        # See [Data
-        # types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
-        #
         # @param [String] sql The SQL query string. See [Query
         #   syntax](https://cloud.google.com/spanner/docs/query-syntax).
         #
@@ -121,11 +104,30 @@ module Google
         #   the literal values are the hash values. If the query string contains
         #   something like "WHERE id > @msg_id", then the params must contain
         #   something like `:msg_id => 1`.
+        #
+        #   Ruby types are mapped to Spanner types as follows:
+        #
+        #   | Spanner     | Ruby           | Notes  |
+        #   |-------------|----------------|---|
+        #   | `BOOL`      | `true`/`false` | |
+        #   | `INT64`     | `Integer`      | |
+        #   | `FLOAT64`   | `Float`        | |
+        #   | `STRING`    | `String`       | |
+        #   | `DATE`      | `Date`         | |
+        #   | `TIMESTAMP` | `Time`, `DateTime` | |
+        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
+        #   | `ARRAY`     | `Array` | Nested arrays are not supported. |
+        #   | `STRUCT`    | `Hash`, {Data} | |
+        #
+        #   See [Data
+        #   types](https://cloud.google.com/spanner/docs/data-definition-language#data_types).
+        #
+        #   See [Data Types - Constructing a
+        #   STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
         # @param [Hash] types Types of the SQL parameters in `params`. It is not
         #   always possible for Cloud Spanner to infer the right SQL type from a
-        #   value in `params`. In these cases, the `types` hash can be used to
-        #   specify the exact SQL type for some or all of the SQL query
-        #   parameters.
+        #   value in `params`. In these cases, the `types` hash must be used to
+        #   specify the SQL type for these values.
         #
         #   The keys of the hash should be query string parameter placeholders,
         #   minus the "@". The values of the hash should be Cloud Spanner type
@@ -138,11 +140,11 @@ module Google
         #   * `:INT64`
         #   * `:STRING`
         #   * `:TIMESTAMP`
-        #
-        #   Arrays are specified by providing the type code in an array. For
-        #   example, an array of integers are specified as `[:INT64]`.
-        #
-        #   Structs are not yet supported in query parameters.
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Types for STRUCT values (`Hash`/{Data} objects) are
+        #     specified using a {Fields} object.
         #
         #   Types are optional.
         # @return [Google::Cloud::Spanner::Results] The results of the query
@@ -171,6 +173,69 @@ module Google
         #   db.transaction do |tx|
         #     results = tx.execute "SELECT * FROM users WHERE active = @active",
         #                          params: { active: true }
+        #
+        #     results.rows.each do |row|
+        #       puts "User #{row[:id]} is #{row[:name]}"
+        #     end
+        #   end
+        #
+        # @example Query with a SQL STRUCT query parameter as a Hash:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.transaction do |tx|
+        #     user_hash = { id: 1, name: "Charlie", active: false }
+        #
+        #     results = tx.execute "SELECT * FROM users WHERE " \
+        #                          "ID = @user_struct.id " \
+        #                          "AND name = @user_struct.name " \
+        #                          "AND active = @user_struct.active",
+        #                          params: { user_struct: user_hash }
+        #
+        #     results.rows.each do |row|
+        #       puts "User #{row[:id]} is #{row[:name]}"
+        #     end
+        #   end
+        #
+        # @example Specify the SQL STRUCT type using Fields object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.transaction do |tx|
+        #     user_type = tx.fields id: :INT64, name: :STRING, active: :BOOL
+        #     user_hash = { id: 1, name: nil, active: false }
+        #
+        #     results = tx.execute "SELECT * FROM users WHERE " \
+        #                          "ID = @user_struct.id " \
+        #                          "AND name = @user_struct.name " \
+        #                          "AND active = @user_struct.active",
+        #                          params: { user_struct: user_hash },
+        #                          types: { user_struct: user_type }
+        #
+        #     results.rows.each do |row|
+        #       puts "User #{row[:id]} is #{row[:name]}"
+        #     end
+        #   end
+        #
+        # @example Or, query with a SQL STRUCT as a typed Data object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.transaction do |tx|
+        #     user_type = tx.fields id: :INT64, name: :STRING, active: :BOOL
+        #     user_data = user_type.struct id: 1, name: nil, active: false
+        #
+        #     results = tx.execute "SELECT * FROM users WHERE " \
+        #                          "ID = @user_struct.id " \
+        #                          "AND name = @user_struct.name " \
+        #                          "AND active = @user_struct.active",
+        #                          params: { user_struct: user_data }
         #
         #     results.rows.each do |row|
         #       puts "User #{row[:id]} is #{row[:name]}"
@@ -466,6 +531,81 @@ module Google
         #
         def fields_for table
           execute("SELECT * FROM #{table} WHERE 1 = 0").fields
+        end
+
+        ##
+        # Creates a configuration object ({Fields}) that may be provided to
+        # queries or used to create STRUCT objects. (The STRUCT will be
+        # represented by the {Data} class.) See {Client#execute} and/or
+        # {Fields#struct}.
+        #
+        # For more information, see [Data Types - Constructing a
+        # STRUCT](https://cloud.google.com/spanner/docs/data-types#constructing-a-struct).
+        #
+        # @param [Array, Hash] types Accepts an array or hash types.
+        #
+        #   Arrays can contain just the type value, or a sub-array of the
+        #   field's name and type value. Hash keys must contain the field name
+        #   as a `Symbol` or `String`, or the field position as an `Integer`.
+        #   Hash values must contain the type value. If a Hash is used the
+        #   fields will be created using the same order as the Hash keys.
+        #
+        #   Supported type values incude:
+        #
+        #   * `:BOOL`
+        #   * `:BYTES`
+        #   * `:DATE`
+        #   * `:FLOAT64`
+        #   * `:INT64`
+        #   * `:STRING`
+        #   * `:TIMESTAMP`
+        #   * `Array` - Lists are specified by providing the type code in an
+        #     array. For example, an array of integers are specified as
+        #     `[:INT64]`.
+        #   * {Fields} - Nested Structs are specified by providing a Fields
+        #     object.
+        #
+        # @return [Fields] The fields of the given types.
+        #
+        # @example Create a STRUCT value with named fields using Fields object:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.transaction do |tx|
+        #     named_type = tx.fields(
+        #       { id: :INT64, name: :STRING, active: :BOOL }
+        #     )
+        #     named_data = named_type.struct(
+        #       { id: 42, name: nil, active: false }
+        #     )
+        #   end
+        #
+        # @example Create a STRUCT value with anonymous field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.transaction do |tx|
+        #     anon_type = tx.fields [:INT64, :STRING, :BOOL]
+        #     anon_data = anon_type.struct [42, nil, false]
+        #   end
+        #
+        # @example Create a STRUCT value with duplicate field names:
+        #   require "google/cloud/spanner"
+        #
+        #   spanner = Google::Cloud::Spanner.new
+        #   db = spanner.client "my-instance", "my-database"
+        #
+        #   db.transaction do |tx|
+        #     dup_type = tx.fields [[:x, :INT64], [:x, :STRING], [:x, :BOOL]]
+        #     dup_data = dup_type.struct [42, nil, false]
+        #   end
+        #
+        def fields types
+          Fields.new types
         end
 
         ##

--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -244,20 +244,7 @@ YARD::Doctest.configure do |doctest|
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
-      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
-      mock.expect :commit, commit_resp, ["session-name", Array, Hash]
-    end
-  end
-
-  doctest.before "Google::Cloud::Spanner::BatchSnapshot#execute@Query using query parameters:" do
-    mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
-      5.times do
-        mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
-      end
-      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users WHERE active = @active", Hash]
+      mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
       mock.expect :commit, commit_resp, ["session-name", Array, Hash]
     end
   end
@@ -426,16 +413,7 @@ YARD::Doctest.configure do |doctest|
       20.times do
         mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
       end
-      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
-    end
-  end
-
-  doctest.before "Google::Cloud::Spanner::Client#execute@Query using query parameters:" do
-    mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
-      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users WHERE active = @active", Hash]
+      mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
     end
   end
 
@@ -672,20 +650,7 @@ YARD::Doctest.configure do |doctest|
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
-      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
-      mock.expect :commit, commit_resp, ["session-name", Array, Hash]
-    end
-  end
-
-  doctest.before "Google::Cloud::Spanner::Snapshot#execute@Query using query parameters:" do
-    mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
-      5.times do
-        mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
-      end
-      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users WHERE active = @active", Hash]
+      mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
       mock.expect :commit, commit_resp, ["session-name", Array, Hash]
     end
   end
@@ -748,20 +713,7 @@ YARD::Doctest.configure do |doctest|
       5.times do
         mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
       end
-      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users", Hash]
-      mock.expect :commit, commit_resp, ["session-name", Array, Hash]
-    end
-  end
-
-  doctest.before "Google::Cloud::Spanner::Transaction#execute@Query using query parameters:" do
-    mock_spanner do |mock, mock_instances, mock_databases|
-      20.times do
-        mock.expect :create_session, session_grpc, ["projects/my-project/instances/my-instance/databases/my-database", Hash]
-      end
-      5.times do
-        mock.expect :begin_transaction, tx_resp, ["session-name", Google::Spanner::V1::TransactionOptions, Hash]
-      end
-      mock.expect :execute_streaming_sql, results_enum, ["session-name", "SELECT * FROM users WHERE active = @active", Hash]
+      mock.expect :execute_streaming_sql, results_enum, ["session-name", String, Hash]
       mock.expect :commit, commit_resp, ["session-name", Array, Hash]
     end
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
@@ -192,10 +192,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
   end
 
   it "can execute a query with a simple Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])).to_h }, resume_token: nil, partition_token: partition_token, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])).to_h }, resume_token: nil, partition_token: partition_token, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } } )
@@ -206,10 +204,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
   end
 
   it "can execute a query with a complex Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )).to_h }, resume_token: nil, partition_token: partition_token, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )).to_h }, resume_token: nil, partition_token: partition_token, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } } )
@@ -220,10 +216,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
   end
 
   it "can execute a query with an empty Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])).to_h }, resume_token: nil, partition_token: partition_token, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])).to_h }, resume_token: nil, partition_token: partition_token, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(sql:  "SELECT * FROM users WHERE settings = @dict", params: { dict: { } } )

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
@@ -245,7 +245,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, index: "", limit: nil, resume_token: nil, partition_token: partition_token, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3]).list_value]), transaction: tx_selector, index: "", limit: nil, resume_token: nil, partition_token: partition_token, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(table: "my-table", columns: columns, keys: [1, 2, 3])
@@ -259,7 +259,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: partition_token, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1,1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2,2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: partition_token, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute_partition partition(table: "my-table", columns: columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey")

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
@@ -215,6 +215,31 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
     assert_results results
   end
 
+  it "can execute a query with an Array of Hashes" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, resume_token: nil, partition_token: partition_token, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
+
+    results = batch_snapshot.execute_partition partition(sql: "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] } )
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query with an Array of STRUCTs" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))).to_h }, resume_token: nil, partition_token: partition_token, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
+
+    struct_fields = Google::Cloud::Spanner::Fields.new name: :STRING, email: :STRING
+    results = batch_snapshot.execute_partition partition(sql: "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] } )
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])).to_h }, resume_token: nil, partition_token: partition_token, options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_test.rb
@@ -189,10 +189,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   end
 
   it "can execute a query with a simple Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -203,10 +201,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   end
 
   it "can execute a query with a complex Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -217,10 +213,8 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   end
 
   it "can execute a query with an empty Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_test.rb
@@ -212,6 +212,31 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
     assert_results results
   end
 
+  it "can execute a query with an Array of Hashes" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
+
+    results = batch_snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query with an Array of STRUCTs" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, options: default_options]
+    batch_snapshot.session.service.mocked_service = mock
+
+    struct_fields = Google::Cloud::Spanner::Fields.new name: :STRING, email: :STRING
+    results = batch_snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
+describe Google::Cloud::Spanner::BatchSnapshot, :partition_query, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
@@ -242,11 +242,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   end
 
   it "can execute a query with a simple Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
     sql = "SELECT * FROM users WHERE settings = @dict"
-    params = Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) })
+    params = Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) })
     param_types = { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }
     mock.expect :partition_query, partitions_resp, [session.path, sql, transaction: tx_selector, params: params, param_types: param_types, partition_options: nil, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
@@ -265,11 +263,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   end
 
   it "can execute a query with a complex Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
     sql = "SELECT * FROM users WHERE settings = @dict"
-    params = Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) })
+    params = Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) })
     param_types = { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }
     mock.expect :partition_query, partitions_resp, [session.path, sql, transaction: tx_selector, params: params, param_types: param_types, partition_options: nil, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
@@ -288,11 +284,9 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute, :mock_spanner do
   end
 
   it "can execute a query with an empty Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
     sql = "SELECT * FROM users WHERE settings = @dict"
-    params = Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) })
+    params = Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) })
     param_types = { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }
     mock.expect :partition_query, partitions_resp, [session.path, sql, transaction: tx_selector, params: params, param_types: param_types, partition_options: nil, options: default_options]
     batch_snapshot.session.service.mocked_service = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_read_test.rb
@@ -52,7 +52,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :partition_read, :mock_spanner d
   it "can read rows by id" do
 
     mock = Minitest::Mock.new
-    key_set = Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value])
+    key_set = Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3]).list_value])
     mock.expect :partition_read, partitions_resp, [session.path, "my-table", key_set, {transaction: tx_selector, index: nil, columns: columns_arg, partition_options: nil, options: default_options}]
     batch_snapshot.session.service.mocked_service = mock
 
@@ -72,7 +72,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :partition_read, :mock_spanner d
   it "can read rows with index" do
 
     mock = Minitest::Mock.new
-    key_set = Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value])
+    key_set = Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1,1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2,2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3,3]).list_value])
     mock.expect :partition_read, partitions_resp, [session.path, "my-table", key_set, {transaction: tx_selector, index: "MyTableCompositeKey", columns: columns_arg, partition_options: nil, options: default_options}]
     batch_snapshot.session.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/read_test.rb
@@ -92,7 +92,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.read "my-table", columns, keys: [1, 2, 3]
@@ -106,7 +106,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1,1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2,2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
@@ -149,7 +149,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
     batch_snapshot.session.service.mocked_service = mock
 
     results = batch_snapshot.read "my-table", columns, keys: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_field_values_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_field_values_test.rb
@@ -32,25 +32,25 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         Google::Spanner::V1::Mutation.new(
           update: Google::Spanner::V1::Mutation::Write.new(
             table: "users", columns: %w(id name updated_at),
-            values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", "spanner.commit_timestamp()"]).list_value]
+            values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", "spanner.commit_timestamp()"]).list_value]
           )
         ),
         Google::Spanner::V1::Mutation.new(
           insert: Google::Spanner::V1::Mutation::Write.new(
             table: "users", columns: %w(id name updated_at),
-            values: [Google::Cloud::Spanner::Convert.raw_to_value([2, "Harvey", "spanner.commit_timestamp()"]).list_value]
+            values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([2, "Harvey", "spanner.commit_timestamp()"]).list_value]
           )
         ),
         Google::Spanner::V1::Mutation.new(
           insert_or_update: Google::Spanner::V1::Mutation::Write.new(
             table: "users", columns: %w(id name updated_at),
-            values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", "spanner.commit_timestamp()"]).list_value]
+            values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", "spanner.commit_timestamp()"]).list_value]
           )
         ),
         Google::Spanner::V1::Mutation.new(
           replace: Google::Spanner::V1::Mutation::Write.new(
             table: "users", columns: %w(id name updated_at),
-            values: [Google::Cloud::Spanner::Convert.raw_to_value([4, "Henry", "spanner.commit_timestamp()"]).list_value]
+            values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([4, "Henry", "spanner.commit_timestamp()"]).list_value]
           )
         )
       ]
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         Google::Spanner::V1::Mutation.new(
           update: Google::Spanner::V1::Mutation::Write.new(
             table: "users", columns: %w(id name updated_at),
-            values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", "spanner.commit_timestamp()"]).list_value]
+            values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", "spanner.commit_timestamp()"]).list_value]
           )
         )
       ]
@@ -101,7 +101,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         Google::Spanner::V1::Mutation.new(
           insert: Google::Spanner::V1::Mutation::Write.new(
             table: "users", columns: %w(id name updated_at),
-            values: [Google::Cloud::Spanner::Convert.raw_to_value([2, "Harvey", "spanner.commit_timestamp()"]).list_value]
+            values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([2, "Harvey", "spanner.commit_timestamp()"]).list_value]
           )
         )
       ]
@@ -124,7 +124,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         Google::Spanner::V1::Mutation.new(
           insert_or_update: Google::Spanner::V1::Mutation::Write.new(
             table: "users", columns: %w(id name updated_at),
-            values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", "spanner.commit_timestamp()"]).list_value]
+            values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", "spanner.commit_timestamp()"]).list_value]
           )
         )
       ]
@@ -147,7 +147,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         Google::Spanner::V1::Mutation.new(
           insert_or_update: Google::Spanner::V1::Mutation::Write.new(
             table: "users", columns: %w(id name updated_at),
-            values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", "spanner.commit_timestamp()"]).list_value]
+            values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", "spanner.commit_timestamp()"]).list_value]
           )
         )
       ]
@@ -170,7 +170,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         Google::Spanner::V1::Mutation.new(
           replace: Google::Spanner::V1::Mutation::Write.new(
             table: "users", columns: %w(id name updated_at),
-            values: [Google::Cloud::Spanner::Convert.raw_to_value([4, "Henry", "spanner.commit_timestamp()"]).list_value]
+            values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([4, "Henry", "spanner.commit_timestamp()"]).list_value]
           )
         )
       ]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -31,32 +31,32 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         insert: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([2, "Harvey", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([2, "Harvey", true]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         insert_or_update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         replace: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([4, "Henry", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([4, "Henry", true]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [1, 2, 3, 4, 5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )
@@ -87,7 +87,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       )
     ]
@@ -110,7 +110,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         insert: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([2, "Harvey", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([2, "Harvey", true]).list_value]
         )
       )
     ]
@@ -133,7 +133,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         insert_or_update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
         )
       )
     ]
@@ -156,7 +156,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         insert_or_update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
         )
       )
     ]
@@ -179,7 +179,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         replace: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([4, "Henry", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([4, "Henry", true]).list_value]
         )
       )
     ]
@@ -203,7 +203,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [1, 2, 3, 4, 5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )
@@ -234,7 +234,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [time1, time2, time3, time4].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )
@@ -284,7 +284,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )
@@ -312,7 +312,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [time5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
@@ -215,11 +215,9 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
   end
 
   it "can execute a query with a simple Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -232,11 +230,9 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
   end
 
   it "can execute a query with a complex Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -249,11 +245,9 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
   end
 
   it "can execute a query with an empty Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -92,7 +92,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: [1, 2, 3]
@@ -113,7 +113,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([time1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([time2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([time3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([time1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([time2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([time3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: [time1, time2, time3]
@@ -130,7 +130,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1,1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2,2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
@@ -182,7 +182,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -69,7 +69,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       )
     ]
@@ -123,7 +123,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       )
     ]
@@ -177,7 +177,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       )
     ]
@@ -231,7 +231,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       )
     ]
@@ -295,7 +295,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       )
     ]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       )
     ]
@@ -123,7 +123,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         insert: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([2, "Harvey", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([2, "Harvey", true]).list_value]
         )
       )
     ]
@@ -151,7 +151,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         insert_or_update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
         )
       )
     ]
@@ -179,7 +179,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         insert_or_update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
         )
       )
     ]
@@ -207,7 +207,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         replace: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([4, "Henry", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([4, "Henry", true]).list_value]
         )
       )
     ]
@@ -236,7 +236,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [1, 2, 3, 4, 5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )
@@ -296,7 +296,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )
@@ -353,32 +353,32 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         insert: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([2, "Harvey", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([2, "Harvey", true]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         insert_or_update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         replace: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([4, "Henry", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([4, "Henry", true]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [1, 2, 3, 4, 5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/grpc_value_to_object_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/grpc_value_to_object_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Convert, :value_to_raw, :mock_spanner do
+describe Google::Cloud::Spanner::Convert, :grpc_value_to_object, :mock_spanner do
   # This tests is a sanity check on the implementation of the conversion method.
   # We are testing the private method. This functionality is also covered elsewhere,
   # but it was thought that since this conversion is so important we might as well
@@ -23,70 +23,70 @@ describe Google::Cloud::Spanner::Convert, :value_to_raw, :mock_spanner do
   it "converts a BOOL value" do
     value = Google::Protobuf::Value.new(bool_value: true)
     type = Google::Spanner::V1::Type.new(code: :BOOL)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal true
   end
 
   it "converts a INT64 value" do
     value = Google::Protobuf::Value.new(string_value: "29")
     type = Google::Spanner::V1::Type.new(code: :INT64)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal 29
   end
 
   it "converts a FLOAT64 value" do
     value = Google::Protobuf::Value.new(number_value: 0.9)
     type = Google::Spanner::V1::Type.new(code: :FLOAT64)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal 0.9
   end
 
   it "converts a FLOAT64 value (Infinity)" do
     value = Google::Protobuf::Value.new(string_value: "Infinity")
     type = Google::Spanner::V1::Type.new(code: :FLOAT64)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal Float::INFINITY
   end
 
   it "converts a FLOAT64 value (-Infinity)" do
     value = Google::Protobuf::Value.new(string_value: "-Infinity")
     type = Google::Spanner::V1::Type.new(code: :FLOAT64)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal -Float::INFINITY
   end
 
   it "converts a FLOAT64 value (NaN)" do
     value = Google::Protobuf::Value.new(string_value: "NaN")
     type = Google::Spanner::V1::Type.new(code: :FLOAT64)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_be :nan? # equality checks on Float::NAN fails
   end
 
   it "converts a TIMESTAMP value" do
     value = Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z")
     type = Google::Spanner::V1::Type.new(code: :TIMESTAMP)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal Time.parse("2017-01-02 03:04:05.06 UTC")
   end
 
   it "converts a DATE value" do
     value = Google::Protobuf::Value.new(string_value: "2017-01-02")
     type = Google::Spanner::V1::Type.new(code: :DATE)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal Date.parse("2017-01-02")
   end
 
   it "converts a STRING value" do
     value = Google::Protobuf::Value.new(string_value: "Charlie")
     type = Google::Spanner::V1::Type.new(code: :STRING)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal "Charlie"
   end
 
   it "converts a BYTES value" do
     value = Google::Protobuf::Value.new(string_value: Base64.encode64("contents"))
     type = Google::Spanner::V1::Type.new(code: :BYTES)
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_be_kind_of StringIO
     raw.read.must_equal "contents"
   end
@@ -94,35 +94,35 @@ describe Google::Cloud::Spanner::Convert, :value_to_raw, :mock_spanner do
   it "converts an ARRAY of INT64 values" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")]))
     type = Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal [1, 2, 3]
   end
 
   it "converts an ARRAY of STRING values" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "foo"), Google::Protobuf::Value.new(string_value: "bar"), Google::Protobuf::Value.new(string_value: "baz")]))
     type = Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRING))
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal %w(foo bar baz)
   end
 
   it "converts a simple STRUCT value" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "bar")]))
     type = Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))]))
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal Google::Cloud::Spanner::Fields.new(foo: :STRING).struct(foo: "bar")
   end
 
   it "converts a complex STRUCT value" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ]))
     type = Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))) ] ))
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal Google::Cloud::Spanner::Fields.new(env: :STRING, score: :FLOAT64, project_ids: [:INT64]).struct({env: "production", score: 0.9, project_ids: [1,2,3]})
   end
 
   it "converts an emtpy STRUCT value" do
     value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: []))
     type = Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: []))
-    raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
+    raw = Google::Cloud::Spanner::Convert.grpc_value_to_object value, type
     raw.must_equal(Google::Cloud::Spanner::Fields.new([]).struct([]))
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_key_range_test.rb
@@ -25,9 +25,9 @@ describe Google::Cloud::Spanner::Convert, :to_key_range, :mock_spanner do
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
     key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
     key_range.start_open.must_be :nil?
-    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
     key_range.end_open.must_be :nil?
   end
 
@@ -37,9 +37,9 @@ describe Google::Cloud::Spanner::Convert, :to_key_range, :mock_spanner do
 
     key_range.must_be_kind_of Google::Spanner::V1::KeyRange
     key_range.start_closed.must_be :nil?
-    key_range.start_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.start_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
     key_range.end_closed.must_be :nil?
-    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
   end
 
   it "creates a Spanner::Range that excludes beginning" do
@@ -48,8 +48,8 @@ describe Google::Cloud::Spanner::Convert, :to_key_range, :mock_spanner do
 
     key_range.must_be_kind_of Google::Spanner::V1::KeyRange
     key_range.start_closed.must_be :nil?
-    key_range.start_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
-    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+    key_range.start_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
+    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
     key_range.end_open.must_be :nil?
   end
 
@@ -58,10 +58,10 @@ describe Google::Cloud::Spanner::Convert, :to_key_range, :mock_spanner do
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
     key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
     key_range.start_open.must_be :nil?
     key_range.end_closed.must_be :nil?
-    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
   end
 
   it "creates an inclusive Range" do
@@ -69,9 +69,9 @@ describe Google::Cloud::Spanner::Convert, :to_key_range, :mock_spanner do
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
     key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
     key_range.start_open.must_be :nil?
-    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+    key_range.end_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
     key_range.end_open.must_be :nil?
   end
 
@@ -80,9 +80,9 @@ describe Google::Cloud::Spanner::Convert, :to_key_range, :mock_spanner do
     key_range = Google::Cloud::Spanner::Convert.to_key_range range
 
     key_range.must_be_kind_of Google::Spanner::V1::KeyRange
-    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value
+    key_range.start_closed.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value
     key_range.start_open.must_be :nil?
     key_range.end_closed.must_be :nil?
-    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.raw_to_value([100]).list_value
+    key_range.end_open.must_equal Google::Cloud::Spanner::Convert.object_to_grpc_value([100]).list_value
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
@@ -205,23 +205,910 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
   end
 
   it "converts a simple Hash value" do
-    skip "Hash query parameters are not yet supported"
     combined_params = Google::Cloud::Spanner::Convert.to_query_params settings: { foo: :bar }
-    combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"foo"=>Google::Protobuf::Value.new(string_value: "bar")})),
+    combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "bar")])),
                                                 Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))]))] })
   end
 
   it "converts a complex Hash value" do
-    skip "Hash query parameters are not yet supported"
     combined_params = Google::Cloud::Spanner::Convert.to_query_params settings: { env: "production", score: 0.9, project_ids: [1,2,3] }
-    combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score"=>Google::Protobuf::Value.new(number_value: 0.9), "env"=>Google::Protobuf::Value.new(string_value: "production"), "project_ids"=>Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })),
+    combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])),
                                                 Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))) ] ))] })
   end
 
   it "converts an emtpy Hash value" do
-    skip "Hash query parameters are not yet supported"
     combined_params = Google::Cloud::Spanner::Convert.to_query_params settings: {}
-    combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})),
+    combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
                                                 Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: []))] })
+  end
+
+  it "converts an empty Array of Data values" do
+    combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: []}, list: [fields(foo: :STRING)])
+    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])),
+                                            Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))])))] })
+  end
+
+  it "converts a nil Array of Data values" do
+    combined_params = Google::Cloud::Spanner::Convert.to_query_params({list: nil}, list: [fields(foo: :STRING)])
+    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+                                            Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))])))] })
+  end
+
+  it "converts an Array of simple Data values" do
+    combined_params = Google::Cloud::Spanner::Convert.to_query_params list: [{ foo: :bar }]
+    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "bar")]))])),
+                                            Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT,struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))]))) ]})
+  end
+
+  it "converts an Array complex Data values" do
+    combined_params = Google::Cloud::Spanner::Convert.to_query_params list: [{ env: "production", score: 0.9, project_ids: [1,2,3] }]
+    combined_params.must_equal({ "list" => [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")]))]))])),
+                                            Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))]))) ]})
+  end
+
+  describe "Struct Parameters Query Examples" do
+    # Simple field access.
+    # [parameters=STRUCT<threadf INT64, userf STRING>(1,"bob") AS struct_param, 10 as p4]
+    # SELECT @struct_param.userf, @p4;
+    describe "Simple field access" do
+      it "with Hash" do
+        params = { struct_param: { threadf: 1, userf: "bob" }, p4: 10 }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(string_value: "1"),
+                  Google::Protobuf::Value.new(string_value: "bob")
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "threadf",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  ),
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "userf",
+                    type: Google::Spanner::V1::Type.new(code: :STRING)
+                  )
+                ]
+              )
+            )
+          ],
+          "p4" => [
+            Google::Protobuf::Value.new(string_value: "10"),
+            Google::Spanner::V1::Type.new(code: :INT64)
+          ]
+        })
+      end
+
+      it "with Hash and type" do
+        fields = Google::Cloud::Spanner::Fields.new threadf: :INT64, userf: :STRING
+        params = { struct_param: { threadf: 1, userf: "bob" }, p4: 10 }
+        types = { struct_param: fields, p4: :INT64 }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(string_value: "1"),
+                  Google::Protobuf::Value.new(string_value: "bob")
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "threadf",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  ),
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "userf",
+                    type: Google::Spanner::V1::Type.new(code: :STRING)
+                  )
+                ]
+              )
+            )
+          ],
+          "p4" => [
+            Google::Protobuf::Value.new(string_value: "10"),
+            Google::Spanner::V1::Type.new(code: :INT64)
+          ]
+        })
+      end
+
+      it "with Data" do
+        fields = Google::Cloud::Spanner::Fields.new threadf: :INT64, userf: :STRING
+        data = fields.struct threadf: 1, userf: "bob"
+        params = { struct_param: data, p4: 10 }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(string_value: "1"),
+                  Google::Protobuf::Value.new(string_value: "bob")
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "threadf",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  ),
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "userf",
+                    type: Google::Spanner::V1::Type.new(code: :STRING)
+                  )
+                ]
+              )
+            )
+          ],
+          "p4" => [
+            Google::Protobuf::Value.new(string_value: "10"),
+            Google::Spanner::V1::Type.new(code: :INT64)
+          ]
+        })
+      end
+    end
+
+    # # Simple field access on NULL struct value.
+    # [parameters=CAST(NULL AS STRUCT<threadf INT64, userf STRING>) AS struct_param]
+    # SELECT @struct_param.userf;
+    describe "Simple field access on NULL struct value" do
+      it "with nil and type" do
+        fields = Google::Cloud::Spanner::Fields.new threadf: :INT64, userf: :STRING
+        params = { struct_param: nil }
+        types = { struct_param: fields }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "threadf",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  ),
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "userf",
+                    type: Google::Spanner::V1::Type.new(code: :STRING)
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+    end
+
+    # # Nested struct field access.
+    # [parameters=STRUCT<structf STRUCT<nestedf STRING>> (STRUCT<nestedf STRING>("bob")) AS struct_param]
+    # SELECT @struct_param.structf.nestedf;
+    describe "Nested struct field access" do
+      it "with Hash" do
+        params = { struct_param: { structf: { nestedf: "bob" } } }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(
+                    list_value: Google::Protobuf::ListValue.new(
+                      values: [
+                        Google::Protobuf::Value.new(string_value: "bob")
+                      ]
+                    )
+                  )
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "structf",
+                    type: Google::Spanner::V1::Type.new(
+                      code: :STRUCT,
+                      struct_type: Google::Spanner::V1::StructType.new(
+                        fields: [
+                          Google::Spanner::V1::StructType::Field.new(
+                            name: "nestedf",
+                            type: Google::Spanner::V1::Type.new(code: :STRING)
+                          )
+                        ]
+                      )
+                    )
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Hash and type" do
+        fields = Google::Cloud::Spanner::Fields.new structf: Google::Cloud::Spanner::Fields.new(nestedf: :STRING)
+        params = { struct_param: { structf: { nestedf: "bob" } } }
+        types = { struct_param: fields }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(
+                    list_value: Google::Protobuf::ListValue.new(
+                      values: [
+                        Google::Protobuf::Value.new(string_value: "bob")
+                      ]
+                    )
+                  )
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "structf",
+                    type: Google::Spanner::V1::Type.new(
+                      code: :STRUCT,
+                      struct_type: Google::Spanner::V1::StructType.new(
+                        fields: [
+                          Google::Spanner::V1::StructType::Field.new(
+                            name: "nestedf",
+                            type: Google::Spanner::V1::Type.new(code: :STRING)
+                          )
+                        ]
+                      )
+                    )
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Data" do
+        fields = Google::Cloud::Spanner::Fields.new structf: Google::Cloud::Spanner::Fields.new(nestedf: :STRING)
+        data = fields.struct structf: { nestedf: "bob" }
+        params = { struct_param: data }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(
+                    list_value: Google::Protobuf::ListValue.new(
+                      values: [
+                        Google::Protobuf::Value.new(string_value: "bob")
+                      ]
+                    )
+                  )
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "structf",
+                    type: Google::Spanner::V1::Type.new(
+                      code: :STRUCT,
+                      struct_type: Google::Spanner::V1::StructType.new(
+                        fields: [
+                          Google::Spanner::V1::StructType::Field.new(
+                            name: "nestedf",
+                            type: Google::Spanner::V1::Type.new(code: :STRING)
+                          )
+                        ]
+                      )
+                    )
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+    end
+
+    # # Nested struct field access on NULL struct value.
+    # [parameters=CAST(STRUCT(null) AS STRUCT<structf STRUCT<nestedf STRING>>) AS  struct_param]
+    # SELECT @struct_param.structf.nestedf;
+    describe "Nested struct field access on NULL struct value" do
+      it "with nil and type" do
+        fields = Google::Cloud::Spanner::Fields.new structf: Google::Cloud::Spanner::Fields.new(nestedf: :STRING)
+        params = { struct_param: nil }
+        types = { struct_param: fields }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "structf",
+                    type: Google::Spanner::V1::Type.new(
+                      code: :STRUCT,
+                      struct_type: Google::Spanner::V1::StructType.new(
+                        fields: [
+                          Google::Spanner::V1::StructType::Field.new(
+                            name: "nestedf",
+                            type: Google::Spanner::V1::Type.new(code: :STRING)
+                          )
+                        ]
+                      )
+                    )
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+    end
+
+    # # Non-NULL struct with no fields (empty struct).
+    # [parameters=CAST(STRUCT() AS STRUCT<>) AS struct_param]
+    # SELECT @struct_param IS NULL;
+    describe "Non-NULL struct with no fields (empty struct)" do
+      it "with Hash" do
+        params = { struct_param: {} }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: []
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: []
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Hash and type" do
+        fields = Google::Cloud::Spanner::Fields.new({})
+        params = { struct_param: {} }
+        types = { struct_param: fields }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: []
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: []
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Data" do
+        fields = Google::Cloud::Spanner::Fields.new({})
+        data = fields.struct({})
+        params = { struct_param: data }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: []
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: []
+              )
+            )
+          ]
+        })
+      end
+    end
+
+    # # NULL struct with no fields.
+    # [parameters=CAST(NULL AS STRUCT<>) AS struct_param]
+    # SELECT @struct_param IS NULL
+    describe "NULL struct with no fields" do
+      it "with nil and type" do
+        fields = Google::Cloud::Spanner::Fields.new({})
+        params = { struct_param: nil }
+        types = { struct_param: fields }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: []
+              )
+            )
+          ]
+        })
+      end
+    end
+
+    # # Struct with single NULL field.
+    # [parameters=STRUCT<f1 INT64>(NULL) AS struct_param]
+    # SELECT @struct_param.f1;
+    describe "Struct with single NULL field" do
+      it "with Hash and type" do
+        fields = Google::Cloud::Spanner::Fields.new f1: :INT64
+        params = { struct_param: { f1: nil } }
+        types = { struct_param: fields }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(null_value: :NULL_VALUE)
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "f1",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Data" do
+        fields = Google::Cloud::Spanner::Fields.new f1: :INT64
+        data = fields.struct f1: nil
+        params = { struct_param: data }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(null_value: :NULL_VALUE)
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "f1",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+    end
+
+    # # Equality check.
+    # [parameters=STRUCT<threadf INT64, userf STRING>(1,"bob") AS struct_param]
+    # SELECT @struct_param=STRUCT<threadf INT64, userf STRING>(1,"bob");
+    describe "Equality check" do
+      it "with Hash" do
+        params = { struct_param: { threadf: 1, userf: "bob" } }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(string_value: "1"),
+                  Google::Protobuf::Value.new(string_value: "bob")
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "threadf",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  ),
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "userf",
+                    type: Google::Spanner::V1::Type.new(code: :STRING)
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Hash and type" do
+        fields = Google::Cloud::Spanner::Fields.new threadf: :INT64, userf: :STRING
+        params = { struct_param: { threadf: 1, userf: "bob" } }
+        types = { struct_param: fields }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(string_value: "1"),
+                  Google::Protobuf::Value.new(string_value: "bob")
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "threadf",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  ),
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "userf",
+                    type: Google::Spanner::V1::Type.new(code: :STRING)
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Data" do
+        fields = Google::Cloud::Spanner::Fields.new threadf: :INT64, userf: :STRING
+        data = fields.struct threadf: 1, userf: "bob"
+        params = { struct_param: data }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(string_value: "1"),
+                  Google::Protobuf::Value.new(string_value: "bob")
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "threadf",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  ),
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "userf",
+                    type: Google::Spanner::V1::Type.new(code: :STRING)
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+    end
+
+    # # Nullness check.
+    # [parameters=ARRAY<STRUCT<threadf INT64, userf STRING>> [(1,"bob")] AS struct_arr_param]
+    # SELECT @struct_arr_param IS NULL;
+    describe "Nullness check" do
+      it "with Array of Hash" do
+        params = { struct_arr_param: [{ threadf: 1, userf: "bob" }] }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_arr_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(
+                    list_value: Google::Protobuf::ListValue.new(
+                      values: [
+                        Google::Protobuf::Value.new(string_value: "1"),
+                        Google::Protobuf::Value.new(string_value: "bob")
+                      ]
+                    )
+                  )
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :ARRAY,
+              array_element_type: Google::Spanner::V1::Type.new(
+                code: :STRUCT,
+                struct_type: Google::Spanner::V1::StructType.new(
+                  fields: [
+                    Google::Spanner::V1::StructType::Field.new(
+                      name: "threadf",
+                      type: Google::Spanner::V1::Type.new(code: :INT64)
+                    ),
+                    Google::Spanner::V1::StructType::Field.new(
+                      name: "userf",
+                      type: Google::Spanner::V1::Type.new(code: :STRING)
+                    )
+                  ]
+                )
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Array of Hash and type" do
+        fields = Google::Cloud::Spanner::Fields.new threadf: :INT64, userf: :STRING
+        params = { struct_arr_param: [{ threadf: 1, userf: "bob" }] }
+        types = { struct_arr_param: [fields] }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_arr_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(
+                    list_value: Google::Protobuf::ListValue.new(
+                      values: [
+                        Google::Protobuf::Value.new(string_value: "1"),
+                        Google::Protobuf::Value.new(string_value: "bob")
+                      ]
+                    )
+                  )
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :ARRAY,
+              array_element_type: Google::Spanner::V1::Type.new(
+                code: :STRUCT,
+                struct_type: Google::Spanner::V1::StructType.new(
+                  fields: [
+                    Google::Spanner::V1::StructType::Field.new(
+                      name: "threadf",
+                      type: Google::Spanner::V1::Type.new(code: :INT64)
+                    ),
+                    Google::Spanner::V1::StructType::Field.new(
+                      name: "userf",
+                      type: Google::Spanner::V1::Type.new(code: :STRING)
+                    )
+                  ]
+                )
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Array of Data" do
+        fields = Google::Cloud::Spanner::Fields.new threadf: :INT64, userf: :STRING
+        data = fields.struct threadf: 1, userf: "bob"
+        params = { struct_arr_param: [data] }
+        types = nil
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_arr_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(
+                    list_value: Google::Protobuf::ListValue.new(
+                      values: [
+                        Google::Protobuf::Value.new(string_value: "1"),
+                        Google::Protobuf::Value.new(string_value: "bob")
+                      ]
+                    )
+                  )
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :ARRAY,
+              array_element_type: Google::Spanner::V1::Type.new(
+                code: :STRUCT,
+                struct_type: Google::Spanner::V1::StructType.new(
+                  fields: [
+                    Google::Spanner::V1::StructType::Field.new(
+                      name: "threadf",
+                      type: Google::Spanner::V1::Type.new(code: :INT64)
+                    ),
+                    Google::Spanner::V1::StructType::Field.new(
+                      name: "userf",
+                      type: Google::Spanner::V1::Type.new(code: :STRING)
+                    )
+                  ]
+                )
+              )
+            )
+          ]
+        })
+      end
+    end
+
+    # # Null array of struct field.
+    # [parameters=STRUCT<intf INT64, arraysf ARRAY<STRUCT<threadid INT64>>> (10,CAST(NULL AS ARRAY<STRUCT<threadid INT64>>)) AS struct_param]
+    # SELECT a.threadid FROM UNNEST(@struct_param.arraysf) a;
+    describe "Null array of struct field" do
+      it "with Hash and type" do
+        fields = Google::Cloud::Spanner::Fields.new intf: :INT64, arraysf: [Google::Cloud::Spanner::Fields.new(threadid: :INT64)]
+        data = fields.struct intf: 10, arraysf: nil
+        params = { struct_param: { intf: 10, arraysf: nil } }
+        types = { struct_param: fields }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(string_value: "10"),
+                  Google::Protobuf::Value.new(null_value: :NULL_VALUE)
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "intf",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  ),
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "arraysf",
+                    type: Google::Spanner::V1::Type.new(
+                      code: :ARRAY,
+                      array_element_type: Google::Spanner::V1::Type.new(
+                        code: :STRUCT,
+                        struct_type: Google::Spanner::V1::StructType.new(
+                          fields: [
+                            Google::Spanner::V1::StructType::Field.new(
+                              name: "threadid",
+                              type: Google::Spanner::V1::Type.new(code: :INT64)
+                            )
+                          ]
+                        )
+                      )
+                    )
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+
+      it "with Data" do
+        fields = Google::Cloud::Spanner::Fields.new intf: :INT64, arraysf: [Google::Cloud::Spanner::Fields.new(threadid: :INT64)]
+        data = fields.struct intf: 10, arraysf: nil
+        params = { struct_param: data }
+        types = { struct_param: fields }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_param" => [
+            Google::Protobuf::Value.new(
+              list_value: Google::Protobuf::ListValue.new(
+                values: [
+                  Google::Protobuf::Value.new(string_value: "10"),
+                  Google::Protobuf::Value.new(null_value: :NULL_VALUE)
+                ]
+              )
+            ),
+            Google::Spanner::V1::Type.new(
+              code: :STRUCT,
+              struct_type: Google::Spanner::V1::StructType.new(
+                fields: [
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "intf",
+                    type: Google::Spanner::V1::Type.new(code: :INT64)
+                  ),
+                  Google::Spanner::V1::StructType::Field.new(
+                    name: "arraysf",
+                    type: Google::Spanner::V1::Type.new(
+                      code: :ARRAY,
+                      array_element_type: Google::Spanner::V1::Type.new(
+                        code: :STRUCT,
+                        struct_type: Google::Spanner::V1::StructType.new(
+                          fields: [
+                            Google::Spanner::V1::StructType::Field.new(
+                              name: "threadid",
+                              type: Google::Spanner::V1::Type.new(code: :INT64)
+                            )
+                          ]
+                        )
+                      )
+                    )
+                  )
+                ]
+              )
+            )
+          ]
+        })
+      end
+    end
+
+    # # Null array of struct.
+    # [parameters=CAST(NULL AS ARRAY<STRUCT<threadid INT64>>) as struct_arr_param]
+    # SELECT a.threadid FROM UNNEST(@struct_arr_param) a;
+    describe "Null array of struct" do
+      it "with nil and type" do
+        fields = Google::Cloud::Spanner::Fields.new threadid: :INT64
+        params = { struct_arr_param: nil }
+        types = { struct_arr_param: [fields] }
+        combined_params = Google::Cloud::Spanner::Convert.to_query_params params, types
+        combined_params.must_equal({
+          "struct_arr_param" => [
+            Google::Protobuf::Value.new(null_value: :NULL_VALUE),
+            Google::Spanner::V1::Type.new(
+              code: :ARRAY,
+              array_element_type: Google::Spanner::V1::Type.new(
+                code: :STRUCT,
+                struct_type: Google::Spanner::V1::StructType.new(
+                  fields: [
+                    Google::Spanner::V1::StructType::Field.new(
+                      name: "threadid",
+                      type: Google::Spanner::V1::Type.new(code: :INT64)
+                    )
+                  ]
+                )
+              )
+            )
+          ]
+        })
+      end
+    end
+  end
+
+  def fields *args
+    Google::Cloud::Spanner::Fields.new *args
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_query_params_test.rb
@@ -205,18 +205,21 @@ describe Google::Cloud::Spanner::Convert, :to_query_params, :mock_spanner do
   end
 
   it "converts a simple Hash value" do
+    skip "Hash query parameters are not yet supported"
     combined_params = Google::Cloud::Spanner::Convert.to_query_params settings: { foo: :bar }
     combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"foo"=>Google::Protobuf::Value.new(string_value: "bar")})),
                                                 Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))]))] })
   end
 
   it "converts a complex Hash value" do
+    skip "Hash query parameters are not yet supported"
     combined_params = Google::Cloud::Spanner::Convert.to_query_params settings: { env: "production", score: 0.9, project_ids: [1,2,3] }
     combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score"=>Google::Protobuf::Value.new(number_value: 0.9), "env"=>Google::Protobuf::Value.new(string_value: "production"), "project_ids"=>Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })),
                                                 Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))) ] ))] })
   end
 
   it "converts an emtpy Hash value" do
+    skip "Hash query parameters are not yet supported"
     combined_params = Google::Cloud::Spanner::Convert.to_query_params settings: {}
     combined_params.must_equal({ "settings" => [Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})),
                                                 Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: []))] })

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/value_to_raw_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/value_to_raw_test.rb
@@ -106,29 +106,23 @@ describe Google::Cloud::Spanner::Convert, :value_to_raw, :mock_spanner do
   end
 
   it "converts a simple STRUCT value" do
-    skip "Spanner does return STRUCT values in a column value"
-
-    value = Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"foo"=>Google::Protobuf::Value.new(string_value: "bar")}))
+    value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "bar")]))
     type = Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "foo", type: Google::Spanner::V1::Type.new(code: :STRING))]))
     raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
-    raw.must_equal({ foo: :bar })
+    raw.must_equal Google::Cloud::Spanner::Fields.new(foo: :STRING).struct(foo: "bar")
   end
 
   it "converts a complex STRUCT value" do
-    skip "Spanner does return STRUCT values in a column value"
-
-    value = Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score"=>Google::Protobuf::Value.new(number_value: 0.9), "env"=>Google::Protobuf::Value.new(string_value: "production"), "project_ids"=>Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) }))
+    value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [ Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ]))
     type = Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64))) ] ))
     raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
-    raw.must_equal({ env: "production", score: 0.9, project_ids: [1,2,3] })
+    raw.must_equal Google::Cloud::Spanner::Fields.new(env: :STRING, score: :FLOAT64, project_ids: [:INT64]).struct({env: "production", score: 0.9, project_ids: [1,2,3]})
   end
 
   it "converts an emtpy STRUCT value" do
-    skip "Spanner does return STRUCT values in a column value"
-
-    value = Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {}))
+    value = Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: []))
     type = Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: []))
     raw = Google::Cloud::Spanner::Convert.value_to_raw value, type
-    raw.must_equal({})
+    raw.must_equal(Google::Cloud::Spanner::Fields.new([]).struct([]))
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/deeply_nested_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/deeply_nested_struct_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,29 +14,29 @@
 
 require "helper"
 
-describe Google::Cloud::Spanner::Fields, :data do
-  let(:fields_hash) { { id: :INT64, name: :STRING, active: :BOOL, age: :INT64, score: :FLOAT64, updated_at: :TIMESTAMP, birthday: :DATE, avatar: :BYTES } } # , project_ids: [:INT64]
+describe Google::Cloud::Spanner::Fields, :deeply_nested_struct do
+  let(:fields_hash) { { id: :INT64, name: :STRING, active: :BOOL, age: :INT64, score: :FLOAT64, updated_at: :TIMESTAMP, birthday: :DATE, avatar: :BYTES, project_ids: [:INT64] } }
   let(:fields) { Google::Cloud::Spanner::Fields.new fields_hash }
 
   it "creates with an array of fields" do
-    data = fields.data id: 1, name: "Charlie", active: true, age: 29, score: 0.9,
-                      updated_at: Time.parse("2017-01-02T03:04:05.060000000Z"),
-                      birthday: Date.parse("1950-01-01"), avatar: StringIO.new("image")
-                      # project_ids: [1, 2, 3]
+    data = fields.struct id: 1, name: "Charlie", active: true, age: 29, score: 0.9,
+                         updated_at: Time.parse("2017-01-02T03:04:05.060000000Z"),
+                         birthday: Date.parse("1950-01-01"), avatar: StringIO.new("image"),
+                         project_ids: [1, 2, 3]
 
     data.must_be_kind_of Google::Cloud::Spanner::Data
 
     data.fields.wont_be :nil?
     data.fields.must_be_kind_of Google::Cloud::Spanner::Fields
-    data.fields.keys.count.must_equal 8
+    data.fields.keys.count.must_equal 9
     data.fields.to_h.must_equal({ id: :INT64, name: :STRING, active: :BOOL, age: :INT64,
                                  score: :FLOAT64, updated_at: :TIMESTAMP, birthday: :DATE,
-                                 avatar: :BYTES }) #project_ids: [:INT64]
+                                 avatar: :BYTES, project_ids: [:INT64] })
 
     data.fields.to_s.wont_be :empty?
     data.fields.inspect.must_match /Google::Cloud::Spanner::Fields/
 
-    data.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar] # , :project_ids
+    data.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
     data_values = data.values
     data_values[0].must_equal 1
     data_values[1].must_equal "Charlie"
@@ -47,7 +47,7 @@ describe Google::Cloud::Spanner::Fields, :data do
     data_values[6].must_equal Date.parse("1950-01-01")
     data_values[7].must_be_kind_of StringIO
     data_values[7].read.must_equal "image"
-    # data_values[8].must_equal [1, 2, 3]
+    data_values[8].must_equal [1, 2, 3]
 
     data[:id].must_equal 1
     data[:name].must_equal "Charlie"
@@ -58,7 +58,7 @@ describe Google::Cloud::Spanner::Fields, :data do
     data[:birthday].must_equal Date.parse("1950-01-01")
     data[:avatar].must_be_kind_of StringIO
     data[:avatar].read.must_equal "image"
-    # data[:project_ids].must_equal [1, 2, 3]
+    data[:project_ids].must_equal [1, 2, 3]
 
     data[0].must_equal 1
     data[1].must_equal "Charlie"
@@ -69,7 +69,7 @@ describe Google::Cloud::Spanner::Fields, :data do
     data[6].must_equal Date.parse("1950-01-01")
     data[7].must_be_kind_of StringIO
     data[7].read.must_equal "image"
-    # data[8].must_equal [1, 2, 3]
+    data[8].must_equal [1, 2, 3]
 
     data_hash = data.to_h
     data_hash[:id].must_equal 1
@@ -81,7 +81,7 @@ describe Google::Cloud::Spanner::Fields, :data do
     data_hash[:birthday].must_equal Date.parse("1950-01-01")
     data_hash[:avatar].must_be_kind_of StringIO
     data_hash[:avatar].read.must_equal "image"
-    # data_hash[:project_ids].must_equal [1, 2, 3]
+    data_hash[:project_ids].must_equal [1, 2, 3]
 
     data_array = data.to_a
     data_array[0].must_equal 1
@@ -93,7 +93,7 @@ describe Google::Cloud::Spanner::Fields, :data do
     data_array[6].must_equal Date.parse("1950-01-01")
     data_array[7].must_be_kind_of StringIO
     data_array[7].read.must_equal "image"
-    # data_array[8].must_equal [1, 2, 3]
+    data_array[8].must_equal [1, 2, 3]
 
     data.to_s.wont_be :empty?
     data.inspect.must_match /Google::Cloud::Spanner::Data/

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
@@ -94,4 +94,25 @@ describe Google::Cloud::Spanner::Fields, :initializer do
     fields.to_a.must_equal [:INT64, :STRING, :BOOL]
     fields.to_h.must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
   end
+
+  it "raises when creating duplicate positions" do
+    err = expect do
+      fields = Google::Cloud::Spanner::Fields.new [[-1, :INT64], [:name, :STRING], [2, :BOOL]]
+    end.must_raise ArgumentError
+    err.message.must_equal "cannot specify position less than 0"
+  end
+
+  it "raises when creating duplicate positions" do
+    err = expect do
+      fields = Google::Cloud::Spanner::Fields.new [[0, :INT64], [:name, :STRING], [3, :BOOL]]
+    end.must_raise ArgumentError
+    err.message.must_equal "cannot specify position more than field count"
+  end
+
+  it "raises when creating duplicate positions" do
+    err = expect do
+      fields = Google::Cloud::Spanner::Fields.new [[0, :INT64], [:name, :STRING], [0, :BOOL]]
+    end.must_raise ArgumentError
+    err.message.must_equal "cannot specify position more than once"
+  end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/initializer_test.rb
@@ -46,13 +46,12 @@ describe Google::Cloud::Spanner::Fields, :initializer do
   end
 
   it "creates with an unsorted mixed array of fields" do
-    skip "Not yet implemented"
     fields = Google::Cloud::Spanner::Fields.new [[:name, :STRING], :BOOL, [0, :INT64]]
 
     fields.types.must_equal [:INT64, :STRING, :BOOL]
     fields.keys.must_equal [0, :name, 2]
     fields.pairs.must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
-    fields.to_a.must_equal [:INT64, [:name, :STRING], :BOOL]
+    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
     fields.to_h.must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
   end
 
@@ -87,13 +86,12 @@ describe Google::Cloud::Spanner::Fields, :initializer do
   end
 
   it "creates with an unsorted mixed hash of fields" do
-    skip "Not yet implemented"
     fields = Google::Cloud::Spanner::Fields.new name: :STRING, 2=>:BOOL, 0=>:INT64
 
     fields.types.must_equal [:INT64, :STRING, :BOOL]
     fields.keys.must_equal [0, :name, 2]
     fields.pairs.must_equal [[0, :INT64], [:name, :STRING], [2, :BOOL]]
-    fields.to_a.must_equal [:INT64, [:name, :STRING], :BOOL]
+    fields.to_a.must_equal [:INT64, :STRING, :BOOL]
     fields.to_h.must_equal({ 0=>:INT64, name: :STRING, 2=>:BOOL })
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/fields/struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/fields/struct_test.rb
@@ -1,0 +1,264 @@
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Fields, :struct do
+  let(:fields_unnamed_array) { [:INT64, :STRING, :BOOL, :INT64, :FLOAT64, :TIMESTAMP, :DATE, :BYTES, [:INT64]] }
+  let(:fields_named_array) { [[:id, :INT64], [:name, :STRING], [:active, :BOOL], [:age, :INT64], [:score, :FLOAT64], [:updated_at, :TIMESTAMP], [:birthday, :DATE], [:avatar, :BYTES], [:project_ids, [:INT64]]] }
+  let(:fields_named_hash) { { id: :INT64, name: :STRING, active: :BOOL, age: :INT64, score: :FLOAT64, updated_at: :TIMESTAMP, birthday: :DATE, avatar: :BYTES, project_ids: [:INT64] } }
+  let(:fields_unnamed_hash) { { 0 => :INT64, 1 => :STRING, 2 => :BOOL, 3 => :INT64, 4 => :FLOAT64, 5 => :TIMESTAMP, 6 => :DATE, 7 => :BYTES, 8 => [:INT64] } }
+  let(:data_array) { [1, "Charlie", true, 29, 0.9, Time.parse("2017-01-02T03:04:05.060000000Z"), Date.parse("1950-01-01"), StringIO.new("image"), [1, 2, 3]] }
+  let(:data_named_hash) { { id: 1, name: "Charlie", active: true, age: 29, score: 0.9, updated_at: Time.parse("2017-01-02T03:04:05.060000000Z"), birthday: Date.parse("1950-01-01"), avatar: StringIO.new("image"), project_ids: [1, 2, 3] } }
+  let(:data_unnamed_hash) { { 0 => 1, 1 => "Charlie", 2 => true, 3 => 29, 4 => 0.9, 5 => Time.parse("2017-01-02T03:04:05.060000000Z"), 6 => Date.parse("1950-01-01"), 7 => StringIO.new("image"), 8 => [1, 2, 3] } }
+
+  it "creates with an unnamed array of fields and an array of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_unnamed_array
+
+    data = fields.struct data_array
+
+    assert_unnamed_struct data
+  end
+
+  it "creates with an named array of fields and an array of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_named_array
+
+    data = fields.struct data_array
+
+    assert_named_struct data
+  end
+
+  it "creates with an unnamed array of fields and a named hash of values" do
+    skip "Cannot create with an unnamed array of fields and a named hash of values, " \
+         "because the value hash keys have names and don't match the fields."
+    fields = Google::Cloud::Spanner::Fields.new fields_unnamed_array
+
+    data = fields.struct data_named_hash
+
+    assert_unnamed_struct data
+  end
+
+  it "creates with an unnamed array of fields and an unnamed hash of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_unnamed_array
+
+    data = fields.struct data_unnamed_hash
+
+    assert_unnamed_struct data
+  end
+
+  it "creates with a named array of fields and a named hash of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_named_array
+
+    data = fields.struct data_named_hash
+
+    assert_named_struct data
+  end
+
+  it "creates with a named array of fields and an unnamed hash of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_named_array
+
+    data = fields.struct data_unnamed_hash
+
+    assert_named_struct data
+  end
+
+  it "creates with a named hash of fields and an array of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_named_hash
+
+    data = fields.struct data_array
+
+    assert_named_struct data
+  end
+
+  it "creates with an unnamed hash of fields and an array of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_unnamed_hash
+
+    data = fields.struct data_array
+
+    assert_unnamed_struct data
+  end
+
+  it "creates with a named hash of fields and a named hash of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_named_hash
+
+    data = fields.struct data_named_hash
+
+    assert_named_struct data
+  end
+
+  it "creates with a named hash of fields and an unnamed hash of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_named_hash
+
+    data = fields.struct data_unnamed_hash
+
+    assert_named_struct data
+  end
+
+  it "creates with an unnamed hash of fields and a named hash of values" do
+    skip "Cannot create with an unnamed hash of fields and a named hash of values, " \
+         "because the value hash keys have names and don't match the fields hash keys."
+    fields = Google::Cloud::Spanner::Fields.new fields_unnamed_hash
+
+    data = fields.struct data_named_hash
+
+    assert_unnamed_struct data
+  end
+
+  it "creates with an unnamed hash of fields and an unnamed hash of values" do
+    fields = Google::Cloud::Spanner::Fields.new fields_unnamed_hash
+
+    data = fields.struct data_unnamed_hash
+
+    assert_unnamed_struct data
+  end
+
+  def assert_unnamed_struct data
+    data.must_be_kind_of Google::Cloud::Spanner::Data
+
+    data.fields.wont_be :nil?
+    data.fields.must_be_kind_of Google::Cloud::Spanner::Fields
+    data.fields.keys.count.must_equal 9
+    data.fields.to_a.must_equal fields_unnamed_array
+    data.fields.to_h.must_equal fields_unnamed_hash
+
+    data.fields.to_s.wont_be :empty?
+    data.fields.inspect.must_match /Google::Cloud::Spanner::Fields/
+
+    data.keys.must_equal [0, 1, 2, 3, 4, 5, 6, 7, 8]
+    data_values = data.values
+    data_values[0].must_equal 1
+    data_values[1].must_equal "Charlie"
+    data_values[2].must_equal true
+    data_values[3].must_equal 29
+    data_values[4].must_equal 0.9
+    data_values[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    data_values[6].must_equal Date.parse("1950-01-01")
+    data_values[7].must_be_kind_of StringIO
+    data_values[7].read.must_equal "image"
+    data_values[8].must_equal [1, 2, 3]
+
+    data[0].must_equal 1
+    data[1].must_equal "Charlie"
+    data[2].must_equal true
+    data[3].must_equal 29
+    data[4].must_equal 0.9
+    data[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    data[6].must_equal Date.parse("1950-01-01")
+    data[7].must_be_kind_of StringIO
+    data[7].read.must_equal "image"
+    data[8].must_equal [1, 2, 3]
+
+    data_hash = data.to_h
+    data_hash[0].must_equal 1
+    data_hash[1].must_equal "Charlie"
+    data_hash[2].must_equal true
+    data_hash[3].must_equal 29
+    data_hash[4].must_equal 0.9
+    data_hash[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    data_hash[6].must_equal Date.parse("1950-01-01")
+    data_hash[7].must_be_kind_of StringIO
+    data_hash[7].read.must_equal "image"
+    data_hash[8].must_equal [1, 2, 3]
+
+    data_array = data.to_a
+    data_array[0].must_equal 1
+    data_array[1].must_equal "Charlie"
+    data_array[2].must_equal true
+    data_array[3].must_equal 29
+    data_array[4].must_equal 0.9
+    data_array[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    data_array[6].must_equal Date.parse("1950-01-01")
+    data_array[7].must_be_kind_of StringIO
+    data_array[7].read.must_equal "image"
+    data_array[8].must_equal [1, 2, 3]
+
+    data.to_s.wont_be :empty?
+    data.inspect.must_match /Google::Cloud::Spanner::Data/
+  end
+
+  def assert_named_struct data
+    data.must_be_kind_of Google::Cloud::Spanner::Data
+
+    data.fields.wont_be :nil?
+    data.fields.must_be_kind_of Google::Cloud::Spanner::Fields
+    data.fields.keys.count.must_equal 9
+    data.fields.to_a.must_equal fields_unnamed_array
+    data.fields.to_h.must_equal fields_named_hash
+
+    data.fields.to_s.wont_be :empty?
+    data.fields.inspect.must_match /Google::Cloud::Spanner::Fields/
+
+    data.keys.must_equal [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+    data_values = data.values
+    data_values[0].must_equal 1
+    data_values[1].must_equal "Charlie"
+    data_values[2].must_equal true
+    data_values[3].must_equal 29
+    data_values[4].must_equal 0.9
+    data_values[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    data_values[6].must_equal Date.parse("1950-01-01")
+    data_values[7].must_be_kind_of StringIO
+    data_values[7].read.must_equal "image"
+    data_values[8].must_equal [1, 2, 3]
+
+    data[:id].must_equal 1
+    data[:name].must_equal "Charlie"
+    data[:active].must_equal true
+    data[:age].must_equal 29
+    data[:score].must_equal 0.9
+    data[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    data[:birthday].must_equal Date.parse("1950-01-01")
+    data[:avatar].must_be_kind_of StringIO
+    data[:avatar].read.must_equal "image"
+    data[:project_ids].must_equal [1, 2, 3]
+
+    data[0].must_equal 1
+    data[1].must_equal "Charlie"
+    data[2].must_equal true
+    data[3].must_equal 29
+    data[4].must_equal 0.9
+    data[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    data[6].must_equal Date.parse("1950-01-01")
+    data[7].must_be_kind_of StringIO
+    data[7].read.must_equal "image"
+    data[8].must_equal [1, 2, 3]
+
+    data_hash = data.to_h
+    data_hash[:id].must_equal 1
+    data_hash[:name].must_equal "Charlie"
+    data_hash[:active].must_equal true
+    data_hash[:age].must_equal 29
+    data_hash[:score].must_equal 0.9
+    data_hash[:updated_at].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    data_hash[:birthday].must_equal Date.parse("1950-01-01")
+    data_hash[:avatar].must_be_kind_of StringIO
+    data_hash[:avatar].read.must_equal "image"
+    data_hash[:project_ids].must_equal [1, 2, 3]
+
+    data_array = data.to_a
+    data_array[0].must_equal 1
+    data_array[1].must_equal "Charlie"
+    data_array[2].must_equal true
+    data_array[3].must_equal 29
+    data_array[4].must_equal 0.9
+    data_array[5].must_equal Time.parse("2017-01-02T03:04:05.060000000Z")
+    data_array[6].must_equal Date.parse("1950-01-01")
+    data_array[7].must_be_kind_of StringIO
+    data_array[7].read.must_equal "image"
+    data_array[8].must_equal [1, 2, 3]
+
+    data.to_s.wont_be :empty?
+    data.inspect.must_match /Google::Cloud::Spanner::Data/
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/anonymous_struct_test.rb
@@ -45,8 +45,8 @@ describe Google::Cloud::Spanner::Results, :anonymous_struct, :mock_spanner do
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
     results.fields.keys.must_equal [0]
     results.fields.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new([:INT64, :INT64])]]]
-    results.fields.to_a.must_equal [[{ 0 => :INT64, 1 => :INT64 }]]
-    results.fields.to_h.must_equal({ 0=> [{ 0 => :INT64, 1 => :INT64 }] })
+    results.fields.to_a.must_equal [[Google::Cloud::Spanner::Fields.new([:INT64, :INT64])]]
+    results.fields.to_h.must_equal({ 0 => [Google::Cloud::Spanner::Fields.new([:INT64, :INT64])] })
 
     rows = results.rows.to_a # grab them all from the enumerator
     rows.count.must_equal 1

--- a/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/deeply_nested_list_test.rb
@@ -183,8 +183,8 @@ describe Google::Cloud::Spanner::Results, :deeply_nested_list, :mock_spanner do
     results.fields.wont_be :nil?
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
     results.fields.keys.must_equal [0]
-    results.fields.to_a.must_equal [[{ name: :STRING, numbers: [:INT64], strings: [:STRING] }]]
-    results.fields.to_h.must_equal({ 0 => [{ name: :STRING, numbers: [:INT64], strings: [:STRING] }] })
+    results.fields.to_a.must_equal [[Google::Cloud::Spanner::Fields.new({ name: :STRING, numbers: [:INT64], strings: [:STRING] })]]
+    results.fields.to_h.must_equal({ 0 => [Google::Cloud::Spanner::Fields.new({ name: :STRING, numbers: [:INT64], strings: [:STRING] })] })
 
     rows = results.rows.to_a # grab them all from the enumerator
     rows.count.must_equal 1

--- a/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/duplicate_struct_test.rb
@@ -45,12 +45,8 @@ describe Google::Cloud::Spanner::Results, :duplicate_struct, :mock_spanner do
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
     results.fields.keys.must_equal [0]
     results.fields.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]])]]]
-    assert_raises Google::Cloud::Spanner::DuplicateNameError do
-      results.fields.to_a
-    end
-    assert_raises Google::Cloud::Spanner::DuplicateNameError do
-      results.fields.to_h
-    end
+    results.fields.to_a.must_equal [[Google::Cloud::Spanner::Fields.new([[:num, :INT64], [:num, :INT64]])]]
+    results.fields.to_h
 
     rows = results.rows.to_a # grab them all from the enumerator
     rows.count.must_equal 1

--- a/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/results/nested_struct_test.rb
@@ -46,19 +46,19 @@ describe Google::Cloud::Spanner::Results, :nested_struct, :mock_spanner do
     results.fields.wont_be :nil?
     results.fields.must_be_kind_of Google::Cloud::Spanner::Fields
     results.fields.keys.must_equal [0]
-    results.fields.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new([[:C1, :STRING], [:C2, :INT64]])]]]
-    results.fields.to_a.must_equal [[{ C1: :STRING, C2: :INT64 }]]
-    results.fields.to_h.must_equal({ 0=> [{ C1: :STRING, C2: :INT64 }] })
+    results.fields.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 })]]]
+    results.fields.to_a.must_equal [[Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 })]]
+    results.fields.to_h.must_equal({ 0 => [Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 })] })
 
     rows = results.rows.to_a # grab them all from the enumerator
     rows.count.must_equal 1
     row = rows.first
     row.must_be_kind_of Google::Cloud::Spanner::Data
     row.keys.must_equal [0]
-    row.values.must_equal [[Google::Cloud::Spanner::Fields.new([[:C1, :STRING], [:C2, :INT64]]).new(["a", 1]),
-                            Google::Cloud::Spanner::Fields.new([[:C1, :STRING], [:C2, :INT64]]).new(["b", 2])]]
-    row.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new([[:C1, :STRING], [:C2, :INT64]]).new(["a", 1]),
-                               Google::Cloud::Spanner::Fields.new([[:C1, :STRING], [:C2, :INT64]]).new(["b", 2])]]]
+    row.values.must_equal [[Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["a", 1]),
+                            Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["b", 2])]]
+    row.pairs.must_equal [[0, [Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["a", 1]),
+                               Google::Cloud::Spanner::Fields.new({ C1: :STRING, C2: :INT64 }).new(["b", 2])]]]
     row.to_a.must_equal [[{ C1: "a", C2: 1 }, { C1: "b", C2: 2 }]]
     row.to_h.must_equal({ 0 => [{ C1: "a", C2: 1 }, { C1: "b", C2: 2 }] })
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
@@ -31,32 +31,32 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         insert: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([2, "Harvey", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([2, "Harvey", true]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         insert_or_update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         replace: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([4, "Henry", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([4, "Henry", true]).list_value]
         )
       ),
       Google::Spanner::V1::Mutation.new(
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [1, 2, 3, 4, 5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )
@@ -84,7 +84,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([1, "Charlie", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
         )
       )
     ]
@@ -104,7 +104,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         insert: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([2, "Harvey", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([2, "Harvey", true]).list_value]
         )
       )
     ]
@@ -124,7 +124,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         insert_or_update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
         )
       )
     ]
@@ -144,7 +144,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         insert_or_update: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([3, "Marley", false]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
         )
       )
     ]
@@ -164,7 +164,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
       Google::Spanner::V1::Mutation.new(
         replace: Google::Spanner::V1::Mutation::Write.new(
           table: "users", columns: %w(id name active),
-          values: [Google::Cloud::Spanner::Convert.raw_to_value([4, "Henry", true]).list_value]
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([4, "Henry", true]).list_value]
         )
       )
     ]
@@ -185,7 +185,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [1, 2, 3, 4, 5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )
@@ -229,7 +229,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
         delete: Google::Spanner::V1::Mutation::Delete.new(
           table: "users", key_set: Google::Spanner::V1::KeySet.new(
             keys: [5].map do |i|
-              Google::Cloud::Spanner::Convert.raw_to_value([i]).list_value
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
             end
           )
         )

--- a/google-cloud-spanner/test/google/cloud/spanner/session/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/execute_test.rb
@@ -194,10 +194,8 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
   end
 
   it "can execute a query with a simple Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     params, types = params_types({ dict: { env: :production } })
@@ -209,10 +207,8 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
   end
 
   it "can execute a query with a complex Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     params, types = params_types({ dict: { env: "production", score: 0.9, project_ids: [1,2,3] } })
@@ -224,10 +220,8 @@ describe Google::Cloud::Spanner::Session, :execute, :mock_spanner do
   end
 
   it "can execute a query with an empty Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     params, types = params_types({ dict: { } })

--- a/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
@@ -85,7 +85,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
 
   it "can read rows by id" do
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", columns, Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", columns, Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns, keys: key_set([1, 2, 3])
@@ -97,7 +97,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
 
   it "can read rows with index" do
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", columns, Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", columns, Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1,1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2,2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns, keys: key_set([[1,1], [2,2], [3,3]]), index: "MyTableCompositeKey"
@@ -134,7 +134,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
 
   it "can read just one row with limit" do
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session.path, "my-table", columns, Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session.path, "my-table", columns, Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = session.read "my-table", columns, keys: key_set(1), limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
@@ -189,10 +189,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   end
 
   it "can execute a query with a simple Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -203,10 +201,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   end
 
   it "can execute a query with a complex Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -217,10 +213,8 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
   end
 
   it "can execute a query with an empty Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_test.rb
@@ -212,6 +212,31 @@ describe Google::Cloud::Spanner::Snapshot, :execute, :mock_spanner do
     assert_results results
   end
 
+  it "can execute a query with an Array of Hashes" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    results = snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query with an Array of STRUCTs" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    struct_fields = snapshot.fields name: :STRING, email: :STRING
+    results = snapshot.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session.path, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -92,7 +92,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, keys: [1, 2, 3]
@@ -106,7 +106,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1,1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2,2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
@@ -149,7 +149,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = snapshot.read "my-table", columns, keys: 1, limit: 1

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
@@ -189,10 +189,8 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   end
 
   it "can execute a query with a simple Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {"env"=>Google::Protobuf::Value.new(string_value: "production")})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: :production } }
@@ -203,10 +201,8 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   end
 
   it "can execute a query with a complex Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9), "env" => Google::Protobuf::Value.new(string_value: "production"), "project_ids" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) })) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { env: "production", score: 0.9, project_ids: [1,2,3] } }
@@ -217,10 +213,8 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
   end
 
   it "can execute a query with an empty Hash param" do
-    skip "Spanner does not accept STRUCT values in query parameters"
-
     mock = Minitest::Mock.new
-    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(struct_value: Google::Protobuf::Struct.new(fields: {})) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.execute "SELECT * FROM users WHERE settings = @dict", params: { dict: { } }

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_test.rb
@@ -212,6 +212,33 @@ describe Google::Cloud::Spanner::Transaction, :execute, :mock_spanner do
     assert_results results
   end
 
+  it "can execute a query with an Array of Hashes" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, options: default_options]
+
+    session.service.mocked_service = mock
+
+    results = transaction.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [{ name: "mike", email: "mike@example.net" }, { name: "chris", email: "chris@example.net" }] }
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can execute a query with an Array of STRUCTs" do
+    mock = Minitest::Mock.new
+    mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, options: default_options]
+
+    session.service.mocked_service = mock
+
+    struct_fields = transaction.fields name: :STRING, email: :STRING
+    results = transaction.execute "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", params: { data: [struct_fields.data(["mike", "mike@example.net"]), struct_fields.data(["chris","chris@example.net"])] }
+
+    mock.verify
+
+    assert_results results
+  end
+
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: tx_selector, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -92,7 +92,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3]).list_value]), transaction: tx_selector, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, keys: [1, 2, 3]
@@ -106,7 +106,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1,1]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([2,2]).list_value, Google::Cloud::Spanner::Convert.raw_to_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1,1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2,2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3,3]).list_value]), transaction: tx_selector, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, keys: [[1,1], [2,2], [3,3]], index: "MyTableCompositeKey"
@@ -149,7 +149,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.raw_to_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value]), transaction: tx_selector, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
     session.service.mocked_service = mock
 
     results = transaction.read "my-table", columns, keys: 1, limit: 1


### PR DESCRIPTION
This PR adds support for defining and using STRUCT query parameters.

This can be done by sending a Ruby `Hash` of values as a query parameter.

```ruby
require "google/cloud/spanner"

spanner = Google::Cloud::Spanner.new

db = spanner.client "my-instance", "my-database"

results = db.execute "SELECT * FROM users WHERE " \
                     "ID = @user_struct.id " \
                     "AND name = @user_struct.name " \
                     "AND active = @user_struct.active",
                     params: { user_struct: { id: 1, name: "Charlie", active: false } }

results.rows.each do |row|
  puts "User #{row[:id]} is #{row[:name]}"
end
```

Or, the STRUCT can be defined using a `Fields` object and passing values to `Fields#struct`:

```ruby
require "google/cloud/spanner"

spanner = Google::Cloud::Spanner.new

db = spanner.client "my-instance", "my-database"

user_type = db.fields id: :INT64, name: :STRING, active: :BOOL
user_struct = user_type.struct({ id: 1, name: "Charlie", active: false })

results = db.execute "SELECT * FROM users WHERE " \
                     "ID = @user_struct.id " \
                     "AND name = @user_struct.name " \
                     "AND active = @user_struct.active",
                     params: { user_struct: user_struct }

results.rows.each do |row|
  puts "User #{row[:id]} is #{row[:name]}"
end
```

This allows users to create STRUCT values that cannot be defined using a Ruby `Hash`.  e.g. anonymous fields, duplicate field names, etc.

This functionality is not yet widely available, so this PR should not be merged until it is. But it should be reviewed now.