### PR TITLE
Disable warnings while auto-loading gems

### DIFF
--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -186,6 +186,31 @@ module Google
       warn "To suppress this message, set the" \
         " GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable."
     end
+
+    ##
+    # Safely load all google-cloud-* gems.
+    # @private
+    #
+    def self.auto_load_gems
+      original_verbosity = $VERBOSE
+      $VERBOSE = nil
+
+      auto_load_files.each { |auto_load_file| require auto_load_file }
+
+      $VERBOSE = original_verbosity
+    end
+
+    ##
+    # Find all google-cloud-* files for available gems.
+    # @private
+    #
+    def self.auto_load_files
+      if Gem.respond_to? :find_latest_files
+        return Gem.find_latest_files "google-cloud-*.rb"
+      end
+      # Ruby 2.0 does not have Gem.find_latest_files
+      Gem.find_files "google-cloud-*.rb"
+    end
   end
 end
 
@@ -196,12 +221,4 @@ Google::Cloud.init_configuration
 Google::Cloud.warn_on_old_ruby_version
 
 # Auto-load all Google Cloud service gems.
-auto_load_files = if Gem.respond_to? :find_latest_files
-                    Gem.find_latest_files "google-cloud-*.rb"
-                  else
-                    # Ruby 2.0 does not have Gem.find_latest_files
-                    Gem.find_files "google-cloud-*.rb"
-                  end
-auto_load_files.each do |google_cloud_service|
-  require google_cloud_service
-end
+Google::Cloud.auto_load_gems


### PR DESCRIPTION
This change avoids circlular require warnings by disabling warnings while auto-loading plugin files. This is one possible change that can fix #2168, by suppressing the warning. I don't have any other approaches yet that do not harm backwards compatibility, so I'm posting this PR now.