### PR TITLE
Add Session labels to Project#client and #batch_client

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/edge_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/edge_test.rb
@@ -26,13 +26,13 @@ describe "Spanner Client", :edge, :spanner do
   end
 
   it "reads with invalid table fails" do
-    assert_raises GRPC::NotFound do
+    assert_raises Google::Cloud::NotFoundError do
       db.read "invalid_table", [:id, :int]
     end
   end
 
   it "reads with invalid column fails" do
-    assert_raises GRPC::NotFound do
+    assert_raises Google::Cloud::NotFoundError do
       db.read table_name, [:id, :invalid]
     end
   end
@@ -59,19 +59,19 @@ describe "Spanner Client", :edge, :spanner do
   end
 
   it "queries to a non-existing table fails" do
-    assert_raises GRPC::InvalidArgument do
+    assert_raises Google::Cloud::InvalidArgumentError do
       db.execute "SELECT id, name FROM invalid_table"
     end
   end
 
   it "queries to a non-existing column fails" do
-    assert_raises GRPC::InvalidArgument do
+    assert_raises Google::Cloud::InvalidArgumentError do
       db.execute "SELECT id, name FROM #{table_name}"
     end
   end
 
   it "queries with bad SQL fails" do
-    assert_raises GRPC::InvalidArgument do
+    assert_raises Google::Cloud::InvalidArgumentError do
       db.execute "SELECT Apples AND Oranges"
     end
   end

--- a/google-cloud-spanner/lib/google/cloud/spanner/batch_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/batch_client.rb
@@ -65,10 +65,11 @@ module Google
       class BatchClient
         ##
         # @private Creates a new Spanner BatchClient instance.
-        def initialize project, instance_id, database_id
+        def initialize project, instance_id, database_id, session_labels: nil
           @project = project
           @instance_id = instance_id
           @database_id = database_id
+          @session_labels = session_labels
         end
 
         # The unique identifier for the project.
@@ -406,7 +407,8 @@ module Google
           grpc = @project.service.create_session \
             Admin::Database::V1::DatabaseAdminClient.database_path(
               project_id, instance_id, database_id
-            )
+            ),
+            labels: @session_labels
           Session.from_grpc(grpc, @project.service)
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -52,11 +52,13 @@ module Google
       class Client
         ##
         # @private Creates a new Spanner Client instance.
-        def initialize project, instance_id, database_id, opts = {}
+        def initialize project, instance_id, database_id, session_labels: nil,
+                       pool_opts: {}
           @project = project
           @instance_id = instance_id
           @database_id = database_id
-          @pool = Pool.new self, opts
+          @session_labels = session_labels
+          @pool = Pool.new self, pool_opts
         end
 
         # The unique identifier for the project.
@@ -1091,7 +1093,8 @@ module Google
           grpc = @project.service.create_session \
             Admin::Database::V1::DatabaseAdminClient.database_path(
               project_id, instance_id, database_id
-            )
+            ),
+            labels: @session_labels
           Session.from_grpc(grpc, @project.service)
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -219,6 +219,8 @@ module Google
         def create_instance instance_id, name: nil, config: nil, nodes: nil,
                             labels: nil
           config = config.path if config.respond_to? :path
+          # Convert from possible Google::Protobuf::Map
+          labels = Hash[labels.map { |k, v| [String(k), String(v)] }] if labels
           grpc = service.create_instance \
             instance_id, name: name, config: config, nodes: nodes,
                          labels: labels
@@ -435,6 +437,21 @@ module Google
         #     becomes available. The default is `true`.
         #   * `:threads` (Integer) The number of threads in the thread pool. The
         #     default is twice the number of available CPUs.
