### PR TITLE
Add necessary requires to bigtable tests

### DIFF
--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance_admin_client_test.rb
@@ -14,7 +14,6 @@
 
 
 require "test_helper"
-require "google/cloud/bigtable/instance_admin_client"
 
 class InstanceAdminTestError < StandardError
   def initialize(operation_name)

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table_admin_client_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table_admin_client_test.rb
@@ -14,7 +14,6 @@
 
 
 require "test_helper"
-require "google/cloud/bigtable/table_admin_client"
 
 class TableAdminTestError < StandardError
   def initialize(operation_name)

--- a/google-cloud-bigtable/test/google/cloud/bigtable_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable_test.rb
@@ -14,6 +14,9 @@
 
 
 require "test_helper"
+require "google/cloud/bigtable/instance_admin_client"
+require "google/cloud/bigtable/table_admin_client"
+require "google/cloud/bigtable/data_client"
 
 describe Google::Cloud do
   describe "#bigtable" do

--- a/google-cloud-bigtable/test/google/cloud/bigtable_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable_test.rb
@@ -14,9 +14,6 @@
 
 
 require "test_helper"
-require "google/cloud/bigtable/instance_admin_client"
-require "google/cloud/bigtable/table_admin_client"
-require "google/cloud/bigtable/data_client"
 
 describe Google::Cloud do
   describe "#bigtable" do

--- a/google-cloud-bigtable/test/test_helper.rb
+++ b/google-cloud-bigtable/test/test_helper.rb
@@ -23,6 +23,8 @@ require "google/cloud"
 require "google/cloud/bigtable"
 require "google/cloud/bigtable/admin/credentials"
 require "google/cloud/bigtable/data_client"
+require "google/cloud/bigtable/instance_admin_client"
+require "google/cloud/bigtable/table_admin_client"
 require "google/cloud/bigtable/table_data_operations"
 require "google/cloud/bigtable"
 


### PR DESCRIPTION
Moving requires to test_helper.

Currently these two files are being required only from certain tests that use them, but not from all test files that use them. In particular, `test/google/cloud/bigtable_test.rb` uses these classes but doesn't require the files. This is causing the tests to fail on some platforms (possibly inconsistently) because it imposes an order dependency on loading test files. I'm able to reproduce this on Mac OS X but not Debian (possibly because of differences in the sort order of the file system).

Sample error:
```
NameError: uninitialized constant Google::Cloud::Bigtable::TableAdminClient
/usr/local/google/home/dazuma/src/github/google-cloud-ruby/google-cloud-bigtable/test/google/cloud/bigtable_test.rb:68:in `block (2 levels) in <top (required)>'
/usr/local/google/home/dazuma/src/github/google-cloud-ruby/google-cloud-bigtable/test/google/cloud/bigtable_test.rb:20:in `block in <top (required)>'
/usr/local/google/home/dazuma/src/github/google-cloud-ruby/google-cloud-bigtable/test/google/cloud/bigtable_test.rb:19:in `<top (required)>'
```

Fixed by moving all the needed requires to the test_helper.
