### PR TITLE
Use CircleCI 2.0 for post-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
         name: Install bundle
         command: gem update --system && gem install bundler && bundle update
     - run: bundle exec rake circleci:build
-    - run: bundle exec rake circleci:post
 
   test-ruby-2.4:
     docker:
@@ -25,7 +24,6 @@ jobs:
         name: Install bundle
         command: gem update --system && gem install bundler && bundle update
     - run: bundle exec rake circleci:build
-    - run: bundle exec rake test:coveralls
 
   test-ruby-2.3:
     docker:
@@ -38,6 +36,18 @@ jobs:
         name: Install bundle
         command: gem update --system && gem install bundler && bundle update
     - run: bundle exec rake circleci:build
+
+  post:
+    docker:
+    - image: circleci/ruby:2.5.1-stretch
+    working_directory: ~/GoogleCloudPlatform/google-cloud-ruby
+    shell: /bin/bash --login -eo pipefail
+    steps:
+    - checkout
+    - run:
+        name: Install bundle
+        command: gem update --system && gem install bundler && bundle update
+    - run: bundle exec rake circleci:post
 
   release:
     working_directory: ~/GoogleCloudPlatform/google-cloud-ruby
@@ -68,6 +78,13 @@ workflows:
           <<: *test-filters
       - test-ruby-2.3:
           <<: *test-filters
+
+  post-build:
+    jobs:
+      - post:
+          filters:
+            branches:
+              only: master
 
   gem-release:
     jobs:

--- a/Rakefile
+++ b/Rakefile
@@ -548,14 +548,10 @@ namespace :circleci do
 
   desc "Runs post-build logic on CircleCI."
   task :post do
-    # We don't run post-build on pull requests
-    if ENV["CIRCLE_PR_NUMBER"].nil?
-      if ENV["CIRCLE_BRANCH"] == "master"
-        Rake::Task["bundleupdate"].invoke
-        Rake::Task["jsondoc:master"].invoke
-        Rake::Task["docs:build_master"].invoke
-      end
-    end
+    Rake::Task["bundleupdate"].invoke
+    Rake::Task["jsondoc:master"].invoke
+    Rake::Task["docs:build_master"].invoke
+    Rake::Task["test:coveralls"].invoke
   end
 
   task :release do


### PR DESCRIPTION
Run post-build tasks in a separate job. Use CircleCI 2.0 configuration to only run this job on the master branch.