+        # @param [Hash] session_labels The labels to be applied to all sessions
+        #   created by the client. Cloud Labels are a flexible and lightweight
+        #   mechanism for organizing cloud resources into groups that reflect a
+        #   customer's organizational needs and deployment strategies. Cloud
+        #   Labels can be used to filter collections of resources. They can be
+        #   used to control how resource metrics are aggregated. And they can be
+        #   used as arguments to policy management rules (e.g. route, firewall,
+        #   load balancing, etc.). Optional. The default is `nil`.
+        #
+        #   * Label keys must be between 1 and 63 characters long and must
+        #     conform to the following regular expression:
+        #     `[a-z]([-a-z0-9]*[a-z0-9])?`.
+        #   * Label values must be between 0 and 63 characters long and must
+        #     conform to the regular expression `([a-z]([-a-z0-9]*[a-z0-9])?)?`.
+        #   * No more than 64 labels can be associated with a given resource.
         #
         # @return [Client] The newly created client.
         #
@@ -453,9 +470,15 @@ module Google
         #     end
         #   end
         #
-        def client instance_id, database_id, pool: {}
+        def client instance_id, database_id, pool: {}, session_labels: nil
+          if session_labels
+            # Convert from possible Google::Protobuf::Map
+            session_labels = \
+              Hash[session_labels.map { |k, v| [String(k), String(v)] }]
+          end
           Client.new self, instance_id, database_id,
-                     valid_session_pool_options(pool)
+                     session_labels: session_labels,
+                     pool_opts: valid_session_pool_options(pool)
         end
 
         ##
@@ -466,6 +489,21 @@ module Google
         #   Required.
         # @param [String] database_id The unique identifier for the database.
         #   Required.
+        # @param [Hash] session_labels The labels to be applied to all sessions
+        #   created by the batch client. Labels are a flexible and lightweight
+        #   mechanism for organizing cloud resources into groups that reflect a
+        #   customer's organizational needs and deployment strategies. Cloud
+        #   Labels can be used to filter collections of resources. They can be
+        #   used to control how resource metrics are aggregated. And they can be
+        #   used as arguments to policy management rules (e.g. route, firewall,
+        #   load balancing, etc.). Optional. The default is `nil`.
+        #
+        #   * Label keys must be between 1 and 63 characters long and must
+        #     conform to the following regular expression:
+        #     `[a-z]([-a-z0-9]*[a-z0-9])?`.
+        #   * Label values must be between 0 and 63 characters long and must
+        #     conform to the regular expression `([a-z]([-a-z0-9]*[a-z0-9])?)?`.
+        #   * No more than 64 labels can be associated with a given resource.
         #
         # @return [Client] The newly created client.
         #
@@ -494,8 +532,14 @@ module Google
         #   results = new_batch_snapshot.execute_partition \
         #     new_partition
         #
-        def batch_client instance_id, database_id
-          BatchClient.new self, instance_id, database_id
+        def batch_client instance_id, database_id, session_labels: nil
+          if session_labels
+            # Convert from possible Google::Protobuf::Map
+            session_labels = \
+              Hash[session_labels.map { |k, v| [String(k), String(v)] }]
+          end
+          BatchClient.new self, instance_id, database_id,
+                          session_labels: session_labels
         end
 
         protected

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -437,7 +437,7 @@ module Google
         #     becomes available. The default is `true`.
         #   * `:threads` (Integer) The number of threads in the thread pool. The
         #     default is twice the number of available CPUs.
-        # @param [Hash] session_labels The labels to be applied to all sessions
+        # @param [Hash] labels The labels to be applied to all sessions
         #   created by the client. Cloud Labels are a flexible and lightweight
         #   mechanism for organizing cloud resources into groups that reflect a
         #   customer's organizational needs and deployment strategies. Cloud
@@ -470,14 +470,11 @@ module Google
         #     end
         #   end
         #
-        def client instance_id, database_id, pool: {}, session_labels: nil
-          if session_labels
-            # Convert from possible Google::Protobuf::Map
-            session_labels = \
-              Hash[session_labels.map { |k, v| [String(k), String(v)] }]
-          end
+        def client instance_id, database_id, pool: {}, labels: nil
+          # Convert from possible Google::Protobuf::Map
+          labels = Hash[labels.map { |k, v| [String(k), String(v)] }] if labels
           Client.new self, instance_id, database_id,
