### PR TITLE
Fix YARD build in Ruby 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -40,6 +40,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-bigquery-data_transfer/Gemfile
+++ b/google-cloud-bigquery-data_transfer/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -14,6 +14,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -13,6 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # Ruby 2.0. We think this is because of a bug in Bundler 1.6. Specify a viable
   # version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-container/Gemfile
+++ b/google-cloud-container/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -14,6 +14,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-dataproc/Gemfile
+++ b/google-cloud-dataproc/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -13,6 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -17,6 +17,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-dialogflow/Gemfile
+++ b/google-cloud-dialogflow/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-dlp/Gemfile
+++ b/google-cloud-dlp/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -13,6 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -17,6 +17,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -13,6 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-language/Gemfile
+++ b/google-cloud-language/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -17,6 +17,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-monitoring/Gemfile
+++ b/google-cloud-monitoring/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-os_login/Gemfile
+++ b/google-cloud-os_login/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -13,6 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-redis/Gemfile
+++ b/google-cloud-redis/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -13,6 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -13,6 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-speech/Gemfile
+++ b/google-cloud-speech/Gemfile
@@ -14,6 +14,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -14,6 +14,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-tasks/Gemfile
+++ b/google-cloud-tasks/Gemfile
@@ -16,4 +16,5 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -16,6 +16,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-translate/Gemfile
+++ b/google-cloud-translate/Gemfile
@@ -13,6 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-video_intelligence/Gemfile
+++ b/google-cloud-video_intelligence/Gemfile
@@ -11,6 +11,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -14,6 +14,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -40,6 +40,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -13,6 +13,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -21,6 +21,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
   # We think this is because of a bug in Bundler 1.6.
   # Specify a viable version to allow the build to succeed.
   gem "jwt", "~> 1.5"
+  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
 end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0


### PR DESCRIPTION
Pin `kramdown` to `< 1.17.0` conditionally for Ruby 2.0.0 to fix:

```sh
bundle exec rake jsondoc

rake aborted!

TypeError: no implicit conversion of String into Integer

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown/header.rb:48:in `[]'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown/header.rb:48:in `parse_header_contents'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown/header.rb:34:in `parse_atx_header'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown.rb:148:in `block (2 levels) in parse_blocks'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown.rb:146:in `each'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown.rb:146:in `any?'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown.rb:146:in `block in parse_blocks'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown.rb:144:in `catch'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown.rb:144:in `parse_blocks'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/kramdown.rb:89:in `parse'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/parser/base.rb:69:in `parse'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/kramdown-1.17.0/lib/kramdown/document.rb:104:in `initialize'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/helpers/html_helper.rb:85:in `new'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/helpers/html_helper.rb:85:in `html_markup_markdown'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/helpers/html_helper.rb:59:in `htmlify'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/layout/html/setup.rb:67:in `diskfile'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:367:in `render_section'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:259:in `block (2 levels) in run'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:256:in `each'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:256:in `block in run'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:398:in `add_options'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:255:in `run'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:277:in `block in yieldall'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:412:in `with_section'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:277:in `yieldall'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/layout/html/layout.erb:21:in `_erb_cache_5'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:287:in `erb'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/layout/html/setup.rb:62:in `layout'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:367:in `render_section'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:259:in `block (2 levels) in run'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:256:in `each'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:256:in `block in run'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:398:in `add_options'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:255:in `run'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:136:in `run'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/fulldoc/html/setup.rb:52:in `block in serialize_index'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/engine.rb:123:in `block in with_serializer'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/logging.rb:82:in `capture'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/engine.rb:121:in `with_serializer'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/fulldoc/html/setup.rb:51:in `serialize_index'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/fulldoc/html/setup.rb:68:in `serialize_file'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/fulldoc/html/setup.rb:11:in `block in init'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/fulldoc/html/setup.rb:10:in `each'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/fulldoc/html/setup.rb:10:in `each_with_index'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/templates/default/fulldoc/html/setup.rb:10:in `init'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:193:in `initialize'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:131:in `new'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/template.rb:136:in `run'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/templates/engine.rb:105:in `generate'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/cli/yardoc.rb:355:in `run_generate'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/cli/yardoc.rb:267:in `run'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/yard-0.9.14/lib/yard/rake/yardoc_task.rb:74:in `block in define'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/bin/ruby_executable_hooks:15:in `eval'

/opt/circleci/.rvm/gems/ruby-2.0.0-p648/bin/ruby_executable_hooks:15:in `<main>'

Tasks: TOP => jsondoc => yard

(See full trace by running task with --trace)

rake aborted!
```