### PR TITLE
[Bigtable] Get table admin api changes 

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/read_rows_test.rb
@@ -23,6 +23,7 @@ describe "DataClient Read Rows", :bigtable do
 
   it "read single row" do
     row = table.read_row("test-1")
+    row.key.must_equal "test-1"
     row.must_be_kind_of Google::Cloud::Bigtable::Row
   end
 

--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -35,11 +35,12 @@ describe "Instance Tables", :bigtable do
       t.must_be_kind_of Google::Cloud::Bigtable::Table
     end
 
-    table = instance.table(table_id)
+    table = instance.table(table_id, skip_lookup: false)
     table.must_be_kind_of Google::Cloud::Bigtable::Table
 
     table.delete
-    instance.table(table_id).must_be :nil?
+    table = instance.table(table_id)
+    table.exists?.must_equal false
   end
 
   it "create table with initial splits" do
@@ -52,7 +53,7 @@ describe "Instance Tables", :bigtable do
     end
 
     table.must_be_kind_of Google::Cloud::Bigtable::Table
-    instance.table(table_id, view: :FULL).wont_be :nil?
+    instance.table(table_id, view: :FULL, skip_lookup: false).wont_be :nil?
     table.delete
   end
 
@@ -65,7 +66,7 @@ describe "Instance Tables", :bigtable do
 
     table.must_be_kind_of Google::Cloud::Bigtable::Table
     table.granularity_millis?.must_equal true
-    instance.table(table_id, view: :NAME_ONLY).wont_be :nil?
+    instance.table(table_id, view: :NAME_ONLY, skip_lookup: false).wont_be :nil?
     table.delete
   end
 

--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -35,7 +35,7 @@ describe "Instance Tables", :bigtable do
       t.must_be_kind_of Google::Cloud::Bigtable::Table
     end
 
-    table = instance.table(table_id, skip_lookup: false)
+    table = instance.table(table_id, perform_lookup: true)
     table.must_be_kind_of Google::Cloud::Bigtable::Table
 
     table.delete
@@ -53,7 +53,7 @@ describe "Instance Tables", :bigtable do
     end
 
     table.must_be_kind_of Google::Cloud::Bigtable::Table
-    instance.table(table_id, view: :FULL, skip_lookup: false).wont_be :nil?
+    instance.table(table_id, view: :FULL, perform_lookup: true).wont_be :nil?
     table.delete
   end
 
@@ -66,7 +66,7 @@ describe "Instance Tables", :bigtable do
 
     table.must_be_kind_of Google::Cloud::Bigtable::Table
     table.granularity_millis?.must_equal true
-    instance.table(table_id, view: :NAME_ONLY, skip_lookup: false).wont_be :nil?
+    instance.table(table_id, view: :NAME_ONLY, perform_lookup: true).wont_be :nil?
     table.delete
   end
 

--- a/google-cloud-bigtable/acceptance/bigtable_helper.rb
+++ b/google-cloud-bigtable/acceptance/bigtable_helper.rb
@@ -71,11 +71,7 @@ module Acceptance
     end
 
     def bigtable_table
-      @table ||= @bigtable.table(
-        $bigtable_instance_id,
-        $bigtable_table_id,
-        skip_lookup: true
-      )
+      @table ||= @bigtable.table($bigtable_instance_id, $bigtable_table_id)
     end
 
     def random_str

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/column_range.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/column_range.rb
@@ -31,7 +31,7 @@ module Google
       #   require "google/cloud/bigtable"
       #
       #   bigtable = Google::Cloud::Bigtable.new
-      #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+      #   table = bigtable.table("my-instance", "my-table")
       #
       #   # Range that includes all qualifiers including "user-001" up until "user-010"
       #   table.column_range("cf").from("user-001").to("user-010")
@@ -84,7 +84,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.column_range("cf").from("qualifier-1")
         #
@@ -92,7 +92,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.column_range("cf").from("qualifier-1", inclusive: false)
         #
@@ -116,7 +116,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.column_range("cf").to("qualifier-10", inclusive: true)
         #
@@ -124,7 +124,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.column_range("cf").to("qualifier-10")
         #
