### PR TITLE
Build: Remove yard-doctest autoloading

### DIFF
--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -134,7 +134,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -81,7 +81,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-debugger/Rakefile
+++ b/google-cloud-debugger/Rakefile
@@ -131,7 +131,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -109,7 +109,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -85,7 +85,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-firestore/Rakefile
+++ b/google-cloud-firestore/Rakefile
@@ -187,7 +187,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -113,7 +113,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -108,7 +108,6 @@ end
 desc "Run yard-doctest example tests."
 #task doctest: :yard do
 task :doctest do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-resource_manager/Rakefile
+++ b/google-cloud-resource_manager/Rakefile
@@ -41,7 +41,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-spanner/Rakefile
+++ b/google-cloud-spanner/Rakefile
@@ -114,7 +114,6 @@ end
 
 desc "Run yard-doctest example tests."
 task :doctest do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -121,7 +121,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -114,7 +114,6 @@ end
 
 desc "Runs yard-doctest example tests."
 task :doctest do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -105,7 +105,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -81,7 +81,6 @@ end
 
 desc "Run yard-doctest example tests."
 task doctest: :yard do
-  sh "bundle exec yard config -a autoload_plugins yard-doctest"
   sh "bundle exec yard doctest"
 end
 


### PR DESCRIPTION
This was adding the plugin multiple times, and would print the following warning multiple times when a rake task was run:

`[error]: Error loading plugin 'yard-doctest'`