### PR TITLE
BigQuery: Refactor GCS usage in Acceptance Tests

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -160,48 +160,28 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
   end
 
   it "imports data from a list of files in your bucket with load_job" do
-    begin
-      more_data = rows.map { |row| JSON.generate row }.join("\n")
-      bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket" }
-      file1 = bucket.create_file local_file
-      file2 = bucket.create_file StringIO.new(more_data),
-                                 "more-kitten-test-data.json"
-      gs_url = "gs://#{file2.bucket}/#{file2.name}"
+    more_data = rows.map { |row| JSON.generate row }.join("\n")
+    file1 = bucket.create_file local_file, random_file_destination_name
+    file2 = bucket.create_file StringIO.new(more_data), random_file_destination_name
+    gs_url = "gs://#{file2.bucket}/#{file2.name}"
 
-      # Test both by file object and URL as string
-      job = dataset.load_job table_id, [file1, gs_url]
-      job.wait_until_done!
-      job.wont_be :failed?
-      job.input_files.must_equal 2
-      job.output_rows.must_equal 6
-    ensure
-      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
-      if post_bucket
-        post_bucket.files.map &:delete
-        safe_gcs_execute { post_bucket.delete }
-      end
-    end
+    # Test both by file object and URL as string
+    job = dataset.load_job table_id, [file1, gs_url]
+    job.wait_until_done!
+    job.wont_be :failed?
+    job.input_files.must_equal 2
+    job.output_rows.must_equal 6
   end
 
   it "imports data from a list of files in your bucket with load" do
-    begin
-      more_data = rows.map { |row| JSON.generate row }.join("\n")
-      bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket" }
-      file1 = bucket.create_file local_file
-      file2 = bucket.create_file StringIO.new(more_data),
-                                 "more-kitten-test-data.json"
-      gs_url = "gs://#{file2.bucket}/#{file2.name}"
+    more_data = rows.map { |row| JSON.generate row }.join("\n")
+    file1 = bucket.create_file local_file, random_file_destination_name
+    file2 = bucket.create_file StringIO.new(more_data), random_file_destination_name
+    gs_url = "gs://#{file2.bucket}/#{file2.name}"
 
-      # Test both by file object and URL as string
-      result = dataset.load table_id, [file1, gs_url]
-      result.must_equal true
-    ensure
-      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
-      if post_bucket
-        post_bucket.files.map &:delete
-        safe_gcs_execute { post_bucket.delete }
-      end
-    end
+    # Test both by file object and URL as string
+    result = dataset.load table_id, [file1, gs_url]
+    result.must_equal true
   end
 
   it "adds an access entry with specifying user scope" do

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -201,27 +201,17 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   end
 
   it "imports data from a list of files in your bucket with load_job" do
-    begin
-      more_data = rows.map { |row| JSON.generate row }.join("\n")
-      bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket" }
-      file1 = bucket.create_file local_file
-      file2 = bucket.create_file StringIO.new(more_data),
-                                 "more-kitten-test-data.json"
-      gs_url = "gs://#{file2.bucket}/#{file2.name}"
+    more_data = rows.map { |row| JSON.generate row }.join("\n")
+    file1 = bucket.create_file local_file, random_file_destination_name
+    file2 = bucket.create_file StringIO.new(more_data), random_file_destination_name
+    gs_url = "gs://#{file2.bucket}/#{file2.name}"
 
-      # Test both by file object and URL as string
-      job = dataset.load_job table_with_schema.table_id, [file1, gs_url]
-      job.wait_until_done!
-      job.wont_be :failed?
-      job.input_files.must_equal 2
-      job.output_rows.must_equal 6
-    ensure
-      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
-      if post_bucket
-        post_bucket.files.map &:delete
-        safe_gcs_execute { post_bucket.delete }
-      end
-    end
+    # Test both by file object and URL as string
+    job = dataset.load_job table_with_schema.table_id, [file1, gs_url]
+    job.wait_until_done!
+    job.wont_be :failed?
+    job.input_files.must_equal 2
+    job.output_rows.must_equal 6
   end
 
   it "imports data from a local file and creates a new table with specified schema in a block with load" do