@@ -147,7 +147,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.column_range("cf").between("qualifier-1", "qualifier-10")
         #
@@ -165,7 +165,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.column_range("cf").of("qualifier-1", "qualifier-10")
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -451,7 +451,7 @@ module Google
         # @param skip_lookup [Boolean] Create table object without verifying
         #   that the table resource exists.
         #   Calls made on this object will raise errors if the table.
-        #   does not exist. Default is `false`. Optional.
+        #   does not exist. Default value is `true`. Optional.
         #   It helps to reduce admin apis calls.
         # @param app_profile_id [String] The unique identifier for the app profile. Optional.
         #   It is used only in data operations.
@@ -480,7 +480,7 @@ module Google
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   entry = table.new_mutation_entry("user-1")
         #   entry.set_cell(
@@ -493,7 +493,7 @@ module Google
         #   table.mutate_row(entry)
 
         #
-        def table table_id, view: nil, skip_lookup: nil, app_profile_id: nil
+        def table table_id, view: nil, skip_lookup: true, app_profile_id: nil
           ensure_service!
 
           if skip_lookup

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
@@ -44,7 +44,7 @@ module Google
       #   require "google/cloud/bigtable"
       #
       #   bigtable = Google::Cloud::Bigtable.new
-      #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+      #   table = bigtable.table("my-instance", "my-table")
       #
       #   entry = table.new_mutation_entry("user-1")
       #   entry.set_cell(

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -49,7 +49,7 @@ module Google
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   entry = table.new_mutation_entry.new("user-1")
         #   entry.set_cell("cf1", "field1", "XYZ")
@@ -60,7 +60,7 @@ module Google
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   entry = table.new_mutation_entry("user-1")
         #   entry.set_cell(
@@ -99,11 +99,11 @@ module Google
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   entries = []
-        #   entries << table.new_mutation_entry.new("row-1").set_cell("cf1", "field1", "XYZ")
-        #   entries << table.new_mutation_entry.new("row-2").set_cell("cf1", "field1", "ABC")
+        #   entries << table.new_mutation_entry("row-1").set_cell("cf1", "field1", "XYZ")
+        #   entries << table.new_mutation_entry("row-2").set_cell("cf1", "field1", "ABC")
         #   table.mutate_row(entries)
         #
         def mutate_rows entries
@@ -127,7 +127,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   rule_1 = table.new_read_modify_write_rule("cf", "field01")
         #   rule_1.append("append-xyz")
@@ -143,7 +143,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   rule = table.new_read_modify_write_rule("cf", "field01").append("append-xyz")
         #
@@ -206,7 +206,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   predicate_filter = Google::Cloud::Bigtable::RowFilter.key("user-10")
         #   on_match_mutations = Google::Cloud::Bigtable::MutationEntry.new
@@ -264,7 +264,7 @@ module Google
         #   require "google/cloud"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.sample_row_keys.each do |sample_row_key|
         #     p sample_row_key.key # user00116
@@ -293,7 +293,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   entry = table.new_mutation_entry("row-key-1")
         #
@@ -317,7 +317,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #   rule = table.new_read_modify_write_rule("cf", "qualifier-1")
         #   rule.append("append-xyz")
         #
@@ -325,7 +325,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #   rule = table.new_read_modify_write_rule("cf", "qualifier-1")
         #   rule.increment(100)
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -309,7 +309,7 @@ module Google
         # @param skip_lookup [Boolean]
         #   Get table object without verifying that the table resource exists.
         #   Calls made on this object will raise errors if the table does not exist.
-        #   Default is `false`. Optional.
+        #   Default value is `true`. Optional.
         #   It helps to reduce admin apis calls.
         # @param app_profile_id [String] The unique identifier for the app profile. Optional.
         #   It is used only in data operations.
@@ -322,18 +322,25 @@ module Google
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table")
+        #   table = bigtable.table("my-instance", "my-table", skip_lookup: false, view: :SCHEMA_VIEW)
         #   if table
         #     p table.name
         #     p table.column_families
         #   end
