### PR TITLE
Fix undefined method `split' for nil:NilClass with an empty array 

### DIFF
--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
@@ -215,7 +215,7 @@ module Google
           backtrace = exception.backtrace
           message = exception.message
 
-          unless backtrace.nil?
+          if !backtrace.nil? && !backtrace.first.nil?
             error_location = backtrace.first
 
             message = "#{error_location}: #{message} (#{exception.class})\n\t" +

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
@@ -213,12 +213,12 @@ module Google
         #   from the given exception.
         def self.from_exception exception
           backtrace = exception.backtrace
-          message = exception.message
+          message = "#{exception.message} (#{exception.class})"
 
-          unless backtrace.nil?
-            error_location = String backtrace.first
+          if !backtrace.nil? && !backtrace.empty?
+            error_location = backtrace.first
 
-            message = "#{error_location}: #{message} (#{exception.class})\n\t" +
+            message = "#{error_location}: #{message}\n\t" +
                       backtrace.drop(1).join("\n\t")
             file_path, line_number, function_name = error_location.split(":")
             function_name = function_name.to_s[/`(.*)'/, 1]

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
@@ -215,8 +215,8 @@ module Google
           backtrace = exception.backtrace
           message = exception.message
 
-          if !backtrace.nil? && !backtrace.first.nil?
-            error_location = backtrace.first
+          unless backtrace.nil?
+            error_location = String backtrace.first
 
             message = "#{error_location}: #{message} (#{exception.class})\n\t" +
                       backtrace.drop(1).join("\n\t")

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
@@ -73,20 +73,21 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
   end
 
   describe ".from_exception" do
-    exception_message = "A serious error from application"
+    let(:exception_message) { "A serious error from application" }
     let(:exception) { StandardError.new exception_message }
+    let(:error_message) { "#{exception_message} (#{exception.class})" }
 
     it "includes exception message when backtrace isn't present" do
       error_event =
         Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
-      error_event.message.must_equal exception_message
+      error_event.message.must_equal error_message
     end
 
     it "includes exception message when backtrace is an empty array" do
       exception.set_backtrace([])
       error_event =
         Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
-      error_event.message.must_match exception_message
+      error_event.message.must_equal error_message
     end
 
     it "includes exception message and backtrace if backtrace is available" do
@@ -95,7 +96,7 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
 
       error_event =
         Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
-      error_event.message.must_match exception_message
+      error_event.message.must_match error_message
       error_event.message.must_match backtrace
     end
 
@@ -105,7 +106,7 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
 
       error_event =
         Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
-      error_event.message.must_match exception_message
+      error_event.message.must_match error_message
       error_event.file_path.must_equal(
         "test/test_more.rb"
       )

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
@@ -86,7 +86,7 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
       exception.set_backtrace([])
       error_event =
         Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
-      error_event.message.must_equal exception_message
+      error_event.message.must_match exception_message
     end
 
     it "includes exception message and backtrace if backtrace is available" do

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
@@ -82,6 +82,13 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
       error_event.message.must_equal exception_message
     end
 
+    it "includes exception message when backtrace is an empty array" do
+      exception.set_backtrace([])
+      error_event =
+        Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
+      error_event.message.must_equal exception_message
+    end
+
     it "includes exception message and backtrace if backtrace is available" do
       backtrace = "test/test_more.rb:123:`<testee_sub>'"
       exception.set_backtrace([backtrace])


### PR DESCRIPTION
This PR is based on the issue.
https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/2149
