### PR TITLE
Regenerate video_intelligence and provide a synth script

### DIFF
--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -79,20 +79,15 @@ module Google
     # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
     #   to see the full list of Cloud APIs that we cover.
     #
+    # [Product Documentation]: https://cloud.google.com/video-intelligence
+    #
     # ## Enabling Logging
     #
-    # To enable logging for this library, set the logger for the underlying
-    # [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The
-    # logger that you set may be a Ruby stdlib
-    # [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html)
-    # as shown below, or a
-    # [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
-    # that will write logs to [Stackdriver
-    # Logging](https://cloud.google.com/logging/). See
-    # [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
-    # and the gRPC
-    # [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb)
-    # for additional information.
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
     #
     # Configuring a Ruby stdlib logger:
     #
@@ -111,9 +106,6 @@ module Google
     #   extend MyLogger
     # end
     # ```
-    #
-    # [Product Documentation]: https://cloud.google.com/video-intelligence
-    #
     #
     module VideoIntelligence
       # rubocop:enable LineLength
@@ -157,6 +149,11 @@ module Google
       #     or the specified config is missing data points.
       #   @param timeout [Numeric]
       #     The default timeout, in seconds, for calls made through this client.
+      #   @param metadata [Hash]
+      #     Default metadata to be sent with each request. This can be overridden on a per call basis.
+      #   @param exception_transformer [Proc]
+      #     An optional proc that intercepts any exceptions raised during an API call to inject
+      #     custom error handling.
       def self.new(*args, version: :v1, **kwargs)
         unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
           raise "The version: #{version} is not available. The available versions " \

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 require "google/cloud/video_intelligence/v1/video_intelligence_service_client"
+require "google/cloud/videointelligence/v1/video_intelligence_pb"
+require "google/rpc/status_pb"
 
 module Google
   module Cloud
@@ -80,6 +82,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/video-intelligence
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module VideoIntelligence
       module V1
@@ -112,11 +139,18 @@ module Google
         #   or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
+        # @param metadata [Hash]
+        #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param exception_transformer [Proc]
+        #   An optional proc that intercepts any exceptions raised during an API call to inject
+        #   custom error handling.
         def self.new \
             credentials: nil,
             scopes: nil,
             client_config: nil,
             timeout: nil,
+            metadata: nil,
+            exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
           kwargs = {
@@ -124,6 +158,8 @@ module Google
             scopes: scopes,
             client_config: client_config,
             timeout: timeout,
+            metadata: metadata,
+            exception_transformer: exception_transformer,
             lib_name: lib_name,
             lib_version: lib_version
           }.select { |_, v| v != nil }

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/credentials.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,16 +17,15 @@ require "googleauth"
 module Google
   module Cloud
     module VideoIntelligence
-      ##
-      # @deprecated Use version-specific credentials classes
-      #
-      class Credentials < Google::Auth::Credentials
-        SCOPE = [
-          "https://www.googleapis.com/auth/cloud-platform"
-        ].freeze
-        PATH_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
-        JSON_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
-        DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+      module V1
+        class Credentials < Google::Auth::Credentials
+          SCOPE = [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ].freeze
+          PATH_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
+          JSON_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
+          DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+        end
       end
     end
   end

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ module Google
       #
       # | Class | Description |
       # | ----- | ----------- |
-      # | [VideoIntelligenceServiceClient][] | Cloud Video Intelligence API. |
+      # | [VideoIntelligenceServiceClient][] | Service that implements Google Cloud Video Intelligence API. |
       # | [Data Types][] | Data types for Google::Cloud::VideoIntelligence::V1 |
       #
       # [VideoIntelligenceServiceClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-video_intelligence/latest/google/cloud/videointelligence/v1/videointelligenceserviceclient

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/longrunning/operations.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/longrunning/operations.rb
@@ -1,0 +1,92 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Longrunning
+    # This resource represents a long-running operation that is the result of a
+    # network API call.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The server-assigned name, which is only unique within the same service that
+    #     originally returns it. If you use the default HTTP mapping, the
+    #     +name+ should have the format of +operations/some/unique/name+.
+    # @!attribute [rw] metadata
+    #   @return [Google::Protobuf::Any]
+    #     Service-specific metadata associated with the operation.  It typically
+    #     contains progress information and common metadata such as create time.
+    #     Some services might not provide such metadata.  Any method that returns a
+    #     long-running operation should document the metadata type, if any.
+    # @!attribute [rw] done
+    #   @return [true, false]
+    #     If the value is +false+, it means the operation is still in progress.
+    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     available.
+    # @!attribute [rw] error
+    #   @return [Google::Rpc::Status]
+    #     The error result of the operation in case of failure or cancellation.
+    # @!attribute [rw] response
+    #   @return [Google::Protobuf::Any]
+    #     The normal response of the operation in case of success.  If the original
+    #     method returns no data on success, such as +Delete+, the response is
+    #     +google.protobuf.Empty+.  If the original method is standard
+    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
+    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     is the original method name.  For example, if the original method name
+    #     is +TakeSnapshot()+, the inferred response type is
+    #     +TakeSnapshotResponse+.
+    class Operation; end
+
+    # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation resource.
+    class GetOperationRequest; end
+
+    # The request message for {Google::Longrunning::Operations::ListOperations Operations::ListOperations}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation collection.
+    # @!attribute [rw] filter
+    #   @return [String]
+    #     The standard list filter.
+    # @!attribute [rw] page_size
+    #   @return [Integer]
+    #     The standard list page size.
+    # @!attribute [rw] page_token
+    #   @return [String]
+    #     The standard list page token.
+    class ListOperationsRequest; end
+
+    # The response message for {Google::Longrunning::Operations::ListOperations Operations::ListOperations}.
+    # @!attribute [rw] operations
+    #   @return [Array<Google::Longrunning::Operation>]
+    #     A list of operations that matches the specified filter in the request.
+    # @!attribute [rw] next_page_token
+    #   @return [String]
+    #     The standard List next-page token.
+    class ListOperationsResponse; end
+
+    # The request message for {Google::Longrunning::Operations::CancelOperation Operations::CancelOperation}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation resource to be cancelled.
+    class CancelOperationRequest; end
+
+    # The request message for {Google::Longrunning::Operations::DeleteOperation Operations::DeleteOperation}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation resource to be deleted.
+    class DeleteOperationRequest; end
+  end
+end

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,6 +83,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/video-intelligence
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module VideoIntelligence
       module V1

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,6 @@
 # and updates to that file get reflected here through a refresh process.
 # For the short term, the refresh process will only be runnable by Google
 # engineers.