-                     session_labels: session_labels,
+                     session_labels: labels,
                      pool_opts: valid_session_pool_options(pool)
         end
 
@@ -489,7 +486,7 @@ module Google
         #   Required.
         # @param [String] database_id The unique identifier for the database.
         #   Required.
-        # @param [Hash] session_labels The labels to be applied to all sessions
+        # @param [Hash] labels The labels to be applied to all sessions
         #   created by the batch client. Labels are a flexible and lightweight
         #   mechanism for organizing cloud resources into groups that reflect a
         #   customer's organizational needs and deployment strategies. Cloud
@@ -532,14 +529,10 @@ module Google
         #   results = new_batch_snapshot.execute_partition \
         #     new_partition
         #
-        def batch_client instance_id, database_id, session_labels: nil
-          if session_labels
-            # Convert from possible Google::Protobuf::Map
-            session_labels = \
-              Hash[session_labels.map { |k, v| [String(k), String(v)] }]
-          end
-          BatchClient.new self, instance_id, database_id,
-                          session_labels: session_labels
+        def batch_client instance_id, database_id, labels: nil
+          # Convert from possible Google::Protobuf::Map
+          labels = Hash[labels.map { |k, v| [String(k), String(v)] }] if labels
+          BatchClient.new self, instance_id, database_id, session_labels: labels
         end
 
         protected

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -206,6 +206,8 @@ module Google
             results.instance_variable_set :@enum,     enum
             results.instance_variable_set :@service,  service
           end
+        rescue GRPC::BadStatus => e
+          raise Google::Cloud::Error.from_error(e)
         end
 
         # @private

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -241,10 +241,12 @@ module Google
           end
         end
 
-        def create_session database_name
+        def create_session database_name, labels: nil
           opts = default_options_from_session database_name
+          session = Google::Spanner::V1::Session.new(labels: labels) if labels
           execute do
-            service.create_session database_name, options: opts
+            service.create_session database_name, session: session,
+                                                  options: opts
           end
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -597,10 +597,12 @@ module Google
           @last_updated_at = Time.now
           return self
         rescue Google::Cloud::NotFoundError
+          labels = @grpc.labels.to_h unless @grpc.labels.to_h.empty?
           @grpc = service.create_session \
             Admin::Database::V1::DatabaseAdminClient.database_path(
               project_id, instance_id, database_id
-            )
+            ),
+            labels: labels
           @last_updated_at = Time.now
           return self
         end
@@ -613,10 +615,12 @@ module Google
           execute "SELECT 1"
           return true
         rescue Google::Cloud::NotFoundError
+          labels = @grpc.labels.to_h unless @grpc.labels.to_h.empty?
           @grpc = service.create_session \
             Admin::Database::V1::DatabaseAdminClient.database_path(
               project_id, instance_id, database_id
-            )
+            ),
+            labels: labels
           return false
         end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   let(:batch_client) { spanner.batch_client instance_id, database_id }
 
   let(:labels) { { "env" => "production" } }
-  let(:batch_client_labels) { spanner.batch_client instance_id, database_id, session_labels: labels }
+  let(:batch_client_labels) { spanner.batch_client instance_id, database_id, labels: labels }
 
   it "knows its project_id" do
     batch_client.project_id.must_equal project

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
@@ -31,6 +31,9 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:batch_client) { spanner.batch_client instance_id, database_id }
 
+  let(:labels) { { "env" => "production" } }
+  let(:batch_client_labels) { spanner.batch_client instance_id, database_id, session_labels: labels }
+
   it "knows its project_id" do
     batch_client.project_id.must_equal project
   end
@@ -80,11 +83,28 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
   it "creates a batch_snapshot" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
     batch_snapshot = batch_client.batch_snapshot
