### PR TITLE
Regenerate Bigtable to address 2101

### DIFF
--- a/google-cloud-bigtable/lib/google/bigtable/admin/v2/bigtable_instance_admin_pb.rb
+++ b/google-cloud-bigtable/lib/google/bigtable/admin/v2/bigtable_instance_admin_pb.rb
@@ -103,6 +103,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :name, :string, 1
     optional :ignore_warnings, :bool, 2
   end
+  add_message "google.bigtable.admin.v2.UpdateAppProfileMetadata" do
+  end
 end
 
 module Google
@@ -130,6 +132,7 @@ module Google
         ListAppProfilesResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.bigtable.admin.v2.ListAppProfilesResponse").msgclass
         UpdateAppProfileRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.bigtable.admin.v2.UpdateAppProfileRequest").msgclass
         DeleteAppProfileRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.bigtable.admin.v2.DeleteAppProfileRequest").msgclass
+        UpdateAppProfileMetadata = Google::Protobuf::DescriptorPool.generated_pool.lookup("google.bigtable.admin.v2.UpdateAppProfileMetadata").msgclass
       end
     end
   end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
@@ -269,79 +269,136 @@ module Google
 
               @create_instance = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:create_instance),
-                defaults["create_instance"]
+                defaults["create_instance"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @get_instance = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:get_instance),
-                defaults["get_instance"]
+                defaults["get_instance"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @list_instances = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:list_instances),
-                defaults["list_instances"]
+                defaults["list_instances"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @update_instance = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:update_instance),
-                defaults["update_instance"]
+                defaults["update_instance"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @partial_update_instance = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:partial_update_instance),
-                defaults["partial_update_instance"]
+                defaults["partial_update_instance"],
+                params_extractor: proc do |request|
+                  {'instance.name' => request.instance.name}
+                end
               )
               @delete_instance = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:delete_instance),
-                defaults["delete_instance"]
+                defaults["delete_instance"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @create_cluster = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:create_cluster),
-                defaults["create_cluster"]
+                defaults["create_cluster"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @get_cluster = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:get_cluster),
-                defaults["get_cluster"]
+                defaults["get_cluster"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @list_clusters = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:list_clusters),
-                defaults["list_clusters"]
+                defaults["list_clusters"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @update_cluster = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:update_cluster),
-                defaults["update_cluster"]
+                defaults["update_cluster"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @delete_cluster = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:delete_cluster),
-                defaults["delete_cluster"]
+                defaults["delete_cluster"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @create_app_profile = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:create_app_profile),
-                defaults["create_app_profile"]
+                defaults["create_app_profile"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @get_app_profile = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:get_app_profile),
-                defaults["get_app_profile"]
+                defaults["get_app_profile"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @list_app_profiles = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:list_app_profiles),
-                defaults["list_app_profiles"]
+                defaults["list_app_profiles"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @update_app_profile = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:update_app_profile),
-                defaults["update_app_profile"]
+                defaults["update_app_profile"],
+                params_extractor: proc do |request|
+                  {'app_profile.name' => request.app_profile.name}
+                end
               )
               @delete_app_profile = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:delete_app_profile),
-                defaults["delete_app_profile"]
+                defaults["delete_app_profile"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @get_iam_policy = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:get_iam_policy),
-                defaults["get_iam_policy"]
+                defaults["get_iam_policy"],
+                params_extractor: proc do |request|
+                  {'resource' => request.resource}
+                end
               )
               @set_iam_policy = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:set_iam_policy),
-                defaults["set_iam_policy"]
+                defaults["set_iam_policy"],
+                params_extractor: proc do |request|
+                  {'resource' => request.resource}
+                end
               )
               @test_iam_permissions = Google::Gax.create_api_call(
                 @bigtable_instance_admin_stub.method(:test_iam_permissions),
-                defaults["test_iam_permissions"]
+                defaults["test_iam_permissions"],
+                params_extractor: proc do |request|
+                  {'resource' => request.resource}
+                end
               )
             end
 
@@ -379,8 +436,14 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.project_path("[PROJECT]")
+            #
+            #   # TODO: Initialize +instance_id+:
             #   instance_id = ''