+        #
+        # @example Get table object without calling get table admin api.
+        #   require "google/cloud/bigtable"
+        #
+        #   bigtable = Google::Cloud::Bigtable.new
+        #
+        #   table = bigtable.table("my-instance", "my-table")
         #
         # @example Get table with all fields. Clusters states, column families
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", view: :FULL)
+        #   table = bigtable.table("my-instance", "my-table", view: :FULL, skip_lookup: false)
         #   if table
         #     puts table.name
         #     p table.column_families
@@ -345,7 +352,7 @@ module Google
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table", skip_lookup: false)
         #
         #   entry = table.new_mutation_entry("user-1")
         #   entry.set_cell(
@@ -356,12 +363,22 @@ module Google
         #   ).delete_from_column("cf2", "field02")
         #
         #   table.mutate_row(entry)
-
+        # @example Read rows using app profile routing
+        #   require "google/cloud/bigtable"
+        #
+        #   bigtable = Google::Cloud::Bigtable.new
+        #
+        #   table = bigtable.table("my-instance", "my-table", app_profile_id: "my-app-profile")
+        #
+        #   table.read_rows(limit: 5).each do |row|
+        #     row
+        #   end
+        
         def table \
             instance_id,
             table_id,
             view: nil,
-            skip_lookup: nil,
+            skip_lookup: true,
             app_profile_id: nil
           ensure_service!
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -373,7 +373,7 @@ module Google
         #   table.read_rows(limit: 5).each do |row|
         #     row
         #   end
-        
+
         def table \
             instance_id,
             table_id,

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
@@ -48,7 +48,7 @@ module Google
         #   require "google/cloud"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.sample_row_keys.each do |sample_row_key|
         #     p sample_row_key.key # user00116
@@ -90,7 +90,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.read_rows(limit: 10).each do |row|
         #     puts row
@@ -100,7 +100,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.read_rows(keys: ["user-1", "user-2"]).each do |row|
         #     puts row
@@ -110,7 +110,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range =  table.row_range.between("user-1", "user-100")
         #
@@ -123,7 +123,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   filter = table.filter.key("user-*")
         #   # OR
@@ -138,7 +138,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   filter = table.filter.key("user-*")
         #   # OR
@@ -177,8 +177,8 @@ module Google
               &block
             )
           rescue *RowsReader::RETRYABLE_ERRORS => e
-            retry_count += 1
-            if retry_count >= RowsReader::RETRY_LIMIT
+            rows_reader.retry_count += 1
+            unless rows_reader.retryable?
               raise Google::Cloud::Error.from_error(e)
             end
             rows_limit, row_set = rows_reader.retry_options(limit, row_set)
@@ -198,7 +198,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   row = table.read_row("user-1")
         #
@@ -207,14 +207,14 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   filter = Google::Cloud::Bigtable::RowFilter.cells_per_row(3)
         #
         #   row = table.read_row("user-1", filter: filter)
         #
         def read_row key, filter: nil
-          read_rows(keys: [key], filter: filter, limit: 1).first
+          read_rows(keys: [key], filter: filter).first
         end
 
         # Create new instance of ValueRange.
@@ -225,7 +225,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.value_range
         #   range.from("abc")
@@ -238,7 +238,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.value_range.from("abc", inclusive: false).to("xyz")
         #
@@ -255,7 +255,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.column_range("test-family")
         #   range.from("abc")
@@ -268,7 +268,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.column_range("test-family").from("key-1", inclusive: false).to("key-5")
         #
@@ -284,7 +284,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.row_range
         #   range.from("abc")
@@ -297,7 +297,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.row_range.from("key-1", inclusive: false).to("key-5")
         #
@@ -313,7 +313,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   filter = table.filter.key("user-*")
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
@@ -163,7 +163,6 @@ module Google
               limit: limit
             )
           end
-          retry_count = 0
           row_set = build_row_set(keys, ranges)
           rows_limit = limit
           rows_filter = filter.to_grpc if filter

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/row_range.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/row_range.rb
@@ -29,7 +29,7 @@ module Google
       #   require "google/cloud/bigtable"
       #
       #   bigtable = Google::Cloud::Bigtable.new
