### PR TITLE
Guard against GCS rate limits

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -162,7 +162,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
   it "imports data from a list of files in your bucket with load_job" do
     begin
       more_data = rows.map { |row| JSON.generate row }.join("\n")
-      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket" }
       file1 = bucket.create_file local_file
       file2 = bucket.create_file StringIO.new(more_data),
                                  "more-kitten-test-data.json"
@@ -178,7 +178,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
       post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
       if post_bucket
         post_bucket.files.map &:delete
-        post_bucket.delete
+        safe_gcs_execute { post_bucket.delete }
       end
     end
   end
@@ -186,7 +186,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
   it "imports data from a list of files in your bucket with load" do
     begin
       more_data = rows.map { |row| JSON.generate row }.join("\n")
-      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket" }
       file1 = bucket.create_file local_file
       file2 = bucket.create_file StringIO.new(more_data),
                                  "more-kitten-test-data.json"
@@ -199,7 +199,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
       post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
       if post_bucket
         post_bucket.files.map &:delete
-        post_bucket.delete
+        safe_gcs_execute { post_bucket.delete }
       end
     end
   end

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -203,7 +203,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   it "imports data from a list of files in your bucket with load_job" do
     begin
       more_data = rows.map { |row| JSON.generate row }.join("\n")
-      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket" }
       file1 = bucket.create_file local_file
       file2 = bucket.create_file StringIO.new(more_data),
                                  "more-kitten-test-data.json"
@@ -219,7 +219,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
       if post_bucket
         post_bucket.files.map &:delete
-        post_bucket.delete
+        safe_gcs_execute { post_bucket.delete }
       end
     end
   end
@@ -256,7 +256,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   it "imports data from a list of files in your bucket with load" do
     begin
       more_data = rows.map { |row| JSON.generate row }.join("\n")
-      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket"
+      bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket" }
       file1 = bucket.create_file local_file
       file2 = bucket.create_file StringIO.new(more_data),
                                  "more-kitten-test-data.json"
@@ -269,7 +269,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
       post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
       if post_bucket
         post_bucket.files.map &:delete
-        post_bucket.delete
+        safe_gcs_execute { post_bucket.delete }
       end
     end
   end

--- a/google-cloud-bigquery/acceptance/bigquery/location_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/location_test.rb
@@ -103,7 +103,7 @@ describe Google::Cloud::Bigquery, :location, :bigquery do
 
   it "creates a load job with location" do
     begin
-      bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket", location: region
+      bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket", location: region }
       file = bucket.create_file local_file
 
       # Load the file to a dataset in the region with an load job in the region.
@@ -117,7 +117,7 @@ describe Google::Cloud::Bigquery, :location, :bigquery do
       post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
       if post_bucket
         post_bucket.files.map &:delete
-        post_bucket.delete
+        safe_gcs_execute { post_bucket.delete }
       end
     end
   end
@@ -186,7 +186,7 @@ describe Google::Cloud::Bigquery, :location, :bigquery do
 
       Tempfile.open "empty_extract_file.json" do |tmp|
         tmp.size.must_equal 0
-        bucket = Google::Cloud.storage.create_bucket "#{prefix}_bucket", location: region
+        bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket", location: region }
         extract_file = bucket.create_file tmp, "kitten-test-data-backup.json"
         job_id = "test_job_#{SecureRandom.urlsafe_base64(21)}" # client-generated
 
@@ -205,7 +205,7 @@ describe Google::Cloud::Bigquery, :location, :bigquery do
       post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
       if post_bucket
         post_bucket.files.map &:delete
-        post_bucket.delete
+        safe_gcs_execute { post_bucket.delete }
       end
     end
   end

--- a/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
@@ -35,12 +35,12 @@ describe Google::Cloud::Bigquery::External, :bigquery do
   let(:data_csv) { CSV.generate { |csv| data.each { |row| csv << row } } }
   let(:data_io) { StringIO.new data_csv }
   let(:storage) { Google::Cloud.storage }
-  let(:bucket) { Google::Cloud.storage.bucket("#{prefix}_external") || Google::Cloud.storage.create_bucket("#{prefix}_external") }
+  let(:bucket) { Google::Cloud.storage.bucket("#{prefix}_external") || safe_gcs_execute { Google::Cloud.storage.create_bucket("#{prefix}_external") } }
   let(:file) { bucket.file("pets.csv") || bucket.create_file(data_io, "pets.csv") }
 
   after do
     bucket.files.all.map(&:delete)
-    bucket.delete
+    safe_gcs_execute { bucket.delete }
   end
 
   it "queries an external table (with autodetect)" do

--- a/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
@@ -35,12 +35,12 @@ describe Google::Cloud::Bigquery::Table, :external, :bigquery do
   let(:data_csv) { CSV.generate { |csv| data.each { |row| csv << row } } }
   let(:data_io) { StringIO.new data_csv }
   let(:storage) { Google::Cloud.storage }