-#
-# The only allowed edits are to method and file documentation. A 3-way
-# merge preserves those additions if the generated source changes.
 
 require "json"
 require "pathname"
@@ -30,7 +27,7 @@ require "google/gax/operation"
 require "google/longrunning/operations_client"
 
 require "google/cloud/videointelligence/v1/video_intelligence_pb"
-require "google/cloud/video_intelligence/credentials"
+require "google/cloud/video_intelligence/v1/credentials"
 
 module Google
   module Cloud
@@ -49,6 +46,9 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
+          # The default set of gRPC interceptors.
+          GRPC_INTERCEPTORS = []
+
           DEFAULT_TIMEOUT = 30
 
           # The scopes needed to make gRPC calls to all of the methods defined in
@@ -58,7 +58,8 @@ module Google
           ].freeze
 
           class OperationsClient < Google::Longrunning::OperationsClient
-            SERVICE_ADDRESS = SERVICE_ADDRESS
+            self::SERVICE_ADDRESS = VideoIntelligenceServiceClient::SERVICE_ADDRESS
+            self::GRPC_INTERCEPTORS = VideoIntelligenceServiceClient::GRPC_INTERCEPTORS
           end
 
           # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
@@ -85,11 +86,18 @@ module Google
           #   or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
+          # @param metadata [Hash]
+          #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param exception_transformer [Proc]
+          #   An optional proc that intercepts any exceptions raised during an API call to inject
+          #   custom error handling.
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
+              metadata: nil,
+              exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
             # These require statements are intentionally placed here to initialize
@@ -98,7 +106,7 @@ module Google
             require "google/gax/grpc"
             require "google/cloud/videointelligence/v1/video_intelligence_services_pb"
 
-            credentials ||= Google::Cloud::VideoIntelligence::Credentials.default
+            credentials ||= Google::Cloud::VideoIntelligence::V1::Credentials.default
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
@@ -110,7 +118,7 @@ module Google
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Google::Cloud::VideoIntelligence::Credentials.new(credentials).updater_proc
+              updater_proc = Google::Cloud::VideoIntelligence::V1::Credentials.new(credentials).updater_proc
             end
             if credentials.is_a?(GRPC::Core::Channel)
               channel = credentials
@@ -134,6 +142,7 @@ module Google
             google_api_client.freeze
 
             headers = { :"x-goog-api-client" => google_api_client }
+            headers.merge!(metadata) unless metadata.nil?
             client_config_file = Pathname.new(__dir__).join(
               "video_intelligence_service_client_config.json"
             )
@@ -145,13 +154,14 @@ module Google
                 Google::Gax::Grpc::STATUS_CODE_NAMES,
                 timeout,
                 errors: Google::Gax::Grpc::API_ERRORS,
-                kwargs: headers
+                metadata: headers
               )
             end
 
             # Allow overriding the service path/port in subclasses.
             service_path = self.class::SERVICE_ADDRESS
             port = self.class::DEFAULT_SERVICE_PORT
+            interceptors = self.class::GRPC_INTERCEPTORS
             @video_intelligence_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
               port,
@@ -159,12 +169,14 @@ module Google
               channel: channel,
               updater_proc: updater_proc,
               scopes: scopes,
+              interceptors: interceptors,
               &Google::Cloud::Videointelligence::V1::VideoIntelligenceService::Stub.method(:new)
             )
 
             @annotate_video = Google::Gax.create_api_call(
               @video_intelligence_service_stub.method(:annotate_video),
-              defaults["annotate_video"]
+              defaults["annotate_video"],
+              exception_transformer: exception_transformer
             )
           end
 
@@ -216,9 +228,12 @@ module Google
           #   require "google/cloud/video_intelligence/v1"
           #
           #   video_intelligence_service_client = Google::Cloud::VideoIntelligence::V1.new
+          #   input_uri = "gs://demomaker/cat.mp4"
+          #   features_element = :LABEL_DETECTION
+          #   features = [features_element]
           #
           #   # Register a callback during the method call.
-          #   operation = video_intelligence_service_client.annotate_video do |op|
+          #   operation = video_intelligence_service_client.annotate_video(input_uri: input_uri, features: features) do |op|
           #     raise op.results.message if op.error?
           #     op_results = op.results
           #     # Process the results.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,13 +13,15 @@
 # limitations under the License.
 
 require "google/cloud/video_intelligence/v1beta1/video_intelligence_service_client"
+require "google/cloud/videointelligence/v1beta1/video_intelligence_pb"
+require "google/rpc/status_pb"
 
 module Google
   module Cloud
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Video Intelligence API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Video Intelligence API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Video Intelligence API][Product Documentation]:
     # Google Cloud Video Intelligence API.