+            #
+            #   # TODO: Initialize +instance+:
             #   instance = {}
+            #
+            #   # TODO: Initialize +clusters+:
             #   clusters = {}
             #
             #   # Register a callback during the method call.
@@ -529,8 +592,14 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+            #
+            #   # TODO: Initialize +display_name+:
             #   display_name = ''
+            #
+            #   # TODO: Initialize +type+:
             #   type = :TYPE_UNSPECIFIED
+            #
+            #   # TODO: Initialize +labels+:
             #   labels = {}
             #   response = bigtable_instance_admin_client.update_instance(formatted_name, display_name, type, labels)
 
@@ -566,15 +635,45 @@ module Google
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
-            # @return [Google::Longrunning::Operation]
+            # @return [Google::Gax::Operation]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   require "google/cloud/bigtable/admin/v2"
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
+            #
+            #   # TODO: Initialize +instance+:
             #   instance = {}
+            #
+            #   # TODO: Initialize +update_mask+:
             #   update_mask = {}
-            #   response = bigtable_instance_admin_client.partial_update_instance(instance, update_mask)
+            #
+            #   # Register a callback during the method call.
+            #   operation = bigtable_instance_admin_client.partial_update_instance(instance, update_mask) do |op|
+            #     raise op.results.message if op.error?
+            #     op_results = op.results
+            #     # Process the results.
+            #
+            #     metadata = op.metadata
+            #     # Process the metadata.
+            #   end
+            #
+            #   # Or use the return value to register a callback.
+            #   operation.on_done do |op|
+            #     raise op.results.message if op.error?
+            #     op_results = op.results
+            #     # Process the results.
+            #
+            #     metadata = op.metadata
+            #     # Process the metadata.
+            #   end
+            #
+            #   # Manually reload the operation.
+            #   operation.reload!
+            #
+            #   # Or block until the operation completes, triggering callbacks on
+            #   # completion.
+            #   operation.wait_until_done!
 
             def partial_update_instance \
                 instance,
@@ -585,7 +684,15 @@ module Google
                 update_mask: update_mask
               }.delete_if { |_, v| v.nil? }
               req = Google::Gax::to_proto(req, Google::Bigtable::Admin::V2::PartialUpdateInstanceRequest)
-              @partial_update_instance.call(req, options)
+              operation = Google::Gax::Operation.new(
+                @partial_update_instance.call(req, options),
+                @operations_client,
+                Google::Bigtable::Admin::V2::Instance,
+                Google::Bigtable::Admin::V2::UpdateInstanceMetadata,
+                call_options: options
+              )
+              operation.on_done { |operation| yield(operation) } if block_given?
+              operation
             end
 
             # Delete an instance from a project.
@@ -640,7 +747,11 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+            #
+            #   # TODO: Initialize +cluster_id+:
             #   cluster_id = ''
+            #
+            #   # TODO: Initialize +cluster+:
             #   cluster = {}
             #
             #   # Register a callback during the method call.
@@ -784,7 +895,11 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.cluster_path("[PROJECT]", "[INSTANCE]", "[CLUSTER]")
+            #
+            #   # TODO: Initialize +location+:
             #   location = ''
+            #
+            #   # TODO: Initialize +serve_nodes+:
             #   serve_nodes = 0
             #
             #   # Register a callback during the method call.
@@ -899,7 +1014,11 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+            #
+            #   # TODO: Initialize +app_profile_id+:
             #   app_profile_id = ''
+            #
+            #   # TODO: Initialize +app_profile+:
             #   app_profile = {}
             #   response = bigtable_instance_admin_client.create_app_profile(formatted_parent, app_profile_id, app_profile)
 
@@ -1021,15 +1140,45 @@ module Google
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
-            # @return [Google::Longrunning::Operation]
+            # @return [Google::Gax::Operation]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   require "google/cloud/bigtable/admin/v2"
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
+            #
+            #   # TODO: Initialize +app_profile+:
             #   app_profile = {}
+            #
+            #   # TODO: Initialize +update_mask+:
             #   update_mask = {}
