### PR TITLE
Add Speech get_operation method

### DIFF
--- a/google-cloud-speech/lib/google/cloud/speech/v1/helpers.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/helpers.rb
@@ -14,6 +14,7 @@
 
 require "google/cloud/speech/v1/speech_client"
 require "google/cloud/speech/v1/stream"
+require "uri"
 
 module Google
   module Cloud
@@ -85,6 +86,124 @@ module Google
                 @streaming_recognize.call(request_protos, options)
               end
             )
+          end
+
+          ##
+          # Gets the latest state of a long-running operation. Clients can use
+          # this method to poll the operation result at intervals as recommended
+          # by the API service.
+          #
+          # @param name [String]
+          #   The name of the operation resource.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Gax::Operation]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/speech"
+          #
+          #   speech_client = Google::Cloud::Speech.new version: :v1
+          #
+          #   op = speech_client.get_operation "-"
+          #
+          #   # Process error operations.
+          #   log_error op.error if op.error?
+          #
+          #   if op.done?
+          #     # Process completed operations.
+          #     log_finished op.response, op.metadata
+          #   else
+          #     # Process pending operations.
+          #     log_pending op.name, op.metadata
+          #   end
+          #
+          def get_operation name, options: nil
+            proto_op = @operations_client.get_operation name, options: options
+            wrap_proto_op_with_gax_op proto_op, options
+          end
+
+          ##
+          # Lists operations that match the specified filter in the request. If
+          # the server doesn't support this method, it returns `UNIMPLEMENTED`.
+          #
+          # NOTE: the `name` binding below allows API services to override the
+          # binding to use different resource name schemes, such as
+          # `users/*/operations`.
+          #
+          # @param name [String]
+          #   The name of the operation collection.
+          # @param filter [String]
+          #   The standard list filter.
+          # @param page_size [Integer]
+          #   The maximum number of resources contained in the underlying API
+          #   response. If page streaming is performed per-resource, this
+          #   parameter does not affect the return value. If page streaming is
+          #   performed per-page, this determines the maximum number of
+          #   resources in a page.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
+          #   An enumerable of Google::Gax::Operation instances. See
+          #   Google::Gax::PagedEnumerable documentation for other operations
+          #   such as per-page iteration or access to the response object.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/speech"
+          #
+          #   speech_client = Google::Cloud::Speech.new version: :v1
+          #
+          #   # List all callbacks.
+          #   speech_client.list_operations "*", "" do |op|
+          #     # Process error operations.
+          #     log_error op.error if op.error?
+          #
+          #     if op.done?
+          #       # Process completed operations.
+          #       log_finished op.response, op.metadata
+          #     else
+          #       # Process pending operations.
+          #       log_pending op.name, op.metadata
+          #     end
+          #   end
+          #
+          def list_operations name, filter, page_size: nil, options: nil
+            paged_enum = @operations_client.list_operations \
+              name, filter, page_size: page_size, options: options
+            paged_enum.lazy.map do |proto_op|
+              wrap_proto_op_with_gax_op proto_op, options
+            end
+          end
+
+          protected
+
+          ##
+          # @private
+          # Lookup the Protobuf class from the type URL
+          def wrap_proto_op_with_gax_op proto_op, options
+            Google::Gax::Operation.new(
+              proto_op,
+              @operations_client,
+              get_type_class_from_proto_any(proto_op.response),
+              get_type_class_from_proto_any(proto_op.metadata),
+              call_options: options
+            )
+          end
+
+          ##
+          # @private
+          # Lookup the Protobuf class from the type URL
+          def get_type_class_from_proto_any proto_any
+            return Google::Protobuf::Any if proto_any.nil?
+
+            uri = URI.parse proto_any.type_url
+            type = uri.path.split("/".freeze).last
+            desc = Google::Protobuf::DescriptorPool.generated_pool.lookup type
+            return desc.msgclass if desc
+
+            # default is Any
+            Google::Protobuf::Any
           end
         end
       end

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/helpers.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/helpers.rb
@@ -86,6 +86,124 @@ module Google
               end
             )
           end
