### PR TITLE
Use Pub/Sub Subscriber Error Handler

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -256,7 +256,11 @@ module Google
 
           def perform_callback_async rec_msg
             Concurrent::Future.new(executor: callback_thread_pool) do
-              subscriber.callback.call rec_msg
+              begin
+                subscriber.callback.call rec_msg
+              rescue => callback_error
+                subscriber.error! callback_error
+              end
             end.execute
           end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -258,7 +258,7 @@ module Google
             Concurrent::Future.new(executor: callback_thread_pool) do
               begin
                 subscriber.callback.call rec_msg
-              rescue => callback_error
+              rescue StandardError => callback_error
                 subscriber.error! callback_error
               end
             end.execute


### PR DESCRIPTION
Use the recently added error handler to relay errors recieved while calling the Subscriber callbacks, or while pushing `acknowledge` or `modify_ack_deadline` requests as part of the Subscriber callbacks.