### PR TITLE
Pub/Sub Subscriber Stream Threading

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_stream_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_stream_pusher.rb
@@ -59,8 +59,6 @@ module Google
                   end
                 end
 
-                @batch_created_at ||= Time.now
-
                 push_batch_request! if @batch.ready?
               end
 
@@ -86,8 +84,6 @@ module Google
                     @batch.delay deadline, ack_id
                   end
                 end
-
-                @batch_created_at ||= Time.now
 
                 push_batch_request! if @batch.ready?
               end
@@ -137,7 +133,7 @@ module Google
                   next
                 end
 
-                time_from_batch_creation = Time.now - @batch_created_at
+                time_from_batch_creation = Time.now - @batch.created_at
                 time_until_next_push = @interval - time_from_batch_creation
 
                 if time_until_next_push <= 0
@@ -157,16 +153,16 @@ module Google
             @stream.push @batch.request
 
             @batch = nil
-            @batch_created_at = nil
           end
 
           class Batch
-            attr_reader :max_bytes, :request
+            attr_reader :max_bytes, :request, :created_at
 
             def initialize max_bytes: 10000000
               @max_bytes = max_bytes
               @request = Google::Pubsub::V1::StreamingPullRequest.new
               @total_message_bytes = 0
+              @created_at = Time.now
             end
 
             def ack ack_id

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_stream_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_stream_pusher.rb
@@ -60,7 +60,6 @@ module Google
                 end
 
                 @batch_created_at ||= Time.now
-                @background_thread ||= Thread.new { run_background }
 
                 push_batch_request! if @batch.ready?
               end
@@ -89,7 +88,6 @@ module Google
                 end
 
                 @batch_created_at ||= Time.now
-                @background_thread ||= Thread.new { run_background }
 
                 push_batch_request! if @batch.ready?
               end
@@ -100,15 +98,25 @@ module Google
             nil
           end
 
-          def stop
+          def start
             synchronize do
-              @stopped = true
+              @stopped = false
 
-              # Stop any background activity, clean up happens in wait!
-              @background_thread.kill if @background_thread
+              @background_thread ||= Thread.new { run_background }
             end
 
-            push_batch_request!
+            self
+          end
+
+          def stop
+            synchronize do
+              push_batch_request!
+
+              @stopped = true
+              @cond.broadcast
+            end
+
+            self
           end
 
           def started?
@@ -119,25 +127,34 @@ module Google
             synchronize { @stopped }
           end
 
+          def batch_nil?
+            synchronize { @batch.nil? }
+          end
+
           protected
 
           def run_background
-            synchronize do
-              until @stopped
-                if @batch.nil?
-                  @cond.wait
+            until stopped?
+              if batch_nil?
+                synchronize do
+                  @cond.wait # wait until broadcast
                   next
                 end
+              end
 
-                time_since_batch_creation = Time.now - @batch_created_at
-                if time_since_batch_creation > @interval
-                  # interval met, publish the batch...
-                  push_batch_request!
-                  @cond.wait
-                else
-                  # still waiting for the interval to publish the batch...
-                  @cond.wait(@interval - time_since_batch_creation)
-                end
+              time_until_next_push = synchronize do
+                @interval - (Time.now - @batch_created_at)
+              end
+
+              if time_until_next_push <= 0
+                time_until_next_push = nil # wait until broadcast
+
+                # interval met, publish the batch...
+                synchronize { push_batch_request! }
+              end
+
+              synchronize do
+                @cond.wait time_until_next_push
               end
             end
           end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_unary_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_unary_pusher.rb
@@ -59,8 +59,6 @@ module Google
                   end
                 end
 
-                @batch_created_at ||= Time.now
-
                 push_batch_request! if @batch.ready?
               end
 
@@ -86,8 +84,6 @@ module Google
                     @batch.delay deadline, ack_id
                   end
                 end
-
-                @batch_created_at ||= Time.now
 
                 push_batch_request! if @batch.ready?
               end
@@ -137,7 +133,7 @@ module Google
                   next
                 end
 
-                time_from_batch_creation = Time.now - @batch_created_at
+                time_from_batch_creation = Time.now - @batch.created_at
                 time_until_next_push = @interval - time_from_batch_creation
 
                 if time_until_next_push <= 0
@@ -172,16 +168,16 @@ module Google
             end
 
             @batch = nil
-            @batch_created_at = nil
           end
 
           class Batch
-            attr_reader :max_bytes, :request
+            attr_reader :max_bytes, :request, :created_at
 
             def initialize max_bytes: 10000000
               @max_bytes = max_bytes
               @request = Google::Pubsub::V1::StreamingPullRequest.new
               @total_message_bytes = 0
+              @created_at = Time.now
             end
 
             def ack ack_id

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_unary_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_unary_pusher.rb
@@ -127,32 +127,25 @@ module Google
             synchronize { @stopped }
           end
 
