### PR TITLE
Facilitate partial file downloads

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -367,6 +367,20 @@ describe Google::Cloud::Storage::File, :storage do
     end
   end
 
+  it "should upload and partially download text" do
+    inmemory = StringIO.new "Hello world!"
+    uploaded = bucket.create_file inmemory, "uploaded/with/inmemory.png"
+
+    downloaded = uploaded.download range: "bytes=3-6"
+    downloaded.must_be_kind_of StringIO
+
+    downloaded.rewind
+    downloaded.read.must_equal "lo w"
+    downloaded.read.encoding.must_equal inmemory.read.encoding
+
+    uploaded.delete
+  end
+
   it "should upload and download a file with customer-supplied encryption key" do
     original = File.new files[:logo][:path], "rb"
     uploaded = bucket.create_file original, "CloudLogo.png", encryption_key: encryption_key

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -371,7 +371,7 @@ describe Google::Cloud::Storage::File, :storage do
     inmemory = StringIO.new "Hello world!"
     uploaded = bucket.create_file inmemory, "uploaded/with/inmemory.png"
 
-    downloaded = uploaded.download range: "bytes=3-6"
+    downloaded = uploaded.download range: 3..6
     downloaded.must_be_kind_of StringIO
 
     downloaded.rewind

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -440,14 +440,14 @@ module Google
         #   AES-256 encryption key used to encrypt the file, if one was provided
         #   to {Bucket#create_file}.
         #
-        # @param [String] range Optional. The value to use in the Range header
-        #   of the download request. Provide this to perform a partial download.
-        #   When a range is provided, no verification is performed regardless of
-        #   the `verify` parameter's value.
+        # @param [Range] range Optional. The byte range of the file's contents
+        #   to download. Provide this to perform a partial download. When a
+        #   range is provided, no verification is performed regardless of the
+        #   `verify` parameter's value.
         #
         #   Infinite range values are not supported. The provided range must
-        #   have a finite beginning and end. For example, "bytes=3-6" is
-        #   acceptable, while "bytes=3-" is not.
+        #   have a finite beginning and end. For example, `3..6` is acceptable,
+        #   while `3..` and `..6` are not.
         #
         # @param [Boolean] skip_decompress Optional. If `true`, the data for a
         #   Storage object returning a `Content-Encoding: gzip` response header

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -561,9 +561,9 @@ module Google
         #   bucket = storage.bucket "my-bucket"
         #   file = bucket.file "path/to/my-file.ext"
         #
-        #   downloaded = file.download range: 3..6
+        #   downloaded = file.download range: 6..10
         #   downloaded.rewind
-        #   downloaded.read #=> "Hello world!"
+        #   downloaded.read #=> "world"
         #
         def download path = nil, verify: :md5, encryption_key: nil, range: nil,
                      skip_decompress: nil

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -561,9 +561,9 @@ module Google
         #   bucket = storage.bucket "my-bucket"
         #   file = bucket.file "path/to/my-file.ext"
         #
-        #   downloaded = file.download range: "bytes=3-6"
+        #   downloaded = file.download range: 3..6
         #   downloaded.rewind
-        #   downloaded.read #=> "lo w"
+        #   downloaded.read #=> "Hello world!"
         #
         def download path = nil, verify: :md5, encryption_key: nil, range: nil,
                      skip_decompress: nil

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -440,14 +440,11 @@ module Google
         #   AES-256 encryption key used to encrypt the file, if one was provided
         #   to {Bucket#create_file}.
         #
-        # @param [Range] range Optional. The byte range of the file's contents
-        #   to download. Provide this to perform a partial download. When a
-        #   range is provided, no verification is performed regardless of the
-        #   `verify` parameter's value.
-        #
-        #   Infinite range values are not supported. The provided range must
-        #   have a finite beginning and end. For example, `3..6` is acceptable,
-        #   while `3..` and `..6` are not.
+        # @param [Range, String] range Optional. The byte range of the file's
+        #   contents to download or a string header value. Provide this to
+        #   perform a partial download. When a range is provided, no
+        #   verification is performed regardless of the `verify` parameter's
+        #   value.
         #
         # @param [Boolean] skip_decompress Optional. If `true`, the data for a
         #   Storage object returning a `Content-Encoding: gzip` response header

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -484,9 +484,13 @@ module Google
         end
 
         def range_header options, range
-          if range
+          case range
+          when Range
             options[:header] ||= {}
             options[:header]["Range"] = "bytes=#{range.min}-#{range.max}"
+          when String
+            options[:header] ||= {}
+            options[:header]["Range"] = range
           end
 
           options

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -361,8 +361,14 @@ module Google
         #     Apis::StorageV1::StorageService and Apis::Core::DownloadCommand at
         #     the end of this file.
         def download_file bucket_name, file_path, target_path, generation: nil,
-                          key: nil, user_project: nil
+                          key: nil, range: nil, user_project: nil
           options = key_options key
+
+          if range
+            options[:header] ||= {}
+            options[:header]["Range"] = range
+          end
+
           execute do
             service.get_object_with_response \
               bucket_name, file_path,

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -363,11 +363,7 @@ module Google
         def download_file bucket_name, file_path, target_path, generation: nil,
                           key: nil, range: nil, user_project: nil
           options = key_options key
