### PR TITLE
Propagate Logging list arguments

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry/list.rb
@@ -73,7 +73,9 @@ module Google
             grpc = @service.list_entries token: token, resources: @resources,
                                          filter: @filter, order: @order,
                                          max: @max, projects: @projects
-            self.class.from_grpc grpc, @service
+            self.class.from_grpc grpc, @service, resources: @resources,
+                                                 filter: @filter, order: @order,
+                                                 max: @max, projects: @projects
           end
 
           ##

--- a/google-cloud-logging/lib/google/cloud/logging/log/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/log/list.rb
@@ -72,7 +72,8 @@ module Google
             ensure_service!
             grpc = @service.list_logs token: token, resource: @resource,
                                       max: @max
-            self.class.from_grpc grpc, @service
+            self.class.from_grpc grpc, @service, resource: @resource,
+                                                 max: @max
           end
 
           ##

--- a/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/metric/list.rb
@@ -72,7 +72,7 @@ module Google
             return nil unless next?
             ensure_service!
             grpc = @service.list_metrics token: token, max: @max
-            self.class.from_grpc grpc, @service
+            self.class.from_grpc grpc, @service, @max
           end
 
           ##

--- a/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource_descriptor/list.rb
@@ -75,7 +75,7 @@ module Google
             list_grpc = @service.list_resource_descriptors(
               token: token, max: @max
             )
-            self.class.from_grpc list_grpc, @service
+            self.class.from_grpc list_grpc, @service, @max
           end
 
           ##

--- a/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/sink/list.rb
@@ -71,7 +71,7 @@ module Google
             return nil unless next?
             ensure_service!
             list_grpc = @service.list_sinks token: token, max: @max
-            self.class.from_grpc list_grpc, @service
+            self.class.from_grpc list_grpc, @service, @max
           end
 
           ##

--- a/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
@@ -97,9 +97,23 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     first_entries.token.wont_be :nil?
     first_entries.token.must_equal "next_page_token"
 
+    # ensure the correct values are propogated to the ivars
+    first_entries.instance_variable_get(:@projects).must_equal ["project1", "project2", "project3"],
+    first_entries.instance_variable_get(:@resources).must_be_nil
+    first_entries.instance_variable_get(:@filter).must_equal 'resource.type:"gce_"'
+    first_entries.instance_variable_get(:@order).must_equal "timestamp"
+    first_entries.instance_variable_get(:@max).must_be_nil
+
     second_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
     second_entries.count.must_equal 2
     second_entries.token.must_be :nil?
+
+    # ensure the correct values are propogated to the ivars
+    second_entries.instance_variable_get(:@projects).must_equal ["project1", "project2", "project3"],
+    second_entries.instance_variable_get(:@resources).must_be_nil
+    second_entries.instance_variable_get(:@filter).must_equal 'resource.type:"gce_"'
+    second_entries.instance_variable_get(:@order).must_equal "timestamp"
+    second_entries.instance_variable_get(:@max).must_be_nil
   end
 
   it "paginates entries using next? and next" do
@@ -144,10 +158,26 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     first_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
     first_entries.count.must_equal 3
     first_entries.next?.must_equal true #must_be :next?
+    first_entries.token.must_equal "next_page_token"
+
+    # ensure the correct values are propogated to the ivars
+    first_entries.instance_variable_get(:@projects).must_equal ["project1", "project2", "project3"],
+    first_entries.instance_variable_get(:@resources).must_be_nil
+    first_entries.instance_variable_get(:@filter).must_equal 'resource.type:"gce_"'
+    first_entries.instance_variable_get(:@order).must_equal "timestamp"
+    first_entries.instance_variable_get(:@max).must_be_nil
 
     second_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
     second_entries.count.must_equal 2
     second_entries.next?.must_equal false #wont_be :next?
+    second_entries.token.must_be :nil?
+
+    # ensure the correct values are propogated to the ivars
+    second_entries.instance_variable_get(:@projects).must_equal ["project1", "project2", "project3"],
+    second_entries.instance_variable_get(:@resources).must_be_nil
+    second_entries.instance_variable_get(:@filter).must_equal 'resource.type:"gce_"'
+    second_entries.instance_variable_get(:@order).must_equal "timestamp"
+    second_entries.instance_variable_get(:@max).must_be_nil
   end
 
   it "paginates entries using all" do

--- a/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
@@ -96,7 +96,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
   it "paginates metrics with next? and next and max set" do
     first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_log_metrics, first_list_res, [project_path, page_size: 3, options: default_options]
@@ -110,11 +110,19 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     first_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
     first_metrics.count.must_equal 3
-    first_metrics.next?.must_equal true #must_be :next?
+    first_metrics.next?.must_equal true
+    first_metrics.token.must_equal "next_page_token"
+
+    # ensure the correct values are propogated to the ivars
+    first_metrics.instance_variable_get(:@max).must_equal 3
 
     second_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
     second_metrics.count.must_equal 2
-    second_metrics.next?.must_equal false #wont_be :next?
+    second_metrics.next?.must_equal true
+    second_metrics.token.must_equal "second_page_token"
+
+    # ensure the correct values are propogated to the ivars
+    second_metrics.instance_variable_get(:@max).must_equal 3
   end
 
   it "paginates metrics with all" do

--- a/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
@@ -97,7 +97,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
   it "paginates resource descriptors with next? and next and max set" do
     first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
-    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2, "second_page_token"))
 
     mock = Minitest::Mock.new
     mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: 3, options: default_options]
@@ -112,11 +112,19 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     first_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
     first_descriptors.count.must_equal 3
-    first_descriptors.next?.must_equal true #must_be :next?
+    first_descriptors.next?.must_equal true
+    first_descriptors.token.must_equal "next_page_token"
+
+    # ensure the correct values are propogated to the ivars
+    first_descriptors.instance_variable_get(:@max).must_equal 3
 
     second_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
     second_descriptors.count.must_equal 2
-    second_descriptors.next?.must_equal false #wont_be :next?
+    second_descriptors.next?.must_equal true
+    second_descriptors.token.must_equal "second_page_token"
+
+    # ensure the correct values are propogated to the ivars
+    second_descriptors.instance_variable_get(:@max).must_equal 3
   end
 
   it "paginates resource descriptors with all" do

--- a/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
@@ -96,7 +96,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
   it "paginates sinks with next? and next and max set" do
     first_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))))
-    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))))
+    second_list_res = OpenStruct.new(page: OpenStruct.new(response: Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2, "second_page_token"))))
 
     mock = Minitest::Mock.new
     mock.expect :list_sinks, first_list_res, [project_path, page_size: 3, options: default_options]
@@ -110,11 +110,19 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     first_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
     first_sinks.count.must_equal 3
-    first_sinks.next?.must_equal true #must_be :next?
+    first_sinks.next?.must_equal true
+    first_sinks.token.must_equal "next_page_token"
+
+    # ensure the correct values are propogated to the ivars
+    first_sinks.instance_variable_get(:@max).must_equal 3
 
     second_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
     second_sinks.count.must_equal 2
-    second_sinks.next?.must_equal false #wont_be :next?
+    second_sinks.next?.must_equal true
+    second_sinks.token.must_equal "second_page_token"
+
+    # ensure the correct values are propogated to the ivars
+    second_sinks.instance_variable_get(:@max).must_equal 3
   end
 
   it "paginates sinks with all" do


### PR DESCRIPTION
This change fixes a bug in Logging's list classes. The arguments needed for subsequent list calls would not propagate to the second list object, so the API call for the third list object would raise an error.

[fixes #2163]