### PR TITLE
Tasks: set google-gax dependency to v1.3

### DIFF
--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.0.0"
 
-  gem.add_dependency "google-gax", "~> 1.0"
+  gem.add_dependency "google-gax", "~> 1.3"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
Fix for issue [https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/2171](https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/2171)