### PR TITLE
Regenerate the autogen part of trace and provide a synth script

### DIFF
--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "stackdriver-core", "~> 1.3"
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.3"
 
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-trace/lib/google/cloud/trace/v1/credentials.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/credentials.rb
@@ -19,11 +19,7 @@ module Google
     module Trace
       module V1
         class Credentials < Google::Auth::Credentials
-          SCOPE = [
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/trace.append",
-            "https://www.googleapis.com/auth/trace.readonly"
-          ].freeze
+          SCOPE = ["https://www.googleapis.com/auth/cloud-platform"].freeze
           PATH_ENV_VARS = %w(TRACE_CREDENTIALS TRACE_KEYFILE GOOGLE_CLOUD_CREDENTIALS GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
           JSON_ENV_VARS = %w(TRACE_CREDENTIALS_JSON TRACE_KEYFILE_JSON GOOGLE_CLOUD_CREDENTIALS_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
           DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]

--- a/google-cloud-trace/lib/google/cloud/trace/v1/credentials.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/credentials.rb
@@ -1,0 +1,34 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "googleauth"
+
+module Google
+  module Cloud
+    module Trace
+      module V1
+        class Credentials < Google::Auth::Credentials
+          SCOPE = [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/trace.append",
+            "https://www.googleapis.com/auth/trace.readonly"
+          ].freeze
+          PATH_ENV_VARS = %w(TRACE_CREDENTIALS TRACE_KEYFILE GOOGLE_CLOUD_CREDENTIALS GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
+          JSON_ENV_VARS = %w(TRACE_CREDENTIALS_JSON TRACE_KEYFILE_JSON GOOGLE_CLOUD_CREDENTIALS_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
+          DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ module Google
       #
       # | Class | Description |
       # | ----- | ----------- |
-      # | [TraceServiceClient][] | Send and retrieve trace data from Stackdriver Trace. Data is generated and available by default for all App Engine applications. Data from other applications can be written to Stackdriver Trace for display, reporting, and analysis. |
+      # | [TraceServiceClient][] | This file describes an API for collecting and viewing traces and spans within a trace. |
       # | [Data Types][] | Data types for Google::Cloud::Trace::V1 |
       #
       # [TraceServiceClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-trace/latest/google/devtools/cloudtrace/v1/traceserviceclient
@@ -106,9 +106,11 @@ module Google
         #     * +/http/client_region+
         #     * +/http/host+
         #     * +/http/method+
+        #     * +/http/path+
         #     * +/http/redirected_url+
         #     * +/http/request/size+
         #     * +/http/response/size+
+        #     * +/http/route+
         #     * +/http/status_code+
         #     * +/http/url+
         #     * +/http/user_agent+

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/empty.rb
@@ -1,0 +1,28 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Protobuf
+    # A generic empty message that you can re-use to avoid defining duplicated
+    # empty messages in your APIs. A typical example is to use it as the request
+    # or the response type of an API method. For instance:
+    #
+    #     service Foo {
+    #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+    #     }
+    #
+    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    class Empty; end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/overview.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,10 +20,9 @@ module Google
     # # Ruby Client for Stackdriver Trace API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
     #
     # [Stackdriver Trace API][Product Documentation]:
-    # Send and retrieve trace data from Stackdriver Trace. Data is generated and
-    # available by default for all App Engine applications. Data from other
-    # applications can be written to Stackdriver Trace for display, reporting, and
-    # analysis.
+    # Sends application trace data to Stackdriver Trace for viewing. Trace data is
+    # collected for all App Engine applications by default. Trace data from other
+    # applications can be provided using this API.
     # - [Product Documentation][]
     #
     # ## Quick Start
@@ -31,12 +30,35 @@ module Google
     # steps:
     #
     # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
-    # 2. [Enable the Stackdriver Trace API.](https://console.cloud.google.com/apis/api/cloudtrace)
-    # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+    # 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+    # 3. [Enable the Stackdriver Trace API.](https://console.cloud.google.com/apis/api/trace)
+    # 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
     #
     # ### Installation
     # ```
     # $ gem install google-cloud-trace
+    # ```
+    #
+    # ### Preview
+    # #### TraceServiceClient
+    # ```rb
+    # require "google/cloud/trace"
+    #
+    # trace_service_client = Google::Cloud::Trace.new
+    # project_id_2 = project_id
+    #
+    # # Iterate over all results.
+    # trace_service_client.list_traces(project_id_2).each do |element|
+    #   # Process element.
+    # end
+    #
+    # # Or iterate over results one page at a time.
+    # trace_service_client.list_traces(project_id_2).each_page do |page|
+    #   # Process each page at a time.
+    #   page.each do |element|
+    #     # Process element.
+    #   end
+    # end
     # ```
     #
     # ### Next Steps
@@ -45,8 +67,33 @@ module Google
     # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
     #   to see the full list of Cloud APIs that we cover.
     #
-    # [Product Documentation]: https://cloud.google.com/cloudtrace
+    # [Product Documentation]: https://cloud.google.com/trace
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module Trace
       module V1

--- a/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client_config.json
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client_config.json
@@ -17,32 +17,23 @@
           "rpc_timeout_multiplier": 1.5,
           "max_rpc_timeout_millis": 30000,
           "total_timeout_millis": 45000
-        },
-        "write_sink": {
-          "initial_retry_delay_millis": 100,
-          "retry_delay_multiplier": 1.2,
-          "max_retry_delay_millis": 1000,
-          "initial_rpc_timeout_millis": 30000,
-          "rpc_timeout_multiplier": 1.5,
-          "max_rpc_timeout_millis": 60000,
-          "total_timeout_millis": 120000
         }
       },
       "methods": {
-        "ListTraces": {
-          "timeout_millis": 60000,
+        "PatchTraces": {
+          "timeout_millis": 30000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "GetTrace": {
-          "timeout_millis": 60000,
+          "timeout_millis": 30000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
-        "PatchTraces": {
+        "ListTraces": {
           "timeout_millis": 30000,
-          "retry_codes_name": "non_idempotent",
-          "retry_params_name": "write_sink"
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/google-cloud-trace/lib/google/cloud/trace/v2/credentials.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/credentials.rb
@@ -19,10 +19,7 @@ module Google
     module Trace
       module V2
         class Credentials < Google::Auth::Credentials
-          SCOPE = [
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/trace.append"
-          ].freeze
+          SCOPE = ["https://www.googleapis.com/auth/cloud-platform"].freeze
           PATH_ENV_VARS = %w(TRACE_CREDENTIALS TRACE_KEYFILE GOOGLE_CLOUD_CREDENTIALS GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
           JSON_ENV_VARS = %w(TRACE_CREDENTIALS_JSON TRACE_KEYFILE_JSON GOOGLE_CLOUD_CREDENTIALS_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
           DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]

--- a/google-cloud-trace/lib/google/cloud/trace/v2/credentials.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/credentials.rb
@@ -1,0 +1,33 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "googleauth"
+
+module Google
+  module Cloud
+    module Trace
+      module V2
+        class Credentials < Google::Auth::Credentials
+          SCOPE = [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/trace.append"
+          ].freeze
+          PATH_ENV_VARS = %w(TRACE_CREDENTIALS TRACE_KEYFILE GOOGLE_CLOUD_CREDENTIALS GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
+          JSON_ENV_VARS = %w(TRACE_CREDENTIALS_JSON TRACE_KEYFILE_JSON GOOGLE_CLOUD_CREDENTIALS_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
+          DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/trace.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/tracing.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/tracing.rb
@@ -1,0 +1,43 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Devtools
+    module Cloudtrace
+      ##
+      # # Stackdriver Trace API Contents
+      #
+      # | Class | Description |
+      # | ----- | ----------- |
+      # | [TraceServiceClient][] | This file describes an API for collecting and viewing traces and spans within a trace. |
+      # | [Data Types][] | Data types for Google::Cloud::Trace::V2 |
+      #
+      # [TraceServiceClient]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-trace/latest/google/devtools/cloudtrace/v2/traceserviceclient
+      # [Data Types]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-trace/latest/google/devtools/cloudtrace/v2/datatypes
+      #
+      module V2
+        # The request message for the +BatchWriteSpans+ method.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     Required. The name of the project where the spans belong. The format is
+        #     +projects/[PROJECT_ID]+.
+        # @!attribute [rw] spans
+        #   @return [Array<Google::Devtools::Cloudtrace::V2::Span>]
+        #     A list of new spans. The span names must not match existing
+        #     spans, or the results are undefined.
+        class BatchWriteSpansRequest; end
+      end
+    end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/any.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/empty.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/empty.rb
@@ -1,0 +1,28 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Protobuf
+    # A generic empty message that you can re-use to avoid defining duplicated
+    # empty messages in your APIs. A typical example is to use it as the request
+    # or the response type of an API method. For instance:
+    #
+    #     service Foo {
+    #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+    #     }
+    #
+    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    class Empty; end
+  end
+end

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/timestamp.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/wrappers.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/rpc/status.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/rpc/status.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/overview.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/overview.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,6 +46,8 @@ module Google
     #
     # trace_service_client = Google::Cloud::Trace.new
     # formatted_name = Google::Cloud::Trace::V2::TraceServiceClient.project_path(project_id)
+    #
+    # # TODO: Initialize +spans+:
     # spans = []
     # trace_service_client.batch_write_spans(formatted_name, spans)
     # ```
@@ -58,6 +60,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/trace
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module Trace
       module V2

--- a/google-cloud-trace/lib/google/devtools/cloudtrace/v1/trace_services_pb.rb
+++ b/google-cloud-trace/lib/google/devtools/cloudtrace/v1/trace_services_pb.rb
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -1,0 +1,66 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This script is used to synthesize generated parts of this library."""
+
+import synthtool as s
+import synthtool.gcp as gcp
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+gapic = gcp.GAPICGenerator()
+
+v1_library = gapic.ruby_library(
+    'trace', 'v1',
+    config_path='/google/devtools/cloudtrace/artman_cloudtrace_v1.yaml',
+    artman_output_name='google-cloud-ruby/google-cloud-trace'
+)
+s.copy(v1_library / 'lib/google/cloud/trace/v1')
+s.copy(v1_library / 'lib/google/devtools/cloudtrace/v1')
+
+# Omitting lib/google/cloud/trace/v1.rb for now because we are not exposing the
+# low-level API.
+
+# https://github.com/googleapis/gapic-generator/issues/2118
+s.replace(
+    'lib/google/cloud/trace/v1/credentials.rb',
+    'TRACE_KEYFILE GOOGLE_CLOUD_KEYFILE',
+    'TRACE_CREDENTIALS TRACE_KEYFILE GOOGLE_CLOUD_CREDENTIALS GOOGLE_CLOUD_KEYFILE')
+s.replace(
+    'lib/google/cloud/trace/v1/credentials.rb',
+    'TRACE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON',
+    'TRACE_CREDENTIALS_JSON TRACE_KEYFILE_JSON GOOGLE_CLOUD_CREDENTIALS_JSON GOOGLE_CLOUD_KEYFILE_JSON')
+
+
+v2_library = gapic.ruby_library(
+    'trace', 'v2',
+    config_path='/google/devtools/cloudtrace/artman_cloudtrace_v2.yaml',
+    artman_output_name='google-cloud-ruby/google-cloud-trace'
+)
+s.copy(v2_library / 'lib/google/cloud/trace/v2')
+s.copy(v2_library / 'lib/google/devtools/cloudtrace/v2')
+
+# Omitting lib/google/cloud/trace/v2.rb for now because we are not exposing the
+# low-level API.
+
+# https://github.com/googleapis/gapic-generator/issues/2118
+s.replace(
+    'lib/google/cloud/trace/v2/credentials.rb',
+    'TRACE_KEYFILE GOOGLE_CLOUD_KEYFILE',
+    'TRACE_CREDENTIALS TRACE_KEYFILE GOOGLE_CLOUD_CREDENTIALS GOOGLE_CLOUD_KEYFILE')
+s.replace(
+    'lib/google/cloud/trace/v2/credentials.rb',
+    'TRACE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON',
+    'TRACE_CREDENTIALS_JSON TRACE_KEYFILE_JSON GOOGLE_CLOUD_CREDENTIALS_JSON GOOGLE_CLOUD_KEYFILE_JSON')

--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -43,6 +43,11 @@ s.replace(
     'TRACE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON',
     'TRACE_CREDENTIALS_JSON TRACE_KEYFILE_JSON GOOGLE_CLOUD_CREDENTIALS_JSON GOOGLE_CLOUD_KEYFILE_JSON')
 
+# https://github.com/googleapis/gapic-generator/issues/2124
+s.replace(
+    'lib/google/cloud/trace/v1/credentials.rb',
+    'SCOPE = \[[^\]]+\]\.freeze',
+    'SCOPE = ["https://www.googleapis.com/auth/cloud-platform"].freeze')
 
 v2_library = gapic.ruby_library(
     'trace', 'v2',
@@ -64,3 +69,9 @@ s.replace(
     'lib/google/cloud/trace/v2/credentials.rb',
     'TRACE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON',
     'TRACE_CREDENTIALS_JSON TRACE_KEYFILE_JSON GOOGLE_CLOUD_CREDENTIALS_JSON GOOGLE_CLOUD_KEYFILE_JSON')
+
+# https://github.com/googleapis/gapic-generator/issues/2124
+s.replace(
+    'lib/google/cloud/trace/v2/credentials.rb',
+    'SCOPE = \[[^\]]+\]\.freeze',
+    'SCOPE = ["https://www.googleapis.com/auth/cloud-platform"].freeze')


### PR DESCRIPTION
Add a synth script for generating trace low-level libraries, and regenerate them. Handwritten libraries are not changed.

There are some minor changes, mostly to documentation. (Unfortunately, the calls were reordered, so the diffs aren't as clean as they could be.)
