### PR TITLE
Update CSV mime type

### DIFF
--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_local_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
 
     temp_csv do |file|
       mock.expect :insert_job, load_job_resp_gapi("some/file/path.csv"),
-        [project, load_job_gapi(table_reference, "CSV"), upload_source: file, content_type: "text/comma-separated-values"]
+        [project, load_job_gapi(table_reference, "CSV"), upload_source: file, content_type: "text/csv"]
 
       job = dataset.load_job table_id, file, format: :csv
       job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
@@ -46,7 +46,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :local, :mock_bigquery do
 
     temp_csv do |file|
       mock.expect :insert_job, load_job_resp_gapi("some/file/path.csv"),
-        [project, load_job_csv_options_gapi(table_reference), upload_source: file, content_type: "text/comma-separated-values"]
+        [project, load_job_csv_options_gapi(table_reference), upload_source: file, content_type: "text/csv"]
 
       job = dataset.load_job table_id, file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_local_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :local, :mock_bigquery do
 
     temp_csv do |file|
       mock.expect :insert_job, load_job_resp_gapi("some/file/path.csv"),
-        [project, load_job_gapi(table_reference, "CSV"), upload_source: file, content_type: "text/comma-separated-values"]
+        [project, load_job_gapi(table_reference, "CSV"), upload_source: file, content_type: "text/csv"]
 
       result = dataset.load table_id, file, format: :csv
       result.must_equal true
@@ -46,7 +46,7 @@ describe Google::Cloud::Bigquery::Dataset, :load, :local, :mock_bigquery do
 
     temp_csv do |file|
       mock.expect :insert_job, load_job_resp_gapi("some/file/path.csv"),
-        [project, load_job_csv_options_gapi(table_reference), upload_source: file, content_type: "text/comma-separated-values"]
+        [project, load_job_csv_options_gapi(table_reference), upload_source: file, content_type: "text/csv"]
 
       result = dataset.load table_id, file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_job_local_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
 
     temp_csv do |file|
       mock.expect :insert_job, load_job_resp_gapi(table, "some/file/path.csv"),
-        [project, load_job_gapi(table_gapi.table_reference, "CSV"), upload_source: file, content_type: "text/comma-separated-values"]
+        [project, load_job_gapi(table_gapi.table_reference, "CSV"), upload_source: file, content_type: "text/csv"]
 
       job = table.load_job file, format: :csv
       job.must_be_kind_of Google::Cloud::Bigquery::LoadJob
@@ -45,7 +45,7 @@ describe Google::Cloud::Bigquery::Table, :load_job, :local, :mock_bigquery do
 
     temp_csv do |file|
       mock.expect :insert_job, load_job_resp_gapi(table, "some/file/path.csv"),
-        [project, load_job_csv_options_gapi(table_gapi.table_reference), upload_source: file, content_type: "text/comma-separated-values"]
+        [project, load_job_csv_options_gapi(table_gapi.table_reference), upload_source: file, content_type: "text/csv"]
 
       job = table.load_job file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_load_local_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Bigquery::Table, :load, :local, :mock_bigquery do
 
     temp_csv do |file|
       mock.expect :insert_job, load_job_resp_gapi(table, "some/file/path.csv"),
-        [project, load_job_gapi(table_gapi.table_reference, "CSV"), upload_source: file, content_type: "text/comma-separated-values"]
+        [project, load_job_gapi(table_gapi.table_reference, "CSV"), upload_source: file, content_type: "text/csv"]
 
       result = table.load file, format: :csv
       result.must_equal true
@@ -44,7 +44,7 @@ describe Google::Cloud::Bigquery::Table, :load, :local, :mock_bigquery do
 
     temp_csv do |file|
       mock.expect :insert_job, load_job_resp_gapi(table, "some/file/path.csv"),
-        [project, load_job_csv_options_gapi(table_gapi.table_reference), upload_source: file, content_type: "text/comma-separated-values"]
+        [project, load_job_csv_options_gapi(table_gapi.table_reference), upload_source: file, content_type: "text/csv"]
 
       result = table.load file, format: :csv, jagged_rows: true, quoted_newlines: true, autodetect: true,
         encoding: "ISO-8859-1", delimiter: "\t", ignore_unknown: true, max_bad_records: 42, null_marker: "\N",

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -286,7 +286,7 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
       job_resp_gapi = load_job_resp_gapi(table, "some/file/path.csv")
       job_resp_gapi.status = status "done"
       mock.expect :insert_job, job_resp_gapi,
-        [project, load_job_gapi(table_gapi.table_reference, "CSV", location: nil), upload_source: file, content_type: "text/comma-separated-values"]
+        [project, load_job_gapi(table_gapi.table_reference, "CSV", location: nil), upload_source: file, content_type: "text/csv"]
 
       result = table.load file, format: :csv
       result.must_equal true


### PR DESCRIPTION
The mime-types 3.2.0 gem has changed the type for .csv files. This is needed to get the builds passing again.