-            #   response = bigtable_instance_admin_client.update_app_profile(app_profile, update_mask)
+            #
+            #   # Register a callback during the method call.
+            #   operation = bigtable_instance_admin_client.update_app_profile(app_profile, update_mask) do |op|
+            #     raise op.results.message if op.error?
+            #     op_results = op.results
+            #     # Process the results.
+            #
+            #     metadata = op.metadata
+            #     # Process the metadata.
+            #   end
+            #
+            #   # Or use the return value to register a callback.
+            #   operation.on_done do |op|
+            #     raise op.results.message if op.error?
+            #     op_results = op.results
+            #     # Process the results.
+            #
+            #     metadata = op.metadata
+            #     # Process the metadata.
+            #   end
+            #
+            #   # Manually reload the operation.
+            #   operation.reload!
+            #
+            #   # Or block until the operation completes, triggering callbacks on
+            #   # completion.
+            #   operation.wait_until_done!
 
             def update_app_profile \
                 app_profile,
@@ -1042,7 +1191,15 @@ module Google
                 ignore_warnings: ignore_warnings
               }.delete_if { |_, v| v.nil? }
               req = Google::Gax::to_proto(req, Google::Bigtable::Admin::V2::UpdateAppProfileRequest)
-              @update_app_profile.call(req, options)
+              operation = Google::Gax::Operation.new(
+                @update_app_profile.call(req, options),
+                @operations_client,
+                Google::Bigtable::Admin::V2::AppProfile,
+                Google::Bigtable::Admin::V2::UpdateAppProfileMetadata,
+                call_options: options
+              )
+              operation.on_done { |operation| yield(operation) } if block_given?
+              operation
             end
 
             # This is a private alpha release of Cloud Bigtable replication. This feature
@@ -1066,6 +1223,8 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.app_profile_path("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]")
+            #
+            #   # TODO: Initialize +ignore_warnings+:
             #   ignore_warnings = false
             #   bigtable_instance_admin_client.delete_app_profile(formatted_name, ignore_warnings)
 
@@ -1147,6 +1306,8 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
             #   formatted_resource = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+            #
+            #   # TODO: Initialize +policy+:
             #   policy = {}
             #   response = bigtable_instance_admin_client.set_iam_policy(formatted_resource, policy)
 
@@ -1189,6 +1350,8 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin.new
             #   formatted_resource = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+            #
+            #   # TODO: Initialize +permissions+:
             #   permissions = []
             #   response = bigtable_instance_admin_client.test_iam_permissions(formatted_resource, permissions)
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client.rb
@@ -264,55 +264,94 @@ module Google
 
               @create_table = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:create_table),
-                defaults["create_table"]
+                defaults["create_table"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @create_table_from_snapshot = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:create_table_from_snapshot),
-                defaults["create_table_from_snapshot"]
+                defaults["create_table_from_snapshot"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @list_tables = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:list_tables),
-                defaults["list_tables"]
+                defaults["list_tables"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @get_table = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:get_table),
-                defaults["get_table"]
+                defaults["get_table"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @delete_table = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:delete_table),
-                defaults["delete_table"]
+                defaults["delete_table"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @modify_column_families = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:modify_column_families),
-                defaults["modify_column_families"]
+                defaults["modify_column_families"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @drop_row_range = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:drop_row_range),
-                defaults["drop_row_range"]
+                defaults["drop_row_range"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @generate_consistency_token = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:generate_consistency_token),
-                defaults["generate_consistency_token"]
+                defaults["generate_consistency_token"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @check_consistency = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:check_consistency),
-                defaults["check_consistency"]
+                defaults["check_consistency"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @snapshot_table = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:snapshot_table),
-                defaults["snapshot_table"]
+                defaults["snapshot_table"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @get_snapshot = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:get_snapshot),
-                defaults["get_snapshot"]
+                defaults["get_snapshot"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
               @list_snapshots = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:list_snapshots),
-                defaults["list_snapshots"]
+                defaults["list_snapshots"],
+                params_extractor: proc do |request|
+                  {'parent' => request.parent}
+                end
               )
               @delete_snapshot = Google::Gax.create_api_call(
                 @bigtable_table_admin_stub.method(:delete_snapshot),
-                defaults["delete_snapshot"]
+                defaults["delete_snapshot"],
+                params_extractor: proc do |request|
+                  {'name' => request.name}
+                end
               )
             end
 