@@ -42,6 +44,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/video-intelligence
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module VideoIntelligence
       module V1beta1
@@ -74,11 +101,18 @@ module Google
         #   or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
+        # @param metadata [Hash]
+        #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param exception_transformer [Proc]
+        #   An optional proc that intercepts any exceptions raised during an API call to inject
+        #   custom error handling.
         def self.new \
             credentials: nil,
             scopes: nil,
             client_config: nil,
             timeout: nil,
+            metadata: nil,
+            exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
           kwargs = {
@@ -86,6 +120,8 @@ module Google
             scopes: scopes,
             client_config: client_config,
             timeout: timeout,
+            metadata: metadata,
+            exception_transformer: exception_transformer,
             lib_name: lib_name,
             lib_version: lib_version
           }.select { |_, v| v != nil }

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Video Intelligence API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Video Intelligence API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Video Intelligence API][Product Documentation]:
     # Google Cloud Video Intelligence API.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/credentials.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,16 +17,15 @@ require "googleauth"
 module Google
   module Cloud
     module VideoIntelligence
-      ##
-      # @deprecated Use version-specific credentials classes
-      #
-      class Credentials < Google::Auth::Credentials
-        SCOPE = [
-          "https://www.googleapis.com/auth/cloud-platform"
-        ].freeze
-        PATH_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
-        JSON_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
-        DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+      module V1beta1
+        class Credentials < Google::Auth::Credentials
+          SCOPE = [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ].freeze
+          PATH_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
+          JSON_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
+          DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+        end
       end
     end
   end

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ module Google
       #
       # | Class | Description |
       # | ----- | ----------- |
-      # | [VideoIntelligenceServiceClient][] | Google Cloud Video Intelligence API. |
+      # | [VideoIntelligenceServiceClient][] | Service that implements Google Cloud Video Intelligence API. |
       # | [Data Types][] | Data types for Google::Cloud::VideoIntelligence::V1beta1 |
       #
       # [VideoIntelligenceServiceClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-video_intelligence/latest/google/cloud/videointelligence/v1beta1/videointelligenceserviceclient

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/longrunning/operations.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/longrunning/operations.rb
@@ -1,0 +1,92 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Longrunning
+    # This resource represents a long-running operation that is the result of a
+    # network API call.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The server-assigned name, which is only unique within the same service that
+    #     originally returns it. If you use the default HTTP mapping, the
+    #     +name+ should have the format of +operations/some/unique/name+.
+    # @!attribute [rw] metadata
+    #   @return [Google::Protobuf::Any]
+    #     Service-specific metadata associated with the operation.  It typically
+    #     contains progress information and common metadata such as create time.
+    #     Some services might not provide such metadata.  Any method that returns a
+    #     long-running operation should document the metadata type, if any.
+    # @!attribute [rw] done
+    #   @return [true, false]
+    #     If the value is +false+, it means the operation is still in progress.
+    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     available.
+    # @!attribute [rw] error
+    #   @return [Google::Rpc::Status]
+    #     The error result of the operation in case of failure or cancellation.
+    # @!attribute [rw] response
+    #   @return [Google::Protobuf::Any]
+    #     The normal response of the operation in case of success.  If the original
+    #     method returns no data on success, such as +Delete+, the response is
+    #     +google.protobuf.Empty+.  If the original method is standard
+    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
+    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     is the original method name.  For example, if the original method name
+    #     is +TakeSnapshot()+, the inferred response type is
+    #     +TakeSnapshotResponse+.
+    class Operation; end
+
+    # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation resource.
+    class GetOperationRequest; end
+
+    # The request message for {Google::Longrunning::Operations::ListOperations Operations::ListOperations}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation collection.
+    # @!attribute [rw] filter
+    #   @return [String]
+    #     The standard list filter.
+    # @!attribute [rw] page_size
+    #   @return [Integer]
+    #     The standard list page size.
+    # @!attribute [rw] page_token
+    #   @return [String]
+    #     The standard list page token.
+    class ListOperationsRequest; end
+
+    # The response message for {Google::Longrunning::Operations::ListOperations Operations::ListOperations}.
+    # @!attribute [rw] operations
+    #   @return [Array<Google::Longrunning::Operation>]
+    #     A list of operations that matches the specified filter in the request.
+    # @!attribute [rw] next_page_token
+    #   @return [String]
+    #     The standard List next-page token.
+    class ListOperationsResponse; end
+
+    # The request message for {Google::Longrunning::Operations::CancelOperation Operations::CancelOperation}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation resource to be cancelled.
+    class CancelOperationRequest; end
+
+    # The request message for {Google::Longrunning::Operations::DeleteOperation Operations::DeleteOperation}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation resource to be deleted.
+    class DeleteOperationRequest; end
+  end
+end

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Video Intelligence API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Video Intelligence API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Video Intelligence API][Product Documentation]:
     # Google Cloud Video Intelligence API.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Video Intelligence API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Video Intelligence API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Video Intelligence API][Product Documentation]:
     # Google Cloud Video Intelligence API.
@@ -45,6 +45,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/video-intelligence
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module VideoIntelligence
       module V1beta1

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,6 @@
 # and updates to that file get reflected here through a refresh process.
 # For the short term, the refresh process will only be runnable by Google
 # engineers.
-#
-# The only allowed edits are to method and file documentation. A 3-way
-# merge preserves those additions if the generated source changes.
 
 require "json"
 require "pathname"
@@ -30,7 +27,7 @@ require "google/gax/operation"
 require "google/longrunning/operations_client"
 
 require "google/cloud/videointelligence/v1beta1/video_intelligence_pb"
