### PR TITLE
Fix Trace documentation template value

### DIFF
--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
@@ -66,7 +66,7 @@ module Google
         #   @return [String]
         #     Name of the span. Must be less than 128 bytes. The span name is sanitized
         #     and displayed in the Stackdriver Trace tool in the
-        #     {% dynamic print site_values.console_name %}.
+        #     Google Cloud Platform Console.
         #     The name may be a method name or some other per-call site name.
         #     For the same executable and the same call point, a best practice is
         #     to use a consistent name, which makes it easier to correlate

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/trace.rb
@@ -44,7 +44,7 @@ module Google
         #   @return [Google::Devtools::Cloudtrace::V2::TruncatableString]
         #     A description of the span's operation (up to 128 bytes).
         #     Stackdriver Trace displays the description in the
-        #     {% dynamic print site_values.console_name %}.
+        #     Google Cloud Platform Console.
         #     For example, the display name can be a qualified method name or a file name
         #     and a line number where the operation is called. A best practice is to use
         #     the same display name within an application and at the same call point.

--- a/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
@@ -270,7 +270,7 @@ module Google
           # @param display_name [Google::Devtools::Cloudtrace::V2::TruncatableString | Hash]
           #   A description of the span's operation (up to 128 bytes).
           #   Stackdriver Trace displays the description in the
-          #   {% dynamic print site_values.console_name %}.
+          #   Google Cloud Platform Console.
           #   For example, the display name can be a qualified method name or a file name
           #   and a line number where the operation is called. A best practice is to use
           #   the same display name within an application and at the same call point.


### PR DESCRIPTION
While working on the documentation migration, I ran into this. GitHub Pages sees this text as a Liquid directive and fails because of it. It looks like this is intended to be replaced with a value that makes more sense.

Is this something that should be added to the `synth.py` file? Or should this be addressed in the earlier Protobuf or GAPIC file generation?