-          def batch_nil?
-            synchronize { @batch.nil? }
-          end
-
           protected
 
           def run_background
-            until stopped?
-              if batch_nil?
-                synchronize do
+            synchronize do
+              until @stopped
+                if @batch.nil?
                   @cond.wait # wait until broadcast
                   next
                 end
-              end
 
-              time_until_next_push = synchronize do
-                @interval - (Time.now - @batch_created_at)
-              end
+                time_from_batch_creation = Time.now - @batch_created_at
+                time_until_next_push = @interval - time_from_batch_creation
 
-              if time_until_next_push <= 0
-                # interval met, publish the batch...
-                synchronize { push_batch_request! }
-                time_until_next_push = nil # wait until broadcast
-              end
+                if time_until_next_push <= 0
+                  # interval met, publish the batch...
+                  push_batch_request!
+                  time_until_next_push = nil # wait until broadcast
+                end
 
-              synchronize do
                 @cond.wait time_until_next_push
               end
             end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -1,0 +1,106 @@
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "monitor"
+
+module Google
+  module Cloud
+    module Pubsub
+      class Subscriber
+        ##
+        # @private
+        class Inventory
+          include MonitorMixin
+
+          attr_reader :stream, :limit
+
+          def initialize stream, limit
+            @stream = stream
+            @limit = limit
+            @_ack_ids = []
+            @wait_cond = new_cond
+
+            super()
+          end
+
+          def ack_ids
+            @_ack_ids
+          end
+
+          def add *ack_ids
+            ack_ids = Array(ack_ids).flatten
+            synchronize do
+              @_ack_ids += ack_ids
+              unless @stopped
+                @background_thread ||= Thread.new { background_run }
+              end
+            end
+          end
+
+          def remove *ack_ids
+            ack_ids = Array(ack_ids).flatten
+            synchronize do
+              @_ack_ids -= ack_ids
+              if @_ack_ids.empty?
+                if @background_thread
+                  @background_thread.kill
+                  @background_thread = nil
+                end
+              end
+            end
+          end
+
+          def count
+            synchronize do
+              @_ack_ids.count
+            end
+          end
+
+          def empty?
+            synchronize do
+              @_ack_ids.empty?
+            end
+          end
+
+          def stop
+            synchronize do
+              @stopped = true
+              @background_thread.kill if @background_thread
+            end
+          end
+
+          def full?
+            count >= limit
+          end
+
+          protected
+
+          def background_run
+            until synchronize { @stopped }
+              delay = calc_delay
+              synchronize { @wait_cond.wait delay }
+
+              stream.delay_inventory!
+            end
+          end
+
+          def calc_delay
+            (stream.subscriber.deadline - 3) * rand(0.8..0.9)
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -40,7 +40,9 @@ module Google
           end
 
           def add *ack_ids
-            ack_ids = Array(ack_ids).flatten
+            ack_ids.flatten!.compact!
+            return if ack_ids.empty?
+
             synchronize do
               @_ack_ids += ack_ids
               unless @stopped
@@ -50,7 +52,9 @@ module Google
           end
 
           def remove *ack_ids
-            ack_ids = Array(ack_ids).flatten
+            ack_ids.flatten!.compact!
+            return if ack_ids.empty?
+
             synchronize do
               @_ack_ids -= ack_ids
               if @_ack_ids.empty?

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -130,7 +130,7 @@ module Google
             return true if ack_ids.empty?
 
             synchronize do
-              @async_pusher ||= AsyncUnaryPusher.new self
+              @async_pusher ||= AsyncUnaryPusher.new(self).start
               @async_pusher.acknowledge ack_ids
               @inventory.remove ack_ids
               unpause_streaming!
@@ -146,7 +146,7 @@ module Google
             return true if mod_ack_ids.empty?
 
             synchronize do
-              @async_pusher ||= AsyncUnaryPusher.new self
+              @async_pusher ||= AsyncUnaryPusher.new(self).start
               @async_pusher.delay deadline, mod_ack_ids
               @inventory.remove mod_ack_ids
               unpause_streaming!
@@ -173,7 +173,7 @@ module Google
             synchronize do
               return true if @inventory.empty?
 
-              @async_pusher ||= AsyncUnaryPusher.new self
+              @async_pusher ||= AsyncUnaryPusher.new(self).start
               @async_pusher.delay subscriber.deadline, @inventory.ack_ids
             end
 
@@ -235,7 +235,7 @@ module Google
 
                 synchronize do
                   # Create receipt of received messages reception
-                  @async_pusher ||= AsyncUnaryPusher.new self
+                  @async_pusher ||= AsyncUnaryPusher.new(self).start
                   @async_pusher.delay subscriber.deadline, received_ack_ids
 
                   # Add received messages to inventory


### PR DESCRIPTION
Refactor how the Subscriber's Stream object manages its background thread. Use `retry` instead of creating multiple threads.