### PR TITLE
Support DocumentSnapshot objects as cursors

### DIFF
--- a/google-cloud-firestore/acceptance/firestore/query_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/query_test.rb
@@ -160,4 +160,26 @@ describe "Query", :firestore_acceptance do
     results.map(&:document_id).must_equal ["doc1", "doc2"]
     results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
   end
+
+  it "can call cursor methods with a DocumentSnapshot object" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    rand_query_col.doc("doc1").create({foo: "a"})
+    rand_query_col.doc("doc2").create({foo: "b"})
+
+    results = rand_query_col.order(:foo).start_at(rand_query_col.doc("doc1").get).get
+    results.map(&:document_id).must_equal ["doc1", "doc2"]
+    results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
+
+    results = rand_query_col.order(:foo).start_after(rand_query_col.doc("doc1").get).get
+    results.map(&:document_id).must_equal ["doc2"]
+    results.map { |doc| doc[:foo] }.must_equal ["b"]
+
+    results = rand_query_col.order(:foo).end_before(rand_query_col.doc("doc2").get).get
+    results.map(&:document_id).must_equal ["doc1"]
+    results.map { |doc| doc[:foo] }.must_equal ["a"]
+
+    results = rand_query_col.order(:foo).end_at(rand_query_col.doc("doc2").get).get
+    results.map(&:document_id).must_equal ["doc1", "doc2"]
+    results.map { |doc| doc[:foo] }.must_equal ["a", "b"]
+  end
 end

--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -212,7 +212,7 @@ module Google
         ##
         # Creates a field path object representing the sentinel ID of a
         # document. It can be used in queries to sort or filter by the document
-        # ID. See {Client#document_id}.
+        # ID. See {FieldPath#document_id}.
         #
         # @return [FieldPath] The field path object.
         #
@@ -225,9 +225,8 @@ module Google
         #   cities_col = firestore.col "cities"
         #
         #   # Create a query
-        #   query = cities_col.start_at("NYC").order(
-        #     Google::Cloud::Firestore::FieldPath.document_id
-        #   )
+        #   query = cities_col.order(firestore.document_id)
+        #                     .start_at("NYC")
         #
         #   query.get do |city|
         #     puts "#{city.document_id} has #{city[:population]} residents."

--- a/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
@@ -129,9 +129,9 @@ module Google
         #   cities_col = firestore.col "cities"
         #
         #   # Create a query
-        #   query = cities_col.start_at("NYC").order(
+        #   query = cities_col.order(
         #     Google::Cloud::Firestore::FieldPath.document_id
-        #   )
+        #   ).start_at("NYC")
         #
         #   query.get do |city|
         #     puts "#{city.document_id} has #{city[:population]} residents."

--- a/google-cloud-firestore/support/doctest_helper.rb
+++ b/google-cloud-firestore/support/doctest_helper.rb
@@ -241,6 +241,34 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Firestore::Query#start_at@Starting a query at a DocumentSnapshot" do
+    mock_firestore do |mock|
+      mock.expect :batch_get_documents, batch_get_resp, batch_get_args
+      mock.expect :run_query, run_query_resp, run_query_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Firestore::Query#start_after@Starting a query after a DocumentSnapshot" do
+    mock_firestore do |mock|
+      mock.expect :batch_get_documents, batch_get_resp, batch_get_args
+      mock.expect :run_query, run_query_resp, run_query_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Firestore::Query#end_before@Ending a query before a DocumentSnapshot" do
+    mock_firestore do |mock|
+      mock.expect :batch_get_documents, batch_get_resp, batch_get_args
+      mock.expect :run_query, run_query_resp, run_query_args
+    end
+  end
+
+  doctest.before "Google::Cloud::Firestore::Query#end_at@Ending a query at a DocumentSnapshot" do
+    mock_firestore do |mock|
+      mock.expect :batch_get_documents, batch_get_resp, batch_get_args
+      mock.expect :run_query, run_query_resp, run_query_args
+    end
+  end
+
   doctest.before "Google::Cloud::Firestore::CollectionReference" do
     mock_firestore do |mock|
       mock.expect :run_query, run_query_resp, run_query_args

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/query_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/query_test.rb
@@ -21,231 +21,243 @@ describe Google::Cloud::Firestore::CollectionReference, :query, :mock_firestore 
 
   let(:read_time) { Time.now }
 
