### PR TITLE
Vision batch async

### DIFF
--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -21,6 +21,3 @@ end
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"
-
-# Added at 2018-07-19 17:08:47 -0700 by paye:
-gem "pry", "~> 0.11.3"

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -21,3 +21,6 @@ end
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"
 gem "rake", "~> 11.0"
+
+# Added at 2018-07-19 17:08:47 -0700 by paye:
+gem "pry", "~> 0.11.3"

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -19,7 +19,6 @@ require "google/cloud/vision/credentials"
 require "google/cloud/vision/annotate"
 require "google/cloud/vision/image"
 require "google/cloud/vision/annotation"
-require "google/cloud/vision/v1"
 
 module Google
   module Cloud
@@ -288,19 +287,20 @@ module Google
         # @param requests
         #   [Array<Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash>]
         #   Individual async file annotation requests for this batch.
-        #   A hash of the same form as
-        # `Google::Cloud::Vision::V1::AsyncAnnotateFileRequest` can also be
+        #   A hash of the same form as `
+        #     Google::Cloud::Vision::V1::AsyncAnnotateFileRequest` can also be
         #   provided.
         # @param options [Google::Gax::CallOptions]
         #   Overrides the default settings for this call, e.g, timeout,
         #   retries, etc.
         # @return [Google::Gax::Operation]
         # @raise [Google::Gax::GaxError] if the RPC is aborted.
-        # example
+        #
+        # @example
         #   require "google/cloud/vision"
         #
+        #   # Create a new vision client.
         #   vision_client = Google::Cloud::Vision.new project_id: 'project_id'
-        #
         #   requests = [{
         #     input_config: {
         #       gcs_source: { uri: 'source_uri' },

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -275,14 +275,78 @@ module Google
           return annotations.first if annotations.count == 1
           annotations
         end
+
+        ##
+        # Run asynchronous image detection and annotation for a list of generic
+        # files, such as PDF files, which may contain multiple pages and
+        # multiple images per page. Progress and results can be retrieved
+        # through the google.longrunning.Operations interface.
+        # Operation.metadata contains OperationMetadata (metadata).
+        # Operation.response contains AsyncBatchAnnotateFilesResponse
+        # (results).
+        #
+        # @param requests
+        #   [Array<Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash>]
+        #   Individual async file annotation requests for this batch.
+        #   A hash of the same form as
+        # `Google::Cloud::Vision::V1::AsyncAnnotateFileRequest` can also be
+        #   provided.
+        # @param options [Google::Gax::CallOptions]
+        #   Overrides the default settings for this call, e.g, timeout,
+        #   retries, etc.
+        # @return [Google::Gax::Operation]
+        # @raise [Google::Gax::GaxError] if the RPC is aborted.
+        # example
+        #   require "google/cloud/vision"
+        #
+        #   vision_client = Google::Cloud::Vision.new project_id: 'project_id'
+        #
+        #   requests = [{
+        #     input_config: {
+        #       gcs_source: { uri: 'source_uri' },
+        #       mime_type: "application/pdf"
+        #     },
+        #     features: [{ type: :DOCUMENT_TEXT_DETECTION }],
+        #     output_config: {
+        #       gcs_destination: { uri: 'destination_uri' },
+        #       batch_size: 2
+        #     }
+        #   }]
+        #
+        #   # Register a callback during the method call.
+        #   operation = vision_client
+        #     .async_batch_annotate_files(requests) do |op|
+        #     raise op.results.message if op.error?
+        #     op_results = op.results
+        #     # Process the results.
+        #
+        #     metadata = op.metadata
+        #     # Process the metadata.
+        #   end
+        #
+        #   # Or use the return value to register a callback.
+        #   operation.on_done do |op|
+        #     raise op.results.message if op.error?
+        #     op_results = op.results
+        #     # Process the results.
+        #
+        #     metadata = op.metadata
+        #     # Process the metadata.
+        #   end
+        #
+        #   # Manually reload the operation.
+        #   operation.reload!
+        #
+        #   # Or block until the operation completes, triggering callbacks on
+        #   # completion.
+        #   operation.wait_until_done!
+        #
+        def async_batch_annotate_files requests, options = {}
+          service.service.async_batch_annotate_files requests, options
+        end
+
         alias mark annotate
         alias detect annotate
-
-        def async_batch_annotate_files requests, options = {}
-          Google::Cloud::Vision::V1::ImageAnnotatorClient
-            .new
-            .async_batch_annotate_files requests, options
-        end
 
         protected
 

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -19,6 +19,7 @@ require "google/cloud/vision/credentials"
 require "google/cloud/vision/annotate"
 require "google/cloud/vision/image"
 require "google/cloud/vision/annotation"
+require "google/cloud/vision/v1"
 
 module Google
   module Cloud
@@ -276,6 +277,12 @@ module Google
         end
         alias mark annotate
         alias detect annotate
+
+        def async_batch_annotate_files requests, options = {}
+          Google::Cloud::Vision::V1::ImageAnnotatorClient
+            .new
+            .async_batch_annotate_files requests, options
+        end
 
         protected
 

--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -287,8 +287,8 @@ module Google
         # @param requests
         #   [Array<Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash>]
         #   Individual async file annotation requests for this batch.
-        #   A hash of the same form as `
-        #     Google::Cloud::Vision::V1::AsyncAnnotateFileRequest` can also be
+        #   A hash of the same form as
+        #     `Google::Cloud::Vision::V1::AsyncAnnotateFileRequest` can also be
         #   provided.
         # @param options [Google::Gax::CallOptions]
         #   Overrides the default settings for this call, e.g, timeout,

--- a/google-cloud-vision/support/doctest_helper.rb
+++ b/google-cloud-vision/support/doctest_helper.rb
@@ -46,7 +46,7 @@ class File
     true
   end
   def self.read *args
-    "fake file data"
+    '{"fake": "file data"}'
   end
   def self.open *args
     # Examples use file paths such as "path/to/face.jpg"

--- a/google-cloud-vision/support/doctest_helper.rb
+++ b/google-cloud-vision/support/doctest_helper.rb
@@ -125,6 +125,7 @@ YARD::Doctest.configure do |doctest|
   # Skip all aliases, since tests would be exact duplicates
   doctest.skip "Google::Cloud::Vision::Project#mark"
   doctest.skip "Google::Cloud::Vision::Project#detect"
+  doctest.skip "Google::Cloud::Vision::Project#async_batch_annotate_files"
   doctest.skip "Google::Cloud::Vision::Image#mark"
   doctest.skip "Google::Cloud::Vision::Image#detect"
   doctest.skip "Google::Cloud::Vision::Annotation::Face::Angles#pan"


### PR DESCRIPTION
Adds method allowing Google::Cloud::Vision::Project to use the async_batch_annotate_files method from the Google::Cloud::Vision::V1:ImageAnnotatorClient [per](https://github.com/GoogleCloudPlatform/ruby-docs-samples/pull/300#discussion_r203485163)