### PR TITLE
Pub/Sub Subscriber Error Handling

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -245,10 +245,11 @@ module Google
 
         # @private returns error object from the stream thread.
         def error! error
-          synchronize do
+          error_callback = synchronize do
             @last_error = error
-            @error_callback.call error unless @error_callback.nil?
+            @error_callback
           end
+          error_callback.call error unless error_callback.nil?
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -247,11 +247,8 @@ module Google
             synchronize { start_streaming! }
           rescue StandardError => e
             synchronize do
-              if @stopped
-                raise Google::Cloud::Error.from_error(e)
-              else
-                start_streaming!
-              end
+              subscriber.error! e
+              start_streaming! unless @stopped
             end
           end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
@@ -32,9 +32,9 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
     rec_message_msg = "pulled-message"
     rec_message_ack_id = 123456789
     pull_res = Google::Pubsub::V1::StreamingPullResponse.decode_json rec_messages_json(rec_message_msg, rec_message_ack_id)
-    responses = [pull_res]
+    response_groups = [[pull_res]]
 
-    stub = StreamingPullStub.new responses.each
+    stub = StreamingPullStub.new response_groups
     called = false
 
     subscription.service.mocked_subscriber = stub
@@ -61,9 +61,9 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
 
   it "can delay multiple messages" do
     pull_res = Google::Pubsub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc, rec_msg2_grpc, rec_msg3_grpc]
-    responses = [pull_res]
+    response_groups = [[pull_res]]
 
-    stub = StreamingPullStub.new responses.each
+    stub = StreamingPullStub.new response_groups
     called = 0
 
     subscription.service.mocked_subscriber = stub

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
@@ -32,9 +32,9 @@ describe Google::Cloud::Pubsub::Subscriber, :nack, :mock_pubsub do
     rec_message_msg = "pulled-message"
     rec_message_ack_id = 123456789
     pull_res = Google::Pubsub::V1::StreamingPullResponse.decode_json rec_messages_json(rec_message_msg, rec_message_ack_id)
-    responses = [pull_res]
+    response_groups = [[pull_res]]
 
-    stub = StreamingPullStub.new responses.each
+    stub = StreamingPullStub.new response_groups
     called = false
 
     subscription.service.mocked_subscriber = stub
@@ -60,9 +60,9 @@ describe Google::Cloud::Pubsub::Subscriber, :nack, :mock_pubsub do
 
   it "can nack multiple messages" do
     pull_res = Google::Pubsub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc, rec_msg2_grpc, rec_msg3_grpc]
-    responses = [pull_res]
+    response_groups = [[pull_res]]
 
-    stub = StreamingPullStub.new responses.each
+    stub = StreamingPullStub.new response_groups
     called = 0
 
     subscription.service.mocked_subscriber = stub

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/restart_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/restart_test.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Google::Cloud::Pubsub::Subscriber, :acknowledge, :mock_pubsub do
+describe Google::Cloud::Pubsub::Subscriber, :error, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:sub_name) { "subscription-name-goes-here" }
   let(:sub_json) { subscription_json topic_name, sub_name }
@@ -28,43 +28,15 @@ describe Google::Cloud::Pubsub::Subscriber, :acknowledge, :mock_pubsub do
   let(:rec_msg3_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
                           rec_message_json("rec_message3-msg-goes-here", 1113) }
 
-  it "can acknowledge a single message" do
-    rec_message_msg = "pulled-message"
-    rec_message_ack_id = 123456789
-    pull_res = Google::Pubsub::V1::StreamingPullResponse.decode_json rec_messages_json(rec_message_msg, rec_message_ack_id)
-    response_groups = [[pull_res]]
-
-    stub = StreamingPullStub.new response_groups
-    called = false
-
-    subscription.service.mocked_subscriber = stub
-    subscriber = subscription.listen streams: 1 do |result|
-      assert_kind_of Google::Cloud::Pubsub::ReceivedMessage, result
-      assert_equal rec_message_msg, result.data
-      assert_equal "ack-id-#{rec_message_ack_id}", result.ack_id
-
-      result.ack!
-      called = true
-    end
-    subscriber.start
-
-    subscriber_retries = 0
-    while !called
-      fail "total number of calls were never made" if subscriber_retries > 100
-      subscriber_retries += 1
-      sleep 0.01
-    end
-
-    subscriber.stop
-    subscriber.wait!
-  end
-
-  it "can acknowledge multiple messages" do
-    pull_res = Google::Pubsub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc, rec_msg2_grpc, rec_msg3_grpc]
-    response_groups = [[pull_res]]
+  it "restarts on known errors" do
+    pull_res1 = Google::Pubsub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc]
+    pull_res2 = Google::Pubsub::V1::StreamingPullResponse.new received_messages: [rec_msg2_grpc]
+    pull_res3 = Google::Pubsub::V1::StreamingPullResponse.new received_messages: [rec_msg3_grpc]
+    response_groups = [[pull_res1, GRPC::Internal.new], [pull_res2, GRPC::Cancelled.new], [pull_res3]]
 
     stub = StreamingPullStub.new response_groups
     called = 0
+    errors = []
 
     subscription.service.mocked_subscriber = stub
     subscriber = subscription.listen streams: 1 do |msg|
@@ -72,6 +44,12 @@ describe Google::Cloud::Pubsub::Subscriber, :acknowledge, :mock_pubsub do
       msg.ack!
       called +=1
     end
+
+    subscriber.on_error do |error|
+      raise error
+      errors << error
+    end
+
     subscriber.start
 
     subscriber_retries = 0
@@ -80,6 +58,8 @@ describe Google::Cloud::Pubsub::Subscriber, :acknowledge, :mock_pubsub do
       subscriber_retries += 1
       sleep 0.01
     end
+
+    errors.count.must_equal 0
 
     subscriber.stop
     subscriber.wait!


### PR DESCRIPTION
We have a couple reports of Pub/Sub Subscriber behaving inconsistently. Unhandled errors should be recovered from, but we can add some additional handling to be able to track the errors when they happen.