### PR TITLE
Pub/Sub: Reduce String GC

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -267,7 +267,8 @@ module Google
             data = data.read
           end
           # Convert data to encoded byte array to match the protobuf defn
-          data_bytes = String(data).dup.force_encoding("ASCII-8BIT").freeze
+          data_bytes = \
+            String(data).dup.force_encoding(Encoding::ASCII_8BIT).freeze
 
           # Convert attributes to strings to match the protobuf definition
           attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/batch_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/batch_publisher.rb
@@ -84,7 +84,8 @@ module Google
             data = data.read
           end
           # Convert data to encoded byte array to match the protobuf defn
-          data_bytes = String(data).dup.force_encoding("ASCII-8BIT").freeze
+          data_bytes = \
+            String(data).dup.force_encoding(Encoding::ASCII_8BIT).freeze
 
           # Convert attributes to strings to match the protobuf definition
           attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
@@ -104,7 +104,7 @@ module Google
         # @private New Message from a Google::Pubsub::V1::PubsubMessage object.
         def self.from_grpc grpc
           new.tap do |m|
-            m.instance_variable_set "@grpc", grpc
+            m.instance_variable_set :@grpc, grpc
           end
         end
       end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
@@ -65,7 +65,7 @@ module Google
           attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]
 
           @grpc = Google::Pubsub::V1::PubsubMessage.new(
-            data: String(data).encode("ASCII-8BIT"),
+            data: String(data).dup.force_encoding(Encoding::ASCII_8BIT),
             attributes: attributes
           )
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
@@ -150,7 +150,7 @@ module Google
               Snapshot.from_grpc grpc, service
             end)
             token = grpc_list.next_page_token
-            token = nil if token == ""
+            token = nil if token == "".freeze
             subs.instance_variable_set :@token,   token
             subs.instance_variable_set :@service, service
             subs.instance_variable_set :@max,     max

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot/list.rb
@@ -151,9 +151,9 @@ module Google
             end)
             token = grpc_list.next_page_token
             token = nil if token == ""
-            subs.instance_variable_set "@token",   token
-            subs.instance_variable_set "@service", service
-            subs.instance_variable_set "@max",     max
+            subs.instance_variable_set :@token,   token
+            subs.instance_variable_set :@service, service
+            subs.instance_variable_set :@max,     max
             subs
           end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
@@ -155,7 +155,7 @@ module Google
               Subscription.from_grpc grpc, service
             end)
             token = grpc_list.next_page_token
-            token = nil if token == ""
+            token = nil if token == "".freeze
             subs.instance_variable_set :@token,   token
             subs.instance_variable_set :@service, service
             subs.instance_variable_set :@max,     max
@@ -170,7 +170,7 @@ module Google
               Subscription.new_lazy grpc, service
             end)
             token = grpc_list.next_page_token
-            token = nil if token == ""
+            token = nil if token == "".freeze
             subs.instance_variable_set :@token,   token
             subs.instance_variable_set :@service, service
             subs.instance_variable_set :@topic,   topic

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/list.rb
@@ -156,9 +156,9 @@ module Google
             end)
             token = grpc_list.next_page_token
             token = nil if token == ""
-            subs.instance_variable_set "@token",   token
-            subs.instance_variable_set "@service", service
-            subs.instance_variable_set "@max",     max
+            subs.instance_variable_set :@token,   token
+            subs.instance_variable_set :@service, service
+            subs.instance_variable_set :@max,     max
             subs
           end
 
@@ -171,10 +171,10 @@ module Google
             end)
             token = grpc_list.next_page_token
             token = nil if token == ""
-            subs.instance_variable_set "@token",   token
-            subs.instance_variable_set "@service", service
-            subs.instance_variable_set "@topic",   topic
-            subs.instance_variable_set "@max",     max
+            subs.instance_variable_set :@token,   token
+            subs.instance_variable_set :@service, service
+            subs.instance_variable_set :@topic,   topic
+            subs.instance_variable_set :@max,     max
             subs
           end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