-      #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+      #   table = bigtable.table("my-instance", "my-table")
       #
       #   # Range that includes all row keys including "user-001" to "user-005"
       #   table.row_range.from("user-001").to("user-005", inclusive: true)
@@ -70,7 +70,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.row_range.from("key-001")
         #
@@ -78,7 +78,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.row_range.from("key-001", inclusive: false)
         #
@@ -102,7 +102,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.row_range.to("key-001", inclusive: true)
         #
@@ -110,7 +110,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.row_range.to("key-001")
         #
@@ -134,7 +134,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.row_range.between("key-001", "key-010")
         #
@@ -153,7 +153,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.row_range.of("key-001", "key-010")
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
@@ -40,6 +40,10 @@ module Google
         RETRY_LIMIT = 3
 
         # @private
+        # @return [Integer] Current retry count
+        attr_accessor :retry_count
+
+        # @private
         #
         # Create read rows instance
         #
@@ -49,6 +53,7 @@ module Google
           @table = table
           @chunk_processor = ChunkProcessor.new
           @rows_count = 0
+          @retry_count = 0
         end
 
         # Read rows
@@ -86,6 +91,7 @@ module Google
               next if row.nil?
               yield row
               @rows_count += 1
+              @retry_count = 0
             end
           end
 
@@ -144,6 +150,13 @@ module Google
 
           @chunk_processor.reset_to_new_row
           [rows_limit, row_set]
+        end
+
+        # Check if read operation is retryable.
+        #
+        # @return [Boolean]
+        def retryable?
+          @retry_count < RowsReader::RETRY_LIMIT
         end
 
         private

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/sample_row_key.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/sample_row_key.rb
@@ -41,7 +41,7 @@ module Google
       #
       #   bigtable = Google::Cloud::Bigtable.new
       #
-      #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+      #   table = bigtable.table("my-instance", "my-table")
       #
       #   table.sample_row_keys.each do |r|
       #     p r

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
@@ -207,7 +207,7 @@ module Google
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   if table.exists?
         #     p "Table is exists."
@@ -219,9 +219,8 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   instance = bigtable.instance("my-instance", skip_lookup: true)
         #
-        #   table = instance.table("my-table")
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   if table.exists?
         #     p "Table is exists."
@@ -562,7 +561,7 @@ module Google
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   table.delete_rows_by_prefix("user-100")
         #
@@ -584,7 +583,7 @@ module Google
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   # Delete rows using row key prefix.
         #   table.drop_row_range("user-100")

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/value_range.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/value_range.rb
@@ -31,7 +31,7 @@ module Google
       #   require "google/cloud/bigtable"
       #
       #   bigtable = Google::Cloud::Bigtable.new
-      #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+      #   table = bigtable.table("my-instance", "my-table")
       #
       #   # Range that includes all row keys including "value-001" to "value-005" excluding
       #   table.value_range.from("value-001").to("value-005")
@@ -72,7 +72,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.value_range.from("value-001")
         #
@@ -80,7 +80,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.value_range.from("value-001", inclusive: false)
         #
@@ -104,7 +104,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.value_range.to("value-010", inclusive: true)
         #
@@ -112,7 +112,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.value_range.to("value-010")
         #
@@ -136,7 +136,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.value_range.between("value-001", "value-010")
         #
@@ -154,7 +154,7 @@ module Google
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
-        #   table = bigtable.table("my-instance", "my-table", skip_lookup: true)
+        #   table = bigtable.table("my-instance", "my-table")
         #
         #   range = table.value_range.of("value-001", "value-010")
         #

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/table_test.rb
@@ -42,7 +42,7 @@ describe Google::Cloud::Bigtable::Instance, :table, :mock_bigtable do
     mock = Minitest::Mock.new
     mock.expect :get_table, get_res, [table_path(instance_id, table_id), view: :FULL]
     bigtable.service.mocked_tables = mock
-    table = instance.table(table_id, view: :FULL, skip_lookup: false)
+    table = instance.table(table_id, view: :FULL, perform_lookup: true)
 
     mock.verify
 
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigtable::Instance, :table, :mock_bigtable do
 
     bigtable.service.mocked_tables = stub
 
