### PR TITLE
Correct the argument type for the schema in Schema::dump

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -84,7 +84,7 @@ module Google
           # The JSON schema file is the same as for the [`bq`
           # CLI](https://cloud.google.com/bigquery/docs/schemas#specifying_a_json_schema_file).
           #
-          # @param [IO, String] schema An `Google::Cloud::Bigquery::Schema`.
+          # @param [Schema] schema An `Google::Cloud::Bigquery::Schema`.
           #
           # @param [IO, String] destination An `IO` to which to write the
           #   schema, or a `String` containing the filename to write to.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -84,7 +84,7 @@ module Google
           # The JSON schema file is the same as for the [`bq`
           # CLI](https://cloud.google.com/bigquery/docs/schemas#specifying_a_json_schema_file).
           #
-          # @param [Schema] schema An `Google::Cloud::Bigquery::Schema`.
+          # @param [Schema] schema A `Google::Cloud::Bigquery::Schema`.
           #
           # @param [IO, String] destination An `IO` to which to write the
           #   schema, or a `String` containing the filename to write to.


### PR DESCRIPTION
I had a copy-paste error in the documents for `Schema::dump` that listed the `schema` argument as `IO, String`. This corrects that.