-require "google/cloud/video_intelligence/credentials"
+require "google/cloud/video_intelligence/v1beta1/credentials"
 
 module Google
   module Cloud
@@ -49,6 +46,9 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
+          # The default set of gRPC interceptors.
+          GRPC_INTERCEPTORS = []
+
           DEFAULT_TIMEOUT = 30
 
           # The scopes needed to make gRPC calls to all of the methods defined in
@@ -58,7 +58,8 @@ module Google
           ].freeze
 
           class OperationsClient < Google::Longrunning::OperationsClient
-            SERVICE_ADDRESS = SERVICE_ADDRESS
+            self::SERVICE_ADDRESS = VideoIntelligenceServiceClient::SERVICE_ADDRESS
+            self::GRPC_INTERCEPTORS = VideoIntelligenceServiceClient::GRPC_INTERCEPTORS
           end
 
           # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
@@ -85,11 +86,18 @@ module Google
           #   or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
+          # @param metadata [Hash]
+          #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+          # @param exception_transformer [Proc]
+          #   An optional proc that intercepts any exceptions raised during an API call to inject
+          #   custom error handling.
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
               client_config: {},
               timeout: DEFAULT_TIMEOUT,
+              metadata: nil,
+              exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
             # These require statements are intentionally placed here to initialize
@@ -98,7 +106,7 @@ module Google
             require "google/gax/grpc"
             require "google/cloud/videointelligence/v1beta1/video_intelligence_services_pb"
 
-            credentials ||= Google::Cloud::VideoIntelligence::Credentials.default
+            credentials ||= Google::Cloud::VideoIntelligence::V1beta1::Credentials.default
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
@@ -110,7 +118,7 @@ module Google
             )
 
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Google::Cloud::VideoIntelligence::Credentials.new(credentials).updater_proc
+              updater_proc = Google::Cloud::VideoIntelligence::V1beta1::Credentials.new(credentials).updater_proc
             end
             if credentials.is_a?(GRPC::Core::Channel)
               channel = credentials
@@ -134,6 +142,7 @@ module Google
             google_api_client.freeze
 
             headers = { :"x-goog-api-client" => google_api_client }
+            headers.merge!(metadata) unless metadata.nil?
             client_config_file = Pathname.new(__dir__).join(
               "video_intelligence_service_client_config.json"
             )
@@ -145,13 +154,14 @@ module Google
                 Google::Gax::Grpc::STATUS_CODE_NAMES,
                 timeout,
                 errors: Google::Gax::Grpc::API_ERRORS,
-                kwargs: headers
+                metadata: headers
               )
             end
 
             # Allow overriding the service path/port in subclasses.
             service_path = self.class::SERVICE_ADDRESS
             port = self.class::DEFAULT_SERVICE_PORT
+            interceptors = self.class::GRPC_INTERCEPTORS
             @video_intelligence_service_stub = Google::Gax::Grpc.create_stub(
               service_path,
               port,
@@ -159,12 +169,14 @@ module Google
               channel: channel,
               updater_proc: updater_proc,
               scopes: scopes,
+              interceptors: interceptors,
               &Google::Cloud::Videointelligence::V1beta1::VideoIntelligenceService::Stub.method(:new)
             )
 
             @annotate_video = Google::Gax.create_api_call(
               @video_intelligence_service_stub.method(:annotate_video),
-              defaults["annotate_video"]
+              defaults["annotate_video"],
+              exception_transformer: exception_transformer
             )
           end
 

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,13 +13,15 @@
 # limitations under the License.
 
 require "google/cloud/video_intelligence/v1beta2/video_intelligence_service_client"
+require "google/cloud/videointelligence/v1beta2/video_intelligence_pb"
+require "google/rpc/status_pb"
 
 module Google
   module Cloud
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Video Intelligence API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Video Intelligence API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Video Intelligence API][Product Documentation]:
     # Google Cloud Video Intelligence API.
@@ -42,6 +44,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/video-intelligence
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module VideoIntelligence
       module V1beta2
@@ -74,11 +101,18 @@ module Google
         #   or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
+        # @param metadata [Hash]
+        #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+        # @param exception_transformer [Proc]
+        #   An optional proc that intercepts any exceptions raised during an API call to inject
+        #   custom error handling.
         def self.new \
             credentials: nil,
             scopes: nil,
             client_config: nil,
             timeout: nil,
+            metadata: nil,
+            exception_transformer: nil,
             lib_name: nil,
             lib_version: nil
           kwargs = {
@@ -86,6 +120,8 @@ module Google
             scopes: scopes,
             client_config: client_config,
             timeout: timeout,
+            metadata: metadata,
+            exception_transformer: exception_transformer,
             lib_name: lib_name,
             lib_version: lib_version
           }.select { |_, v| v != nil }

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2.rb
@@ -21,7 +21,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Video Intelligence API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Video Intelligence API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Video Intelligence API][Product Documentation]:
     # Google Cloud Video Intelligence API.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/credentials.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,16 +17,15 @@ require "googleauth"
 module Google
   module Cloud
     module VideoIntelligence
-      ##
-      # @deprecated Use version-specific credentials classes
-      #
-      class Credentials < Google::Auth::Credentials
-        SCOPE = [
-          "https://www.googleapis.com/auth/cloud-platform"
-        ].freeze
-        PATH_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
-        JSON_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
-        DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+      module V1beta2
+        class Credentials < Google::Auth::Credentials
+          SCOPE = [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ].freeze
+          PATH_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
+          JSON_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
+          DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+        end
       end
     end
   end

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ module Google
       #
       # | Class | Description |
       # | ----- | ----------- |
