### PR TITLE
Disable Stackdriver components with Rails.env.production

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -108,7 +108,9 @@ module Google
           gcp_config = rails_config.google_cloud
           dbg_config = gcp_config.debugger
 
-          Cloud.configure.use_debugger ||= gcp_config.use_debugger
+          if Cloud.configure.use_debugger.nil?
+            Cloud.configure.use_debugger = gcp_config.use_debugger
+          end
           Debugger.configure do |config|
             config.project_id ||= begin
               config.project || dbg_config.project_id || dbg_config.project

--- a/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
@@ -94,6 +94,16 @@ describe Google::Cloud::Debugger::Railtie do
       end
     end
 
+    it "Set use_debugger to false if explicitly disabled in production" do
+      Google::Cloud::Debugger::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, true do
+          Google::Cloud.configure.use_debugger = false
+          Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_debugger.must_equal false
+        end
+      end
+    end
+
     it "returns true if use_debugger is explicitly true even Rails is not in production" do
       rails_config.google_cloud.use_debugger = true
 

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -109,7 +109,9 @@ module Google
           gcp_config = rails_config.google_cloud
           er_config = gcp_config.error_reporting
 
-          Cloud.configure.use_error_reporting ||= gcp_config.use_error_reporting
+          if Cloud.configure.use_error_reporting.nil?
+            Cloud.configure.use_error_reporting = gcp_config.use_error_reporting
+          end
           ErrorReporting.configure do |config|
             config.project_id ||= config.project
             config.project_id ||= er_config.project_id || er_config.project

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
@@ -100,6 +100,16 @@ describe Google::Cloud::ErrorReporting::Railtie do
       end
     end
 
+    it "Set use_error_reporting to false if explicitly disabled in production" do
+      Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, true do
+          Google::Cloud.configure.use_error_reporting = false
+          Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_error_reporting.must_equal false
+        end
+      end
+    end
+
     it "returns true if use_error_reporting is explicitly true even Rails is not in production" do
       rails_config.google_cloud.use_error_reporting = true
 

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -95,7 +95,7 @@ module Google
           # Done if Google::Cloud.configure.use_logging is explicitly false
           return if Google::Cloud.configure.use_logging == false
 
-          # Verify credentials and set use_error_reporting to false if
+          # Verify credentials and set use_logging to false if
           # credentials are invalid
           unless valid_credentials? Logging.configure.project_id,
                                     Logging.configure.keyfile

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -114,7 +114,9 @@ module Google
           gcp_config = rails_config.google_cloud
           log_config = gcp_config.logging
 
-          Cloud.configure.use_logging ||= gcp_config.use_logging
+          if Cloud.configure.use_logging.nil?
+            Cloud.configure.use_logging = gcp_config.use_logging
+          end
           Logging.configure do |config|
             config.project_id ||= config.project
             config.project_id ||= log_config.project_id || log_config.project

--- a/google-cloud-logging/test/google/cloud/logging/rails_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/rails_test.rb
@@ -184,6 +184,16 @@ describe Google::Cloud::Logging::Railtie do
       end
     end
 
+    it "Set use_error_reporting to false if explicitly disabled in production" do
+      Google::Cloud::Logging::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, true do
+          Google::Cloud.configure.use_logging = false
+          Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_logging.must_equal false
+        end
+      end
+    end
+
     it "returns true if config.google_cloud.use_logging is explicitly true even Rails is not in production" do
       rails_config.google_cloud.use_logging = true
 

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -128,7 +128,7 @@ module Google
           # Done if Google::Cloud.configure.use_trace is explicitly false
           return if Google::Cloud.configure.use_trace == false
 
-          # Verify credentials and set use_error_reporting to false if
+          # Verify credentials and set use_trace to false if
           # credentials are invalid
           unless valid_credentials? Trace.configure.project_id,
                                     Trace.configure.credentials

--- a/google-cloud-trace/test/google/cloud/trace/rails_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/rails_test.rb
@@ -195,6 +195,16 @@ describe Google::Cloud::Trace::Railtie do
       end
     end
 
+    it "Set use_trace to false if explicitly disabled in production" do
+      Google::Cloud::Trace::Railtie.stub :valid_credentials?, true do
+        Rails.env.stub :production?, true do
+          Google::Cloud.configure.use_trace = false
+          Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
+          Google::Cloud.configure.use_trace.must_equal false
+        end
+      end
+    end
+
     it "returns true if use_trace is explicitly true even Rails is not in production" do
       rails_config.google_cloud.use_trace = true
 


### PR DESCRIPTION
Currently, error reporting, logging, and debugging cannot be disabled when `Rails.env.production?` is `true`  despite the docs saying `Google::Cloud.configure.use_*` should enable or _disable_ any of the services.

This PR fixes some conditionals to honor `false` as a value. Note that this exact change already exists in Trace so I just added the test there.