### PR TITLE
Defer starting debugger agents created by middleware

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -55,7 +55,7 @@ module Google
         #
         # @private
         #
-        def self.deferred_start(debugger)
+        def self.deferred_start debugger
           if @debuggers_to_start
             @debuggers_to_start << debugger
           else
@@ -85,7 +85,8 @@ module Google
         # method at the appropriate time.
         #
         def self.start_agents
-          @debuggers_to_start.each { |d| d.start }
+          return unless @debuggers_to_start
+          @debuggers_to_start.each(&:start)
           @debuggers_to_start = nil
         end
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -37,6 +37,14 @@ module Google
       # on how to configure the Railtie and Middleware.
       #
       class Railtie < ::Rails::Railtie
+        ##
+        # Immediately start the debugger agent.
+        # This simply calls {Google::Cloud::Debugger::Middleware.start_agents}.
+        #
+        def self.start_agents
+          Google::Cloud::Debugger::Middleware.start_agents
+        end
+
         config.google_cloud = ::ActiveSupport::OrderedOptions.new unless
           config.respond_to? :google_cloud
         config.google_cloud[:debugger] = ::ActiveSupport::OrderedOptions.new
@@ -87,7 +95,7 @@ module Google
 
           # Otherwise set use_debugger to true if Rails is running in
           # the production environment
-          Google::Cloud.configure.use_debugger ||= Rails.env.production?
+          Google::Cloud.configure.use_debugger ||= ::Rails.env.production?
         end
 
         # rubocop:disable all

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -38,8 +38,9 @@ module Google
       #
       class Railtie < ::Rails::Railtie
         ##
-        # Immediately start the debugger agent.
+        # Inform the Railtie that it is safe to start debugger agents.
         # This simply calls {Google::Cloud::Debugger::Middleware.start_agents}.
+        # See its documentation for more information.
         #
         def self.start_agents
           Google::Cloud::Debugger::Middleware.start_agents

--- a/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
@@ -57,6 +57,15 @@ describe Google::Cloud::Debugger::Middleware, :mock_debugger do
         debugger.agent.async_running?.must_equal true
       end
     end
+
+    it "is idempotent" do
+      Google::Cloud::Debugger::Credentials.stub :default, "/default/keyfile.json" do
+        middleware
+        Google::Cloud::Debugger::Middleware.start_agents
+        Google::Cloud::Debugger::Middleware.start_agents
+        debugger.agent.async_running?.must_equal true
+      end
+    end
   end
 
   describe "#call" do


### PR DESCRIPTION
Currently the debugger middleware starts the debugger agent immediately on middleware construction. When run on a forking webserver that does preloading of the application in the master process (e.g. puma in clustered mode), this causes the agent threads, and more importantly the grpc connection, to be opened in the master process. Thus, when the workers are forked, it wreaks all sorts of havoc with grpc. (See https://github.com/grpc/grpc/issues/7951).

This change defers the starting of the debugger agent until the first request is received. (It simply calls debugger.start in the `call` method of the middleware. Since debugger.start is idempotent, this is okay to call on each request.)

Then, because this would generally cause that first request not to be debuggable, (since the debugee will not have been registered by the time the request is handled), we introduce an API that basically says: "It's now safe to start agents." An application can call `Google::Cloud::Debugger::Middleware.start_agents` after forking (e.g. in a unicorn `after_fork` block, or a puma `on_worker_boot` block) to have it start agents at that time, before the first request is handled. If an application does not prefork, it can safely call this method at any time early in the init process.

This should solve https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1860 and will deal with at least one major cause of https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1772
