### PR TITLE
Firestore: remove unneeded base64 encoding applied to BLOB fields

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -115,8 +115,7 @@ module Google
             elsif obj.respond_to?(:read) && obj.respond_to?(:rewind)
               obj.rewind
               content = obj.read.force_encoding "ASCII-8BIT"
-              encoded_content = Base64.strict_encode64 content
-              Google::Firestore::V1beta1::Value.new bytes_value: encoded_content
+              Google::Firestore::V1beta1::Value.new bytes_value: content
             else
               raise ArgumentError,
                    "A value of type #{obj.class} is not supported."

--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -70,7 +70,7 @@ module Google
             when :string_value
               value.string_value
             when :bytes_value
-              StringIO.new Base64.decode64 value.bytes_value
+              StringIO.new value.bytes_value
             when :reference_value
               Google::Cloud::Firestore::DocumentReference.from_path \
                 value.reference_value, context

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/raw_to_value_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/raw_to_value_test.rb
@@ -81,7 +81,7 @@ describe Google::Cloud::Firestore::Convert, :raw_to_value, :mock_firestore do
   end
 
   it "converts a bytes value" do
-    value = Google::Firestore::V1beta1::Value.new bytes_value: Base64.strict_encode64("contents")
+    value = Google::Firestore::V1beta1::Value.new bytes_value: "contents"
 
     converted = Google::Cloud::Firestore::Convert.raw_to_value StringIO.new("contents")
     converted.must_equal value

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/raw_to_value_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/raw_to_value_test.rb
@@ -81,9 +81,9 @@ describe Google::Cloud::Firestore::Convert, :raw_to_value, :mock_firestore do
   end
 
   it "converts a bytes value" do
-    value = Google::Firestore::V1beta1::Value.new bytes_value: "contents"
+    value = Google::Firestore::V1beta1::Value.new bytes_value: "c\0ntents"
 
-    converted = Google::Cloud::Firestore::Convert.raw_to_value StringIO.new("contents")
+    converted = Google::Cloud::Firestore::Convert.raw_to_value StringIO.new("c\0ntents")
     converted.must_equal value
   end
 

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
@@ -78,7 +78,7 @@ describe Google::Cloud::Firestore::Convert, :value_to_raw, :mock_firestore do
 	contents.write("c\0ntents")
 	contents.close_write()
 	
-    raw.must_equal contents.string
+    raw.string.must_equal contents.string
   end
 
   it "converts a reference value" do

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
@@ -72,13 +72,8 @@ describe Google::Cloud::Firestore::Convert, :value_to_raw, :mock_firestore do
     value = Google::Firestore::V1beta1::Value.new(bytes_value: "c\0ntents")
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-	
-	contents = StringIO.new
-	contents.binmode()
-	contents.write("c\0ntents")
-	contents.close_write()
-	
-    raw.string.must_equal contents.string
+	raw.must_be_kind_of StringIO
+	raw.read.must_equal "c\0ntents"
   end
 
   it "converts a reference value" do

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
@@ -78,7 +78,7 @@ describe Google::Cloud::Firestore::Convert, :value_to_raw, :mock_firestore do
 	contents.write("c\0ntents")
 	contents.close_write()
 	
-    raw.must_equal contents
+    raw.must_equal contents.string
   end
 
   it "converts a reference value" do

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
@@ -72,8 +72,8 @@ describe Google::Cloud::Firestore::Convert, :value_to_raw, :mock_firestore do
     value = Google::Firestore::V1beta1::Value.new(bytes_value: "c\0ntents")
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-	raw.must_be_kind_of StringIO
-	raw.read.must_equal "c\0ntents"
+    raw.must_be_kind_of StringIO
+    raw.read.must_equal "c\0ntents"
   end
 
   it "converts a reference value" do

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
@@ -69,7 +69,7 @@ describe Google::Cloud::Firestore::Convert, :value_to_raw, :mock_firestore do
   end
 
   it "converts a bytes value" do