-      # | [VideoIntelligenceServiceClient][] | Google Cloud Video Intelligence API. |
+      # | [VideoIntelligenceServiceClient][] | Service that implements Google Cloud Video Intelligence API. |
       # | [Data Types][] | Data types for Google::Cloud::VideoIntelligence::V1beta2 |
       #
       # [VideoIntelligenceServiceClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-video_intelligence/latest/google/cloud/videointelligence/v1beta2/videointelligenceserviceclient

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/longrunning/operations.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/longrunning/operations.rb
@@ -1,0 +1,92 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Longrunning
+    # This resource represents a long-running operation that is the result of a
+    # network API call.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The server-assigned name, which is only unique within the same service that
+    #     originally returns it. If you use the default HTTP mapping, the
+    #     +name+ should have the format of +operations/some/unique/name+.
+    # @!attribute [rw] metadata
+    #   @return [Google::Protobuf::Any]
+    #     Service-specific metadata associated with the operation.  It typically
+    #     contains progress information and common metadata such as create time.
+    #     Some services might not provide such metadata.  Any method that returns a
+    #     long-running operation should document the metadata type, if any.
+    # @!attribute [rw] done
+    #   @return [true, false]
+    #     If the value is +false+, it means the operation is still in progress.
+    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     available.
+    # @!attribute [rw] error
+    #   @return [Google::Rpc::Status]
+    #     The error result of the operation in case of failure or cancellation.
+    # @!attribute [rw] response
+    #   @return [Google::Protobuf::Any]
+    #     The normal response of the operation in case of success.  If the original
+    #     method returns no data on success, such as +Delete+, the response is
+    #     +google.protobuf.Empty+.  If the original method is standard
+    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
+    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     is the original method name.  For example, if the original method name
+    #     is +TakeSnapshot()+, the inferred response type is
+    #     +TakeSnapshotResponse+.
+    class Operation; end
+
+    # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation resource.
+    class GetOperationRequest; end
+
+    # The request message for {Google::Longrunning::Operations::ListOperations Operations::ListOperations}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation collection.
+    # @!attribute [rw] filter
+    #   @return [String]
+    #     The standard list filter.
+    # @!attribute [rw] page_size
+    #   @return [Integer]
+    #     The standard list page size.
+    # @!attribute [rw] page_token
+    #   @return [String]
+    #     The standard list page token.
+    class ListOperationsRequest; end
+
+    # The response message for {Google::Longrunning::Operations::ListOperations Operations::ListOperations}.
+    # @!attribute [rw] operations
+    #   @return [Array<Google::Longrunning::Operation>]
+    #     A list of operations that matches the specified filter in the request.
+    # @!attribute [rw] next_page_token
+    #   @return [String]
+    #     The standard List next-page token.
+    class ListOperationsResponse; end
+
+    # The request message for {Google::Longrunning::Operations::CancelOperation Operations::CancelOperation}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation resource to be cancelled.
+    class CancelOperationRequest; end
+
+    # The request message for {Google::Longrunning::Operations::DeleteOperation Operations::DeleteOperation}.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     The name of the operation resource to be deleted.
+    class DeleteOperationRequest; end
+  end
+end

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/duration.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/duration.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Video Intelligence API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Video Intelligence API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Video Intelligence API][Product Documentation]:
     # Google Cloud Video Intelligence API.
@@ -45,6 +45,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/video-intelligence
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module VideoIntelligence
       module V1beta2

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/overview.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/overview.rb
@@ -17,7 +17,7 @@ module Google
     # rubocop:disable LineLength
 
     ##
-    # # Ruby Client for Google Cloud Video Intelligence API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+    # # Ruby Client for Google Cloud Video Intelligence API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Google Cloud Video Intelligence API][Product Documentation]:
     # Google Cloud Video Intelligence API.

