### PR TITLE
Officially support only Ruby 2.3 and later

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,12 +2,6 @@ environment:
   matrix:
     - RUBY_VERSION: 23-x64
       DEVKIT: C:\Ruby23-x64\DevKit
-    - RUBY_VERSION: 22-x64
-      DEVKIT: C:\Ruby23-x64\DevKit
-    - RUBY_VERSION: 21-x64
-      DEVKIT: C:\Ruby23-x64\DevKit
-    - RUBY_VERSION: 200-x64
-      DEVKIT: C:\Ruby23-x64\DevKit
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,12 @@ os:
 - osx
 osx_image: xcode8.3
 rvm:
-- 2.5.0
-- 2.4.3
-- 2.3.6
-- 2.2.9
-- 2.1.10
+- 2.5.1
+- 2.4.4
+- 2.3.7
 matrix:
   allow_failures:
-  - rvm: 2.5.0
+  - rvm: 2.5.1
 branches:
   except:
   - gh-pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ In order to use the google-cloud-ruby console and run the project's tests, there
 small amount of setup:
 
 1. Install Ruby.
-    google-cloud-ruby requires Ruby 2.0+. You may choose to manage your Ruby and gem installations with [RVM](https://rvm.io/), [rbenv](https://github.com/rbenv/rbenv), or [chruby](https://github.com/postmodern/chruby).
+    google-cloud-ruby requires Ruby 2.3+. You may choose to manage your Ruby and gem installations with [RVM](https://rvm.io/), [rbenv](https://github.com/rbenv/rbenv), or [chruby](https://github.com/postmodern/chruby).
 
 2. Install [Bundler](http://bundler.io/).
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "google-cloud-bigtable", path: "google-cloud-bigtable"
 gem "google-cloud-container", path: "google-cloud-container"
 gem "google-cloud-dataproc", path: "google-cloud-dataproc"
 gem "google-cloud-datastore", path: "google-cloud-datastore"
+gem "google-cloud-debugger", path: "google-cloud-debugger"
 gem "google-cloud-dialogflow", path: "google-cloud-dialogflow"
 gem "google-cloud-dlp", path: "google-cloud-dlp"
 gem "google-cloud-dns", path: "google-cloud-dns"
@@ -49,19 +50,7 @@ gem "google-cloud-vision", path: "google-cloud-vision"
 gem "google-cloud", path: "google-cloud"
 gem "gcloud", path: "gcloud"
 gem "stackdriver-core", path: "stackdriver-core"
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.0")
-  gem "stackdriver", path: "stackdriver"
-  gem "google-cloud-debugger", path: "google-cloud-debugger"
-end
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
+gem "stackdriver", path: "stackdriver"
 
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rake", "~> 11.0"
+gem "rake", "~> 12.0"
 gem "minitest", "~> 5.10"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.1"
@@ -51,11 +51,3 @@ gem "google-cloud", path: "google-cloud"
 gem "gcloud", path: "gcloud"
 gem "stackdriver-core", path: "stackdriver-core"
 gem "stackdriver", path: "stackdriver"
-
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
-
-# TEMP: nokogiri (a dependency of rails) 1.7 requires Ruby 2.1 or later.
-# Since we're still testing on Ruby 2.0, pin nokogiri to 1.6 for now.
-gem "nokogiri", "~> 1.6.8"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 12.3"
 gem "minitest", "~> 5.10"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.1"

--- a/README.md
+++ b/README.md
@@ -909,14 +909,14 @@ $ gem install google-cloud-video_intelligence
 
 ## Supported Ruby Versions
 
-These libraries are currently supported on Ruby 2.0+.
+These libraries are currently supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core (that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life). Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -912,8 +912,8 @@ $ gem install google-cloud-video_intelligence
 These libraries are currently supported on Ruby 2.3+.
 
 Google provides official support for Ruby versions that are actively supported
-by Ruby Core (that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life). Currently, this means Ruby 2.3
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/build/post_test.rb
+++ b/build/post_test.rb
@@ -1,6 +1,9 @@
 require "pty"
 
 commands = [
+  # These jobs are run on separate versions just so they run on different
+  # servers and don't block each other. They don't actually have a version
+  # dependency.
   "rvm-exec 2.5.1 bundle update; rvm-exec 2.5.1 bundle exec rake circleci:post",
   "rvm-exec 2.4.4 bundle update; rvm-exec 2.4.4 bundle exec rake test:coveralls"
 ]

--- a/build/post_test.rb
+++ b/build/post_test.rb
@@ -1,8 +1,8 @@
 require "pty"
 
 commands = [
-  "rvm-exec 2.5.0 bundle update; rvm-exec 2.5.0 bundle exec rake circleci:post",
-  "rvm-exec 2.4.2 bundle update; rvm-exec 2.4.2 bundle exec rake test:coveralls"
+  "rvm-exec 2.5.1 bundle update; rvm-exec 2.5.1 bundle exec rake circleci:post",
+  "rvm-exec 2.4.4 bundle update; rvm-exec 2.4.4 bundle exec rake test:coveralls"
 ]
 
 node_index = Integer ENV["CIRCLE_NODE_INDEX"]

--- a/build/test.rb
+++ b/build/test.rb
@@ -1,25 +1,15 @@
 require "pty"
 
 command_groups = [
-  ["rvm-exec 2.5.0 gem install bundler",
-   "rvm-exec 2.5.0 bundle update",
-   "rvm-exec 2.5.0 bundle exec rake circleci:build"],
-  ["rvm-exec 2.4.2 gem install bundler",
-   "rvm-exec 2.4.2 bundle update",
-   "rvm-exec 2.4.2 bundle exec rake circleci:build"],
-  ["rvm-exec 2.3.5 gem install bundler",
-   "rvm-exec 2.3.5 bundle update",
-   "rvm-exec 2.3.5 bundle exec rake circleci:build"],
-  ["rvm-exec 2.2.7 gem install bundler",
-   "rvm-exec 2.2.7 bundle update",
-   "rvm-exec 2.2.7 bundle exec rake circleci:build"],
-  ["rvm rubygems current",
-   "gem install bundler",
-   "bundle update",
-   "bundle exec rake circleci:build"],
-  ["rvm-exec 2.0.0-p648 gem install bundler",
-   "rvm-exec 2.0.0-p648 bundle update",
-   "rvm-exec 2.0.0-p648 bundle exec rake circleci:build"]
+  ["rvm-exec 2.5.1 gem install bundler",
+   "rvm-exec 2.5.1 bundle update",
+   "rvm-exec 2.5.1 bundle exec rake circleci:build"],
+  ["rvm-exec 2.4.4 gem install bundler",
+   "rvm-exec 2.4.4 bundle update",
+   "rvm-exec 2.4.4 bundle exec rake circleci:build"],
+  ["rvm-exec 2.3.7 gem install bundler",
+   "rvm-exec 2.3.7 bundle update",
+   "rvm-exec 2.3.7 bundle exec rake circleci:build"]
 ]
 
 node_index = Integer ENV["CIRCLE_NODE_INDEX"]

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,9 @@
 machine:
   timezone: America/Los_Angeles
 
-  # Since 2.1.9 test execution fails to locate gem dependencies when run via
-  # rvm-exec, set it to be the machine default.
   ruby:
     version:
-      2.1.9
+      2.5.1
 
 general:
   branches:
@@ -20,15 +18,10 @@ dependencies:
     - "/opt/circleci/.rvm"
 
   pre:
-    # The following three commands install 2.0.0
     - rvm get stable
-    - gem update --system
-    - rvm-exec 2.5.0 gem update --system
-    - rvm-exec 2.4.2 gem update --system
-    - rvm-exec 2.3.5 gem update --system
-    - rvm-exec 2.2.7 gem update --system
-    - rvm install 2.0.0-p648
-    - rvm-exec 2.0.0-p648 gem update --system
+    - rvm-exec 2.5.1 gem update --system
+    - rvm-exec 2.4.4 gem update --system
+    - rvm-exec 2.3.7 gem update --system
 
 test:
   override:
@@ -44,7 +37,7 @@ deployment:
     tag: /(\S*)\/v(\S*)/
     owner: GoogleCloudPlatform
     commands:
-      - rvm-exec 2.5.0 bundle exec rake circleci:release
+      - rvm-exec 2.5.1 bundle exec rake circleci:release
 
 notify:
   webhooks:

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -37,9 +37,6 @@ gem "google-cloud-translate", path: "../google-cloud-translate"
 gem "google-cloud-video_intelligence",
     path: "../google-cloud-video_intelligence"
 gem "google-cloud-vision", path: "../google-cloud-vision"
-
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
-gem "rake", "~> 11.0"
 gem "stackdriver-core", path: "../stackdriver-core"
+
+gem "rake", "~> 11.0"

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -38,14 +38,6 @@ gem "google-cloud-video_intelligence",
     path: "../google-cloud-video_intelligence"
 gem "google-cloud-vision", path: "../google-cloud-vision"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -39,4 +39,4 @@ gem "google-cloud-video_intelligence",
 gem "google-cloud-vision", path: "../google-cloud-vision"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -39,4 +39,4 @@ gem "google-cloud-video_intelligence",
 gem "google-cloud-vision", path: "../google-cloud-vision"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -33,14 +33,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-bigquery-data_transfer/Gemfile
+++ b/google-cloud-bigquery-data_transfer/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-bigquery-data_transfer/Gemfile
+++ b/google-cloud-bigquery-data_transfer/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-bigquery-data_transfer/Gemfile
+++ b/google-cloud-bigquery-data_transfer/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-bigquery-data_transfer/Gemfile
+++ b/google-cloud-bigquery-data_transfer/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-bigquery-data_transfer/README.md
+++ b/google-cloud-bigquery-data_transfer/README.md
@@ -74,14 +74,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-bigquery-data_transfer/latest/google/cloud/bigquery/datatransfer/v1
 [Product Documentation]: https://cloud.google.com/bigquerydatatransfer

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -9,14 +9,6 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -9,7 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -67,14 +67,14 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -8,14 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds on Travis-CI are resolving a version that cannot run on
-  # Ruby 2.0. We think this is because of a bug in Bundler 1.6. Specify a viable
-  # version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -8,7 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -52,14 +52,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-bigtable/latest/google/bigtable/v2
 [Product Documentation]: https://cloud.google.com/bigtable

--- a/google-cloud-container/Gemfile
+++ b/google-cloud-container/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-container/Gemfile
+++ b/google-cloud-container/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-container/Gemfile
+++ b/google-cloud-container/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-container/Gemfile
+++ b/google-cloud-container/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-container/README.md
+++ b/google-cloud-container/README.md
@@ -63,14 +63,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-container/latest/google/container/v1
 [Product Documentation]: https://cloud.google.com/container-engine

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -9,4 +9,4 @@ gem "google-api-client", "~> 0.23"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-gax", "~> 1.0"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -9,14 +9,6 @@ gem "google-api-client", "~> 0.23"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-gax", "~> 1.0"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -9,4 +9,4 @@ gem "google-api-client", "~> 0.23"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-gax", "~> 1.0"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -9,7 +9,4 @@ gem "google-api-client", "~> 0.23"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-gax", "~> 1.0"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-core/README.md
+++ b/google-cloud-core/README.md
@@ -6,14 +6,14 @@ This library contains shared types, such as error classes, for the google-cloud 
 
 ## Supported Ruby Versions
 
-This library is currently supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-dataproc/Gemfile
+++ b/google-cloud-dataproc/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-dataproc/Gemfile
+++ b/google-cloud-dataproc/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-dataproc/Gemfile
+++ b/google-cloud-dataproc/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-dataproc/Gemfile
+++ b/google-cloud-dataproc/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-dataproc/README.md
+++ b/google-cloud-dataproc/README.md
@@ -74,14 +74,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-dataproc/latest/google/cloud/dataproc/v1
 [Product Documentation]: https://cloud.google.com/dataproc

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -8,14 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -8,7 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -71,14 +71,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -8,9 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-logging", path: "../google-cloud-logging"
-
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
-gem "rake", "~> 11.0"
 gem "stackdriver-core", path: "../stackdriver-core"
+
+gem "rake", "~> 11.0"

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -10,4 +10,4 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -8,17 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-logging", path: "../google-cloud-logging"
-# TEMP: nokogiri (a dependency of rails) 1.7 requires Ruby 2.1 or later.
-# Since we're still testing on Ruby 2.0, pin nokogiri to 1.6 for now.
-gem "nokogiri", "~> 1.6.8"
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -10,4 +10,4 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -246,14 +246,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.2 or later.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 This library follows [Semantic Versioning](http://semver.org/). It is currently
 in major version zero (0.y.z), which means that anything may change at any time

--- a/google-cloud-dialogflow/Gemfile
+++ b/google-cloud-dialogflow/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-dialogflow/Gemfile
+++ b/google-cloud-dialogflow/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-dialogflow/Gemfile
+++ b/google-cloud-dialogflow/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-dialogflow/Gemfile
+++ b/google-cloud-dialogflow/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-dialogflow/README.md
+++ b/google-cloud-dialogflow/README.md
@@ -52,14 +52,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-dialogflow/latest/google/cloud/dialogflow/v2
 [Product Documentation]: https://cloud.google.com/dialogflow

--- a/google-cloud-dlp/Gemfile
+++ b/google-cloud-dlp/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-dlp/Gemfile
+++ b/google-cloud-dlp/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-dlp/Gemfile
+++ b/google-cloud-dlp/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-dlp/Gemfile
+++ b/google-cloud-dlp/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-dlp/README.md
+++ b/google-cloud-dlp/README.md
@@ -23,14 +23,14 @@ $ gem install google-cloud-dlp
 
 ### Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ### Preview
 #### DlpServiceClient
@@ -39,15 +39,15 @@ require "google/cloud/dlp"
 
 dlp = Google::Cloud::Dlp.new
 
-inspect_config = { 
-  info_types: [{ name: "PHONE_NUMBER" }], 
+inspect_config = {
+  info_types: [{ name: "PHONE_NUMBER" }],
   min_likelihood: :POSSIBLE
 }
 item = { value: "my phone number is 215-512-1212" }
 parent = "projects/#{ENV["MY_PROJECT"]}"
 
-response = dlp.inspect_content parent, 
-  inspect_config: inspect_config, 
+response = dlp.inspect_content parent,
+  inspect_config: inspect_config,
   item: item
 ```
 

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -8,14 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -8,7 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-dns/README.md
+++ b/google-cloud-dns/README.md
@@ -60,14 +60,14 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-env/README.md
+++ b/google-cloud-env/README.md
@@ -6,14 +6,14 @@ This library provides information on the application hosting environment for app
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -7,9 +7,6 @@ gem "gcloud-jsondoc",
     branch: "gcloud-jsondoc"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
-
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
-gem "rake", "~> 11.0"
 gem "stackdriver-core", path: "../stackdriver-core"
+
+gem "rake", "~> 11.0"

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -8,18 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# TEMP: nokogiri (a dependency of rails) 1.7 requires Ruby 2.1 or later.
-# Since we're still testing on Ruby 2.0, pin nokogiri to 1.6 for now.
-gem "nokogiri", "~> 1.6.8"
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -202,14 +202,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -8,14 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -8,7 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-firestore/README.md
+++ b/google-cloud-firestore/README.md
@@ -50,14 +50,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-firestore/latest/google/firestore/v1beta1
 [Product Documentation]: https://cloud.google.com/firestore

--- a/google-cloud-language/Gemfile
+++ b/google-cloud-language/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-language/Gemfile
+++ b/google-cloud-language/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-language/Gemfile
+++ b/google-cloud-language/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-language/Gemfile
+++ b/google-cloud-language/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-language/README.md
+++ b/google-cloud-language/README.md
@@ -65,14 +65,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-language/latest/google/cloud/language/v1
 [Product Documentation]: https://cloud.google.com/natural-language

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -10,4 +10,4 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -8,17 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
-# TEMP: nokogiri (a dependency of rails) 1.7 requires Ruby 2.1 or later.
-# Since we're still testing on Ruby 2.0, pin nokogiri to 1.6 for now.
-gem "nokogiri", "~> 1.6.8"
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -10,4 +10,4 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -8,9 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
-
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
-gem "rake", "~> 11.0"
 gem "stackdriver-core", path: "../stackdriver-core"
+
+gem "rake", "~> 11.0"

--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -180,14 +180,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-monitoring/Gemfile
+++ b/google-cloud-monitoring/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-monitoring/Gemfile
+++ b/google-cloud-monitoring/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-monitoring/Gemfile
+++ b/google-cloud-monitoring/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-monitoring/Gemfile
+++ b/google-cloud-monitoring/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-monitoring/README.md
+++ b/google-cloud-monitoring/README.md
@@ -75,14 +75,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-monitoring/latest/google/monitoring/v3
 [Product Documentation]: https://cloud.google.com/monitoring

--- a/google-cloud-os_login/Gemfile
+++ b/google-cloud-os_login/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-os_login/Gemfile
+++ b/google-cloud-os_login/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-os_login/Gemfile
+++ b/google-cloud-os_login/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-os_login/Gemfile
+++ b/google-cloud-os_login/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-os_login/README.md
+++ b/google-cloud-os_login/README.md
@@ -51,14 +51,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-os_login/latest/google/cloud/oslogin
 [Product Documentation]: https://cloud.google.com/compute/docs/oslogin/rest/

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -8,14 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -8,7 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -74,14 +74,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-redis/Gemfile
+++ b/google-cloud-redis/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-redis/Gemfile
+++ b/google-cloud-redis/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-redis/Gemfile
+++ b/google-cloud-redis/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-redis/Gemfile
+++ b/google-cloud-redis/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-redis/README.md
+++ b/google-cloud-redis/README.md
@@ -52,14 +52,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-redis/latest/google/cloud/redis/v1beta1
 [Product Documentation]: https://cloud.google.com/redis

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -8,14 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -8,7 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -80,14 +80,14 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -8,14 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -8,7 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-spanner/README.md
+++ b/google-cloud-spanner/README.md
@@ -60,14 +60,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-speech/Gemfile
+++ b/google-cloud-speech/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-speech/Gemfile
+++ b/google-cloud-speech/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-speech/Gemfile
+++ b/google-cloud-speech/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-speech/Gemfile
+++ b/google-cloud-speech/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-speech/README.md
+++ b/google-cloud-speech/README.md
@@ -88,3 +88,37 @@ See https://www.ruby-lang.org/en/downloads/branches/ for further details.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-speech/latest/google/cloud/speech
 [Product Documentation]: https://cloud.google.com/speech
+
+## Supported Ruby Versions
+
+This library is supported on Ruby 2.3+.
+
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
+
+## Versioning
+
+This library follows [Semantic Versioning](http://semver.org/).
+
+It is currently in major version zero (0.y.z), which means that anything may change at any time and the public API should not be considered stable.
+
+## Contributing
+
+Contributions to this library are always welcome and highly encouraged.
+
+See the [Contributing Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/guides/contributing) for more information on how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. See [Code of Conduct](../CODE_OF_CONDUCT.md) for more information.
+
+## License
+
+This library is licensed under Apache 2.0. Full license text is available in [LICENSE](LICENSE).
+
+## Support
+
+Please [report bugs at the project on Github](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues).
+Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-cloud-ruby) about the client or APIs on [StackOverflow](http://stackoverflow.com).

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -9,7 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -9,14 +9,6 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-storage/README.md
+++ b/google-cloud-storage/README.md
@@ -60,14 +60,14 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-tasks/Gemfile
+++ b/google-cloud-tasks/Gemfile
@@ -10,11 +10,3 @@ gem "gcloud-jsondoc",
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end

--- a/google-cloud-tasks/Gemfile
+++ b/google-cloud-tasks/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-tasks/Gemfile
+++ b/google-cloud-tasks/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-tasks/Gemfile
+++ b/google-cloud-tasks/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-text_to_speech/Gemfile
+++ b/google-cloud-text_to_speech/Gemfile
@@ -6,15 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
-gem "rake", "~> 11.0"
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
+gem "rake", "~> 12.3"

--- a/google-cloud-text_to_speech/README.md
+++ b/google-cloud-text_to_speech/README.md
@@ -59,11 +59,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -7,9 +7,6 @@ gem "gcloud-jsondoc",
     branch: "gcloud-jsondoc"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
-
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
-gem "rake", "~> 11.0"
 gem "stackdriver-core", path: "../stackdriver-core"
+
+gem "rake", "~> 11.0"

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -7,17 +7,6 @@ gem "gcloud-jsondoc",
     branch: "gcloud-jsondoc"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
-# TEMP: nokogiri (a dependency of rails) 1.7 requires Ruby 2.1 or later.
-# Since we're still testing on Ruby 2.0, pin nokogiri to 1.6 for now.
-gem "nokogiri", "~> 1.6.8"
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version

--- a/google-cloud-trace/README.md
+++ b/google-cloud-trace/README.md
@@ -207,14 +207,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-translate/Gemfile
+++ b/google-cloud-translate/Gemfile
@@ -8,14 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-translate/Gemfile
+++ b/google-cloud-translate/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-translate/Gemfile
+++ b/google-cloud-translate/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-translate/Gemfile
+++ b/google-cloud-translate/Gemfile
@@ -8,7 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -64,14 +64,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud-video_intelligence/Gemfile
+++ b/google-cloud-video_intelligence/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-video_intelligence/Gemfile
+++ b/google-cloud-video_intelligence/Gemfile
@@ -6,4 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-video_intelligence/Gemfile
+++ b/google-cloud-video_intelligence/Gemfile
@@ -6,7 +6,4 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-video_intelligence/Gemfile
+++ b/google-cloud-video_intelligence/Gemfile
@@ -6,14 +6,6 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-video_intelligence/README.md
+++ b/google-cloud-video_intelligence/README.md
@@ -89,14 +89,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-video_intelligence/latest/google/cloud/videointelligence/v1
 [Product Documentation]: https://cloud.google.com/video-intelligence

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -9,4 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -9,14 +9,6 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -9,7 +9,4 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/google-cloud-vision/README.md
+++ b/google-cloud-vision/README.md
@@ -55,14 +55,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -37,14 +37,6 @@ gem "google-cloud-video_intelligence",
     path: "../google-cloud-video_intelligence"
 gem "google-cloud-vision", path: "../google-cloud-vision"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -38,4 +38,4 @@ gem "google-cloud-video_intelligence",
 gem "google-cloud-vision", path: "../google-cloud-vision"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -38,4 +38,4 @@ gem "google-cloud-video_intelligence",
 gem "google-cloud-vision", path: "../google-cloud-vision"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -36,9 +36,6 @@ gem "google-cloud-translate", path: "../google-cloud-translate"
 gem "google-cloud-video_intelligence",
     path: "../google-cloud-video_intelligence"
 gem "google-cloud-vision", path: "../google-cloud-vision"
-
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
-gem "rake", "~> 11.0"
 gem "stackdriver-core", path: "../stackdriver-core"
+
+gem "rake", "~> 11.0"

--- a/google-cloud/README.md
+++ b/google-cloud/README.md
@@ -4,14 +4,14 @@ This gem is a convenience package for loading all gems in the google-cloud proje
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -8,14 +8,6 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
-
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -8,4 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -8,7 +8,4 @@ gem "gcloud-jsondoc",
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/stackdriver-core/README.md
+++ b/stackdriver-core/README.md
@@ -6,14 +6,14 @@ This library contains shared types and utilities for Stackdriver-related librari
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core (that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life). Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 ## Versioning
 

--- a/stackdriver-core/README.md
+++ b/stackdriver-core/README.md
@@ -9,8 +9,8 @@ This library contains shared types and utilities for Stackdriver-related librari
 This library is supported on Ruby 2.3+.
 
 Google provides official support for Ruby versions that are actively supported
-by Ruby Core (that is, Ruby versions that are either in normal maintenance or
-in security maintenance, and not end of life). Currently, this means Ruby 2.3
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -13,7 +13,4 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "google-cloud-trace", path: "../google-cloud-trace"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-# WORKAROUND: builds are having problems since the release of 3.0.0
-# pin to the last known good version
-gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -12,17 +12,6 @@ gem "google-cloud-error_reporting", path: "../google-cloud-error_reporting"
 gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "google-cloud-trace", path: "../google-cloud-trace"
 gem "stackdriver-core", path: "../stackdriver-core"
-# TEMP: nokogiri (a dependency of rails) 1.7 requires Ruby 2.1 or later.
-# Since we're still testing on Ruby 2.0, pin nokogiri to 1.6 for now.
-gem "nokogiri", "~> 1.6.8"
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1")
-  # WORKAROUND: builds are failing on Ruby 2.0.
-  # We think this is because of a bug in Bundler 1.6.
-  # Specify a viable version to allow the build to succeed.
-  gem "jwt", "~> 1.5"
-  gem "kramdown", "< 1.17.0" # Error in yard with 1.17.0
-end
 
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -13,4 +13,4 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "google-cloud-trace", path: "../google-cloud-trace"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake", "~> 11.0"
+gem "rake"

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -13,4 +13,4 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "google-cloud-trace", path: "../google-cloud-trace"
 gem "stackdriver-core", path: "../stackdriver-core"
 
-gem "rake"
+gem "rake", "~> 12.3"

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -108,14 +108,14 @@ See the gem documentation for each individual gem for more information.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.2+.
+This library is supported on Ruby 2.3+.
 
-However, Ruby 2.3 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After June 1, 2018, Google will provide
-official support only for Ruby versions that are considered current and
-supported by Ruby Core (that is, Ruby versions that are either in normal
-maintenance or in security maintenance).
-See https://www.ruby-lang.org/en/downloads/branches/ for further details.
+Google provides official support for Ruby versions that are actively supported
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Currently, this means Ruby 2.3
+and later. Older versions of Ruby _may_ still work, but are unsupported and not
+recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
+about the Ruby support schedule.
 
 This library follows [Semantic Versioning](http://semver.org/).
 It is currently in major version zero (0.y.z), which means that anything may change at any time and the public API should not be considered stable.


### PR DESCRIPTION
Update the official Ruby version support matrix to include only Ruby 2.3 and later, according to the plan we put in place three months ago. Specifically:
* Document in the readmes that Ruby 2.3 and later is supported, and that in general we support the Ruby versions that are not yet end-of-life.
* Shrink the test matrix to include only 2.3-2.5 (and update to the latest patchlevels of each).
* However, retain the current `>= 2.0.0` gem version restriction to reflect that we are not _preventing_ earlier versions and that earlier versions may still work, but are just not actively supported. 

I updated only the main readme and the readme for one gem so far, to get feedback on the wording. I'll update the remaining readmes once we're okay with it.