### PR TITLE
Add DDL statistics fields to Bigquery::QueryJob

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -136,6 +136,15 @@ describe Google::Cloud::Bigquery, :bigquery do
     job.wait_until_done!
     rows = job.data
     rows.total.must_equal 100
+
+    # @gapi.statistics.query
+    job.cache_hit?.must_equal true
+    job.bytes_processed.must_equal 0
+    job.query_plan.must_be :nil?
+    # Sometimes values are nil in the returned job, so currently comment out unreliable expectations
+    # job.statement_type.must_equal "SELECT"
+    job.ddl_operation_performed.must_be :nil?
+    job.ddl_target_table.must_be :nil?
   end
 
   it "should run a query job with job labels" do

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_ddl_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_ddl_test.rb
@@ -1,0 +1,56 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bigquery_helper"
+
+describe Google::Cloud::Bigquery::Dataset, :ddl, :bigquery do
+  let(:dataset_id) { "#{prefix}_dataset" }
+  let(:dataset) do
+    d = bigquery.dataset dataset_id
+    if d.nil?
+      d = bigquery.create_dataset dataset_id
+    end
+    d
+  end
+  let(:table_id) { "dataset_ddl_table_#{SecureRandom.hex(16)}" }
+
+
+  it "creates and drops a table with ddl stats" do
+    create_job = dataset.query_job "CREATE TABLE #{table_id} (x INT64)"
+    create_job.wait_until_done!
+
+    create_job.statement_type.must_equal "CREATE_TABLE"
+    create_job.ddl_operation_performed.must_equal "CREATE"
+    table_ref = create_job.ddl_target_table
+    table_ref.must_be_kind_of Google::Cloud::Bigquery::Table
+    table_ref.project_id.must_equal bigquery.project
+    table_ref.dataset_id.must_equal dataset_id
+    table_ref.table_id.must_equal table_id
+    table_ref.reference?.must_equal true
+    table_ref.exists?.must_equal true
+
+    drop_job = dataset.query_job "DROP TABLE #{table_id}"
+    drop_job.wait_until_done!
+
+    drop_job.statement_type.must_equal "DROP_TABLE"
+    drop_job.ddl_operation_performed.must_equal "DROP"
+    table_ref_2 = create_job.ddl_target_table
+    table_ref_2.must_be_kind_of Google::Cloud::Bigquery::Table
+    table_ref_2.project_id.must_equal bigquery.project
+    table_ref_2.dataset_id.must_equal dataset_id
+    table_ref_2.table_id.must_equal table_id
+    table_ref_2.reference?.must_equal true
+    table_ref_2.exists?.must_equal false
+  end
+end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2172,10 +2172,10 @@ module Google
 
         ##
         # @private New Table from a Google API Client object.
-        def self.from_gapi gapi, conn
+        def self.from_gapi gapi, service
           new.tap do |f|
             f.gapi = gapi
-            f.service = conn
+            f.service = service
           end
         end
 
@@ -2191,6 +2191,15 @@ module Google
             )
             b.service = service
             b.instance_variable_set :@reference, reference_gapi
+          end
+        end
+
+        ##
+        # @private New lazy Table object from a Google API Client object.
+        def self.new_reference_from_gapi gapi, service
+          new.tap do |b|
+            b.service = service
+            b.instance_variable_set :@reference, gapi
           end
         end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -31,13 +31,22 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
 
-    job_gapi = query_job_gapi(query, location: nil)
-    mock.expect :insert_job, job_gapi, [project, job_gapi]
+    job_gapi = query_job_gapi query, location: nil
+    job_resp_gapi = query_job_resp_gapi query
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
 
     job = bigquery.query_job query
     mock.verify
 
     job.must_be_kind_of Google::Cloud::Bigquery::QueryJob
+
+    # Sometimes statistics.query is nil in the returned job, test for that behavior here.
+    job.cache_hit?.must_equal false
+    job.bytes_processed.must_be :nil?
+    job.query_plan.must_be :nil?
+    job.statement_type.must_be :nil?
+    job.ddl_operation_performed.must_be :nil?
+    job.ddl_target_table.must_be :nil?
   end
 
   it "queries the data with options set" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -52,8 +52,14 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
   end
 
   it "knows its statistics data" do
-    job.wont_be :cache_hit?
     job.bytes_processed.must_equal 123456
+    job.cache_hit?.must_equal true
+    job.ddl_operation_performed.must_equal "CREATE"
+    job.ddl_target_table.must_be_kind_of Google::Cloud::Bigquery::Table
+    job.ddl_target_table.project_id.must_equal "target_project_id"
+    job.ddl_target_table.dataset_id.must_equal "target_dataset_id"
+    job.ddl_target_table.table_id.must_equal "target_table_id"
+    job.statement_type.must_equal "CREATE_TABLE"
   end
 
   it "knows its query config" do
@@ -152,8 +158,13 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
   def statistics_query_gapi
     Google::Apis::BigqueryV2::JobStatistics2.new(
       billing_tier: 1,
-      cache_hit: false,
-      total_bytes_processed: 123456,
+      cache_hit: true,
+      ddl_operation_performed: "CREATE",
+      ddl_target_table: Google::Apis::BigqueryV2::TableReference.new(
+        project_id: "target_project_id",
+        dataset_id: "target_dataset_id",
+        table_id: "target_table_id"
+      ),
       query_plan: [
         Google::Apis::BigqueryV2::ExplainQueryStage.new(
           compute_ratio_avg: 1.0,
@@ -179,7 +190,9 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
           write_ratio_avg: 0.05389444608201358,
           write_ratio_max: 0.05389444608201358
         )
-      ]
+      ],
+      statement_type: "CREATE_TABLE",
+      total_bytes_processed: 123456
     )
   end
 end


### PR DESCRIPTION
Add `#statement_type`, `#ddl_operation_performed`, `#ddl_target_table`.
Guard against `nil` `statistics.query` in `QueryJob` methods.
Add tests for all `QueryJob` statistics fields.