### PR TITLE
Fix documentation for Vision::Project#async_batch_annotate_files

### DIFF
--- a/google-cloud-vision/lib/google/cloud/vision/project.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/project.rb
@@ -275,6 +275,8 @@ module Google
           annotations
         end
 
+        # rubocop:disable LineLength
+
         ##
         # Run asynchronous image detection and annotation for a list of generic
         # files, such as PDF files, which may contain multiple pages and
@@ -284,8 +286,7 @@ module Google
         # Operation.response contains AsyncBatchAnnotateFilesResponse
         # (results).
         #
-        # @param requests
-        #   [Array<Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash>]
+        # @param requests [Array<Google::Cloud::Vision::V1::AsyncAnnotateFileRequest|Hash>]
         #   Individual async file annotation requests for this batch.
         #   A hash of the same form as
         #     `Google::Cloud::Vision::V1::AsyncAnnotateFileRequest` can also be
@@ -344,6 +345,8 @@ module Google
         def async_batch_annotate_files requests, options = {}
           service.service.async_batch_annotate_files requests, options
         end
+
+        # rubocop:enable LineLength
 
         alias mark annotate
         alias detect annotate


### PR DESCRIPTION
Place types on same line as @param directive.

Fixes missing `types` in YARD output.

Before this change:

```
"params": [
        {
          "name": "requests",
          "types": null,
          "description": "[Array&lt;Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash&gt;]\nIndividual async file annotation requests for this batch.\nA hash of the same form as\n  <code>Google::Cloud::Vision::V1::AsyncAnnotateFileRequest</code> can also be\nprovided.",
          "optional": false,
          "nullable": false
        },
```

After this change:

```
"params": [
        {
          "name": "requests",
          "types": ["Array<Google::Cloud::Vision::V1::AsyncAnnotateFileRequest|Hash>"],
          "description": "Individual async file annotation requests for this batch.\nA hash of the same form as\n  <code>Google::Cloud::Vision::V1::AsyncAnnotateFileRequest</code> can also be\nprovided.",
          "optional": false,
          "nullable": false
        },
```


[Fixes #2282]