### PR TITLE
Capture env["rack.exception"] errors from Rack env

### DIFF
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -24,6 +24,8 @@ module Google
       # to Stackdriver Error Reporting.
       #
       class Middleware
+        EXCEPTION_KEYS = ["sinatra.error", "rack.exception"].freeze
+
         # A Google::Cloud::ErrorReporting::Project client used to report
         # error events.
         attr_reader :error_reporting
@@ -76,8 +78,13 @@ module Google
 
           # sinatra doesn't always raise the Exception, but it saves it in
           # env['sinatra.error']
-          if env["sinatra.error"].is_a? Exception
-            report_exception env, env["sinatra.error"]
+          #
+          # some frameworks (i.e. hanami) will save a rendering exception in
+          # env['rack.exception']
+          EXCEPTION_KEYS.each do |exception_key|
+            next unless env[exception_key].is_a? Exception
+
+            report_exception env, env[exception_key]
           end
 
           response

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -133,6 +133,21 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
         end
       end
     end
+
+    it "also reports env['rack.exception'] if exists" do
+      stub_call = ->(env) {
+        env['rack.exception'] = app_exception
+      }
+      stub_report_exception = ->(_, exception) {
+        exception.message.must_equal app_exception_msg
+      }
+
+      rack_app.stub :call, stub_call do
+        middleware.stub :report_exception, stub_report_exception do
+          middleware.call rack_env
+        end
+      end
+    end
   end
 
   describe "#report_exception" do


### PR DESCRIPTION
Some frameworks, including Hanami, set the env["rack.exception"] key in Rack to
report an exception. This patch makes it so we check for that error in the
error_reporting middleware.

For more info, see:

- https://github.com/hanami/model/pull/485
- https://github.com/bugsnag/bugsnag-ruby/blob/fb9c0d7910d859edcf4d8e4d0cab8646f61b9e00/lib/bugsnag/integrations/rack.rb#L62