### PR TITLE
Storage: Protect against duplicate members on a Policy role

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/policy.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/policy.rb
@@ -189,7 +189,7 @@ module Google
               next if roles[role_name].empty?
               Google::Apis::StorageV1::Policy::Binding.new(
                 role: role_name,
-                members: roles[role_name]
+                members: roles[role_name].uniq
               )
             end
           )

--- a/google-cloud-storage/test/google/cloud/storage/policy_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/policy_test.rb
@@ -35,6 +35,22 @@ describe Google::Cloud::Storage::Policy do
     role.frozen?.must_equal false
   end
 
+  describe :to_gapi do
+    it "creates a Google::Apis::StorageV1::Policy object with the equivalent deduped roles" do
+      # Add a duplicate entry.
+      existing_role, existing_members = policy.roles.first
+      policy.add(existing_role, existing_members.first)
+
+      gapi_policy = policy.to_gapi
+
+      gapi_policy.class.must_equal Google::Apis::StorageV1::Policy
+      gapi_policy.bindings.size.must_equal policy.roles.size
+      gapi_policy.bindings.each do |binding|
+        binding.members.sort.must_equal policy.roles[binding.role].uniq.sort
+      end
+    end
+  end
+
   describe :from_gapi do
     it "creates from a typical Google::Apis::StorageV1::Policy object" do
       gapi = Google::Apis::StorageV1::Policy.new(


### PR DESCRIPTION
The API will reject requests to add a role that already exists.  This has caused us to liter our code with this check every time we're adding a new role.  Figured it would be better to just contribute to the library directly.