@@ -150,9 +150,9 @@ module Google
             end)
             token = grpc_list.next_page_token
             token = nil if token == ""
-            topics.instance_variable_set "@token",   token
-            topics.instance_variable_set "@service", service
-            topics.instance_variable_set "@max",     max
+            topics.instance_variable_set :@token,   token
+            topics.instance_variable_set :@service, service
+            topics.instance_variable_set :@max,     max
             topics
           end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic/list.rb
@@ -149,7 +149,7 @@ module Google
               Topic.from_grpc grpc, service
             end)
             token = grpc_list.next_page_token
-            token = nil if token == ""
+            token = nil if token == "".freeze
             topics.instance_variable_set :@token,   token
             topics.instance_variable_set :@service, service
             topics.instance_variable_set :@max,     max

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
@@ -22,9 +22,9 @@ describe Google::Cloud::Pubsub::AsyncPublisher, :mock_pubsub do
   let(:message1) { "new-message-here" }
   let(:message2) { "second-new-message" }
   let(:message3) { "third-new-message" }
-  let(:msg_encoded1) { message1.encode("ASCII-8BIT") }
-  let(:msg_encoded2) { message2.encode("ASCII-8BIT") }
-  let(:msg_encoded3) { message3.encode("ASCII-8BIT") }
+  let(:msg_encoded1) { message1.encode(Encoding::ASCII_8BIT) }
+  let(:msg_encoded2) { message2.encode(Encoding::ASCII_8BIT) }
+  let(:msg_encoded3) { message3.encode(Encoding::ASCII_8BIT) }
 
   it "publishes a message" do
     messages = [

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
 
   it "publishes a message" do
     messages = [
-      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT))
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
@@ -54,7 +54,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
 
   it "publishes a message with a callback" do
     messages = [
-      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT))
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
@@ -97,7 +97,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
 
   it "publishes a message with multibyte characters" do
     messages = [
-      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT))
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
@@ -112,7 +112,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
       assert_kind_of Google::Cloud::Pubsub::PublishResult, result
       assert result.succeeded?
       assert_equal "msg1", result.msg_id
-      assert_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT"), result.data
+      assert_equal "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT), result.data
       callback_called = true
     end
 
@@ -141,7 +141,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
 
   it "publishes a message using an IO-ish object" do
     messages = [
-      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT))
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
@@ -161,7 +161,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
         assert_kind_of Google::Cloud::Pubsub::PublishResult, result
         assert result.succeeded?
         assert_equal "msg1", result.msg_id
-        assert_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT"), result.data
+        assert_equal "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT), result.data
         callback_called = true
       end
     end
@@ -191,7 +191,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
 
   it "publishes a message with attributes" do
     messages = [
-      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"), attributes: {"format" => "text"})
+      Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT), attributes: {"format" => "text"})
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
@@ -206,7 +206,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
       assert_kind_of Google::Cloud::Pubsub::PublishResult, result
       assert result.succeeded?
       assert_equal "msg1", result.msg_id
-      assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+      assert_equal "async-message".force_encoding(Encoding::ASCII_8BIT), result.data
       assert_equal "text", result.attributes["format"]
       callback_called = true
     end
@@ -241,7 +241,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
 
     it "publishes a message" do
       messages = [
-        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT))
       ]
       publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
       mock = Minitest::Mock.new
@@ -274,7 +274,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
 
     it "publishes a message with attributes" do
       messages = [
-        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"), attributes: { "format" => "text" })
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT), attributes: { "format" => "text" })
       ]
       publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
       mock = Minitest::Mock.new
@@ -289,7 +289,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
         assert_kind_of Google::Cloud::Pubsub::PublishResult, result
         assert result.succeeded?
         assert_equal "msg1", result.msg_id
-        assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+        assert_equal "async-message".force_encoding(Encoding::ASCII_8BIT), result.data
         assert_equal "text", result.attributes["format"]
         callback_called = true
       end
