### PR TITLE
Update synth scripts for vision and text-to-speech

### DIFF
--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -21,27 +21,13 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICGenerator()
-common = gcp.CommonTemplates()
 
-v1_library = gapic._generate_code(
-    'texttospeech', 'v1', 'ruby',
-    config_path='artman_texttospeech_v1.yaml',
-    artman_output_name='google-cloud-ruby/google-cloud-texttospeech')
+v1_library = gapic.ruby_library(
+    'texttospeech', 'v1',
+    artman_output_name='google-cloud-ruby/google-cloud-texttospeech'
+)
 
-s.copy(v1_library / "lib/google/cloud/text_to_speech/v1")
-s.copy(v1_library / "lib/google/cloud/text_to_speech/v1.rb")
-s.copy(v1_library / "lib/google/cloud/texttospeech/v1")
-s.copy(v1_library / "test/google/cloud/text_to_speech/v1")
-
-# Temporary until https://github.com/googleapis/gapic-generator/pull/2079
-# shows up in a build.
-s.replace(
-    "lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb",
-    'require "google/cloud/text_to_speech/credentials"',
-    'require "google/cloud/text_to_speech/v1/credentials"')
-
-# https://github.com/googleapis/gapic-generator/issues/2080
-s.replace(
-    "test/google/cloud/text_to_speech/v1/text_to_speech_client_test.rb",
-    "assert_not_nil",
-    "refute_nil")
+s.copy(v1_library / 'lib/google/cloud/text_to_speech/v1')
+s.copy(v1_library / 'lib/google/cloud/text_to_speech/v1.rb')
+s.copy(v1_library / 'lib/google/cloud/texttospeech/v1')
+s.copy(v1_library / 'test/google/cloud/text_to_speech/v1')

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -1,10 +1,22 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This script is used to synthesize generated parts of this library."""
+
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-from pathlib import Path
-import subprocess
-import os
-
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -17,16 +29,6 @@ v1_library = gapic.ruby_library(
 s.copy(v1_library / 'lib/google/cloud/vision/v1')
 s.copy(v1_library / 'lib/google/cloud/vision/v1.rb')
 
-
-# https://github.com/googleapis/gapic-generator/issues/2080
-s.replace(
-    "test/google/cloud/vision/v1/image_annotator_client_test.rb",
-    "assert_not_nil",
-    "refute_nil")
-
-# Temporary until https://github.com/googleapis/gapic-generator/pull/2079
-# shows up in an artman release.
-s.replace(
-    "lib/google/cloud/vision/v1/image_annotator_client.rb",
-    "google/cloud/vision/credentials",
-    "google/cloud/vision/v1/credentials")
+# Note: Not copying 'test/google/cloud/vision/v1' yet, because it generates
+# tests for a gapic-only library, whereas this library currently is handwritten
+# atop a low-level gapic.


### PR DESCRIPTION
Simplify the existing synth scripts (for vision and text-to-speech) to match recent updates to synthtool, and to standardize usage.

I verified that rerunning synth on these libraries currently yields no changes.