@@ -361,7 +400,11 @@ module Google
             #
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin.new
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+            #
+            #   # TODO: Initialize +table_id+:
             #   table_id = ''
+            #
+            #   # TODO: Initialize +table+:
             #   table = {}
             #   response = bigtable_table_admin_client.create_table(formatted_parent, table_id, table)
 
@@ -410,7 +453,11 @@ module Google
             #
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin.new
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
+            #
+            #   # TODO: Initialize +table_id+:
             #   table_id = ''
+            #
+            #   # TODO: Initialize +source_snapshot+:
             #   source_snapshot = ''
             #
             #   # Register a callback during the method call.
@@ -597,6 +644,8 @@ module Google
             #
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin.new
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
+            #
+            #   # TODO: Initialize +modifications+:
             #   modifications = []
             #   response = bigtable_table_admin_client.modify_column_families(formatted_name, modifications)
 
@@ -712,6 +761,8 @@ module Google
             #
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin.new
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
+            #
+            #   # TODO: Initialize +consistency_token+:
             #   consistency_token = ''
             #   response = bigtable_table_admin_client.check_consistency(formatted_name, consistency_token)
 
@@ -760,17 +811,49 @@ module Google
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
-            # @return [Google::Longrunning::Operation]
+            # @return [Google::Gax::Operation]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   require "google/cloud/bigtable/admin/v2"
             #
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin.new
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
+            #
+            #   # TODO: Initialize +cluster+:
             #   cluster = ''
+            #
+            #   # TODO: Initialize +snapshot_id+:
             #   snapshot_id = ''
+            #
+            #   # TODO: Initialize +description+:
             #   description = ''
-            #   response = bigtable_table_admin_client.snapshot_table(formatted_name, cluster, snapshot_id, description)
+            #
+            #   # Register a callback during the method call.
+            #   operation = bigtable_table_admin_client.snapshot_table(formatted_name, cluster, snapshot_id, description) do |op|
+            #     raise op.results.message if op.error?
+            #     op_results = op.results
+            #     # Process the results.
+            #
+            #     metadata = op.metadata
+            #     # Process the metadata.
+            #   end
+            #
+            #   # Or use the return value to register a callback.
+            #   operation.on_done do |op|
+            #     raise op.results.message if op.error?
+            #     op_results = op.results
+            #     # Process the results.
+            #
+            #     metadata = op.metadata
+            #     # Process the metadata.
+            #   end
+            #
+            #   # Manually reload the operation.
+            #   operation.reload!
+            #
+            #   # Or block until the operation completes, triggering callbacks on
+            #   # completion.
+            #   operation.wait_until_done!
 
             def snapshot_table \
                 name,
@@ -787,7 +870,15 @@ module Google
                 ttl: ttl
               }.delete_if { |_, v| v.nil? }
               req = Google::Gax::to_proto(req, Google::Bigtable::Admin::V2::SnapshotTableRequest)
-              @snapshot_table.call(req, options)
+              operation = Google::Gax::Operation.new(
+                @snapshot_table.call(req, options),
+                @operations_client,
+                Google::Bigtable::Admin::V2::Snapshot,
+                Google::Bigtable::Admin::V2::SnapshotTableMetadata,
+                call_options: options
+              )
+              operation.on_done { |operation| yield(operation) } if block_given?
+              operation
             end
 
             # This is a private alpha release of Cloud Bigtable snapshots. This feature

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_config.json
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_config.json
@@ -17,13 +17,31 @@
           "rpc_timeout_multiplier": 1.0,
           "max_rpc_timeout_millis": 20000,
           "total_timeout_millis": 600000