-  let(:bucket) { Google::Cloud.storage.bucket("#{prefix}_external") || Google::Cloud.storage.create_bucket("#{prefix}_external") }
+  let(:bucket) { Google::Cloud.storage.bucket("#{prefix}_external") || safe_gcs_execute { Google::Cloud.storage.create_bucket("#{prefix}_external") } }
   let(:file) { bucket.file("pets.csv") || bucket.create_file(data_io, "pets.csv") }
 
   after do
     bucket.files.all.map(&:delete)
-    bucket.delete
+    safe_gcs_execute { bucket.delete }
   end
 
   it "creates a table pointing to external data (with autodetect)" do

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -78,6 +78,20 @@ module Acceptance
   end
 end
 
+def safe_gcs_execute retries: 20, delay: 2
+  current_retries = 0
+  loop do
+    begin
+      return yield
+    rescue Google::Cloud::ResourceExhaustedError
+      raise unless current_retries >= retries
+
+      sleep delay
+      current_retries += 1
+    end
+  end
+end
+
 def clean_up_bigquery_datasets
   puts "Cleaning up bigquery datasets after tests."
   $bigquery.datasets.all do |dataset|

--- a/google-cloud-speech/acceptance/speech/async_test.rb
+++ b/google-cloud-speech/acceptance/speech/async_test.rb
@@ -17,7 +17,7 @@ require "speech_helper"
 describe "Asynchonous Recognition", :speech do
   let(:filepath) { "acceptance/data/audio.raw" }
 
-  let(:bucket)   { storage.bucket($speech_prefix) || storage.create_bucket($speech_prefix) }
+  let(:bucket)   { storage.bucket($speech_prefix) || safe_gcs_execute { storage.create_bucket($speech_prefix) } }
   let(:gcs_file) { bucket.file("audio.raw") || bucket.create_file(filepath, "audio.raw") }
   let(:gcs_url)  { gcs_file.to_gs_url }
 

--- a/google-cloud-speech/acceptance/speech/sync_test.rb
+++ b/google-cloud-speech/acceptance/speech/sync_test.rb
@@ -17,7 +17,7 @@ require "speech_helper"
 describe "Synchonous Recognition", :speech do
   let(:filepath) { "acceptance/data/audio.raw" }
 
-  let(:bucket)   { storage.bucket($speech_prefix) || storage.create_bucket($speech_prefix) }
+  let(:bucket)   { storage.bucket($speech_prefix) || safe_gcs_execute { storage.create_bucket($speech_prefix) } }
   let(:gcs_file) { bucket.file("audio.raw") || bucket.create_file(filepath, "audio.raw") }
   let(:gcs_url)  { gcs_file.to_gs_url }
 

--- a/google-cloud-speech/acceptance/speech_helper.rb
+++ b/google-cloud-speech/acceptance/speech_helper.rb
@@ -77,6 +77,20 @@ module Acceptance
   end
 end
 
+def safe_gcs_execute retries: 20, delay: 2
+  current_retries = 0
+  loop do
+    begin
+      return yield
+    rescue Google::Cloud::ResourceExhaustedError
+      raise unless current_retries >= retries
+
+      sleep delay
+      current_retries += 1
+    end
+  end
+end
+
 # Create buckets to be shared with all the tests
 require "time"
 require "securerandom"
@@ -87,7 +101,7 @@ def clean_up_speech_storage_objects
   puts "Cleaning up storage buckets after speech tests."
   if b = $storage.bucket($speech_prefix)
     b.files.all(&:delete)
-    b.delete
+    safe_gcs_execute { b.delete }
   end
 rescue => e
   puts "Error while cleaning up storage buckets after speech tests.\n\n#{e}"

--- a/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :storage do
   let(:bucket_name) { $bucket_names.first }
   let :bucket do
     storage.bucket(bucket_name) ||
-    storage.create_bucket(bucket_name)
+    safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
   let(:user_val) { "user-blowmage@gmail.com" }
 

--- a/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :storage do
   let(:bucket_name) { $bucket_names.first }
   let :bucket do
     storage.bucket(bucket_name) ||
-    storage.create_bucket(bucket_name)
+    safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
   let(:user_val) { "user-blowmage@gmail.com" }
 

--- a/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_encryption_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Storage::Bucket, :encryption, :storage do
   let(:kms_key) { "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-1" }
   let(:kms_key_2) { "projects/helical-zone-771/locations/#{bucket_location}/keyRings/ruby-test/cryptoKeys/ruby-test-key-2" }
   let :bucket do
-    b = storage.create_bucket(bucket_name, location: bucket_location)
+    b = safe_gcs_execute { storage.create_bucket(bucket_name, location: bucket_location) }
     b.default_kms_key = kms_key
     b
   end
@@ -32,7 +32,7 @@ describe Google::Cloud::Storage::Bucket, :encryption, :storage do
 
   after do
     bucket.files.all &:delete
-    bucket.delete
+    safe_gcs_execute { bucket.delete }
   end
 
   let(:files) do