+
+          ##
+          # Gets the latest state of a long-running operation. Clients can use
+          # this method to poll the operation result at intervals as recommended
+          # by the API service.
+          #
+          # @param name [String]
+          #   The name of the operation resource.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Gax::Operation]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/speech"
+          #
+          #   speech_client = Google::Cloud::Speech.new version: :v1p1beta1
+          #
+          #   op = speech_client.get_operation "-"
+          #
+          #   # Process error operations.
+          #   log_error op.error if op.error?
+          #
+          #   if op.done?
+          #     # Process completed operations.
+          #     log_finished op.response, op.metadata
+          #   else
+          #     # Process pending operations.
+          #     log_pending op.name, op.metadata
+          #   end
+          #
+          def get_operation name, options: nil
+            proto_op = @operations_client.get_operation name, options: options
+            wrap_proto_op_with_gax_op proto_op, options
+          end
+
+          ##
+          # Lists operations that match the specified filter in the request. If
+          # the server doesn't support this method, it returns `UNIMPLEMENTED`.
+          #
+          # NOTE: the `name` binding below allows API services to override the
+          # binding to use different resource name schemes, such as
+          # `users/*/operations`.
+          #
+          # @param name [String]
+          #   The name of the operation collection.
+          # @param filter [String]
+          #   The standard list filter.
+          # @param page_size [Integer]
+          #   The maximum number of resources contained in the underlying API
+          #   response. If page streaming is performed per-resource, this
+          #   parameter does not affect the return value. If page streaming is
+          #   performed per-page, this determines the maximum number of
+          #   resources in a page.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
+          #   An enumerable of Google::Gax::Operation instances. See
+          #   Google::Gax::PagedEnumerable documentation for other operations
+          #   such as per-page iteration or access to the response object.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/speech"
+          #
+          #   speech_client = Google::Cloud::Speech.new version: :v1p1beta1
+          #
+          #   # List all callbacks.
+          #   speech_client.list_operations "*", "" do |op|
+          #     # Process error operations.
+          #     log_error op.error if op.error?
+          #
+          #     if op.done?
+          #       # Process completed operations.
+          #       log_finished op.response, op.metadata
+          #     else
+          #       # Process pending operations.
+          #       log_pending op.name, op.metadata
+          #     end
+          #   end
+          #
+          def list_operations name, filter, page_size: nil, options: nil
+            paged_enum = @operations_client.list_operations \
+              name, filter, page_size: page_size, options: options
+            paged_enum.lazy.map do |proto_op|
+              wrap_proto_op_with_gax_op proto_op, options
+            end
+          end
+
+          protected
+
+          ##
+          # @private
+          # Lookup the Protobuf class from the type URL
+          def wrap_proto_op_with_gax_op proto_op, options
+            Google::Gax::Operation.new(
+              proto_op,
+              @operations_client,
+              get_type_class_from_proto_any(proto_op.response),
+              get_type_class_from_proto_any(proto_op.metadata),
+              call_options: options
+            )
+          end
+
+          ##
+          # @private
+          # Lookup the Protobuf class from the type URL
+          def get_type_class_from_proto_any proto_any
+            return Google::Protobuf::Any if proto_any.nil?
+
+            uri = URI.parse proto_any.type_url
+            type = uri.path.split("/".freeze).last
+            desc = Google::Protobuf::DescriptorPool.generated_pool.lookup type
+            return desc.msgclass if desc
+
+            # default is Any
+            Google::Protobuf::Any
+          end
         end
       end
     end