+        },
+        "create_table": {
+          "initial_retry_delay_millis": 100,
+          "retry_delay_multiplier": 1.3,
+          "max_retry_delay_millis": 60000,
+          "initial_rpc_timeout_millis": 130000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 130000,
+          "total_timeout_millis": 3600000
+        },
+        "drop_row_range": {
+          "initial_retry_delay_millis": 100,
+          "retry_delay_multiplier": 1.3,
+          "max_retry_delay_millis": 60000,
+          "initial_rpc_timeout_millis": 900000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 900000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {
         "CreateTable": {
           "timeout_millis": 130000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "create_table"
         },
         "CreateTableFromSnapshot": {
           "timeout_millis": 60000,
@@ -51,9 +69,9 @@
           "retry_params_name": "default"
         },
         "DropRowRange": {
-          "timeout_millis": 60000,
+          "timeout_millis": 900000,
           "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "retry_params_name": "drop_row_range"
         },
         "GenerateConsistencyToken": {
           "timeout_millis": 60000,
@@ -62,7 +80,7 @@
         },
         "CheckConsistency": {
           "timeout_millis": 60000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "SnapshotTable": {

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_instance_admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_instance_admin.rb
@@ -311,6 +311,14 @@ module Google
         #   @return [true, false]
         #     If true, ignore safety checks when deleting the app profile.
         class DeleteAppProfileRequest; end
+
+        # This is a private alpha release of Cloud Bigtable replication. This feature
+        # is not currently available to most Cloud Bigtable customers. This feature
+        # might be changed in backward-incompatible ways and is not recommended for
+        # production use. It is not subject to any SLA or deprecation policy.
+        #
+        # The metadata for the Operation returned by UpdateAppProfile.
+        class UpdateAppProfileMetadata; end
       end
     end
   end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client.rb
@@ -171,27 +171,45 @@ module Google
 
             @read_rows = Google::Gax.create_api_call(
               @bigtable_stub.method(:read_rows),
-              defaults["read_rows"]
+              defaults["read_rows"],
+              params_extractor: proc do |request|
+                {'table_name' => request.table_name}
+              end
             )
             @sample_row_keys = Google::Gax.create_api_call(
               @bigtable_stub.method(:sample_row_keys),
-              defaults["sample_row_keys"]
+              defaults["sample_row_keys"],
+              params_extractor: proc do |request|
+                {'table_name' => request.table_name}
+              end
             )
             @mutate_row = Google::Gax.create_api_call(
               @bigtable_stub.method(:mutate_row),
-              defaults["mutate_row"]
+              defaults["mutate_row"],
+              params_extractor: proc do |request|
+                {'table_name' => request.table_name}
+              end
             )
             @mutate_rows = Google::Gax.create_api_call(
               @bigtable_stub.method(:mutate_rows),
-              defaults["mutate_rows"]
+              defaults["mutate_rows"],
+              params_extractor: proc do |request|
+                {'table_name' => request.table_name}
+              end
             )
             @check_and_mutate_row = Google::Gax.create_api_call(
               @bigtable_stub.method(:check_and_mutate_row),
-              defaults["check_and_mutate_row"]
+              defaults["check_and_mutate_row"],
+              params_extractor: proc do |request|
+                {'table_name' => request.table_name}
+              end
             )
             @read_modify_write_row = Google::Gax.create_api_call(
               @bigtable_stub.method(:read_modify_write_row),
-              defaults["read_modify_write_row"]
+              defaults["read_modify_write_row"],
+              params_extractor: proc do |request|
+                {'table_name' => request.table_name}
+              end
             )
           end
 
@@ -339,7 +357,11 @@ module Google
           #
           #   bigtable_client = Google::Cloud::Bigtable::V2.new
           #   formatted_table_name = Google::Cloud::Bigtable::V2::BigtableClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
+          #
+          #   # TODO: Initialize +row_key+:
           #   row_key = ''
+          #
+          #   # TODO: Initialize +mutations+:
           #   mutations = []
           #   response = bigtable_client.mutate_row(formatted_table_name, row_key, mutations)
 
@@ -393,6 +415,8 @@ module Google
           #
           #   bigtable_client = Google::Cloud::Bigtable::V2.new
           #   formatted_table_name = Google::Cloud::Bigtable::V2::BigtableClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
+          #
+          #   # TODO: Initialize +entries+:
           #   entries = []
           #   bigtable_client.mutate_rows(formatted_table_name, entries).each do |element|
           #     # Process element.
@@ -462,6 +486,8 @@ module Google
           #
           #   bigtable_client = Google::Cloud::Bigtable::V2.new
           #   formatted_table_name = Google::Cloud::Bigtable::V2::BigtableClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
+          #
+          #   # TODO: Initialize +row_key+:
           #   row_key = ''
           #   response = bigtable_client.check_and_mutate_row(formatted_table_name, row_key)
 
@@ -522,7 +548,11 @@ module Google
           #
           #   bigtable_client = Google::Cloud::Bigtable::V2.new
           #   formatted_table_name = Google::Cloud::Bigtable::V2::BigtableClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
+          #
+          #   # TODO: Initialize +row_key+:
           #   row_key = ''
+          #
+          #   # TODO: Initialize +rules+:
           #   rules = []
           #   response = bigtable_client.read_modify_write_row(formatted_table_name, row_key, rules)
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client_config.json
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client_config.json
@@ -32,12 +32,12 @@
         },
         "MutateRow": {
           "timeout_millis": 60000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MutateRows": {
           "timeout_millis": 60000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "CheckAndMutateRow": {

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client_test.rb
@@ -450,16 +450,23 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
 
       # Create expected grpc response
       name = "name3373707"
-      done = true
-      expected_response = { name: name, done: done }
-      expected_response = Google::Gax::to_proto(expected_response, Google::Longrunning::Operation)
+      display_name = "displayName1615086568"
+      expected_response = { name: name, display_name: display_name }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Bigtable::Admin::V2::Instance)
+      result = Google::Protobuf::Any.new
+      result.pack(expected_response)
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/partial_update_instance_test',
+        done: true,
+        response: result
+      )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::PartialUpdateInstanceRequest, request)
         assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
         assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
-        OpenStruct.new(execute: expected_response)
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:partial_update_instance, mock_method)
 
@@ -474,7 +481,48 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           response = client.partial_update_instance(instance, update_mask)
 
           # Verify the response
-          assert_equal(expected_response, response)
+          assert_equal(expected_response, response.response)
+        end
+      end
+    end
+
+    it 'invokes partial_update_instance and returns an operation error.' do
+      # Create request parameters
+      instance = {}
+      update_mask = {}
+
+      # Create expected grpc response
+      operation_error = Google::Rpc::Status.new(
+        message: 'Operation error for Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient#partial_update_instance.'
+      )
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/partial_update_instance_test',
+        done: true,
+        error: operation_error
+      )
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Bigtable::Admin::V2::PartialUpdateInstanceRequest, request)
+        assert_equal(Google::Gax::to_proto(instance, Google::Bigtable::Admin::V2::Instance), request.instance)
+        assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
+        OpenStruct.new(execute: operation)
+      end
+      mock_stub = MockGrpcClientStub.new(:partial_update_instance, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockBigtableInstanceAdminCredentials.new("partial_update_instance")
+
+      Google::Bigtable::Admin::V2::BigtableInstanceAdmin::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Bigtable::Admin::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
+
+          # Call method
+          response = client.partial_update_instance(instance, update_mask)
+
+          # Verify the response
+          assert(response.error?)
+          assert_equal(operation_error, response.error)
         end
       end
     end
@@ -1306,16 +1354,28 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
 
       # Create expected grpc response
       name = "name3373707"
-      done = true
-      expected_response = { name: name, done: done }
-      expected_response = Google::Gax::to_proto(expected_response, Google::Longrunning::Operation)
+      etag = "etag3123477"
+      description = "description-1724546052"
+      expected_response = {
+        name: name,
+        etag: etag,
+        description: description
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Bigtable::Admin::V2::AppProfile)
+      result = Google::Protobuf::Any.new
+      result.pack(expected_response)
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/update_app_profile_test',
+        done: true,
+        response: result
+      )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of(Google::Bigtable::Admin::V2::UpdateAppProfileRequest, request)
         assert_equal(Google::Gax::to_proto(app_profile, Google::Bigtable::Admin::V2::AppProfile), request.app_profile)
         assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