--- a/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :storage do
   let(:bucket_name) { $bucket_names.first }
   let :bucket do
     storage.bucket(bucket_name) ||
-    storage.create_bucket(bucket_name)
+    safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
   let(:topic_name) { "#{prefix}_bucket_notification_topic" }
   let(:topic_name_full_path) { "//pubsub.googleapis.com/projects/#{storage.project}/topics/#{topic_name}" }

--- a/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
@@ -28,8 +28,10 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
   # The original bucket belongs to a second project, with requester pays enabled.
   let :storage_2_bucket do
     storage_2.bucket(bucket_name) ||
-      storage_2.create_bucket(bucket_name) do |b|
-        b.requester_pays = true
+      safe_gcs_execute do
+        storage_2.create_bucket(bucket_name) do |b|
+          b.requester_pays = true
+        end
       end
   end
   # The bucket used in tests is retrieved by the main project, with user_project set to bill to the main project.

--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
   let(:bucket_name) { $bucket_names.first }
   let :bucket do
     storage.bucket(bucket_name) ||
-    storage.create_bucket(bucket_name)
+    safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
 
   before do
@@ -31,7 +31,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
 
     storage.bucket(one_off_bucket_name).must_be :nil?
 
-    one_off_bucket = storage.create_bucket one_off_bucket_name, user_project: true
+    one_off_bucket = safe_gcs_execute { storage.create_bucket one_off_bucket_name, user_project: true }
 
     storage.bucket(one_off_bucket_name).wont_be :nil?
 
@@ -65,7 +65,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     one_off_bucket_copy.user_project.must_equal true
 
     one_off_bucket.files.all &:delete
-    one_off_bucket.delete
+    safe_gcs_execute { one_off_bucket.delete }
 
     storage.bucket(one_off_bucket_name).must_be :nil?
   end

--- a/google-cloud-storage/acceptance/storage/buckets_test.rb
+++ b/google-cloud-storage/acceptance/storage/buckets_test.rb
@@ -18,7 +18,7 @@ describe "Storage", :buckets, :storage do
   let(:buckets) do
     bucket_names.map do |b|
       storage.bucket(b) ||
-      storage.create_bucket(b)
+      safe_gcs_execute { storage.create_bucket(b) }
     end
   end
   let(:bucket_names) { $bucket_names }

--- a/google-cloud-storage/acceptance/storage/file_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_acl_test.rb
@@ -17,7 +17,7 @@ require "storage_helper"
 describe Google::Cloud::Storage::File, :acl, :storage do
   let :bucket do
     storage.bucket(bucket_name) ||
-    storage.create_bucket(bucket_name)
+    safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
   let(:bucket_name) { $bucket_names.first }
 

--- a/google-cloud-storage/acceptance/storage/file_encryption_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_encryption_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Storage::File, :storage do
   let(:bucket_location) { "us-central1" }
 
   let :bucket do
-    storage.create_bucket bucket_name, location: bucket_location
+    safe_gcs_execute {storage.create_bucket bucket_name, location: bucket_location }
   end
 
   let(:file_path) { "acceptance/data/abc.txt" }
@@ -44,7 +44,7 @@ describe Google::Cloud::Storage::File, :storage do
 
   after do
     bucket.files.all &:delete
-    bucket.delete
+    safe_gcs_execute { bucket.delete }
   end
 
   describe "customer-supplied encryption key (CSEK)" do

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -20,7 +20,7 @@ require "zlib"
 describe Google::Cloud::Storage::File, :storage do
   let :bucket do
     storage.bucket(bucket_name) ||
-    storage.create_bucket(bucket_name)
+    safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
   let(:bucket_name) { $bucket_names.first }
 

--- a/google-cloud-storage/acceptance/storage/files_test.rb
+++ b/google-cloud-storage/acceptance/storage/files_test.rb
@@ -17,7 +17,7 @@ require "storage_helper"
 describe "Storage", :files, :storage do
   let :bucket do
     storage.bucket(bucket_name) ||
-    storage.create_bucket(bucket_name)
+    safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
   let(:bucket_name) { $bucket_names.first }
 

--- a/google-cloud-vision/acceptance/vision/vision_test.rb
+++ b/google-cloud-vision/acceptance/vision/vision_test.rb
@@ -25,7 +25,7 @@ describe "Vision", :vision do
 
   let(:https_url)  { "https://raw.githubusercontent.com/GoogleCloudPlatform/google-cloud-ruby/master/acceptance/data/face.jpg" }
 
-  let(:bucket)   { storage.bucket($vision_prefix) || storage.create_bucket($vision_prefix) }
+  let(:bucket)   { storage.bucket($vision_prefix) || safe_gcs_execute { storage.create_bucket($vision_prefix) } }
   let(:gcs_file) { bucket.file(face_image) || bucket.create_file(face_image) }
   let(:gcs_url)  { gcs_file.to_gs_url }
 


### PR DESCRIPTION
This PR guards against rate limit error when trying to create or delete buckets. This is a frequent cause of failing acceptance tests.