### PR TITLE
Regenerate speech and provide a synth script

### DIFF
--- a/google-cloud-speech/lib/google/cloud/speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech.rb
@@ -69,6 +69,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/speech
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module Speech
       # rubocop:enable LineLength

--- a/google-cloud-speech/lib/google/cloud/speech/v1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1.rb
@@ -38,9 +38,9 @@ module Google
     # ### Preview
     # #### SpeechClient
     # ```rb
-    # require "google/cloud/speech"
+    # require "google/cloud/speech/v1"
     #
-    # speech_client = Google::Cloud::Speech.new(version: :v1)
+    # speech_client = Google::Cloud::Speech::V1.new
     # language_code = "en-US"
     # sample_rate_hertz = 44100
     # encoding = :FLAC
@@ -62,6 +62,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/speech
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module Speech
       module V1

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/overview.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/overview.rb
@@ -64,6 +64,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/speech
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module Speech
       module V1

--- a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
@@ -46,6 +46,9 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
+          # The default set of gRPC interceptors.
+          GRPC_INTERCEPTORS = []
+
           DEFAULT_TIMEOUT = 30
 
           # The scopes needed to make gRPC calls to all of the methods defined in
@@ -56,6 +59,7 @@ module Google
 
           class OperationsClient < Google::Longrunning::OperationsClient
             self::SERVICE_ADDRESS = SpeechClient::SERVICE_ADDRESS
+            self::GRPC_INTERCEPTORS = SpeechClient::GRPC_INTERCEPTORS
           end
 
           # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
@@ -157,6 +161,7 @@ module Google
             # Allow overriding the service path/port in subclasses.
             service_path = self.class::SERVICE_ADDRESS
             port = self.class::DEFAULT_SERVICE_PORT
+            interceptors = self.class::GRPC_INTERCEPTORS
             @speech_stub = Google::Gax::Grpc.create_stub(
               service_path,
               port,
@@ -164,6 +169,7 @@ module Google
               channel: channel,
               updater_proc: updater_proc,
               scopes: scopes,
+              interceptors: interceptors,
               &Google::Cloud::Speech::V1::Speech::Stub.method(:new)
             )
 

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1.rb
@@ -38,9 +38,9 @@ module Google
     # ### Preview
     # #### SpeechClient
     # ```rb
-    # require "google/cloud/speech"
+    # require "google/cloud/speech/v1p1beta1"
     #
-    # speech_client = Google::Cloud::Speech.new(version: :v1p1beta1)
+    # speech_client = Google::Cloud::Speech::V1p1beta1.new
     # language_code = "en-US"
     # sample_rate_hertz = 44100
     # encoding = :FLAC
@@ -62,6 +62,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/speech
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module Speech
       module V1p1beta1

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/overview.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/overview.rb
@@ -64,6 +64,31 @@ module Google
     #
     # [Product Documentation]: https://cloud.google.com/speech
     #
+    # ## Enabling Logging
+    #
+    # To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+    # The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below,
+    # or a [`Google::Cloud::Logging::Logger`](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger)
+    # that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+    # and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+    #
+    # Configuring a Ruby stdlib logger:
+    #
+    # ```ruby
+    # require "logger"
+    #
+    # module MyLogger
+    #   LOGGER = Logger.new $stderr, level: Logger::WARN
+    #   def logger
+    #     LOGGER
+    #   end
+    # end
+    #
+    # # Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+    # module GRPC
+    #   extend MyLogger
+    # end
+    # ```
     #
     module Speech
       module V1p1beta1

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
@@ -46,6 +46,9 @@ module Google
           # The default port of the service.
           DEFAULT_SERVICE_PORT = 443
 
+          # The default set of gRPC interceptors.
+          GRPC_INTERCEPTORS = []
+
           DEFAULT_TIMEOUT = 30
 
           # The scopes needed to make gRPC calls to all of the methods defined in
@@ -56,6 +59,7 @@ module Google
 
           class OperationsClient < Google::Longrunning::OperationsClient
             self::SERVICE_ADDRESS = SpeechClient::SERVICE_ADDRESS
+            self::GRPC_INTERCEPTORS = SpeechClient::GRPC_INTERCEPTORS
           end
 
           # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
@@ -157,6 +161,7 @@ module Google
             # Allow overriding the service path/port in subclasses.
             service_path = self.class::SERVICE_ADDRESS
             port = self.class::DEFAULT_SERVICE_PORT