-        OpenStruct.new(execute: expected_response)
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:update_app_profile, mock_method)
 
@@ -1330,7 +1390,48 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient do
           response = client.update_app_profile(app_profile, update_mask)
 
           # Verify the response
-          assert_equal(expected_response, response)
+          assert_equal(expected_response, response.response)
+        end
+      end
+    end
+
+    it 'invokes update_app_profile and returns an operation error.' do
+      # Create request parameters
+      app_profile = {}
+      update_mask = {}
+
+      # Create expected grpc response
+      operation_error = Google::Rpc::Status.new(
+        message: 'Operation error for Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient#update_app_profile.'
+      )
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/update_app_profile_test',
+        done: true,
+        error: operation_error
+      )
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Bigtable::Admin::V2::UpdateAppProfileRequest, request)
+        assert_equal(Google::Gax::to_proto(app_profile, Google::Bigtable::Admin::V2::AppProfile), request.app_profile)
+        assert_equal(Google::Gax::to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask)
+        OpenStruct.new(execute: operation)
+      end
+      mock_stub = MockGrpcClientStub.new(:update_app_profile, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockBigtableInstanceAdminCredentials.new("update_app_profile")
+
+      Google::Bigtable::Admin::V2::BigtableInstanceAdmin::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Bigtable::Admin::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
+
+          # Call method
+          response = client.update_app_profile(app_profile, update_mask)
+
+          # Verify the response
+          assert(response.error?)
+          assert_equal(operation_error, response.error)
         end
       end
     end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_client_test.rb
@@ -778,9 +778,21 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
-      done = true
-      expected_response = { name: name_2, done: done }
-      expected_response = Google::Gax::to_proto(expected_response, Google::Longrunning::Operation)
+      data_size_bytes = 2110122398
+      description_2 = "description2568623279"
+      expected_response = {
+        name: name_2,
+        data_size_bytes: data_size_bytes,
+        description: description_2
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Bigtable::Admin::V2::Snapshot)
+      result = Google::Protobuf::Any.new
+      result.pack(expected_response)
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/snapshot_table_test',
+        done: true,
+        response: result
+      )
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -789,7 +801,7 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
         assert_equal(cluster, request.cluster)
         assert_equal(snapshot_id, request.snapshot_id)
         assert_equal(description, request.description)