--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1/video_intelligence_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta1/video_intelligence_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_services_pb.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/videointelligence/v1beta2/video_intelligence_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -1,0 +1,86 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This script is used to synthesize generated parts of this library."""
+
+import synthtool as s
+import synthtool.gcp as gcp
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+gapic = gcp.GAPICGenerator()
+
+v1_library = gapic.ruby_library(
+    'videointelligence', 'v1',
+    artman_output_name='google-cloud-ruby/google-cloud-video_intelligence'
+)
+s.copy(v1_library / 'lib/google/cloud/video_intelligence/v1')
+s.copy(v1_library / 'lib/google/cloud/video_intelligence/v1.rb')
+s.copy(v1_library / 'lib/google/cloud/videointelligence/v1')
+s.copy(v1_library / 'test/google/cloud/video_intelligence/v1')
+
+# https://github.com/googleapis/gapic-generator/issues/2117
+s.replace(
+    'test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb',
+    'CustomTestError', 'CustomTestError_v1')
+s.replace(
+    'test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb',
+    'MockGrpcClientStub', 'MockGrpcClientStub_v1')
+s.replace(
+    'test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb',
+    'MockVideoIntelligenceServiceCredentials',
+    'MockVideoIntelligenceServiceCredentials_v1')
+
+v1beta1_library = gapic.ruby_library(
+    'videointelligence', 'v1beta1',
+    artman_output_name='google-cloud-ruby/google-cloud-video_intelligence'
+)
+s.copy(v1beta1_library / 'lib/google/cloud/video_intelligence/v1beta1')
+s.copy(v1beta1_library / 'lib/google/cloud/video_intelligence/v1beta1.rb')
+s.copy(v1beta1_library / 'lib/google/cloud/videointelligence/v1beta1')
+s.copy(v1beta1_library / 'test/google/cloud/video_intelligence/v1beta1')
+
+# https://github.com/googleapis/gapic-generator/issues/2117
+s.replace(
+    'test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb',
+    'CustomTestError', 'CustomTestError_v1beta1')
+s.replace(
+    'test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb',
+    'MockGrpcClientStub', 'MockGrpcClientStub_v1beta1')
+s.replace(
+    'test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb',
+    'MockVideoIntelligenceServiceCredentials',
+    'MockVideoIntelligenceServiceCredentials_v1beta1')
+
+v1beta2_library = gapic.ruby_library(
+    'videointelligence', 'v1beta2',
+    artman_output_name='google-cloud-ruby/google-cloud-video_intelligence'
+)
+s.copy(v1beta2_library / 'lib/google/cloud/video_intelligence/v1beta2')
+s.copy(v1beta2_library / 'lib/google/cloud/video_intelligence/v1beta2.rb')
+s.copy(v1beta2_library / 'lib/google/cloud/videointelligence/v1beta2')
+s.copy(v1beta2_library / 'test/google/cloud/video_intelligence/v1beta2')
+
+# https://github.com/googleapis/gapic-generator/issues/2117
+s.replace(
+    'test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb',
+    'CustomTestError', 'CustomTestError_v1beta2')
+s.replace(
+    'test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb',
+    'MockGrpcClientStub', 'MockGrpcClientStub_v1beta2')
+s.replace(
+    'test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb',
+    'MockVideoIntelligenceServiceCredentials',
+    'MockVideoIntelligenceServiceCredentials_v1beta2')

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -31,6 +31,9 @@ s.copy(v1_library / 'lib/google/cloud/video_intelligence/v1.rb')
 s.copy(v1_library / 'lib/google/cloud/videointelligence/v1')
 s.copy(v1_library / 'test/google/cloud/video_intelligence/v1')
 
+# Copy base module from the v1 library so v1 is the default
+s.copy(v1_library / 'lib/google/cloud/video_intelligence.rb')
+
 # https://github.com/googleapis/gapic-generator/issues/2117
 s.replace(
     'test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb',

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1/video_intelligence_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ require "google/cloud/video_intelligence/v1/video_intelligence_service_client"
 require "google/cloud/videointelligence/v1/video_intelligence_services_pb"
 require "google/longrunning/operations_pb"
 
-class CustomTestError < StandardError; end
+class CustomTestError_v1 < StandardError; end
 
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStub
+class MockGrpcClientStub_v1
 
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
@@ -53,7 +53,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockVideoIntelligenceServiceCredentials < Google::Cloud::VideoIntelligence::Credentials
+class MockVideoIntelligenceServiceCredentials_v1 < Google::Cloud::VideoIntelligence::V1::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -69,9 +69,14 @@ end
 describe Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient do
 
   describe 'annotate_video' do
-    custom_error = CustomTestError.new "Custom test error for Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient#annotate_video."
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient#annotate_video."
 
     it 'invokes annotate_video without error' do
+      # Create request parameters
+      input_uri = "gs://demomaker/cat.mp4"
+      features_element = :LABEL_DETECTION
+      features = [features_element]
+
       # Create expected grpc response
       expected_response = {}
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Videointelligence::V1::AnnotateVideoResponse)
@@ -84,20 +89,20 @@ describe Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient do
       )
 
       # Mock Grpc layer
-      mock_method = proc do
+      mock_method = proc do |request|
         OpenStruct.new(execute: operation)
       end
-      mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
+      mock_stub = MockGrpcClientStub_v1.new(:annotate_video, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockVideoIntelligenceServiceCredentials.new("annotate_video")
+      mock_credentials = MockVideoIntelligenceServiceCredentials_v1.new("annotate_video")
 
       Google::Cloud::Videointelligence::V1::VideoIntelligenceService::Stub.stub(:new, mock_stub) do
-        Google::Cloud::VideoIntelligence::Credentials.stub(:default, mock_credentials) do
+        Google::Cloud::VideoIntelligence::V1::Credentials.stub(:default, mock_credentials) do
           client = Google::Cloud::VideoIntelligence.new(version: :v1)
 
           # Call method
-          response = client.annotate_video
+          response = client.annotate_video(input_uri: input_uri, features: features)
 
           # Verify the response
           assert_equal(expected_response, response.response)
@@ -106,6 +111,11 @@ describe Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient do
     end
 
     it 'invokes annotate_video and returns an operation error.' do
+      # Create request parameters
+      input_uri = "gs://demomaker/cat.mp4"
+      features_element = :LABEL_DETECTION
+      features = [features_element]
+
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
         message: 'Operation error for Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient#annotate_video.'
@@ -117,20 +127,20 @@ describe Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient do
       )
 
       # Mock Grpc layer
-      mock_method = proc do
+      mock_method = proc do |request|
         OpenStruct.new(execute: operation)
       end
-      mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
+      mock_stub = MockGrpcClientStub_v1.new(:annotate_video, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockVideoIntelligenceServiceCredentials.new("annotate_video")
+      mock_credentials = MockVideoIntelligenceServiceCredentials_v1.new("annotate_video")
 
       Google::Cloud::Videointelligence::V1::VideoIntelligenceService::Stub.stub(:new, mock_stub) do
-        Google::Cloud::VideoIntelligence::Credentials.stub(:default, mock_credentials) do
+        Google::Cloud::VideoIntelligence::V1::Credentials.stub(:default, mock_credentials) do
           client = Google::Cloud::VideoIntelligence.new(version: :v1)
 
           # Call method
-          response = client.annotate_video
+          response = client.annotate_video(input_uri: input_uri, features: features)
 
           # Verify the response
           assert(response.error?)
@@ -140,22 +150,27 @@ describe Google::Cloud::VideoIntelligence::V1::VideoIntelligenceServiceClient do
     end
 
     it 'invokes annotate_video with error' do
+      # Create request parameters
+      input_uri = "gs://demomaker/cat.mp4"
+      features_element = :LABEL_DETECTION
+      features = [features_element]
+
       # Mock Grpc layer
-      mock_method = proc do
+      mock_method = proc do |request|
         raise custom_error
       end
-      mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
+      mock_stub = MockGrpcClientStub_v1.new(:annotate_video, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockVideoIntelligenceServiceCredentials.new("annotate_video")
+      mock_credentials = MockVideoIntelligenceServiceCredentials_v1.new("annotate_video")
 
       Google::Cloud::Videointelligence::V1::VideoIntelligenceService::Stub.stub(:new, mock_stub) do
-        Google::Cloud::VideoIntelligence::Credentials.stub(:default, mock_credentials) do
+        Google::Cloud::VideoIntelligence::V1::Credentials.stub(:default, mock_credentials) do
           client = Google::Cloud::VideoIntelligence.new(version: :v1)
 
           # Call method
           err = assert_raises Google::Gax::GaxError do
-            client.annotate_video
+            client.annotate_video(input_uri: input_uri, features: features)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ require "minitest/spec"
 
 require "google/gax"
 
-require "google/cloud/video_intelligence"
+require "google/cloud/video_intelligence/v1beta1"
 require "google/cloud/video_intelligence/v1beta1/video_intelligence_service_client"
 require "google/cloud/videointelligence/v1beta1/video_intelligence_services_pb"
 require "google/longrunning/operations_pb"
 
-class CustomTestError < StandardError; end
+class CustomTestError_v1beta1 < StandardError; end
 
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStub
+class MockGrpcClientStub_v1beta1
 
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
@@ -53,7 +53,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockVideoIntelligenceServiceCredentials < Google::Cloud::VideoIntelligence::Credentials
+class MockVideoIntelligenceServiceCredentials_v1beta1 < Google::Cloud::VideoIntelligence::V1beta1::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -69,7 +69,7 @@ end
 describe Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceServiceClient do
 
   describe 'annotate_video' do
-    custom_error = CustomTestError.new "Custom test error for Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceServiceClient#annotate_video."
+    custom_error = CustomTestError_v1beta1.new "Custom test error for Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceServiceClient#annotate_video."
 
     it 'invokes annotate_video without error' do
       # Create request parameters
@@ -95,14 +95,14 @@ describe Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceServiceClie
         assert_equal(features, request.features)
         OpenStruct.new(execute: operation)
       end
-      mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
+      mock_stub = MockGrpcClientStub_v1beta1.new(:annotate_video, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockVideoIntelligenceServiceCredentials.new("annotate_video")
+      mock_credentials = MockVideoIntelligenceServiceCredentials_v1beta1.new("annotate_video")
 
       Google::Cloud::Videointelligence::V1beta1::VideoIntelligenceService::Stub.stub(:new, mock_stub) do
-        Google::Cloud::VideoIntelligence::Credentials.stub(:default, mock_credentials) do
-          client = Google::Cloud::VideoIntelligence.new(version: :v1beta1)
+        Google::Cloud::VideoIntelligence::V1beta1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::VideoIntelligence::V1beta1.new
 
           # Call method
           response = client.annotate_video(input_uri, features)
@@ -136,14 +136,14 @@ describe Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceServiceClie
         assert_equal(features, request.features)
         OpenStruct.new(execute: operation)
       end
-      mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
+      mock_stub = MockGrpcClientStub_v1beta1.new(:annotate_video, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockVideoIntelligenceServiceCredentials.new("annotate_video")
+      mock_credentials = MockVideoIntelligenceServiceCredentials_v1beta1.new("annotate_video")
 
       Google::Cloud::Videointelligence::V1beta1::VideoIntelligenceService::Stub.stub(:new, mock_stub) do
-        Google::Cloud::VideoIntelligence::Credentials.stub(:default, mock_credentials) do
-          client = Google::Cloud::VideoIntelligence.new(version: :v1beta1)
+        Google::Cloud::VideoIntelligence::V1beta1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::VideoIntelligence::V1beta1.new
 
           # Call method
           response = client.annotate_video(input_uri, features)
@@ -168,14 +168,14 @@ describe Google::Cloud::VideoIntelligence::V1beta1::VideoIntelligenceServiceClie
         assert_equal(features, request.features)
         raise custom_error
       end
-      mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
+      mock_stub = MockGrpcClientStub_v1beta1.new(:annotate_video, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockVideoIntelligenceServiceCredentials.new("annotate_video")
+      mock_credentials = MockVideoIntelligenceServiceCredentials_v1beta1.new("annotate_video")
 
       Google::Cloud::Videointelligence::V1beta1::VideoIntelligenceService::Stub.stub(:new, mock_stub) do
-        Google::Cloud::VideoIntelligence::Credentials.stub(:default, mock_credentials) do
-          client = Google::Cloud::VideoIntelligence.new(version: :v1beta1)
+        Google::Cloud::VideoIntelligence::V1beta1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::VideoIntelligence::V1beta1.new
 
           # Call method
           err = assert_raises Google::Gax::GaxError do

--- a/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb
+++ b/google-cloud-video_intelligence/test/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ require "minitest/spec"
 
 require "google/gax"
 
-require "google/cloud/video_intelligence"
+require "google/cloud/video_intelligence/v1beta2"
 require "google/cloud/video_intelligence/v1beta2/video_intelligence_service_client"
 require "google/cloud/videointelligence/v1beta2/video_intelligence_services_pb"
 require "google/longrunning/operations_pb"
 
-class CustomTestError < StandardError; end
+class CustomTestError_v1beta2 < StandardError; end
 
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStub
+class MockGrpcClientStub_v1beta2
 
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
@@ -53,7 +53,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockVideoIntelligenceServiceCredentials < Google::Cloud::VideoIntelligence::Credentials
+class MockVideoIntelligenceServiceCredentials_v1beta2 < Google::Cloud::VideoIntelligence::V1beta2::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -69,9 +69,14 @@ end
 describe Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClient do
 
   describe 'annotate_video' do
-    custom_error = CustomTestError.new "Custom test error for Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClient#annotate_video."
+    custom_error = CustomTestError_v1beta2.new "Custom test error for Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClient#annotate_video."
 
     it 'invokes annotate_video without error' do
+      # Create request parameters
+      input_uri = "gs://demomaker/cat.mp4"
+      features_element = :LABEL_DETECTION
+      features = [features_element]
+
       # Create expected grpc response
       expected_response = {}
       expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Videointelligence::V1beta2::AnnotateVideoResponse)
@@ -84,20 +89,20 @@ describe Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClie
       )
 
       # Mock Grpc layer
-      mock_method = proc do
+      mock_method = proc do |request|
         OpenStruct.new(execute: operation)
       end
-      mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
+      mock_stub = MockGrpcClientStub_v1beta2.new(:annotate_video, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockVideoIntelligenceServiceCredentials.new("annotate_video")
+      mock_credentials = MockVideoIntelligenceServiceCredentials_v1beta2.new("annotate_video")
 
       Google::Cloud::Videointelligence::V1beta2::VideoIntelligenceService::Stub.stub(:new, mock_stub) do
-        Google::Cloud::VideoIntelligence::Credentials.stub(:default, mock_credentials) do
-          client = Google::Cloud::VideoIntelligence.new(version: :v1beta2)
+        Google::Cloud::VideoIntelligence::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::VideoIntelligence::V1beta2.new
 
           # Call method
-          response = client.annotate_video
+          response = client.annotate_video(input_uri: input_uri, features: features)
 
           # Verify the response
           assert_equal(expected_response, response.response)
@@ -106,6 +111,11 @@ describe Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClie
     end
 
     it 'invokes annotate_video and returns an operation error.' do
+      # Create request parameters
+      input_uri = "gs://demomaker/cat.mp4"
+      features_element = :LABEL_DETECTION
+      features = [features_element]
+
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
         message: 'Operation error for Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClient#annotate_video.'
@@ -117,20 +127,20 @@ describe Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClie
       )
 
       # Mock Grpc layer
-      mock_method = proc do
+      mock_method = proc do |request|
         OpenStruct.new(execute: operation)
       end
-      mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
+      mock_stub = MockGrpcClientStub_v1beta2.new(:annotate_video, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockVideoIntelligenceServiceCredentials.new("annotate_video")
+      mock_credentials = MockVideoIntelligenceServiceCredentials_v1beta2.new("annotate_video")
 
       Google::Cloud::Videointelligence::V1beta2::VideoIntelligenceService::Stub.stub(:new, mock_stub) do
-        Google::Cloud::VideoIntelligence::Credentials.stub(:default, mock_credentials) do
-          client = Google::Cloud::VideoIntelligence.new(version: :v1beta2)
+        Google::Cloud::VideoIntelligence::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::VideoIntelligence::V1beta2.new
 
           # Call method
-          response = client.annotate_video
+          response = client.annotate_video(input_uri: input_uri, features: features)
 
           # Verify the response
           assert(response.error?)
@@ -140,22 +150,27 @@ describe Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceServiceClie
     end
 
     it 'invokes annotate_video with error' do
+      # Create request parameters
+      input_uri = "gs://demomaker/cat.mp4"
+      features_element = :LABEL_DETECTION
+      features = [features_element]
+
       # Mock Grpc layer
-      mock_method = proc do
+      mock_method = proc do |request|
         raise custom_error
       end
-      mock_stub = MockGrpcClientStub.new(:annotate_video, mock_method)
+      mock_stub = MockGrpcClientStub_v1beta2.new(:annotate_video, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockVideoIntelligenceServiceCredentials.new("annotate_video")
+      mock_credentials = MockVideoIntelligenceServiceCredentials_v1beta2.new("annotate_video")
 
       Google::Cloud::Videointelligence::V1beta2::VideoIntelligenceService::Stub.stub(:new, mock_stub) do
-        Google::Cloud::VideoIntelligence::Credentials.stub(:default, mock_credentials) do
-          client = Google::Cloud::VideoIntelligence.new(version: :v1beta2)
+        Google::Cloud::VideoIntelligence::V1beta2::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::VideoIntelligence::V1beta2.new
 
           # Call method
           err = assert_raises Google::Gax::GaxError do
-            client.annotate_video
+            client.annotate_video(input_uri: input_uri, features: features)
           end
 
           # Verify the GaxError wrapped the custom error that was raised.


### PR DESCRIPTION
Add a synth script for generating video_intelligence, and regenerate the library.

There are some minor changes, mostly to documentation. The only significant change seems to be the moving of the credentials class into the version namespaces. For now I left the old credentials class in place, with a "deprecated" comment on it. Question for people: is it safe to remove the class? I'm not sure if it is considered part of the public surface.