+
+    mock.verify
+
+    batch_snapshot.transaction_id.must_equal transaction_id
+    batch_snapshot.timestamp.must_equal timestamp_time
+    batch_snapshot.session.path.must_equal session.path
+  end
+
+  it "creates a batch_snapshot with session labels" do
+    mock = Minitest::Mock.new
+    session_labels_grpc = Google::Spanner::V1::Session.new labels: labels
+    session_labels_resp_grpc = Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id), labels: labels
+    mock.expect :create_session, session_labels_resp_grpc, [database_path(instance_id, database_id), session: session_labels_grpc, options: default_options]
+    mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
+    spanner.service.mocked_service = mock
+
+    batch_snapshot = batch_client_labels.batch_snapshot
 
     mock.verify
 
@@ -98,7 +118,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     it "creates a batch_snapshot with strong timestamp bound" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -120,7 +140,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     it "creates a batch_snapshot with timestamp option (Time)" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -135,7 +155,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     it "creates a batch_snapshot with read_timestamp option (Time)" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -150,7 +170,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     it "creates a batch_snapshot with timestamp option (DateTime)" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -165,7 +185,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     it "creates a batch_snapshot with read_timestamp option (DateTime)" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -186,7 +206,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     it "creates a batch_snapshot with the staleness option" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -201,7 +221,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
 
     it "creates a batch_snapshot with the exact_staleness option" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_field_values_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_field_values_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       ]
 
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -84,7 +84,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       ]
 
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -107,7 +107,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       ]
 
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -130,7 +130,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       ]
 
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -153,7 +153,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       ]
 
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 
@@ -176,7 +176,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       ]
 
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
       spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -64,7 +64,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -93,7 +93,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -116,7 +116,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -139,7 +139,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -162,7 +162,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -185,7 +185,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -211,7 +211,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -242,7 +242,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -266,7 +266,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -292,7 +292,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -320,7 +320,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -342,7 +342,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: nil, single_use_transaction: tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_resume_test.rb
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Client, :execute, :resume, :mock_spanner do
 
   it "resumes broken response streams" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, RaiseableEnumerator.new(results_enum1), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     mock.expect :execute_streaming_sql, RaiseableEnumerator.new(results_enum2), [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: "abc123", partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_single_use_test.rb
@@ -71,7 +71,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -94,7 +94,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -117,7 +117,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -140,7 +140,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -163,7 +163,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -186,7 +186,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -209,7 +209,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -232,7 +232,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -255,7 +255,7 @@ describe Google::Cloud::Spanner::Client, :execute, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: transaction, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_test.rb
@@ -60,7 +60,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with bool param" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE active = @active", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "active" => Google::Protobuf::Value.new(bool_value: true) }), param_types: { "active" => Google::Spanner::V1::Type.new(code: :BOOL) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -90,7 +90,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with int param" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE age = @age", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "age" => Google::Protobuf::Value.new(string_value: "29") }), param_types: { "age" => Google::Spanner::V1::Type.new(code: :INT64) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with float param" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE score = @score", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "score" => Google::Protobuf::Value.new(number_value: 0.9) }), param_types: { "score" => Google::Spanner::V1::Type.new(code: :FLOAT64) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -122,7 +122,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     timestamp = Time.parse "2017-01-01 20:04:05.06 -0700"
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE updated_at = @updated_at", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "updated_at" => Google::Protobuf::Value.new(string_value: "2017-01-02T03:04:05.060000000Z") }), param_types: { "updated_at" => Google::Spanner::V1::Type.new(code: :TIMESTAMP) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -139,7 +139,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     date = Date.parse "2017-01-02"
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE birthday = @birthday", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "birthday" => Google::Protobuf::Value.new(string_value: "2017-01-02") }), param_types: { "birthday" => Google::Spanner::V1::Type.new(code: :DATE) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -154,7 +154,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with String param" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE name = @name", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "name" => Google::Protobuf::Value.new(string_value: "Charlie") }), param_types: { "name" => Google::Spanner::V1::Type.new(code: :STRING) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -171,7 +171,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
     file = StringIO.new "contents"
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE avatar = @avatar", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "avatar" => Google::Protobuf::Value.new(string_value: Base64.strict_encode64("contents")) }), param_types: { "avatar" => Google::Spanner::V1::Type.new(code: :BYTES) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -186,7 +186,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with an Array param" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -201,7 +201,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with an empty Array param" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE project_ids = @list", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "list" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "list" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -216,7 +216,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with a simple Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id),  session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production")])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING))])) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -231,7 +231,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with a complex Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id),  session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "production"), Google::Protobuf::Value.new(number_value: 0.9), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "1"), Google::Protobuf::Value.new(string_value: "2"), Google::Protobuf::Value.new(string_value: "3")] )) ])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [Google::Spanner::V1::StructType::Field.new(name: "env", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "score", type: Google::Spanner::V1::Type.new(code: :FLOAT64)), Google::Spanner::V1::StructType::Field.new(name: "project_ids", type: Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :INT64)))] )) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -246,7 +246,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with an Array of Hashes" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -259,7 +259,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with an Array of STRUCTs" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE STRUCT<name STRING, email STRING>(name, email) IN UNNEST(@data)", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "data" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "mike"), Google::Protobuf::Value.new(string_value: "mike@example.net")] )), Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [Google::Protobuf::Value.new(string_value: "chris"), Google::Protobuf::Value.new(string_value: "chris@example.net")] ))] )) } ), param_types: { "data" => Google::Spanner::V1::Type.new(code: :ARRAY, array_element_type: Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [ Google::Spanner::V1::StructType::Field.new(name: "name", type: Google::Spanner::V1::Type.new(code: :STRING)), Google::Spanner::V1::StructType::Field.new(name: "email", type: Google::Spanner::V1::Type.new(code: :STRING))] ))) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -273,7 +273,7 @@ describe Google::Cloud::Spanner::Client, :execute, :mock_spanner do
 
   it "can execute a query with an empty Hash param" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE settings = @dict", transaction: nil, params: Google::Protobuf::Struct.new(fields: { "dict" => Google::Protobuf::Value.new(list_value: Google::Protobuf::ListValue.new(values: [])) }), param_types: { "dict" => Google::Spanner::V1::Type.new(code: :STRUCT, struct_type: Google::Spanner::V1::StructType.new(fields: [])) }, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
 
   it "can get a table's fields" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users WHERE 1 = 0", transaction: nil, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