-    table = instance.table(not_found_table_id, skip_lookup: false)
+    table = instance.table(not_found_table_id, perform_lookup: true)
     table.must_be :nil?
   end
 
@@ -82,7 +82,7 @@ describe Google::Cloud::Bigtable::Instance, :table, :mock_bigtable do
     table_id = "my-table"
     app_profile_id = "my-app-profile"
 
-    table = instance.table(table_id, skip_lookup: true, app_profile_id: app_profile_id)
+    table = instance.table(table_id, app_profile_id: app_profile_id)
     table.must_be_kind_of Google::Cloud::Bigtable::Table
     table.path.must_equal table_path(instance_id, table_id)
     table.app_profile_id.must_equal app_profile_id

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/table_test.rb
@@ -42,7 +42,7 @@ describe Google::Cloud::Bigtable::Instance, :table, :mock_bigtable do
     mock = Minitest::Mock.new
     mock.expect :get_table, get_res, [table_path(instance_id, table_id), view: :FULL]
     bigtable.service.mocked_tables = mock
-    table = instance.table(table_id, view: :FULL)
+    table = instance.table(table_id, view: :FULL, skip_lookup: false)
 
     mock.verify
 
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigtable::Instance, :table, :mock_bigtable do
 
     bigtable.service.mocked_tables = stub
 
-    table = instance.table(not_found_table_id)
+    table = instance.table(not_found_table_id, skip_lookup: false)
     table.must_be :nil?
   end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
@@ -36,7 +36,7 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
     mock = Minitest::Mock.new
     mock.expect :get_table, get_res, [table_path(instance_id, table_id), view: :FULL]
     bigtable.service.mocked_tables = mock
-    table = bigtable.table(instance_id, table_id, view: :FULL, skip_lookup: false)
+    table = bigtable.table(instance_id, table_id, view: :FULL, perform_lookup: true)
 
     mock.verify
 
@@ -68,7 +68,7 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
 
     bigtable.service.mocked_tables = stub
 
-    table = bigtable.table(instance_id, not_found_table_id, skip_lookup: false)
+    table = bigtable.table(instance_id, not_found_table_id, perform_lookup: true)
     table.must_be :nil?
   end
 
@@ -104,7 +104,7 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
     table_id = "my-table"
     app_profile_id = "my-app-profile"
 
-    table = bigtable.table(instance_id, table_id, skip_lookup: true, app_profile_id: app_profile_id)
+    table = bigtable.table(instance_id, table_id,  app_profile_id: app_profile_id)
     table.must_be_kind_of Google::Cloud::Bigtable::Table
     table.path.must_equal table_path(instance_id, table_id)
     table.app_profile_id.must_equal app_profile_id

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
@@ -36,7 +36,7 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
     mock = Minitest::Mock.new
     mock.expect :get_table, get_res, [table_path(instance_id, table_id), view: :FULL]
     bigtable.service.mocked_tables = mock
-    table = bigtable.table(instance_id, table_id, view: :FULL)
+    table = bigtable.table(instance_id, table_id, view: :FULL, skip_lookup: false)
 
     mock.verify
 
@@ -68,7 +68,7 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
 
     bigtable.service.mocked_tables = stub
 
-    table = bigtable.table(instance_id, not_found_table_id)
+    table = bigtable.table(instance_id, not_found_table_id, skip_lookup: false)
     table.must_be :nil?
   end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_reader/read_rows_state_machine_acceptance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_reader/read_rows_state_machine_acceptance_test.rb
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigtable::RowsReader, :read_state_machine_acceptance, :m
       mock = Minitest::Mock.new
       bigtable.service.mocked_client = mock
 
-      table = bigtable.table(instance_id, table_id, skip_lookup: true)
+      table = bigtable.table(instance_id, table_id)
 
       get_res = chunk_data_to_read_res(test_data["chunks_base64"])
       mock.expect :read_rows, get_res, [table_path(instance_id, table_id), Hash]
@@ -99,7 +99,7 @@ describe Google::Cloud::Bigtable::RowsReader, :read_state_machine_acceptance, :m
     it test_data["name"] do
       mock = Minitest::Mock.new
       bigtable.service.mocked_client = mock