-    value = Google::Firestore::V1beta1::Value.new(bytes_value: Base64.encode64("contents"))
+    value = Google::Firestore::V1beta1::Value.new(bytes_value: "contents")
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
     raw.must_be_kind_of StringIO

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
@@ -76,7 +76,7 @@ describe Google::Cloud::Firestore::Convert, :value_to_raw, :mock_firestore do
 	contents = StringIO.new
 	contents.binmode()
 	contents.write("c\0ntents")
-	contents.close_writing()
+	contents.close_write()
 	
     raw.must_equal contents
   end

--- a/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/convert/value_to_raw_test.rb
@@ -69,11 +69,16 @@ describe Google::Cloud::Firestore::Convert, :value_to_raw, :mock_firestore do
   end
 
   it "converts a bytes value" do
-    value = Google::Firestore::V1beta1::Value.new(bytes_value: "contents")
+    value = Google::Firestore::V1beta1::Value.new(bytes_value: "c\0ntents")
 
     raw = Google::Cloud::Firestore::Convert.value_to_raw value, firestore
-    raw.must_be_kind_of StringIO
-    raw.read.must_equal "contents"
+	
+	contents = StringIO.new
+	contents.binmode()
+	contents.write("c\0ntents")
+	contents.close_writing()
+	
+    raw.must_equal contents
   end
 
   it "converts a reference value" do

--- a/google-cloud-firestore/test/google/cloud/firestore/document_snapshot/data_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_snapshot/data_test.rb
@@ -99,7 +99,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
   it "holds a bytes value" do
     document.grpc = Google::Firestore::V1beta1::Document.new \
       name: "projects/#{project}/databases/(default)/documents/#{document_path}",
-      fields: { "avatar" => Google::Firestore::V1beta1::Value.new(bytes_value: Base64.strict_encode64("contents")) },
+      fields: { "avatar" => Google::Firestore::V1beta1::Value.new(bytes_value: "contents") },
       create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time),
       update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(document_time)
 
@@ -161,7 +161,7 @@ describe Google::Cloud::Firestore::DocumentSnapshot, :data, :mock_firestore do
                 "ratio" => Google::Firestore::V1beta1::Value.new(double_value: 0.9),
                 "published_at" => Google::Firestore::V1beta1::Value.new(timestamp_value: Google::Protobuf::Timestamp.new(seconds: 1483326245, nanos: 60000000)),
                 "name" => Google::Firestore::V1beta1::Value.new(string_value: "Mike"),
-                "avatar" => Google::Firestore::V1beta1::Value.new(bytes_value: Base64.strict_encode64("contents")),
+                "avatar" => Google::Firestore::V1beta1::Value.new(bytes_value: "contents"),
                 "friend" => Google::Firestore::V1beta1::Value.new(reference_value: "projects/#{project}/databases/(default)/documents/users/chris"),
                 "location" => Google::Firestore::V1beta1::Value.new(geo_point_value: Google::Type::LatLng.new(latitude: 43.878264, longitude: -103.45700740814209)),
                 "details" => Google::Firestore::V1beta1::Value.new(map_value: Google::Firestore::V1beta1::MapValue.new(fields: { "score"=>Google::Firestore::V1beta1::Value.new(double_value: 0.9), "env"=>Google::Firestore::V1beta1::Value.new(string_value: "production"), "project_ids"=>Google::Firestore::V1beta1::Value.new(array_value: Google::Firestore::V1beta1::ArrayValue.new(values: [Google::Firestore::V1beta1::Value.new(integer_value: 1), Google::Firestore::V1beta1::Value.new(integer_value: 2), Google::Firestore::V1beta1::Value.new(integer_value: 3)] )) })) },


### PR DESCRIPTION
It looks like fields of type 'bytes' can be set using binary streams. Before the change however the contents of a stream would be base64-encoded in `google-cloud-firestore/lib/google/cloud/firestore/convert.rb` which would lead to the actual value of the corresponding 'bytes' field to be base64 encoded as well (in addition to the base64 encoding
the Web Console does, for example).