@@ -100,7 +100,7 @@ describe Google::Cloud::Spanner::Client, :read, :error, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(results_enum1), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
     ].to_enum
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, no_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -142,7 +142,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
     ].to_enum
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, all_tokens_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -180,7 +180,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
     ].to_enum
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(bounds_with_abort_enum), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -107,7 +107,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(results_enum1), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     mock.expect :streaming_read, RaiseableEnumerator.new(results_enum2), [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: "abc123", partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -72,7 +72,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -95,7 +95,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -118,7 +118,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -141,7 +141,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -164,7 +164,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -187,7 +187,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -210,7 +210,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -233,7 +233,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -256,7 +256,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
     )
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: transaction, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -70,11 +70,14 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   end
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
+  let(:labels) { { "env" => "production" } }
+  let(:client_labels) { spanner.client instance_id, database_id, pool: { min: 0 }, session_labels: labels }
+
   it "can read all rows" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -91,7 +94,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -112,7 +115,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([time1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([time2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([time3]).list_value]), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -129,7 +132,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1,1]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([2,2]).list_value, Google::Cloud::Spanner::Convert.object_to_grpc_value([3,3]).list_value]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -146,7 +149,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(ranges: [Google::Cloud::Spanner::Convert.to_key_range([1,1]..[3,3])]), transaction: nil, index: "MyTableCompositeKey", limit: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -164,7 +167,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: 5, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -181,13 +184,32 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(keys: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1]).list_value]), transaction: nil, index: nil, limit: 1, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     results = client.read "my-table", columns, keys: 1, limit: 1
 
     shutdown_client! client