-      table = bigtable.table(instance_id, table_id, skip_lookup: true)
+      table = bigtable.table(instance_id, table_id)
 
       get_res = chunk_data_to_read_res(test_data["chunks_base64"])
       mock.expect :read_rows, get_res, [table_path(instance_id, table_id), Hash]

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
@@ -77,4 +77,15 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
     row_ranges.length.must_equal 1
     row_ranges.first.must_equal Google::Bigtable::V2::RowRange.new(start_key_open: "3", end_key_closed: "5")
   end
+
+  it "increment and check read is retryable" do
+    rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
+
+    rows_reader.retryable?.must_equal true
+
+    [true, true, false].each do |expected_value|
+      rows_reader.retry_count += 1
+      rows_reader.retryable?.must_equal expected_value
+    end
+  end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/check_and_mutate_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/check_and_mutate_row_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Bigtable::Table, :check_and_mutate_row, :mock_bigtable d
   it "check and mutate row" do
     mock = Minitest::Mock.new
     bigtable.service.mocked_client = mock
-    table = bigtable.table(instance_id, table_id, skip_lookup: true)
+    table = bigtable.table(instance_id, table_id)
 
     row_key = "user-1"
     predicate_filter = Google::Bigtable::V2::RowFilter.new(row_key_regex_filter: "user-1*")

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/exists_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/exists_test.rb
@@ -34,7 +34,7 @@ describe Google::Cloud::Bigtable::Table, :exists?, :mock_bigtable do
     mock.expect :get_table, table_grpc, [table_path(instance_id, table_id), view: :SCHEMA_VIEW]
     bigtable.service.mocked_tables = mock
 
-    table = bigtable.table(instance_id, table_id, skip_lookup: true)
+    table = bigtable.table(instance_id, table_id)
     table.exists?.must_equal true
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_row_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Bigtable::Table, :mutate_row, :mock_bigtable do
   let(:table_id) { "test-table" }
   let(:app_profile_id) { "test-app-profile-id"}
   let(:table) {
-    bigtable.table(instance_id, table_id, skip_lookup: true, app_profile_id: app_profile_id)
+    bigtable.table(instance_id, table_id, app_profile_id: app_profile_id)
   }
 
   it "mutate row" do

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
@@ -52,7 +52,7 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
     end
   end
   let(:table) {
-    bigtable.table(instance_id, table_id, skip_lookup: true, app_profile_id: app_profile_id)
+    bigtable.table(instance_id, table_id, app_profile_id: app_profile_id)
   }
 
   it "mutate rows with success mutation response" do
@@ -232,7 +232,7 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
     end
 
     bigtable.service.mocked_client = mock
-    
+
     mutation_entries = req_entries.map do |r|
       entry = Google::Cloud::Bigtable::MutationEntry.new(r.row_key)
       entry.mutations.concat(r.mutations)

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
   let(:append_value) { "append-123" }
   let(:increment_amount) { 1 }
   let(:table) {
-    bigtable.table(instance_id, table_id, skip_lookup: true)
+    bigtable.table(instance_id, table_id)
   }
 
   it "read modify and write row with single rule" do
@@ -78,7 +78,7 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
   it "read modify and write row with multiple rule" do
     mock = Minitest::Mock.new
     bigtable.service.mocked_client = mock
-  
+
     row_key = "user-1"
 
     cell1 = { value: cell_value + "1", timestamp_micros: 0 }

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/sample_row_keys_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/sample_row_keys_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Bigtable::Table, :sample_row_keys, :mock_bigtable do
   it "get sample row keys" do
     mock = Minitest::Mock.new
     bigtable.service.mocked_client = mock
-    table = bigtable.table(instance_id, table_id, skip_lookup: true)
+    table = bigtable.table(instance_id, table_id)
 
     row_key = "user-1"
     offset = 1000


### PR DESCRIPTION
- Set default `skip_lookup` to true. This will reduce admin api calls for data operations
- Updated test cases for skip lookup
- Updated smart retry read. Now it if will fail only if successive 3 failure and updated tests
- Doc update and fixes