### PR TITLE
Fix middleware documentation warning

### DIFF
--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -97,8 +97,8 @@ module Google
         # @param [Google::Cloud::Debugger::Project] debugger A debugger to be
         #   used by this middleware. If not given, will construct a new one
         #   using the other parameters.
-        # @param [Hash] *kwargs Hash of configuration settings. Used for
-        #   backward API compatibility. See the [Configuration
+        # @param [Hash] kwargs Hash of configuration settings. Used for backward
+        #   API compatibility. See the [Configuration
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
         #   for the prefered way to set configuration parameters.
         #

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -37,8 +37,8 @@ module Google
         # @param [Google::Cloud::ErrorReporting::Project] error_reporting A
         #   Google::Cloud::ErrorReporting::Project client for reporting
         #   exceptions
-        # @param [Hash] *kwargs Hash of configuration settings. Used for
-        #   backward API compatibility. See the [Configuration
+        # @param [Hash] kwargs Hash of configuration settings. Used for backward
+        #   API compatibility. See the [Configuration
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
         #   for the prefered way to set configuration parameters.
         #

--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -64,7 +64,7 @@ module Google
         RequestInfo = ::Struct.new :trace_id, :log_name, :env
 
         ##
-        # The Google Cloud writer object that calls to {#write_entries} are made
+        # The Google Cloud writer object that calls to `#write_entries` are made
         # on. Either an AsyncWriter or Project object.
         attr_reader :writer
 
@@ -131,7 +131,7 @@ module Google
         #   entries. Generally, to create a logger that blocks on transmitting
         #   log entries, pass the Project; otherwise, to create a logger that
         #   transmits log entries in the background, pass an AsyncWriter. You
-        #   may also pass any other object that responds to #write_entries.
+        #   may also pass any other object that responds to `#write_entries`.
         # @param [String] log_name A log resource name to be associated with the
         #   written log entries.
         # @param [Google::Cloud::Logging::Resource] resource The monitored

--- a/google-cloud-logging/lib/google/cloud/logging/middleware.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/middleware.rb
@@ -43,7 +43,7 @@ module Google
         #   to track Stackdriver request trace ID. It also properly sets
         #   env["rack.logger"] to this assigned logger for accessing. If not
         #   specified, a default logger with be used.
-        # @param [Hash] *kwargs Hash of configuration settings. Used for
+        # @param [Hash] kwargs Hash of configuration settings. Used for
         #   backward API compatibility. See the [Configuration
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
         #   for the prefered way to set configuration parameters.

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -115,8 +115,8 @@ module Google
         # @param [Rack Application] app Rack application
         # @param [Google::Cloud::Trace::Service, AsyncReporter] service
         #   The service object to update traces. Optional if running on GCE.
-        # @param [Hash] *kwargs Hash of configuration settings. Used for
-        #   backward API compatibility. See the [Configuration
+        # @param [Hash] kwargs Hash of configuration settings. Used for backward
+        #   API compatibility. See the [Configuration
         #   Guide](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/stackdriver/guides/instrumentation_configuration)
         #   for the prefered way to set configuration parameters.
         #

--- a/stackdriver-core/lib/stackdriver/core/async_actor.rb
+++ b/stackdriver-core/lib/stackdriver/core/async_actor.rb
@@ -322,9 +322,9 @@ module Stackdriver
       ##
       # @private Set cleanup options.
       #
-      # @param [Hash] *kwargs Hash of cleanup options. :timeout is the cleanup
-      #   wait timeout. :wait_interval is the cleanup wait interval. :force for
-      #   forcefully terminate actor when all other options fail.
+      # @param [Hash] kwargs Hash of cleanup options. `:timeout` is the cleanup
+      #   wait timeout. `:wait_interval` is the cleanup wait interval. `:force`
+      #   for forcefully terminate actor when all other options fail.
       def set_cleanup_options **kwargs
         @cleanup_options.merge! kwargs
       end


### PR DESCRIPTION
Correct "unknown parameter name" warning when generating documentation.

[refs #2299]