-        OpenStruct.new(execute: expected_response)
+        OpenStruct.new(execute: operation)
       end
       mock_stub = MockGrpcClientStub.new(:snapshot_table, mock_method)
 
@@ -809,7 +821,57 @@ describe Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient do
           )
 
           # Verify the response
-          assert_equal(expected_response, response)
+          assert_equal(expected_response, response.response)
+        end
+      end
+    end
+
+    it 'invokes snapshot_table and returns an operation error.' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
+      cluster = ''
+      snapshot_id = ''
+      description = ''
+
+      # Create expected grpc response
+      operation_error = Google::Rpc::Status.new(
+        message: 'Operation error for Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient#snapshot_table.'
+      )
+      operation = Google::Longrunning::Operation.new(
+        name: 'operations/snapshot_table_test',
+        done: true,
+        error: operation_error
+      )
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Bigtable::Admin::V2::SnapshotTableRequest, request)
+        assert_equal(formatted_name, request.name)
+        assert_equal(cluster, request.cluster)
+        assert_equal(snapshot_id, request.snapshot_id)
+        assert_equal(description, request.description)
+        OpenStruct.new(execute: operation)
+      end
+      mock_stub = MockGrpcClientStub.new(:snapshot_table, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockBigtableTableAdminCredentials.new("snapshot_table")
+
+      Google::Bigtable::Admin::V2::BigtableTableAdmin::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Bigtable::Admin::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
+
+          # Call method
+          response = client.snapshot_table(
+            formatted_name,
+            cluster,
+            snapshot_id,
+            description
+          )
+
+          # Verify the response
+          assert(response.error?)
+          assert_equal(operation_error, response.error)
         end
       end
     end


### PR DESCRIPTION
This brings the Bigtable generated client up to date with the currently published protos, including items mentioned in #2101

We may need to check on those configuration changes though. I assume they are correct, but I don't really know.