@@ -330,7 +330,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
 
     it "publishes a message" do
       messages = [
-        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode("ASCII-8BIT"))
+        Google::Pubsub::V1::PubsubMessage.new(data: "async-message".encode(Encoding::ASCII_8BIT))
       ]
 
       stub = Object.new
@@ -350,7 +350,7 @@ describe Google::Cloud::Pubsub::Topic, :publish_async, :mock_pubsub do
         assert_kind_of Google::Cloud::Pubsub::PublishResult, result
         refute result.succeeded?
         assert result.failed?
-        assert_equal "async-message".force_encoding("ASCII-8BIT"), result.data
+        assert_equal "async-message".force_encoding(Encoding::ASCII_8BIT), result.data
         assert_kind_of Google::Cloud::NotFoundError, result.error
         callback_called = true
       end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_test.rb
@@ -21,9 +21,9 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
   let(:message1) { "new-message-here" }
   let(:message2) { "second-new-message" }
   let(:message3) { "third-new-message" }
-  let(:msg_encoded1) { message1.encode("ASCII-8BIT") }
-  let(:msg_encoded2) { message2.encode("ASCII-8BIT") }
-  let(:msg_encoded3) { message3.encode("ASCII-8BIT") }
+  let(:msg_encoded1) { message1.encode(Encoding::ASCII_8BIT) }
+  let(:msg_encoded2) { message2.encode(Encoding::ASCII_8BIT) }
+  let(:msg_encoded3) { message3.encode(Encoding::ASCII_8BIT) }
 
   it "publishes a message" do
    messages = [
@@ -44,7 +44,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
 
   it "publishes a message with multibyte characters" do
    messages = [
-      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT))
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
@@ -56,13 +56,13 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
     mock.verify
 
     msg.must_be_kind_of Google::Cloud::Pubsub::Message
-    msg.data.must_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT")
+    msg.data.must_equal "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT)
     msg.message_id.must_equal "msg1"
   end
 
   it "publishes a message using an IO-ish object" do
    messages = [
-      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+      Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT))
     ]
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
     mock = Minitest::Mock.new
@@ -80,7 +80,7 @@ describe Google::Cloud::Pubsub::Topic, :publish, :mock_pubsub do
     mock.verify
 
     msg.must_be_kind_of Google::Cloud::Pubsub::Message
-    msg.data.must_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT")
+    msg.data.must_equal "\xE3\x81\x82".force_encoding(Encoding::ASCII_8BIT)
     msg.message_id.must_equal "msg1"
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -447,7 +447,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "can publish a message" do
     message = "new-message-here"
-    encoded_msg = message.encode("ASCII-8BIT")
+    encoded_msg = message.encode(Encoding::ASCII_8BIT)
     messages = [
       Google::Pubsub::V1::PubsubMessage.new(data: encoded_msg)
     ]
@@ -466,7 +466,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "can publish a message with attributes" do
     message = "new-message-here"
-    encoded_msg = message.encode("ASCII-8BIT")
+    encoded_msg = message.encode(Encoding::ASCII_8BIT)
     messages = [
       Google::Pubsub::V1::PubsubMessage.new(data: encoded_msg, attributes: { "format" => "text" })
     ]
@@ -487,8 +487,8 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
   it "can publish multiple messages with a block" do
     message1 = "first-new-message"
     message2 = "second-new-message"
-    encoded_msg1 = message1.encode("ASCII-8BIT")
-    encoded_msg2 = message2.encode("ASCII-8BIT")
+    encoded_msg1 = message1.encode(Encoding::ASCII_8BIT)
+    encoded_msg2 = message2.encode(Encoding::ASCII_8BIT)
     messages = [
       Google::Pubsub::V1::PubsubMessage.new(data: encoded_msg1),
       Google::Pubsub::V1::PubsubMessage.new(data: encoded_msg2, attributes: { "format" => "none" })


### PR DESCRIPTION
Reduce the number of throwaway strings created by the Pub/Sub implementation.

[refs #2122]