-  # let :query_results_enum do
-  #   [
-  #     Google::Firestore::V1beta1::RunQueryResponse.new(
-  #       read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
-  #       document: Google::Firestore::V1beta1::Document.new(
-  #         name: "projects/#{project}/databases/(default)/documents/users/mike",
-  #         fields: { "name" => Google::Firestore::V1beta1::Value.new(string_value: "Mike") },
-  #         create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
-  #         update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time)
-  #       )),
-  #     Google::Firestore::V1beta1::RunQueryResponse.new(
-  #       read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
-  #       document: Google::Firestore::V1beta1::Document.new(
-  #         name: "projects/#{project}/databases/(default)/documents/users/chris",
-  #         fields: { "name" => Google::Firestore::V1beta1::Value.new(string_value: "Chris") },
-  #         create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
-  #         update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time)
-  #       ))
-  #   ].to_enum
-  # end
-  #
-  # it "runs a query with a single select" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
-  #       fields: [Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name")])
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.select(:name).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with multiple select values" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
-  #       fields: [
-  #         Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
-  #         Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "status"),
-  #         Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "activity")
-  #       ])
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.select(:name, "status", :activity).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with multiple select calls" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
-  #       fields: [
-  #         Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
-  #         Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "status"),
-  #         Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "activity")
-  #       ])
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.select(:name).select("status").select(:activity).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with from" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "users", all_descendants: false)]
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.from(:users).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with from with all_descendants" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "users", all_descendants: true)]
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.from(:users).all_descendants.get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with from with direct_descendants" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "users", all_descendants: false)]
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.from(:users).direct_descendants.get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with offset and limit" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     offset: 3,
-  #     limit: Google::Protobuf::Int32Value.new(value: 42)
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.offset(3).limit(42).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with a single order" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     order_by: [
-  #       Google::Firestore::V1beta1::StructuredQuery::Order.new(
-  #         field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
-  #         direction: :ASCENDING)]
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.order(:name).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with a multiple order calls" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     order_by: [
-  #       Google::Firestore::V1beta1::StructuredQuery::Order.new(
-  #         field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
-  #         direction: :ASCENDING),
-  #       Google::Firestore::V1beta1::StructuredQuery::Order.new(
-  #         field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
-  #         direction: :DESCENDING)]
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.order(:name).order(firestore.document_id, :desc).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with start_after and end_before" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo")], before: false),
-  #     end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: true)
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.start_after(:foo).end_before(:bar).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with multiple start_after and end_before" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo"), Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: false),
-  #     end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("baz"), Google::Cloud::Firestore::Convert.raw_to_value("bif")], before: true)
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.start_after(:foo, :bar).end_before(:baz, :bif).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with start_at and end_at" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo")], before: true),
-  #     end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: false)
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.start_at(:foo).end_at(:bar).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a query with multiple start_at and end_at" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo"), Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: true),
-  #     end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("baz"), Google::Cloud::Firestore::Convert.raw_to_value("bif")], before: false)
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.start_at(:foo, :bar).end_at(:baz, :bif).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a simple query" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
-  #       fields: [Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name")]),
-  #     from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "users", all_descendants: false)]
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.select(:name).from(:users).get
-  #
-  #   assert_results_enum results_enum
-  # end
-  #
-  # it "runs a complex query" do
-  #   expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
-  #     select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
-  #       fields: [Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name")]),
-  #     from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "users", all_descendants: false)],
-  #     offset: 3,
-  #     limit: Google::Protobuf::Int32Value.new(value: 42),
-  #     order_by: [
-  #       Google::Firestore::V1beta1::StructuredQuery::Order.new(
-  #         field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
-  #         direction: :ASCENDING),
-  #       Google::Firestore::V1beta1::StructuredQuery::Order.new(
-  #         field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
-  #         direction: :DESCENDING)],
-  #     start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo")], before: false),
-  #     end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: true)
-  #   )
-  #   firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
-  #
-  #   results_enum = collection.select(:name).from(:users).offset(3).limit(42).order(:name).order(firestore.document_id, :desc).start_after(:foo).end_before(:bar).get
-  #
-  #   assert_results_enum results_enum
-  # end
+  let :query_results_enum do
+    [
+      Google::Firestore::V1beta1::RunQueryResponse.new(
+        read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+        document: Google::Firestore::V1beta1::Document.new(
+          name: "projects/#{project}/databases/(default)/documents/users/mike",
+          fields: { "name" => Google::Firestore::V1beta1::Value.new(string_value: "Mike") },
+          create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+          update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time)
+        )),
+      Google::Firestore::V1beta1::RunQueryResponse.new(
+        read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+        document: Google::Firestore::V1beta1::Document.new(
+          name: "projects/#{project}/databases/(default)/documents/users/chris",
+          fields: { "name" => Google::Firestore::V1beta1::Value.new(string_value: "Chris") },
+          create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+          update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time)
+        ))
+    ].to_enum
+  end
+
+  it "runs a query with a single select" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
+        fields: [Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name")]
+      ),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.select(:name).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with multiple select values" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
+        fields: [
+          Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
+          Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "status"),
+          Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "activity")
+        ]
+      ),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.select(:name, "status", :activity).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with multiple select calls" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
+        fields: [
+          Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
+          Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "status"),
+          Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "activity")
+        ]
+      ),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.select(:name).select("status").select(:activity).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with all_descendants" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages", all_descendants: true)]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.all_descendants.get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with direct_descendants" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages", all_descendants: false)]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.direct_descendants.get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with offset and limit" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      offset: 3,
+      limit: Google::Protobuf::Int32Value.new(value: 42),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.offset(3).limit(42).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with a single order" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
+          direction: :ASCENDING)],
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.order(:name).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with a multiple order calls" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
+          direction: :ASCENDING),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :DESCENDING)],
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.order(:name).order(firestore.document_id, :desc).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with start_after and end_before" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo")], before: false),
+      end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: true),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")],
+      order_by: [Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"), direction: :ASCENDING)]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.order(:a).start_after(:foo).end_before(:bar).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with multiple start_after and end_before" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo"), Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: false),
+      end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("baz"), Google::Cloud::Firestore::Convert.raw_to_value("bif")], before: true),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")],
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"), direction: :ASCENDING),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "b"), direction: :ASCENDING)
+      ]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.order(:a).order(:b).start_after(:foo, :bar).end_before(:baz, :bif).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with start_at and end_at" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo")], before: true),
+      end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: false),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")],
+      order_by: [Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"), direction: :ASCENDING)]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.order(:a).start_at(:foo).end_at(:bar).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a query with multiple start_at and end_at" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo"), Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: true),
+      end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("baz"), Google::Cloud::Firestore::Convert.raw_to_value("bif")], before: false),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")],
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"), direction: :ASCENDING),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "b"), direction: :ASCENDING)
+      ]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.order(:a).order(:b).start_at(:foo, :bar).end_at(:baz, :bif).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a simple query" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
+        fields: [Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name")]),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")]
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.select(:name).get
+
+    assert_results_enum results_enum
+  end
+
+  it "runs a complex query" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
+        fields: [Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name")]),
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "messages")],
+      offset: 3,
+      limit: Google::Protobuf::Int32Value.new(value: 42),
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name"),
+          direction: :ASCENDING),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :DESCENDING)],
+      start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo")], before: false),
+      end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: true)
+    )
+    firestore_mock.expect :run_query, query_results_enum, [collection.parent_path, structured_query: expected_query, options: default_options]
+
+    results_enum = collection.select(:name).offset(3).limit(42).order(:name).order(firestore.document_id, :desc).start_after(:foo).end_before(:bar).get
+
+    assert_results_enum results_enum
+  end
 
   describe "nested collection" do
     let :query_results_enum do

