### PR TITLE
Fixes for release documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -698,7 +698,8 @@ task :release, :tag do |t, args|
       puts "Successfully built and pushed #{package} for version #{version}"
 
       # jsondoc:package needs jsondoc to have been run prior
-      Rake::Task["jsondoc"].invoke tag
+      Rake::Task["bundleupdate"].invoke
+      Rake::Task["jsondoc"].invoke
       Rake::Task["jsondoc:package"].invoke tag
       Rake::Task["docs:publish_tag"].invoke tag
     rescue => e

--- a/Rakefile
+++ b/Rakefile
@@ -697,6 +697,8 @@ task :release, :tag do |t, args|
       ::Gems.push(File.new path_to_be_pushed)
       puts "Successfully built and pushed #{package} for version #{version}"
 
+      # jsondoc:package needs jsondoc to have been run prior
+      Rake::Task["jsondoc"].invoke tag
       Rake::Task["jsondoc:package"].invoke tag
       Rake::Task["docs:publish_tag"].invoke tag
     rescue => e

--- a/Rakefile
+++ b/Rakefile
@@ -948,7 +948,8 @@ def run_task_if_exists task_name, params = ""
 end
 
 def gh_pages_path gh_pages_dir
-  Pathname.new(Dir.home) + "tmp" + gh_pages_dir
+  tmp_dir = ENV["GCLOUD_TMP_DIR"] || "#{Dir.home}/tmp"
+  Pathname.new(tmp_dir) + gh_pages_dir
 end
 
 def git_repo

--- a/rakelib/yard_builder.rb
+++ b/rakelib/yard_builder.rb
@@ -140,7 +140,8 @@ class YardBuilder
     require "yaml"
     sorted_data_pairs = data.each.sort.map do |gem, versions|
       # Sort in descending order
-      versions.uniq!.sort! do |a, b|
+      versions.uniq!
+      versions.sort! do |a, b|
         Gem::Version.new(b.sub(/^v/,"")) <=> Gem::Version.new(a.sub(/^v/,""))
       end
       [gem, versions]

--- a/rakelib/yard_builder.rb
+++ b/rakelib/yard_builder.rb
@@ -83,9 +83,7 @@ class YardBuilder
   end
 
   def checkout_branch tag
-    dir = Pathname.new(Dir.tmpdir) + tag
-    FileUtils.remove_dir dir if Dir.exists? dir
-    FileUtils.mkdir_p dir
+    dir = create_tmp_dir tag
     clone_branch tag, dir
     yield dir
     safe_remove_dir dir
@@ -221,12 +219,13 @@ class YardBuilder
   end
 
   def create_tmp_dir dir_name
-    tmp_dir = Pathname.new(Dir.tmpdir) + dir_name
+    tmp_dir = ENV["GCLOUD_TMP_DIR"] || Dir.tmpdir
+    dir = Pathname.new(tmp_dir) + dir_name
 
-    safe_remove_dir tmp_dir
-    FileUtils.mkdir_p tmp_dir
+    safe_remove_dir dir
+    FileUtils.mkdir_p dir
 
-    tmp_dir
+    dir
   end
 
   def safe_remove_dir dir


### PR DESCRIPTION
The new circleci configuration runs the `circleci:release` task by itself, but the `jsondoc:release` task needs the `jsondoc` task to have been run prior.