### PR TITLE
Fix Firestore Watch Stream Issue

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/watch/listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/watch/listener.rb
@@ -265,7 +265,10 @@ module Google
 
             # Has the loop broken but we aren't stopped?
             # Could be GRPC has thrown an internal error, so restart.
-            raise RestartStream
+            raise RestartStream unless synchronize { @stopped }
+
+            # We must be stopped, tell the stream to quit.
+            @request_queue.push self
           rescue GRPC::Cancelled, GRPC::DeadlineExceeded, GRPC::Internal,
                  GRPC::ResourceExhausted, GRPC::Unauthenticated,
                  GRPC::Unavailable, GRPC::Core::CallError


### PR DESCRIPTION
The stream should only be restarted if the enum stops but the stream is still open. Also, tell the stream to stop by passing the sentinel value to the EnumeratorQueue object.