--- a/google-cloud-firestore/test/google/cloud/firestore/query/cursors_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/cursors_test.rb
@@ -1,0 +1,435 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Firestore::Query, :cursors, :mock_firestore do
+  let(:query) { Google::Cloud::Firestore::Query.start nil, "#{firestore.path}/documents", firestore }
+  let(:collection) { Google::Cloud::Firestore::CollectionReference.from_path "projects/#{project}/databases/(default)/documents/C", firestore }
+  let(:read_time) { Time.now }
+
+  it "with a document snapshot" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :ASCENDING
+        )
+      ],
+      start_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(
+            Google::Cloud::Firestore::DocumentReference.from_path("projects/projectID/databases/(default)/documents/C/D", firestore)
+          )
+        ],
+        before: true
+      )
+    )
+
+    doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
+
+    generated_query = collection.start_at(doc_snp).query
+    generated_query.must_equal expected_query
+  end
+
+  it "document snapshot and an equality where clause" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      where: Google::Firestore::V1beta1::StructuredQuery::Filter.new(
+        composite_filter: Google::Firestore::V1beta1::StructuredQuery::CompositeFilter.new(
+          op: :AND,
+          filters: [
+            Google::Firestore::V1beta1::StructuredQuery::Filter.new(
+              field_filter: Google::Firestore::V1beta1::StructuredQuery::FieldFilter.new(
+                field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(
+                  field_path: "a"
+                ),
+                op: :EQUAL,
+                value: Google::Firestore::V1beta1::Value.new(integer_value: 3)
+              )
+            )
+          ]
+        )
+      ),
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :ASCENDING
+        )
+      ],
+      end_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(
+            Google::Cloud::Firestore::DocumentReference.from_path("projects/projectID/databases/(default)/documents/C/D", firestore)
+          )
+        ],
+        before: false
+      )
+    )
+
+    doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
+
+    generated_query = collection.where(:a, "==", 3).end_at(doc_snp).query
+    generated_query.must_equal expected_query
+  end
+
+  it "document snapshot and an inequality where clause" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      where: Google::Firestore::V1beta1::StructuredQuery::Filter.new(
+        composite_filter: Google::Firestore::V1beta1::StructuredQuery::CompositeFilter.new(
+          op: :AND,
+          filters: [
+            Google::Firestore::V1beta1::StructuredQuery::Filter.new(
+              field_filter: Google::Firestore::V1beta1::StructuredQuery::FieldFilter.new(
+                field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(
+                  field_path: "a"
+                ),
+                op: :LESS_THAN_OR_EQUAL,
+                value: Google::Firestore::V1beta1::Value.new(integer_value: 3)
+              )
+            )
+          ]
+        )
+      ),
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"),
+          direction: :ASCENDING
+        ),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :ASCENDING
+        )
+      ],
+      end_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(7),
+          Google::Cloud::Firestore::Convert.raw_to_value(
+            Google::Cloud::Firestore::DocumentReference.from_path("projects/projectID/databases/(default)/documents/C/D", firestore)
+          )
+        ],
+        before: true
+      )
+    )
+
+    doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
+
+    generated_query = collection.where(:a, "<=", 3).end_before(doc_snp).query
+    generated_query.must_equal expected_query
+  end
+
+  it "doc snapshot, inequality where clause, and existing orderBy clause" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      where: Google::Firestore::V1beta1::StructuredQuery::Filter.new(
+        composite_filter: Google::Firestore::V1beta1::StructuredQuery::CompositeFilter.new(
+          op: :AND,
+          filters: [
+            Google::Firestore::V1beta1::StructuredQuery::Filter.new(
+              field_filter: Google::Firestore::V1beta1::StructuredQuery::FieldFilter.new(
+                field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(
+                  field_path: "a"
+                ),
+                op: :LESS_THAN,
+                value: Google::Firestore::V1beta1::Value.new(integer_value: 4)
+              )
+            )
+          ]
+        )
+      ),
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"),
+          direction: :DESCENDING
+        ),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :DESCENDING
+        )
+      ],
+      start_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(7),
+          Google::Cloud::Firestore::Convert.raw_to_value(
+            Google::Cloud::Firestore::DocumentReference.from_path("projects/projectID/databases/(default)/documents/C/D", firestore)
+          )
+        ],
+        before: true
+      )
+    )
+
+    doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
+
+    generated_query = collection.order(:a, :desc).where(:a, "<", 4).start_at(doc_snp).query
+    generated_query.must_equal expected_query
+  end
+
+  it "existing orderBy" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      where: Google::Firestore::V1beta1::StructuredQuery::Filter.new(
+        composite_filter: Google::Firestore::V1beta1::StructuredQuery::CompositeFilter.new(
+          op: :AND,
+          filters: [
+            Google::Firestore::V1beta1::StructuredQuery::Filter.new(
+              field_filter: Google::Firestore::V1beta1::StructuredQuery::FieldFilter.new(
+                field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(
+                  field_path: "a"
+                ),
+                op: :LESS_THAN,
+                value: Google::Firestore::V1beta1::Value.new(integer_value: 4)
+              )
+            )
+          ]
+        )
+      ),
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"),
+          direction: :ASCENDING
+        ),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "b"),
+          direction: :DESCENDING
+        ),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :DESCENDING
+        )
+      ],
+      start_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(7),
+          Google::Cloud::Firestore::Convert.raw_to_value(8),
+          Google::Cloud::Firestore::Convert.raw_to_value(
+            Google::Cloud::Firestore::DocumentReference.from_path("projects/projectID/databases/(default)/documents/C/D", firestore)
+          )
+        ],
+        before: false
+      )
+    )
+
+    doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
+
+    generated_query = collection.order(:a).order(:b, :desc).where(:a, "<", 4).start_after(doc_snp).query
+    generated_query.must_equal expected_query
+  end
+
+  it "existing orderBy __name__" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"),
+          direction: :DESCENDING
+        ),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :ASCENDING
+        )
+      ],
+      start_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(7),
+          Google::Cloud::Firestore::Convert.raw_to_value(
+            Google::Cloud::Firestore::DocumentReference.from_path(
+              "projects/projectID/databases/(default)/documents/C/D",
+              firestore
+            )
+          )
+        ],
+        before: true
+      ),
+      end_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(7),
+          Google::Cloud::Firestore::Convert.raw_to_value(
+            Google::Cloud::Firestore::DocumentReference.from_path(
+              "projects/projectID/databases/(default)/documents/C/D",
+              firestore
+            )
+          )
+        ]
+      )
+    )
+
+    doc_snp = document_snapshot("projects/projectID/databases/(default)/documents/C/D", { a: 7, b: 8 })
+
+    generated_query = collection.order(:a, :desc).order(:__name__).start_at(doc_snp).end_at(doc_snp).query
+    generated_query.must_equal expected_query
+  end
+
+  it "without orderBy" do
+    # TODO: I guess we need to raise here?
+    expect do
+      collection.start_at(7).query
+    end.must_raise ArgumentError
+  end
+
+  it "StartAt/EndBefore with values" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"),
+          direction: :ASCENDING
+        )
+      ],
+      start_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(7)
+        ],
+        before: true
+      ),
+      end_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(9)
+        ],
+        before: true
+      )
+    )
+
+    generated_query = collection.order(:a).start_at(7).end_before(9).query
+    generated_query.must_equal expected_query
+  end
+
+  it "StartAfter/EndAt with values" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"),
+          direction: :ASCENDING
+        )
+      ],
+      start_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(7)
+        ],
+        before: false
+      ),
+      end_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(9)
+        ],
+        before: false
+      )
+    )
+
+    generated_query = collection.order(:a).start_after(7).end_at(9).query
+    generated_query.must_equal expected_query
+  end
+
+  it "Start/End with two values" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"),
+          direction: :ASCENDING
+        ),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "b"),
+          direction: :DESCENDING
+        )
+      ],
+      start_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(7),
+          Google::Cloud::Firestore::Convert.raw_to_value(8)
+        ],
+        before: false
+      ),
+      end_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(9),
+          Google::Cloud::Firestore::Convert.raw_to_value(10)
+        ],
+        before: false
+      )
+    )
+
+    generated_query = collection.order(:a).order(:b, :desc).start_after(7, 8).end_at(9, 10).query
+    generated_query.must_equal expected_query
+  end
+
+  it "with __name__" do
+    # TODO: Looks like we need to create the full path when paired with __name__
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :ASCENDING
+        )
+      ],
+      start_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(
+            Google::Cloud::Firestore::DocumentReference.from_path(
+              "projects/projectID/databases/(default)/documents/C/D1",
+              firestore
+            )
+          )
+        ],
+        before: false
+      ),
+      end_at: Google::Firestore::V1beta1::Cursor.new(
+        values: [
+          Google::Cloud::Firestore::Convert.raw_to_value(
+            Google::Cloud::Firestore::DocumentReference.from_path(
+              "projects/projectID/databases/(default)/documents/C/D2",
+              firestore
+            )
+          )
+        ],
+        before: true
+      )
+    )
+
+    generated_query = collection.order(:__name__).start_after("D1").end_before("D2").query
+    generated_query.must_equal expected_query
+  end
+
+  it "last one wins" do
+    expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "C")],
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(
+          field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"),
+          direction: :ASCENDING
+        )
+      ],
+      start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value(2)], before: true),
+      end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value(4)], before: true)
+    )
+
+    generated_query = collection.order(:a).start_after(1).start_at(2).end_at(3).end_before(4).query
+    generated_query.must_equal expected_query
+  end
+
+  def document_snapshot path, data
+    doc_ref = Google::Cloud::Firestore::DocumentReference.from_path path, firestore
+    doc_grpc = Google::Firestore::V1beta1::Document.new(
+      name: path,
+      fields: Google::Cloud::Firestore::Convert.hash_to_fields(data)
+    )
+    Google::Cloud::Firestore::DocumentSnapshot.new.tap do |s|
+      s.grpc = doc_grpc
+      s.instance_variable_set :@ref, doc_ref
+    end
+  end
+end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Firestore::Query, :mock_firestore do
+describe Google::Cloud::Firestore::Query, :get, :mock_firestore do
   let(:query) { Google::Cloud::Firestore::Query.start nil, "#{firestore.path}/documents", firestore }
   let(:read_time) { Time.now }
   let :query_results_enum do