+
+    mock.verify
+
+    assert_results results
+  end
+
+  it "can read all rows with session labels" do
+    columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]
+
+    mock = Minitest::Mock.new
+    session_labels_grpc = Google::Spanner::V1::Session.new labels: labels
+    session_labels_resp_grpc = Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id), labels: labels
+    mock.expect :create_session, session_labels_resp_grpc, [database_path(instance_id, database_id), session: session_labels_grpc, options: default_options]
+    mock.expect :streaming_read, results_enum, [session_grpc.name, "my-table", ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"], Google::Spanner::V1::KeySet.new(all: true), transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil, options: default_options]
+    spanner.service.mocked_service = mock
+
+    results = client_labels.read "my-table", columns
+
+    shutdown_client! client_labels
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -71,7 +71,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
   let(:labels) { { "env" => "production" } }
-  let(:client_labels) { spanner.client instance_id, database_id, pool: { min: 0 }, session_labels: labels }
+  let(:client_labels) { spanner.client instance_id, database_id, pool: { min: 0 }, labels: labels }
 
   it "can read all rows" do
     columns = [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -67,7 +67,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
   it "can execute a simple query without any options" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock
@@ -105,7 +105,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the strong option" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
       spanner.service.mocked_service = mock
@@ -132,7 +132,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the timestamp option (Time)" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
       spanner.service.mocked_service = mock
@@ -152,7 +152,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the read_timestamp option (Time)" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
       spanner.service.mocked_service = mock
@@ -172,7 +172,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the timestamp option (DateTime)" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
       spanner.service.mocked_service = mock
@@ -192,7 +192,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the read_timestamp option (DateTime)" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
       spanner.service.mocked_service = mock
@@ -218,7 +218,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the staleness option" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
       spanner.service.mocked_service = mock
@@ -238,7 +238,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
     it "can execute a simple query with the exact_staleness option" do
       mock = Minitest::Mock.new
-      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+      mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
       mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
       mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
       spanner.service.mocked_service = mock
@@ -259,7 +259,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
 
   it "does not allow nested snapshots" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     spanner.service.mocked_service = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
 
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
 
@@ -183,7 +183,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
 
@@ -237,7 +237,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
 
@@ -301,7 +301,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
 
   it "will rollback and not pass on the error when using Rollback" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
@@ -94,7 +94,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
 
   it "will rollback and pass on the error" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
@@ -123,7 +123,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
 
   it "does not allow nested transactions" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :rollback, nil, [session_grpc.name, transaction_id, options: default_options]
     # transaction checkin

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -68,7 +68,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
   it "can execute a simple query" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :execute_streaming_sql, results_enum, [session_grpc.name, "SELECT * FROM users", transaction: tx_selector, params: nil, param_types: nil, resume_token: nil, partition_token: nil, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, [], transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
@@ -101,7 +101,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
@@ -157,7 +157,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
@@ -185,7 +185,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
@@ -213,7 +213,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
@@ -244,7 +244,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
@@ -273,7 +273,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
@@ -304,7 +304,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
@@ -331,7 +331,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin
@@ -386,7 +386,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     ]
 
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, transaction_grpc, [session_grpc.name, tx_opts, options: default_options]
     mock.expect :commit, commit_resp, [session_grpc.name, mutations, transaction_id: transaction_id, single_use_transaction: nil, options: default_options]
     # transaction checkin

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -34,8 +34,8 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
   it "creates two sessions and one transaction" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock
 
@@ -52,11 +52,11 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
   it "creates five sessions and three transactions" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-003-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-004-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-005-01"), [String, tx_opts, options: default_options]
@@ -75,14 +75,14 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
 
   it "creates eight sessions and three transactions" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-006")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-007")), [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008")), [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-001")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-002")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-003")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-004")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-005")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-006")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-007")), [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, Google::Spanner::V1::Session.new(name: session_path(instance_id, database_id, "session-008")), [database_path(instance_id, database_id), session: nil, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-007-01"), [String, tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-008-01"), [String, tx_opts, options: default_options]
     spanner.service.mocked_service = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
   it "creates new sessions when needed" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     pool.all_sessions.size.must_equal 1
@@ -81,9 +81,9 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
   it "raises when checking out more than MAX sessions" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     spanner.service.mocked_service = mock
 
     pool.all_sessions.size.must_equal 1
@@ -185,7 +185,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
   it "creates new transaction when needed" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     # created when checking out
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
@@ -216,7 +216,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
   it "creates new transaction when needed using with_transaction" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     # created when checking out
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
@@ -248,9 +248,9 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
   it "raises when checking out more than MAX transaction" do
     mock = Minitest::Mock.new
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
-    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
     # created when checking out
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-001-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]
     mock.expect :begin_transaction, Google::Spanner::V1::Transaction.new(id: "tx-002-01"), [session_path(instance_id, database_id, session_id), tx_opts, options: default_options]

