### PR TITLE
Fix bug in AsyncUnaryPusher

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_unary_pusher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/async_unary_pusher.rb
@@ -234,9 +234,10 @@ module Google
             end
 
             def modify_deadline_hash
-              @request.modify_deadline_ack_ids.zip(
+              grouped_hash = @request.modify_deadline_ack_ids.zip(
                 @request.modify_deadline_seconds
               ).group_by { |_ack_id, seconds| seconds }
+              Hash[grouped_hash.map { |k, v| [k, v.map(&:first)] }]
             end
 
             def total_message_bytes

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/delay_test.rb
@@ -20,6 +20,7 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
   let(:sub_json) { subscription_json topic_name, sub_name }
   let(:sub_hash) { JSON.parse sub_json }
   let(:sub_grpc) { Google::Pubsub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_path) { sub_grpc.name }
   let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc sub_grpc, pubsub.service }
   let(:rec_msg1_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
                           rec_message_json("rec_message1-msg-goes-here", 1111) }
@@ -57,6 +58,19 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
+
+    stub.requests.map(&:to_a).must_equal [
+      [Google::Pubsub::V1::StreamingPullRequest.new(
+        subscription: sub_path,
+        stream_ack_deadline_seconds: 60
+      )]
+    ]
+    stub.acknowledge_requests.must_equal []
+    # pusher thread pool may deliver out of order, which stinks...
+    stub.modify_ack_deadline_requests.sort.reverse.must_equal [
+      [sub_path, ["ack-id-123456789"], 60],
+      [sub_path, ["ack-id-123456789"], 42]
+    ]
   end
 
   it "can delay multiple messages" do
@@ -83,5 +97,18 @@ describe Google::Cloud::Pubsub::Subscriber, :delay, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
+
+    stub.requests.map(&:to_a).must_equal [
+      [Google::Pubsub::V1::StreamingPullRequest.new(
+        subscription: sub_path,
+        stream_ack_deadline_seconds: 60
+      )]
+    ]
+    stub.acknowledge_requests.must_equal []
+    # pusher thread pool may deliver out of order, which stinks...
+    stub.modify_ack_deadline_requests.sort.reverse.must_equal [
+      [sub_path, ["ack-id-1111", "ack-id-1112", "ack-id-1113"], 60],
+      [sub_path, ["ack-id-1111", "ack-id-1112", "ack-id-1113"], 42]
+    ]
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/error_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/error_test.rb
@@ -20,6 +20,7 @@ describe Google::Cloud::Pubsub::Subscriber, :error, :mock_pubsub do
   let(:sub_json) { subscription_json topic_name, sub_name }
   let(:sub_hash) { JSON.parse sub_json }
   let(:sub_grpc) { Google::Pubsub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_path) { sub_grpc.name }
   let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc sub_grpc, pubsub.service }
   let(:rec_msg1_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
                           rec_message_json("rec_message1-msg-goes-here", 1111) }
@@ -68,5 +69,7 @@ describe Google::Cloud::Pubsub::Subscriber, :error, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
+
+    # stub requests are not guaranteed, so don't check in this test
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/nack_test.rb
@@ -20,6 +20,7 @@ describe Google::Cloud::Pubsub::Subscriber, :nack, :mock_pubsub do
   let(:sub_json) { subscription_json topic_name, sub_name }
   let(:sub_hash) { JSON.parse sub_json }
   let(:sub_grpc) { Google::Pubsub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_path) { sub_grpc.name }
   let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc sub_grpc, pubsub.service }
   let(:rec_msg1_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
                           rec_message_json("rec_message1-msg-goes-here", 1111) }
@@ -56,6 +57,19 @@ describe Google::Cloud::Pubsub::Subscriber, :nack, :mock_pubsub do
     end
     subscriber.stop
     subscriber.wait!
+
+    stub.requests.map(&:to_a).must_equal [
+      [Google::Pubsub::V1::StreamingPullRequest.new(
+        subscription: sub_path,
+        stream_ack_deadline_seconds: 60
+      )]
+    ]
+    stub.acknowledge_requests.must_equal []
+    # pusher thread pool may deliver out of order, which stinks...
+    stub.modify_ack_deadline_requests.sort.reverse.must_equal [
+      [sub_path, ["ack-id-123456789"], 60],
+      [sub_path, ["ack-id-123456789"], 0]
+    ]
   end
 
   it "can nack multiple messages" do
@@ -82,5 +96,18 @@ describe Google::Cloud::Pubsub::Subscriber, :nack, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
+
+    stub.requests.map(&:to_a).must_equal [
+      [Google::Pubsub::V1::StreamingPullRequest.new(
+        subscription: sub_path,
+        stream_ack_deadline_seconds: 60
+      )]
+    ]
+    stub.acknowledge_requests.must_equal []
+    # pusher thread pool may deliver out of order, which stinks...
+    stub.modify_ack_deadline_requests.sort.reverse.must_equal [
+      [sub_path, ["ack-id-1111", "ack-id-1112", "ack-id-1113"], 60],
+      [sub_path, ["ack-id-1111", "ack-id-1112", "ack-id-1113"], 0]
+    ]
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/restart_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/restart_test.rb
@@ -20,6 +20,7 @@ describe Google::Cloud::Pubsub::Subscriber, :error, :mock_pubsub do
   let(:sub_json) { subscription_json topic_name, sub_name }
   let(:sub_hash) { JSON.parse sub_json }
   let(:sub_grpc) { Google::Pubsub::V1::Subscription.decode_json(sub_json) }
+  let(:sub_path) { sub_grpc.name }
   let(:subscription) { Google::Cloud::Pubsub::Subscription.from_grpc sub_grpc, pubsub.service }
   let(:rec_msg1_grpc) { Google::Pubsub::V1::ReceivedMessage.decode_json \
                           rec_message_json("rec_message1-msg-goes-here", 1111) }
@@ -63,5 +64,7 @@ describe Google::Cloud::Pubsub::Subscriber, :error, :mock_pubsub do
 
     subscriber.stop
     subscriber.wait!
+
+    # stub requests are not guaranteed, so don't check in this test
   end
 end


### PR DESCRIPTION
The `modify_ack_deadline` requests being created by AsyncUnaryPusher were malformed.