### PR TITLE
Alias V1 Credentials

### DIFF
--- a/google-cloud-video_intelligence/Rakefile
+++ b/google-cloud-video_intelligence/Rakefile
@@ -80,9 +80,9 @@ task :acceptance, :project, :keyfile do |t, args|
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or VIDEO_INTELLIGENCE_TEST_PROJECT=test123 VIDEO_INTELLIGENCE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   # clear any env var already set
-  require "google/cloud/video_intelligence/credentials"
-  (Google::Cloud::VideoIntelligence::Credentials::PATH_ENV_VARS +
-   Google::Cloud::VideoIntelligence::Credentials::JSON_ENV_VARS).each do |path|
+  require "google/cloud/video_intelligence/v1/credentials"
+  (Google::Cloud::VideoIntelligence::V1::Credentials::PATH_ENV_VARS +
+   Google::Cloud::VideoIntelligence::V1::Credentials::JSON_ENV_VARS).each do |path|
     ENV[path] = nil
   end
   # always overwrite when running tests

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/credentials.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/credentials.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "googleauth"
+require "google/cloud/video_intelligence/v1/credentials"
 
 module Google
   module Cloud
@@ -20,14 +20,7 @@ module Google
       ##
       # @deprecated Use version-specific credentials classes
       #
-      class Credentials < Google::Auth::Credentials
-        SCOPE = [
-          "https://www.googleapis.com/auth/cloud-platform"
-        ].freeze
-        PATH_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE GOOGLE_CLOUD_KEYFILE GCLOUD_KEYFILE)
-        JSON_ENV_VARS = %w(VIDEO_INTELLIGENCE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON GCLOUD_KEYFILE_JSON)
-        DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
-      end
+      Credentials = Google::Cloud::VideoIntelligence::V1::Credentials
     end
   end
 end


### PR DESCRIPTION
This change keeps backwards compatibility of the credentials path and constant, but uses the V1 credentials instead of duplicating it. This will help keep the deprecated credentials path/constant up to date.