@@ -38,7 +38,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     ].to_enum
   end
 
-  it "runs a query with a single select" do
+  it "gets a query with a single select" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
         fields: [Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name")])
@@ -50,7 +50,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a query with multiple select values" do
+  it "gets a query with multiple select values" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
         fields: [
@@ -66,7 +66,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a query with multiple select calls" do
+  it "gets a query with multiple select calls" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
         fields: [
@@ -82,7 +82,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a collection as a query" do
+  it "gets a collection as a query" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "users", all_descendants: false)]
     )
@@ -93,7 +93,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a query with from with all_descendants" do
+  it "gets a query with from with all_descendants" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "users", all_descendants: true)]
     )
@@ -104,7 +104,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a query with from with direct_descendants" do
+  it "gets a query with from with direct_descendants" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       from: [Google::Firestore::V1beta1::StructuredQuery::CollectionSelector.new(collection_id: "users", all_descendants: false)]
     )
@@ -115,7 +115,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a query with offset and limit" do
+  it "gets a query with offset and limit" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       offset: 3,
       limit: Google::Protobuf::Int32Value.new(value: 42)
@@ -127,7 +127,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a query with a single order" do
+  it "gets a query with a single order" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       order_by: [
         Google::Firestore::V1beta1::StructuredQuery::Order.new(
@@ -141,7 +141,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a query with a multiple order calls" do
+  it "gets a query with a multiple order calls" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       order_by: [
         Google::Firestore::V1beta1::StructuredQuery::Order.new(
@@ -158,55 +158,65 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a query with start_after and end_before" do
+  it "gets a query with start_after and end_before" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      order_by: [Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"), direction: :ASCENDING)],
       start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo")], before: false),
       end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: true)
     )
     firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
 
-    results_enum = query.start_after(:foo).end_before(:bar).get
+    results_enum = query.order(:a).start_after(:foo).end_before(:bar).get
 
     assert_results_enum results_enum
   end
 
-  it "runs a query with multiple start_after and end_before" do
+  it "gets a query with multiple start_after and end_before" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"), direction: :ASCENDING),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "b"), direction: :ASCENDING)
+      ],
       start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo"), Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: false),
       end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("baz"), Google::Cloud::Firestore::Convert.raw_to_value("bif")], before: true)
     )
     firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
 