--- a/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
@@ -22,6 +22,10 @@ describe Google::Cloud::Spanner::Session, :reload, :mock_spanner do
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
   let(:default_options) { Google::Gax::CallOptions.new kwargs: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
 
+  let(:labels) { { "env" => "production" } }
+  let(:session_grpc_labels) { Google::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id), labels: labels }
+  let(:session_labels) { Google::Cloud::Spanner::Session.from_grpc session_grpc_labels, spanner.service }
+
   it "can reload itself" do
     mock = Minitest::Mock.new
     mock.expect :get_session, session_grpc, [session_grpc.name, options: default_options]
@@ -39,5 +43,49 @@ describe Google::Cloud::Spanner::Session, :reload, :mock_spanner do
     session.instance_id.must_equal "my-instance-id"
     session.database_id.must_equal "my-database-id"
     session.session_id.must_equal "session123"
+  end
+
+  it "can recreate itself if error is raised on reload" do
+    mock = Minitest::Mock.new
+    def mock.get_session *args
+      raise GRPC::NotFound.new 5, "not found"
+    end
+    mock.expect :create_session, session_grpc, [database_path(instance_id, database_id), session: nil, options: default_options]
+    session.service.mocked_service = mock
+
+    session.must_be_kind_of Google::Cloud::Spanner::Session
+
+    session.reload!
+
+    mock.verify
+
+    session.must_be_kind_of Google::Cloud::Spanner::Session
+
+    session.project_id.must_equal "test"
+    session.instance_id.must_equal "my-instance-id"
+    session.database_id.must_equal "my-database-id"
+    session.session_id.must_equal "session123"
+  end
+
+  it "can recreate itself with labels if error on reload" do
+    mock = Minitest::Mock.new
+    def mock.get_session *args
+      raise GRPC::NotFound.new 5, "not found"
+    end
+    mock.expect :create_session, session_grpc_labels, [database_path(instance_id, database_id), session: Google::Spanner::V1::Session.new(labels: labels), options: default_options]
+    session_labels.service.mocked_service = mock
+
+    session_labels.must_be_kind_of Google::Cloud::Spanner::Session
+
+    session_labels.reload!
+
+    mock.verify
+
+    session_labels.must_be_kind_of Google::Cloud::Spanner::Session
+
+    session_labels.project_id.must_equal "test"
+    session_labels.instance_id.must_equal "my-instance-id"
+    session_labels.database_id.must_equal "my-database-id"
+    session_labels.session_id.must_equal "session123"
   end
 end


### PR DESCRIPTION
Also:

* Convert labels argument from `Google::Protobuf::Map`.
* Rescue `GRPC` error in `Results.from_enum`.
* Update expected errors in acceptance tests.
* Add error case unit tests for `Session#reload!` and `#keepalive!`

[closes #1817]