--- a/google-cloud-speech/test/google/cloud/speech/v1/get_operation_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/v1/get_operation_test.rb
@@ -1,0 +1,134 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "./speech_client_test"
+require "google/longrunning/operations_services_pb"
+
+describe Google::Cloud::Speech::V1::SpeechClient, :get_operation do
+  let(:custom_error) { CustomTestError_v1.new "Custom test error for Google::Cloud::Speech::V1::SpeechClient#get_operation." }
+
+  it "invokes get_operation without error" do
+    # Create request parameters
+    name = "operation123"
+
+    # Create expected grpc response
+    expected_response = {}
+    expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Speech::V1::LongRunningRecognizeResponse)
+    result = Google::Protobuf::Any.new
+    result.pack(expected_response)
+    operation = Google::Longrunning::Operation.new(
+      name: "operations/get_operation_test",
+      done: true,
+      response: result
+    )
+
+    # Mock Grpc layer
+    mock_method = proc do |request|
+      assert_instance_of(Google::Longrunning::GetOperationRequest, request)
+      assert_equal(name, request.name)
+      OpenStruct.new(execute: operation)
+    end
+    mock_stub = MockGrpcClientStub_v1.new(:get_operation, mock_method)
+
+    # Mock auth layer
+    mock_credentials = MockSpeechCredentials_v1.new("get_operation")
+
+    Google::Cloud::Speech::V1::Speech::Stub.stub(:new, mock_stub) do
+      Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Speech::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Speech.new(version: :v1)
+
+          # Call method
+          response = client.get_operation(name)
+
+          # Verify the response
+          assert_equal(expected_response, response.response)
+        end
+      end
+    end
+  end
+
+  it "invokes get_operation and returns an operation error." do
+    # Create request parameters
+    name = "operation123"
+
+    # Create expected grpc response
+    operation_error = Google::Rpc::Status.new(
+      message: "Operation error for Google::Cloud::Speech::V1::SpeechClient#get_operation."
+    )
+    operation = Google::Longrunning::Operation.new(
+      name: "operations/get_operation_test",
+      done: true,
+      error: operation_error
+    )
+
+    # Mock Grpc layer
+    mock_method = proc do |request|
+      assert_instance_of(Google::Longrunning::GetOperationRequest, request)
+      assert_equal(name, request.name)
+      OpenStruct.new(execute: operation)
+    end
+    mock_stub = MockGrpcClientStub_v1.new(:get_operation, mock_method)
+
+    # Mock auth layer
+    mock_credentials = MockSpeechCredentials_v1.new("get_operation")
+
+    Google::Cloud::Speech::V1::Speech::Stub.stub(:new, mock_stub) do
+      Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Speech::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Speech.new(version: :v1)
+
+          # Call method
+          response = client.get_operation(name)
+
+          # Verify the response
+          assert(response.error?)
+          assert_equal(operation_error, response.error)
+        end
+      end
+    end
+  end
+
+  it "invokes get_operation with error" do
+    # Create request parameters
+    name = "operation123"
+
+    # Mock Grpc layer
+    mock_method = proc do |request|
+      assert_instance_of(Google::Longrunning::GetOperationRequest, request)
+      assert_equal(name, request.name)
+      raise custom_error
+    end
+    mock_stub = MockGrpcClientStub_v1.new(:get_operation, mock_method)
+
+    # Mock auth layer
+    mock_credentials = MockSpeechCredentials_v1.new("get_operation")
+
+    Google::Cloud::Speech::V1::Speech::Stub.stub(:new, mock_stub) do
+      Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Speech::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Speech.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            response = client.get_operation(name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-speech/test/google/cloud/speech/v1p1beta1/get_operation_test.rb
+++ b/google-cloud-speech/test/google/cloud/speech/v1p1beta1/get_operation_test.rb
@@ -1,0 +1,134 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "./speech_client_test"
+require "google/longrunning/operations_services_pb"
+
+describe Google::Cloud::Speech::V1p1beta1::SpeechClient, :get_operation do
+  let(:custom_error) { CustomTestError_v1p1beta1.new "Custom test error for Google::Cloud::Speech::V1p1beta1::SpeechClient#get_operation." }
+
+  it "invokes get_operation without error" do
+    # Create request parameters
+    name = "operation123"
+
+    # Create expected grpc response
+    expected_response = {}
+    expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Speech::V1p1beta1::LongRunningRecognizeResponse)
+    result = Google::Protobuf::Any.new
+    result.pack(expected_response)
+    operation = Google::Longrunning::Operation.new(
+      name: "operations/get_operation_test",
+      done: true,
+      response: result
+    )
+
+    # Mock Grpc layer
+    mock_method = proc do |request|
+      assert_instance_of(Google::Longrunning::GetOperationRequest, request)
+      assert_equal(name, request.name)
+      OpenStruct.new(execute: operation)
+    end
+    mock_stub = MockGrpcClientStub_v1p1beta1.new(:get_operation, mock_method)
+
+    # Mock auth layer
+    mock_credentials = MockSpeechCredentials_v1p1beta1.new("get_operation")
+
+    Google::Cloud::Speech::V1p1beta1::Speech::Stub.stub(:new, mock_stub) do
+      Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Speech::V1p1beta1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Speech.new(version: :v1p1beta1)
+
+          # Call method
+          response = client.get_operation(name)
+
+          # Verify the response
+          assert_equal(expected_response, response.response)
+        end
+      end
+    end
+  end
+
+  it "invokes get_operation and returns an operation error." do
+    # Create request parameters
+    name = "operation123"
+
+    # Create expected grpc response
+    operation_error = Google::Rpc::Status.new(
+      message: "Operation error for Google::Cloud::Speech::V1p1beta1::SpeechClient#get_operation."
+    )
+    operation = Google::Longrunning::Operation.new(
+      name: "operations/get_operation_test",
+      done: true,
+      error: operation_error
+    )
+
+    # Mock Grpc layer
+    mock_method = proc do |request|
+      assert_instance_of(Google::Longrunning::GetOperationRequest, request)
+      assert_equal(name, request.name)
+      OpenStruct.new(execute: operation)
+    end
+    mock_stub = MockGrpcClientStub_v1p1beta1.new(:get_operation, mock_method)
+
+    # Mock auth layer
+    mock_credentials = MockSpeechCredentials_v1p1beta1.new("get_operation")
+
+    Google::Cloud::Speech::V1p1beta1::Speech::Stub.stub(:new, mock_stub) do
+      Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Speech::V1p1beta1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Speech.new(version: :v1p1beta1)
+
+          # Call method
+          response = client.get_operation(name)
+
+          # Verify the response
+          assert(response.error?)
+          assert_equal(operation_error, response.error)
+        end
+      end
+    end
+  end
+
+  it "invokes get_operation with error" do
+    # Create request parameters
+    name = "operation123"
+
+    # Mock Grpc layer
+    mock_method = proc do |request|
+      assert_instance_of(Google::Longrunning::GetOperationRequest, request)
+      assert_equal(name, request.name)
+      raise custom_error
+    end
+    mock_stub = MockGrpcClientStub_v1p1beta1.new(:get_operation, mock_method)
+
+    # Mock auth layer
+    mock_credentials = MockSpeechCredentials_v1p1beta1.new("get_operation")
+
+    Google::Cloud::Speech::V1p1beta1::Speech::Stub.stub(:new, mock_stub) do
+      Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Speech::V1p1beta1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Speech.new(version: :v1p1beta1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            response = client.get_operation(name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This functionality was previously part of the hand-written API, but is missing from the
fully-generated code. Adding the functionality now, before it is generalized in the generated code, because users are asking for this functionality to be restored. This implementation uses the same hooks as the streaming helper code.

```ruby
require "google/cloud/speech"

speech_client = Google::Cloud::Speech.new version: :v1

op = speech_client.get_operation "1234567890"

# Process error operations.
log_error op.error if op.error?

if op.done?
  # Process completed operations.
  log_finished op.response, op.metadata
else
  # Process pending operations.
  log_pending op.name, op.metadata
end
```

[refs #2213, #2204]