-
-          if range
-            options[:header] ||= {}
-            options[:header]["Range"] = range
-          end
+          options = range_header options, range
 
           execute do
             service.get_object_with_response \
@@ -484,6 +480,15 @@ module Google
           headers["x-goog-#{source}encryption-key"] = Base64.strict_encode64 key
           headers["x-goog-#{source}encryption-key-sha256"] = \
             Base64.strict_encode64 key_sha256
+          options
+        end
+
+        def range_header options, range
+          if range
+            options[:header] ||= {}
+            options[:header]["Range"] = "bytes=#{range.min}-#{range.max}"
+          end
+
           options
         end
 

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -62,11 +62,11 @@ module Google
         end
       end
       class File
-        def download path = nil, verify: :md5, encryption_key: nil, range: nil,
-                     skip_decompress: nil
-          # no-op stub, but ensures that calls match this copied signature
-          return StringIO.new("Hello world!") if path.nil?
+        def download path = nil, verify: :md5, encryption_key: nil,
+                     range: 0..-1, skip_decompress: nil
+          StringIO.new("Hello world!"[range]) if path.nil?
         end
+
         def signed_url method: nil, expires: nil, content_type: nil,
                        content_md5: nil, headers: nil, issuer: nil,
                        client_email: nil, signing_key: nil, private_key: nil

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -62,7 +62,8 @@ module Google
         end
       end
       class File
-        def download path = nil, verify: :md5, encryption_key: nil, skip_decompress: nil
+        def download path = nil, verify: :md5, encryption_key: nil, range: nil,
+                     skip_decompress: nil
           # no-op stub, but ensures that calls match this copied signature
           return StringIO.new("Hello world!") if path.nil?
         end

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -374,7 +374,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     end
   end
 
-  it "can partially download itself" do
+  it "can partially download itself with a range" do
     Tempfile.open "google-cloud" do |tmpfile|
       mock = Minitest::Mock.new
       mock.expect :get_object_with_response, [tmpfile, download_http_resp],
@@ -383,6 +383,21 @@ describe Google::Cloud::Storage::File, :mock_storage do
       bucket.service.mocked_service = mock
 
       downloaded = file.download tmpfile, range: 3..6
+      downloaded.path.must_equal tmpfile.path
+
+      mock.verify
+    end
+  end
+
+  it "can partially download itself with a string" do
+    Tempfile.open "google-cloud" do |tmpfile|
+      mock = Minitest::Mock.new
+      mock.expect :get_object_with_response, [tmpfile, download_http_resp],
+        [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: { header: { 'Range' => 'bytes=-6' }}]
+
+      bucket.service.mocked_service = mock
+
+      downloaded = file.download tmpfile, range: 'bytes=-6'
       downloaded.path.must_equal tmpfile.path
 
       mock.verify

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -374,6 +374,21 @@ describe Google::Cloud::Storage::File, :mock_storage do
     end
   end
 
+  it "can partially download itself" do
+    Tempfile.open "google-cloud" do |tmpfile|
+      mock = Minitest::Mock.new
+      mock.expect :get_object, tmpfile,
+        [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: { header: { 'Range' => 'bytes=3-6' }}]
+
+      bucket.service.mocked_service = mock
+
+      downloaded = file.download tmpfile, range: 'bytes=3-6'
+      downloaded.path.must_equal tmpfile.path
+
+      mock.verify
+    end
+  end
+
   describe "verified downloads" do
     it "verifies m5d by default" do
       # Stub these values

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -377,12 +377,12 @@ describe Google::Cloud::Storage::File, :mock_storage do
   it "can partially download itself" do
     Tempfile.open "google-cloud" do |tmpfile|
       mock = Minitest::Mock.new
-      mock.expect :get_object, tmpfile,
+      mock.expect :get_object_with_response, [tmpfile, download_http_resp],
         [bucket.name, file.name, download_dest: tmpfile, generation: nil, user_project: nil, options: { header: { 'Range' => 'bytes=3-6' }}]
 
       bucket.service.mocked_service = mock
 
-      downloaded = file.download tmpfile, range: 'bytes=3-6'
+      downloaded = file.download tmpfile, range: 3..6
       downloaded.path.must_equal tmpfile.path
 
       mock.verify


### PR DESCRIPTION
[Active Storage](https://github.com/rails/rails/tree/master/activestorage) requires partial download support from each of the clients it uses in order to:
* Peek at objects for content type identification purposes without downloading them in full
* Stream objects from cloud storage to tempfiles on disk in a consistent manner across all services

The Google Cloud Storage client, unlike the other clients Active Storage uses, does not provide this support. We currently work around the lack of partial download support by [manually](https://github.com/rails/rails/blob/3e8c660c11df5f650109fb44d060ea7eb0c7ea26/activestorage/lib/active_storage/service/gcs_service.rb#L51-L56) issuing a GET request with a `Range` header to a signed URL:

```ruby
file = file_for(key)
uri  = URI(file.signed_url(expires: 30.seconds))

Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |client|
  client.get(uri, "Range" => "bytes=#{range.begin}-#{range.exclude_end? ? range.end - 1 : range.end}").body
end
```

Because we bypass the GCS client, we miss out on authenticated downloading, connection reuse, error handling, and more. This PR adds partial download support to the client, reducing the code above to the following:

```ruby
file_for(key).download(range: range).string
```