### PR TITLE
Tasks synth: Fix api enable link in the readme, temporarily disable gemspec merge

### DIFF
--- a/google-cloud-tasks/README.md
+++ b/google-cloud-tasks/README.md
@@ -11,7 +11,7 @@ steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-3. [Enable the Cloud Tasks API.](https://console.cloud.google.com/apis/api/tasks)
+3. [Enable the Cloud Tasks API.](https://console.cloud.google.com/apis/library/tasks.googleapis.com)
 4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 
 ### Installation

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -39,6 +39,12 @@ s.replace(
     'TASKS_KEYFILE_JSON\\n(\s+)TASKS_CREDENTIALS_JSON\n',
     'TASKS_CREDENTIALS_JSON\\n\\1TASKS_KEYFILE_JSON\n')
 
+# https://github.com/googleapis/gapic-generator/issues/2195
+s.replace(
+    'README.md',
+    '\\(https://console\\.cloud\\.google\\.com/apis/api/tasks\\)',
+    '(https://console.cloud.google.com/apis/library/tasks.googleapis.com)')
+
 # Temporary until we get Ruby-specific tools into synthtool
 def merge_gemspec(src, dest, path):
     regex = re.compile(r'^\s+gem.version\s*=\s*"[\d\.]+"$', flags=re.MULTILINE)
@@ -51,7 +57,9 @@ def merge_gemspec(src, dest, path):
         src = regex.sub(match.group(0), src, count=1)
     return src
 
-s.copy(v2beta2_library / 'google-cloud-tasks.gemspec', merge=merge_gemspec)
+# Temporarily remove because this is currently autosynthing. Put back once
+# synthtool releases again after 2018-08-03.
+# s.copy(v2beta2_library / 'google-cloud-tasks.gemspec', merge=merge_gemspec)
 
 # https://github.com/googleapis/gapic-generator/issues/2180
 s.replace(


### PR DESCRIPTION
Add another synth patch to fix the readme link to enable the api. Also disable the gemspec merge because the release version of synthtool doesn't have it supported yet, and this library is currently autosynthing (which is probably crashing as a result). Will add the gemspec merge back once a new synthtool is released.