-    results_enum = query.start_after(:foo, :bar).end_before(:baz, :bif).get
+    results_enum = query.order(:a).order(:b).start_after(:foo, :bar).end_before(:baz, :bif).get
 
     assert_results_enum results_enum
   end
 
-  it "runs a query with start_at and end_at" do
+  it "gets a query with start_at and end_at" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      order_by: [Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"), direction: :ASCENDING)],
       start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo")], before: true),
       end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: false)
     )
     firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
 
-    results_enum = query.start_at(:foo).end_at(:bar).get
+    results_enum = query.order(:a).start_at(:foo).end_at(:bar).get
 
     assert_results_enum results_enum
   end
 
-  it "runs a query with multiple start_at and end_at" do
+  it "gets a query with multiple start_at and end_at" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
+      order_by: [
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "a"), direction: :ASCENDING),
+        Google::Firestore::V1beta1::StructuredQuery::Order.new(field: Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "b"), direction: :ASCENDING)
+      ],
       start_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("foo"), Google::Cloud::Firestore::Convert.raw_to_value("bar")], before: true),
       end_at: Google::Firestore::V1beta1::Cursor.new(values: [Google::Cloud::Firestore::Convert.raw_to_value("baz"), Google::Cloud::Firestore::Convert.raw_to_value("bif")], before: false)
     )
     firestore_mock.expect :run_query, query_results_enum, ["projects/#{project}/databases/(default)/documents", structured_query: expected_query, options: default_options]
 
-    results_enum = query.start_at(:foo, :bar).end_at(:baz, :bif).get
+    results_enum = query.order(:a).order(:b).start_at(:foo, :bar).end_at(:baz, :bif).get
 
     assert_results_enum results_enum
   end
 
-  it "runs a simple query" do
+  it "gets a simple query" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
         fields: [Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name")]),
@@ -219,7 +229,7 @@ describe Google::Cloud::Firestore::Query, :mock_firestore do
     assert_results_enum results_enum
   end
 
-  it "runs a complex query" do
+  it "gets a complex query" do
     expected_query = Google::Firestore::V1beta1::StructuredQuery.new(
       select: Google::Firestore::V1beta1::StructuredQuery::Projection.new(
         fields: [Google::Firestore::V1beta1::StructuredQuery::FieldReference.new(field_path: "name")]),


### PR DESCRIPTION
Allow a DocumentSnapshot object as argument to Query cursor methods.

* Ensure consistency between cursor methods and order.
* Add argument validation and errors to cursor methods.
* Add precondition checks to where and order when cursors are present in the query.

[closes #1956]