### PR TITLE
Fix dependency to google-api-client

### DIFF
--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0.0"
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
-  gem.add_dependency "google-api-client", "~> 0.19.0"
+  gem.add_dependency "google-api-client", "~> 0.19"
   gem.add_dependency "googleauth", "~> 0.6.2"
   gem.add_dependency "digest-crc", "~> 0.4"
 


### PR DESCRIPTION
Currently `google-cloud-storage` defines a dependency to a pretty specific feature release of `google-api-client`, breaking the use of it for other libraries that need a newer version of the `google-api-client`.

We from the _fastlane_ team are working on fastlane.ci, which uses [fastlane](https://fastlane.tools) to communicate with the Google Play API, and we use Google Cloud Storage to store build artifacts on Google Cloud.

- Right now, we need at least `google-api-client` of `0.21.2` to support the new Google Play app binaries (via https://github.com/fastlane/fastlane/pull/12568)
- We also need to upload build artifacts to Google Cloud Storage, however we can't add both dependencies due to the strict dependency to `google-api-client` on version `~> 0.19.0` ([source](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/9f1d96c022002a6dad7ee107e39aa818003164d4/google-cloud-storage/google-cloud-storage.gemspec#L22))