@@ -254,24 +244,14 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
   end
 
   it "imports data from a list of files in your bucket with load" do
-    begin
-      more_data = rows.map { |row| JSON.generate row }.join("\n")
-      bucket = safe_gcs_execute { Google::Cloud.storage.create_bucket "#{prefix}_bucket" }
-      file1 = bucket.create_file local_file
-      file2 = bucket.create_file StringIO.new(more_data),
-                                 "more-kitten-test-data.json"
-      gs_url = "gs://#{file2.bucket}/#{file2.name}"
+    more_data = rows.map { |row| JSON.generate row }.join("\n")
+    file1 = bucket.create_file local_file, random_file_destination_name
+    file2 = bucket.create_file StringIO.new(more_data), random_file_destination_name
+    gs_url = "gs://#{file2.bucket}/#{file2.name}"
 
-      # Test both by file object and URL as string
-      result = dataset.load table_with_schema.table_id, [file1, gs_url]
-      result.must_equal true
-    ensure
-      post_bucket = Google::Cloud.storage.bucket "#{prefix}_bucket"
-      if post_bucket
-        post_bucket.files.map &:delete
-        safe_gcs_execute { post_bucket.delete }
-      end
-    end
+    # Test both by file object and URL as string
+    result = dataset.load table_with_schema.table_id, [file1, gs_url]
+    result.must_equal true
   end
 
   it "imports data from GCS Avro file and creates a new table with load" do

--- a/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
@@ -35,13 +35,7 @@ describe Google::Cloud::Bigquery::External, :bigquery do
   let(:data_csv) { CSV.generate { |csv| data.each { |row| csv << row } } }
   let(:data_io) { StringIO.new data_csv }
   let(:storage) { Google::Cloud.storage }
-  let(:bucket) { Google::Cloud.storage.bucket("#{prefix}_external") || safe_gcs_execute { Google::Cloud.storage.create_bucket("#{prefix}_external") } }
   let(:file) { bucket.file("pets.csv") || bucket.create_file(data_io, "pets.csv") }
-
-  after do
-    bucket.files.all.map(&:delete)
-    safe_gcs_execute { bucket.delete }
-  end
 
   it "queries an external table (with autodetect)" do
     ext_table = dataset.external file.to_gs_url

--- a/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_external_test.rb
@@ -35,13 +35,7 @@ describe Google::Cloud::Bigquery::Table, :external, :bigquery do
   let(:data_csv) { CSV.generate { |csv| data.each { |row| csv << row } } }
   let(:data_io) { StringIO.new data_csv }
   let(:storage) { Google::Cloud.storage }
-  let(:bucket) { Google::Cloud.storage.bucket("#{prefix}_external") || safe_gcs_execute { Google::Cloud.storage.create_bucket("#{prefix}_external") } }
   let(:file) { bucket.file("pets.csv") || bucket.create_file(data_io, "pets.csv") }
-
-  after do
-    bucket.files.all.map(&:delete)
-    safe_gcs_execute { bucket.delete }
-  end
 
   it "creates a table pointing to external data (with autodetect)" do
     csv_table = dataset.external file.to_gs_url do |csv|


### PR DESCRIPTION
Instead of creating and deleting a bucket for every test, reuse the same object for each run of tests. Use a random file name in the tests instead of using a new bucket resource each time.

This change provides a nominal performance improvement.

### Before

```
$ time bundle exec rake acceptance
Run options: --seed 820

# Running:

........................................S....................................................................................................................

Finished in 821.606664s, 0.1911 runs/s, 2.5207 assertions/s.

157 runs, 2071 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
Cleaning up bigquery datasets after tests.

real	13m56.526s
user	0m7.609s
sys	0m2.030s
```

### After

```
e exec rake acceptance
Run options: --seed 32954

# Running:

..............................................S..............................................................................................................

Finished in 757.444138s, 0.2073 runs/s, 2.9996 assertions/s.

157 runs, 2272 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
Cleaning up bigquery datasets after tests.
Cleaning up bigquery bucket after tests.

real	12m59.919s
user	0m5.544s
sys	0m1.731s
```