+            interceptors = self.class::GRPC_INTERCEPTORS
             @speech_stub = Google::Gax::Grpc.create_stub(
               service_path,
               port,
@@ -164,6 +169,7 @@ module Google
               channel: channel,
               updater_proc: updater_proc,
               scopes: scopes,
+              interceptors: interceptors,
               &Google::Cloud::Speech::V1p1beta1::Speech::Stub.method(:new)
             )
 

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -1,0 +1,68 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This script is used to synthesize generated parts of this library."""
+
+import synthtool as s
+import synthtool.gcp as gcp
+import logging
+from textwrap import dedent
+
+logging.basicConfig(level=logging.DEBUG)
+
+gapic = gcp.GAPICGenerator()
+
+v1_library = gapic.ruby_library(
+    'speech', 'v1',
+    artman_output_name='google-cloud-ruby/google-cloud-speech'
+)
+s.copy(v1_library / 'lib/google/cloud/speech/v1')
+s.copy(v1_library / 'lib/google/cloud/speech/v1.rb')
+s.copy(v1_library / 'lib/google/cloud/speech.rb')
+
+# PERMANENT: Install partial gapics
+s.replace(
+    'lib/google/cloud/speech/v1.rb',
+    'require "google/cloud/speech/v1/speech_client"',
+    'require "google/cloud/speech/v1/speech_client"\nrequire "google/cloud/speech/v1/helpers"')
+
+# PERMANENT: Remove methods replaced by partial gapics
+s.replace(
+    'lib/google/cloud/speech/v1/speech_client.rb',
+    '\n\n(\s{10}#[^\n]*\n)+\n*\s{10}def streaming_recognize[^\n]+\n(\s{12}[^\n]+\n+)+\s{10}end\n',
+    '\n')
+
+# PERMANENT: Add migration guide to docs
+s.replace(
+    'lib/google/cloud/speech.rb',
+    '# ### Preview',
+    dedent("""\
+      # ### Migration Guide
+          #
+          # The 0.30.0 release introduced breaking changes relative to the previous
+          # release, 0.29.0. For more details and instructions to migrate your code,
+          # please visit the [migration
+          # guide](https://cloud.google.com/speech-to-text/docs/ruby-client-migration).
+          #
+          # ### Preview"""))
+
+# https://github.com/googleapis/gapic-generator/issues/2122
+s.replace(
+    'lib/google/cloud/speech.rb',
+    'gs://gapic-toolkit/hello.flac',
+    'gs://bucket-name/hello.flac')
+s.replace(
+    'lib/google/cloud/speech/v1.rb',
+    'gs://gapic-toolkit/hello.flac',
+    'gs://bucket-name/hello.flac')

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -66,3 +66,29 @@ s.replace(
     'lib/google/cloud/speech/v1.rb',
     'gs://gapic-toolkit/hello.flac',
     'gs://bucket-name/hello.flac')
+
+
+v1p1beta1_library = gapic.ruby_library(
+    'speech', 'v1p1beta1',
+    artman_output_name='google-cloud-ruby/google-cloud-speech'
+)
+s.copy(v1p1beta1_library / 'lib/google/cloud/speech/v1p1beta1')
+s.copy(v1p1beta1_library / 'lib/google/cloud/speech/v1p1beta1.rb')
+
+# PERMANENT: Install partial gapics
+s.replace(
+    'lib/google/cloud/speech/v1p1beta1.rb',
+    'require "google/cloud/speech/v1p1beta1/speech_client"',
+    'require "google/cloud/speech/v1p1beta1/speech_client"\nrequire "google/cloud/speech/v1p1beta1/helpers"')
+
+# PERMANENT: Remove methods replaced by partial gapics
+s.replace(
+    'lib/google/cloud/speech/v1p1beta1/speech_client.rb',
+    '\n\n(\s{10}#[^\n]*\n)+\n*\s{10}def streaming_recognize[^\n]+\n(\s{12}[^\n]+\n+)+\s{10}end\n',
+    '\n')
+
+# https://github.com/googleapis/gapic-generator/issues/2122
+s.replace(
+    'lib/google/cloud/speech/v1p1beta1.rb',
+    'gs://gapic-toolkit/hello.flac',
+    'gs://bucket-name/hello.flac')


### PR DESCRIPTION
Add a synth script for generating speech library, including transforms that invoke the partial gapic helper, and that remove the replaced `streaming_recognize` method and documentation. The method removal transform currently uses a regex and is rather brittle, but it works for now. I'll work on adding a more powerful method removal transform to synthtool later.

I ran regeneration, resulting in very minor changes.