### PR TITLE
Escape literal braces in generated docs

### DIFF
--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
@@ -365,7 +365,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/{project_id}/dataSources/{data_source_id}+
+            #   +projects/\\{project_id}/dataSources/\\{data_source_id}+
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -397,7 +397,7 @@ module Google
             #
             # @param parent [String]
             #   The BigQuery project id for which data sources should be returned.
-            #   Must be in the form: +projects/{project_id}+
+            #   Must be in the form: +projects/\\{project_id}+
             # @param page_size [Integer]
             #   The maximum number of resources contained in the underlying API
             #   response. If page streaming is performed per-resource, this
@@ -452,7 +452,7 @@ module Google
             #
             # @param parent [String]
             #   The BigQuery project id where the transfer configuration should be created.
-            #   Must be in the format /projects/{project_id}/locations/{location_id}
+            #   Must be in the format /projects/\\{project_id}/locations/\\{location_id}
             #   If specified location and location of the destination bigquery dataset
             #   do not match - the request will fail.
             # @param transfer_config [Google::Cloud::Bigquery::Datatransfer::V1::TransferConfig | Hash]
@@ -577,7 +577,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/{project_id}/transferConfigs/{config_id}+
+            #   +projects/\\{project_id}/transferConfigs/\\{config_id}+
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -608,7 +608,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/{project_id}/transferConfigs/{config_id}+
+            #   +projects/\\{project_id}/transferConfigs/\\{config_id}+
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -639,7 +639,7 @@ module Google
             #
             # @param parent [String]
             #   The BigQuery project id for which data sources
-            #   should be returned: +projects/{project_id}+.
+            #   should be returned: +projects/\\{project_id}+.
             # @param data_source_ids [Array<String>]
             #   When specified, only configurations of requested data sources are returned.
             # @param page_size [Integer]
@@ -701,7 +701,7 @@ module Google
             #
             # @param parent [String]
             #   Transfer configuration name in the form:
-            #   +projects/{project_id}/transferConfigs/{config_id}+.
+            #   +projects/\\{project_id}/transferConfigs/\\{config_id}+.
             # @param start_time [Google::Protobuf::Timestamp | Hash]
             #   Start time of the range of transfer runs. For example,
             #   +"2017-05-25T00:00:00+00:00"+.
@@ -752,7 +752,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}+
+            #   +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -783,7 +783,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}+
+            #   +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -815,7 +815,7 @@ module Google
             # @param parent [String]
             #   Name of transfer configuration for which transfer runs should be retrieved.
             #   Format of transfer configuration resource name is:
-            #   +projects/{project_id}/transferConfigs/{config_id}+.
+            #   +projects/\\{project_id}/transferConfigs/\\{config_id}+.
             # @param states [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferState>]
             #   When specified, only transfer runs with requested states are returned.
             # @param page_size [Integer]
@@ -878,7 +878,7 @@ module Google
             #
             # @param parent [String]
             #   Transfer run name in the form:
-            #   +projects/{project_id}/transferConfigs/{config_Id}/runs/{run_id}+.
+            #   +projects/\\{project_id}/transferConfigs/\\{config_Id}/runs/\\{run_id}+.
             # @param page_size [Integer]
             #   The maximum number of resources contained in the underlying API
             #   response. If page streaming is performed per-resource, this
@@ -943,7 +943,7 @@ module Google
             #
             # @param name [String]
             #   The data source in the form:
-            #   +projects/{project_id}/dataSources/{data_source_id}+
+            #   +projects/\\{project_id}/dataSources/\\{data_source_id}+
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/data_transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/data_transfer.rb
@@ -219,14 +219,14 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/dataSources/{data_source_id}+
+          #     +projects/\\{project_id}/dataSources/\\{data_source_id}+
           class GetDataSourceRequest; end
 
           # Request to list supported data sources and their data transfer settings.
           # @!attribute [rw] parent
           #   @return [String]
           #     The BigQuery project id for which data sources should be returned.
-          #     Must be in the form: +projects/{project_id}+
+          #     Must be in the form: +projects/\\{project_id}+
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
@@ -260,7 +260,7 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     The BigQuery project id where the transfer configuration should be created.
-          #     Must be in the format /projects/{project_id}/locations/{location_id}
+          #     Must be in the format /projects/\\{project_id}/locations/\\{location_id}
           #     If specified location and location of the destination bigquery dataset
           #     do not match - the request will fail.
           # @!attribute [rw] transfer_config
@@ -318,7 +318,7 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/transferConfigs/{config_id}+
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+
           class GetTransferConfigRequest; end
 
           # A request to delete data transfer information. All associated transfer runs
@@ -326,28 +326,28 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/transferConfigs/{config_id}+
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+
           class DeleteTransferConfigRequest; end
 
           # A request to get data transfer run information.
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}+
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
           class GetTransferRunRequest; end
 
           # A request to delete data transfer run information.
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}+
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
           class DeleteTransferRunRequest; end
 
           # A request to list data transfers configured for a BigQuery project.
           # @!attribute [rw] parent
           #   @return [String]
           #     The BigQuery project id for which data sources
-          #     should be returned: +projects/{project_id}+.
+          #     should be returned: +projects/\\{project_id}+.
           # @!attribute [rw] data_source_ids
           #   @return [Array<String>]
           #     When specified, only configurations of requested data sources are returned.
@@ -382,7 +382,7 @@ module Google
           #   @return [String]
           #     Name of transfer configuration for which transfer runs should be retrieved.
           #     Format of transfer configuration resource name is:
-          #     +projects/{project_id}/transferConfigs/{config_id}+.
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+.
           # @!attribute [rw] states
           #   @return [Array<Google::Cloud::Bigquery::DataTransfer::V1::TransferState>]
           #     When specified, only transfer runs with requested states are returned.
@@ -426,7 +426,7 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Transfer run name in the form:
-          #     +projects/{project_id}/transferConfigs/{config_Id}/runs/{run_id}+.
+          #     +projects/\\{project_id}/transferConfigs/\\{config_Id}/runs/\\{run_id}+.
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
@@ -464,7 +464,7 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The data source in the form:
-          #     +projects/{project_id}/dataSources/{data_source_id}+
+          #     +projects/\\{project_id}/dataSources/\\{data_source_id}+
           class CheckValidCredsRequest; end
 
           # A response indicating whether the credentials exist and are valid.
@@ -477,7 +477,7 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Transfer configuration name in the form:
-          #     +projects/{project_id}/transferConfigs/{config_id}+.
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+.
           # @!attribute [rw] start_time
           #   @return [Google::Protobuf::Timestamp]
           #     Start time of the range of transfer runs. For example,

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/data_transfer/v1/transfer.rb
@@ -28,7 +28,7 @@ module Google
           #   @return [String]
           #     The resource name of the transfer config.
           #     Transfer config names have the form
-          #     +projects/{project_id}/transferConfigs/{config_id}+.
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+.
           #     Where +config_id+ is usually a uuid, even though it is not
           #     guaranteed or required. The name is ignored when creating a transfer
           #     config.
@@ -97,7 +97,7 @@ module Google
           #   @return [String]
           #     The resource name of the transfer run.
           #     Transfer run names have the form
-          #     +projects/{project_id}/locations/{location}/transferConfigs/{config_id}/runs/{run_id}+.
+          #     +projects/\\{project_id}/locations/\\{location}/transferConfigs/\\{config_id}/runs/\\{run_id}+.
           #     The name is ignored when creating a transfer run.
           # @!attribute [rw] schedule_time
           #   @return [Google::Protobuf::Timestamp]

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
@@ -206,14 +206,14 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/dataSources/{data_source_id}+
+          #     +projects/\\{project_id}/dataSources/\\{data_source_id}+
           class GetDataSourceRequest; end
 
           # Request to list supported data sources and their data transfer settings.
           # @!attribute [rw] parent
           #   @return [String]
           #     The BigQuery project id for which data sources should be returned.
-          #     Must be in the form: +projects/{project_id}+
+          #     Must be in the form: +projects/\\{project_id}+
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
@@ -247,7 +247,7 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     The BigQuery project id where the transfer configuration should be created.
-          #     Must be in the format /projects/{project_id}/locations/{location_id}
+          #     Must be in the format /projects/\\{project_id}/locations/\\{location_id}
           #     If specified location and location of the destination bigquery dataset
           #     do not match - the request will fail.
           # @!attribute [rw] transfer_config
@@ -305,7 +305,7 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/transferConfigs/{config_id}+
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+
           class GetTransferConfigRequest; end
 
           # A request to delete data transfer information. All associated transfer runs
@@ -313,28 +313,28 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/transferConfigs/{config_id}+
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+
           class DeleteTransferConfigRequest; end
 
           # A request to get data transfer run information.
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}+
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
           class GetTransferRunRequest; end
 
           # A request to delete data transfer run information.
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}+
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
           class DeleteTransferRunRequest; end
 
           # A request to list data transfers configured for a BigQuery project.
           # @!attribute [rw] parent
           #   @return [String]
           #     The BigQuery project id for which data sources
-          #     should be returned: +projects/{project_id}+.
+          #     should be returned: +projects/\\{project_id}+.
           # @!attribute [rw] data_source_ids
           #   @return [Array<String>]
           #     When specified, only configurations of requested data sources are returned.
@@ -369,7 +369,7 @@ module Google
           #   @return [String]
           #     Name of transfer configuration for which transfer runs should be retrieved.
           #     Format of transfer configuration resource name is:
-          #     +projects/{project_id}/transferConfigs/{config_id}+.
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+.
           # @!attribute [rw] states
           #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferState>]
           #     When specified, only transfer runs with requested states are returned.
@@ -413,7 +413,7 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Transfer run name in the form:
-          #     +projects/{project_id}/transferConfigs/{config_Id}/runs/{run_id}+.
+          #     +projects/\\{project_id}/transferConfigs/\\{config_Id}/runs/\\{run_id}+.
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
@@ -451,7 +451,7 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The data source in the form:
-          #     +projects/{project_id}/dataSources/{data_source_id}+
+          #     +projects/\\{project_id}/dataSources/\\{data_source_id}+
           class CheckValidCredsRequest; end
 
           # A response indicating whether the credentials exist and are valid.
@@ -464,7 +464,7 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Transfer configuration name in the form:
-          #     +projects/{project_id}/transferConfigs/{config_id}+.
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+.
           # @!attribute [rw] start_time
           #   @return [Google::Protobuf::Timestamp]
           #     Start time of the range of transfer runs. For example,

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
@@ -27,7 +27,7 @@ module Google
           #   @return [String]
           #     The resource name of the transfer config.
           #     Transfer config names have the form
-          #     +projects/{project_id}/transferConfigs/{config_id}+.
+          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+.
           #     Where +config_id+ is usually a uuid, even though it is not
           #     guaranteed or required. The name is ignored when creating a transfer
           #     config.
@@ -95,7 +95,7 @@ module Google
           #   @return [String]
           #     The resource name of the transfer run.
           #     Transfer run names have the form
-          #     +projects/{project_id}/locations/{location}/transferConfigs/{config_id}/runs/{run_id}+.
+          #     +projects/\\{project_id}/locations/\\{location}/transferConfigs/\\{config_id}/runs/\\{run_id}+.
           #     The name is ignored when creating a transfer run.
           # @!attribute [rw] schedule_time
           #   @return [Google::Protobuf::Timestamp]

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -70,3 +70,16 @@ s.replace(
     ],
     '\\[Product Documentation\\]: https://cloud\\.google\\.com/bigquerydatatransfer\n',
     '[Product Documentation]: https://cloud.google.com/bigquery/transfer/\n')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^\n#\\$\\\\])\\{([\\w,]+|\\.+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/bigquery/data_transfer/v1/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -80,6 +80,6 @@ def escape_braces(match):
         if count == 0:
             return content
 s.replace(
-    'lib/google/cloud/bigquery/data_transfer/v1/**/*.rb',
+    'lib/google/cloud/**/*.rb',
     '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
     escape_braces)

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
@@ -616,9 +616,9 @@ module Google
             #   metrics.
             #
             #   * Label keys must be between 1 and 63 characters long and must conform to
-            #     the regular expression: +[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}+.
+            #     the regular expression: +[\p\\{Ll}\p\\{Lo}][\p\\{Ll}\p\\{Lo}\p\\{N}_-]\\{0,62}+.
             #   * Label values must be between 0 and 63 characters long and must conform to
-            #     the regular expression: +[\p{Ll}\p{Lo}\p{N}_-]{0,63}+.
+            #     the regular expression: +[\p\\{Ll}\p\\{Lo}\p\\{N}_-]\\{0,63}+.
             #   * No more than 64 labels can be associated with a given resource.
             #   * Keys and values must both be under 128 bytes.
             # @param state [Google::Bigtable::Admin::V2::Instance::State]
@@ -1297,7 +1297,7 @@ module Google
             # @param resource [String]
             #   REQUIRED: The resource for which the policy is being requested.
             #   +resource+ is usually specified as a path. For example, a Project
-            #   resource is specified as +projects/{project}+.
+            #   resource is specified as +projects/\\{project}+.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -1330,7 +1330,7 @@ module Google
             # @param resource [String]
             #   REQUIRED: The resource for which the policy is being specified.
             #   +resource+ is usually specified as a path. For example, a Project
-            #   resource is specified as +projects/{project}+.
+            #   resource is specified as +projects/\\{project}+.
             # @param policy [Google::Iam::V1::Policy | Hash]
             #   REQUIRED: The complete policy to be applied to the +resource+. The size of
             #   the policy is limited to a few 10s of KB. An empty policy is a
@@ -1374,7 +1374,7 @@ module Google
             # @param resource [String]
             #   REQUIRED: The resource for which the policy detail is being requested.
             #   +resource+ is usually specified as a path. For example, a Project
-            #   resource is specified as +projects/{project}+.
+            #   resource is specified as +projects/\\{project}+.
             # @param permissions [Array<String>]
             #   The set of permissions to check for the +resource+. Permissions with
             #   wildcards (such as '*' or 'storage.*') are not allowed. For more

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/instance.rb
@@ -45,9 +45,9 @@ module Google
         #     metrics.
         #
         #     * Label keys must be between 1 and 63 characters long and must conform to
-        #       the regular expression: +[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}+.
+        #       the regular expression: +[\p\\{Ll}\p\\{Lo}][\p\\{Ll}\p\\{Lo}\p\\{N}_-]\\{0,62}+.
         #     * Label values must be between 0 and 63 characters long and must conform to
-        #       the regular expression: +[\p{Ll}\p{Lo}\p{N}_-]{0,63}+.
+        #       the regular expression: +[\p\\{Ll}\p\\{Lo}\p\\{N}_-]\\{0,63}+.
         #     * No more than 64 labels can be associated with a given resource.
         #     * Keys and values must both be under 128 bytes.
         class Instance

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/iam/v1/iam_policy.rb
@@ -20,7 +20,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
       #     REQUIRED: The complete policy to be applied to the +resource+. The size of
@@ -34,7 +34,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       class GetIamPolicyRequest; end
 
       # Request message for +TestIamPermissions+ method.
@@ -42,7 +42,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
       #     The set of permissions to check for the +resource+. Permissions with

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/iam/v1/policy.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/iam/v1/policy.rb
@@ -85,17 +85,17 @@ module Google
       #     * +allAuthenticatedUsers+: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:{emailid}+: An email address that represents a specific Google
+      #     * +user:\\{emailid}+: An email address that represents a specific Google
       #       account. For example, +alice@gmail.com+ or +joe@example.com+.
       #
       #
-      #     * +serviceAccount:{emailid}+: An email address that represents a service
+      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
       #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
       #
-      #     * +group:{emailid}+: An email address that represents a Google group.
+      #     * +group:\\{emailid}+: An email address that represents a Google group.
       #       For example, +admins@example.com+.
       #
-      #     * +domain:{domain}+: A Google Apps domain name that represents all the
+      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
       #       users of that domain. For example, +google.com+ or +example.com+.
       class Binding; end
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import logging
 import os
+import re
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -43,7 +44,7 @@ s.copy(v2_admin_library / 'lib/google/cloud/bigtable/admin.rb')
 s.copy(v2_admin_library / 'lib/google/bigtable/admin/v2')
 s.copy(v2_admin_library / 'test/google/cloud/bigtable/admin/v2')
 
-# PERMANENT: We don't want the generated overview.rb filesbecause we have our
+# PERMANENT: We don't want the generated overview.rb files because we have our
 # own toplevel docs for the handwritten layer.
 os.remove('lib/google/cloud/bigtable/v2/doc/overview.rb')
 os.remove('lib/google/cloud/bigtable/admin/v2/doc/overview.rb')
@@ -91,3 +92,16 @@ s.replace(
     ],
     '\n\n(\\s+)class OperationsClient < Google::Longrunning::OperationsClient',
     '\n\n\\1# @private\n\\1class OperationsClient < Google::Longrunning::OperationsClient')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/bigtable/admin/v2/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
@@ -563,7 +563,7 @@ module Google
             @get_cluster.call(req, options, &block)
           end
 
-          # Lists all regions/{region}/clusters in a project.
+          # Lists all regions/\\{region}/clusters in a project.
           #
           # @param project_id [String]
           #   Required. The ID of the Google Cloud Platform project that the cluster

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_services_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/clusters_services_pb.rb
@@ -42,7 +42,7 @@ module Google
             rpc :DeleteCluster, DeleteClusterRequest, Google::Longrunning::Operation
             # Gets the resource representation for a cluster in a project.
             rpc :GetCluster, GetClusterRequest, Cluster
-            # Lists all regions/{region}/clusters in a project.
+            # Lists all regions/\\{region}/clusters in a project.
             rpc :ListClusters, ListClustersRequest, ListClustersResponse
             # Gets cluster diagnostic information.
             # After the operation completes, the Operation.response field

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
@@ -298,7 +298,7 @@ module Google
             @get_job.call(req, options, &block)
           end
 
-          # Lists regions/{region}/jobs in a project.
+          # Lists regions/\\{region}/jobs in a project.
           #
           # @param project_id [String]
           #   Required. The ID of the Google Cloud Platform project that the job
@@ -463,8 +463,8 @@ module Google
 
           # Starts a job cancellation request. To access the job resource
           # after cancellation, call
-          # [regions/{region}/jobs.list](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.jobs/list) or
-          # [regions/{region}/jobs.get](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.jobs/get).
+          # [regions/\\{region}/jobs.list](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.jobs/list) or
+          # [regions/\\{region}/jobs.get](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.jobs/get).
           #
           # @param project_id [String]
           #   Required. The ID of the Google Cloud Platform project that the job

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/jobs_services_pb.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/jobs_services_pb.rb
@@ -37,14 +37,14 @@ module Google
             rpc :SubmitJob, SubmitJobRequest, Job
             # Gets the resource representation for a job in a project.
             rpc :GetJob, GetJobRequest, Job
-            # Lists regions/{region}/jobs in a project.
+            # Lists regions/\\{region}/jobs in a project.
             rpc :ListJobs, ListJobsRequest, ListJobsResponse
             # Updates a job in a project.
             rpc :UpdateJob, UpdateJobRequest, Job
             # Starts a job cancellation request. To access the job resource
             # after cancellation, call
-            # [regions/{region}/jobs.list](/dataproc/docs/reference/rest/v1/projects.regions.jobs/list) or
-            # [regions/{region}/jobs.get](/dataproc/docs/reference/rest/v1/projects.regions.jobs/get).
+            # [regions/\\{region}/jobs.list](/dataproc/docs/reference/rest/v1/projects.regions.jobs/list) or
+            # [regions/\\{region}/jobs.get](/dataproc/docs/reference/rest/v1/projects.regions.jobs/get).
             rpc :CancelJob, CancelJobRequest, Job
             # Deletes the job from the project. If the job is active, the delete fails,
             # and the response returns `FAILED_PRECONDITION`.

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -71,3 +71,16 @@ s.replace(
     'lib/google/cloud/dataproc/v1/cluster_controller_client.rb',
     '\n\n(\\s+)class OperationsClient < Google::Longrunning::OperationsClient',
     '\n\n\\1# @private\n\\1class OperationsClient < Google::Longrunning::OperationsClient')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/dataproc/v1/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -81,6 +81,6 @@ def escape_braces(match):
         if count == 0:
             return content
 s.replace(
-    'lib/google/cloud/dataproc/v1/**/*.rb',
+    'lib/google/cloud/**/*.rb',
     '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
     escape_braces)

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import logging
 import os
+import re
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -68,3 +69,16 @@ s.replace(
 s.replace(
     'lib/google/cloud/debugger/v2.rb',
     '/debugger\\.googleapis\\.com', '/clouddebugger.googleapis.com')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/debugger/v2/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/dlp.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/dlp.rb
@@ -1819,7 +1819,7 @@ module Google
           #     Cloud Pub/Sub topic to send notifications to. The topic must have given
           #     publishing access rights to the DLP API service account executing
           #     the long running DlpJob sending the notifications.
-          #     Format is projects/{project}/topics/{topic}.
+          #     Format is projects/\\{project}/topics/\\{topic}.
           class PublishToPubSub; end
 
           # Publish the result summary of a DlpJob to the Cloud Security

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/storage.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/storage.rb
@@ -169,7 +169,7 @@ module Google
             #     The total length of the window cannot exceed 1000 characters. Note that
             #     the finding itself will be included in the window, so that hotwords may
             #     be used to match substrings of the finding itself. For example, the
-            #     certainty of a phone number regex "\(\d{3}\) \d{3}-\d{4}" could be
+            #     certainty of a phone number regex "\(\d\\{3}\) \d\\{3}-\d\\{4}" could be
             #     adjusted upwards if the area code is known to be the local area code of
             #     a company office using the hotword regex "\(xxx\)", where "xxx"
             #     is the area code in question.

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -47,3 +47,16 @@ s.copy(v2_library / '.gitignore')
 s.copy(v2_library / '.rubocop.yml')
 s.copy(v2_library / '.yardopts')
 s.copy(v2_library / 'google-cloud-dlp.gemspec', merge=merge_gemspec)
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/dlp/v2/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -57,6 +57,6 @@ def escape_braces(match):
         if count == 0:
             return content
 s.replace(
-    'lib/google/cloud/dlp/v2/**/*.rb',
+    'lib/google/cloud/**/*.rb',
     '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
     escape_braces)

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-error_reporting/synth.py
+++ b/google-cloud-error_reporting/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import logging
 import os
+import re
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -37,3 +38,16 @@ s.copy(v1beta1_library / 'lib/google/devtools/clouderrorreporting/v1beta1')
 # PERMANENT: We don't want the generated overview.rb file because we have our
 # own toplevel docs for the handwritten layer.
 os.remove('lib/google/cloud/error_reporting/v1beta1/doc/overview.rb')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/error_reporting/v1beta1/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/document.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/document.rb
@@ -21,7 +21,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the document, for example
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       # @!attribute [rw] fields
       #   @return [Hash{String => Google::Firestore::V1beta1::Value}]
       #     The document's fields.
@@ -99,7 +99,7 @@ module Google
       # @!attribute [rw] reference_value
       #   @return [String]
       #     A reference to a document. For example:
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       # @!attribute [rw] geo_point_value
       #   @return [Google::Type::LatLng]
       #     A geo point value representing a point on the surface of Earth.

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/firestore.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/firestore.rb
@@ -19,7 +19,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the Document to get. In the format:
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       # @!attribute [rw] mask
       #   @return [Google::Firestore::V1beta1::DocumentMask]
       #     The fields to return. If not set, returns all fields.
@@ -39,8 +39,8 @@ module Google
       # @!attribute [rw] parent
       #   @return [String]
       #     The parent resource name. In the format:
-      #     +projects/{project_id}/databases/{database_id}/documents+ or
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents+ or
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       #     For example:
       #     +projects/my-project/databases/my-database/documents+ or
       #     +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
@@ -94,8 +94,8 @@ module Google
       # @!attribute [rw] parent
       #   @return [String]
       #     The parent resource. For example:
-      #     +projects/{project_id}/databases/{database_id}/documents+ or
-      #     +projects/{project_id}/databases/{database_id}/documents/chatrooms/{chatroom_id}+
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents+ or
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/chatrooms/\\{chatroom_id}+
       # @!attribute [rw] collection_id
       #   @return [String]
       #     The collection ID, relative to +parent+, to list. For example: +chatrooms+.
@@ -145,7 +145,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the Document to delete. In the format:
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       # @!attribute [rw] current_document
       #   @return [Google::Firestore::V1beta1::Precondition]
       #     An optional precondition on the document.
@@ -156,11 +156,11 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/{project_id}/databases/{database_id}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}+.
       # @!attribute [rw] documents
       #   @return [Array<String>]
       #     The names of the documents to retrieve. In the format:
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       #     The request will fail if any of the document is not a child resource of the
       #     given +database+. Duplicate names will be elided.
       # @!attribute [rw] mask
@@ -191,7 +191,7 @@ module Google
       # @!attribute [rw] missing
       #   @return [String]
       #     A document name that was requested but does not exist. In the format:
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       # @!attribute [rw] transaction
       #   @return [String]
       #     The transaction that was started as part of this request.
@@ -209,7 +209,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/{project_id}/databases/{database_id}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}+.
       # @!attribute [rw] options
       #   @return [Google::Firestore::V1beta1::TransactionOptions]
       #     The options for the transaction.
@@ -226,7 +226,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/{project_id}/databases/{database_id}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}+.
       # @!attribute [rw] writes
       #   @return [Array<Google::Firestore::V1beta1::Write>]
       #     The writes to apply.
@@ -253,7 +253,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/{project_id}/databases/{database_id}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}+.
       # @!attribute [rw] transaction
       #   @return [String]
       #     The transaction to roll back.
@@ -263,8 +263,8 @@ module Google
       # @!attribute [rw] parent
       #   @return [String]
       #     The parent resource name. In the format:
-      #     +projects/{project_id}/databases/{database_id}/documents+ or
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents+ or
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       #     For example:
       #     +projects/my-project/databases/my-database/documents+ or
       #     +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
@@ -325,7 +325,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/{project_id}/databases/{database_id}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}+.
       #     This is only required in the first message.
       # @!attribute [rw] stream_id
       #   @return [String]
@@ -387,7 +387,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/{project_id}/databases/{database_id}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}+.
       # @!attribute [rw] add_target
       #   @return [Google::Firestore::V1beta1::Target]
       #     A target to add to this stream.
@@ -457,7 +457,7 @@ module Google
         # @!attribute [rw] documents
         #   @return [Array<String>]
         #     The names of the documents to retrieve. In the format:
-        #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+        #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
         #     The request will fail if any of the document is not a child resource of
         #     the given +database+. Duplicate names will be elided.
         class DocumentsTarget; end
@@ -466,8 +466,8 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     The parent resource name. In the format:
-        #     +projects/{project_id}/databases/{database_id}/documents+ or
-        #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+        #     +projects/\\{project_id}/databases/\\{database_id}/documents+ or
+        #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
         #     For example:
         #     +projects/my-project/databases/my-database/documents+ or
         #     +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
@@ -548,7 +548,7 @@ module Google
       # @!attribute [rw] parent
       #   @return [String]
       #     The parent document. In the format:
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       #     For example:
       #     +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
       # @!attribute [rw] page_size

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/write.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/write.rb
@@ -22,7 +22,7 @@ module Google
       # @!attribute [rw] delete
       #   @return [String]
       #     A document name to delete. In the format:
-      #     +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
       # @!attribute [rw] transform
       #   @return [Google::Firestore::V1beta1::DocumentTransform]
       #     Applies a tranformation to a document.

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/firestore_client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/firestore_client.rb
@@ -335,7 +335,7 @@ module Google
           #
           # @param name [String]
           #   The resource name of the Document to get. In the format:
-          #   +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
           # @param mask [Google::Firestore::V1beta1::DocumentMask | Hash]
           #   The fields to return. If not set, returns all fields.
           #
@@ -386,8 +386,8 @@ module Google
           #
           # @param parent [String]
           #   The parent resource name. In the format:
-          #   +projects/{project_id}/databases/{database_id}/documents+ or
-          #   +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents+ or
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
           #   For example:
           #   +projects/my-project/databases/my-database/documents+ or
           #   +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
@@ -487,8 +487,8 @@ module Google
           #
           # @param parent [String]
           #   The parent resource. For example:
-          #   +projects/{project_id}/databases/{database_id}/documents+ or
-          #   +projects/{project_id}/databases/{database_id}/documents/chatrooms/{chatroom_id}+
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents+ or
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents/chatrooms/\\{chatroom_id}+
           # @param collection_id [String]
           #   The collection ID, relative to +parent+, to list. For example: +chatrooms+.
           # @param document_id [String]
@@ -619,7 +619,7 @@ module Google
           #
           # @param name [String]
           #   The resource name of the Document to delete. In the format:
-          #   +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
           # @param current_document [Google::Firestore::V1beta1::Precondition | Hash]
           #   An optional precondition on the document.
           #   The request will fail if this is set and not met by the target document.
@@ -660,10 +660,10 @@ module Google
           #
           # @param database [String]
           #   The database name. In the format:
-          #   +projects/{project_id}/databases/{database_id}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}+.
           # @param documents [Array<String>]
           #   The names of the documents to retrieve. In the format:
-          #   +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
           #   The request will fail if any of the document is not a child resource of the
           #   given +database+. Duplicate names will be elided.
           # @param mask [Google::Firestore::V1beta1::DocumentMask | Hash]
@@ -730,7 +730,7 @@ module Google
           #
           # @param database [String]
           #   The database name. In the format:
-          #   +projects/{project_id}/databases/{database_id}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}+.
           # @param options_ [Google::Firestore::V1beta1::TransactionOptions | Hash]
           #   The options for the transaction.
           #   Defaults to a read-write transaction.
@@ -768,7 +768,7 @@ module Google
           #
           # @param database [String]
           #   The database name. In the format:
-          #   +projects/{project_id}/databases/{database_id}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}+.
           # @param writes [Array<Google::Firestore::V1beta1::Write | Hash>]
           #   The writes to apply.
           #
@@ -814,7 +814,7 @@ module Google
           #
           # @param database [String]
           #   The database name. In the format:
-          #   +projects/{project_id}/databases/{database_id}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}+.
           # @param transaction [String]
           #   The transaction to roll back.
           # @param options [Google::Gax::CallOptions]
@@ -852,8 +852,8 @@ module Google
           #
           # @param parent [String]
           #   The parent resource name. In the format:
-          #   +projects/{project_id}/databases/{database_id}/documents+ or
-          #   +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents+ or
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
           #   For example:
           #   +projects/my-project/databases/my-database/documents+ or
           #   +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
@@ -983,7 +983,7 @@ module Google
           #
           # @param parent [String]
           #   The parent document. In the format:
-          #   +projects/{project_id}/databases/{database_id}/documents/{document_path}+.
+          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
           #   For example:
           #   +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
           # @param page_size [Integer]

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import logging
 import os
+import re
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -54,3 +55,16 @@ s.replace(
     ],
     'Google::Cloud::Firestore\\.new\\(version: :v1beta1\\)',
     'Google::Cloud::Firestore::V1beta1.new')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/firestore/v1beta1/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/service.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/service.rb
@@ -135,7 +135,7 @@ module Google
         # @!attribute [rw] key_ring_id
         #   @return [String]
         #     Required. It must be unique within a location and match the regular
-        #     expression +[a-zA-Z0-9_-]{1,63}+
+        #     expression +[a-zA-Z0-9_-]\\{1,63}+
         # @!attribute [rw] key_ring
         #   @return [Google::Cloud::Kms::V1::KeyRing]
         #     A {Google::Cloud::Kms::V1::KeyRing KeyRing} with initial field values.
@@ -149,7 +149,7 @@ module Google
         # @!attribute [rw] crypto_key_id
         #   @return [String]
         #     Required. It must be unique within a KeyRing and match the regular
-        #     expression +[a-zA-Z0-9_-]{1,63}+
+        #     expression +[a-zA-Z0-9_-]\\{1,63}+
         # @!attribute [rw] crypto_key
         #   @return [Google::Cloud::Kms::V1::CryptoKey]
         #     A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} with initial field values.

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/iam_policy.rb
@@ -20,7 +20,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
       #     REQUIRED: The complete policy to be applied to the +resource+. The size of
@@ -34,7 +34,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       class GetIamPolicyRequest; end
 
       # Request message for +TestIamPermissions+ method.
@@ -42,7 +42,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
       #     The set of permissions to check for the +resource+. Permissions with

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/policy.rb
@@ -85,17 +85,17 @@ module Google
       #     * +allAuthenticatedUsers+: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:{emailid}+: An email address that represents a specific Google
+      #     * +user:\\{emailid}+: An email address that represents a specific Google
       #       account. For example, +alice@gmail.com+ or +joe@example.com+.
       #
       #
-      #     * +serviceAccount:{emailid}+: An email address that represents a service
+      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
       #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
       #
-      #     * +group:{emailid}+: An email address that represents a Google group.
+      #     * +group:\\{emailid}+: An email address that represents a Google group.
       #       For example, +admins@example.com+.
       #
-      #     * +domain:{domain}+: A Google Apps domain name that represents all the
+      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
       #       users of that domain. For example, +google.com+ or +example.com+.
       class Binding; end
 

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
@@ -717,7 +717,7 @@ module Google
           #   {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format +projects/*/locations/*+.
           # @param key_ring_id [String]
           #   Required. It must be unique within a location and match the regular
-          #   expression +[a-zA-Z0-9_-]{1,63}+
+          #   expression +[a-zA-Z0-9_-]\\{1,63}+
           # @param key_ring [Google::Cloud::Kms::V1::KeyRing | Hash]
           #   A {Google::Cloud::Kms::V1::KeyRing KeyRing} with initial field values.
           #   A hash of the same form as `Google::Cloud::Kms::V1::KeyRing`
@@ -767,7 +767,7 @@ module Google
           #   {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
           # @param crypto_key_id [String]
           #   Required. It must be unique within a KeyRing and match the regular
-          #   expression +[a-zA-Z0-9_-]{1,63}+
+          #   expression +[a-zA-Z0-9_-]\\{1,63}+
           # @param crypto_key [Google::Cloud::Kms::V1::CryptoKey | Hash]
           #   A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} with initial field values.
           #   A hash of the same form as `Google::Cloud::Kms::V1::CryptoKey`
@@ -1160,7 +1160,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being specified.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param policy [Google::Iam::V1::Policy | Hash]
           #   REQUIRED: The complete policy to be applied to the +resource+. The size of
           #   the policy is limited to a few 10s of KB. An empty policy is a
@@ -1206,7 +1206,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1240,7 +1240,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy detail is being requested.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param permissions [Array<String>]
           #   The set of permissions to check for the +resource+. Permissions with
           #   wildcards (such as '*' or 'storage.*') are not allowed. For more

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -42,3 +42,16 @@ s.replace(
       'lib/google/cloud/kms/v1/doc/overview.rb'
     ],
     '/kms\\.googleapis\\.com', '/cloudkms.googleapis.com')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/kms/v1/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -52,6 +52,6 @@ def escape_braces(match):
         if count == 0:
             return content
 s.replace(
-    'lib/google/cloud/kms/v1/**/*.rb',
+    'lib/google/cloud/**/*.rb',
     '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
     escape_braces)

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
@@ -106,7 +106,7 @@ module Google
     #
     #     * +Annotation+ is just a comment if it follows a +UNIT+ and is
     #       equivalent to +1+ if it is used alone. For examples,
-    #       +{requests}/s == 1/s+, +By{transmitted}/s == By/s+.
+    #       +\\{requests}/s == 1/s+, +By\\{transmitted}/s == By/s+.
     #     * +NAME+ is a sequence of non-blank printable ASCII characters not
     #       containing '{' or '}'.
     #     * +1+ represents dimensionless value 1, such as in +1/s+.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
@@ -26,11 +26,11 @@ module Google
     # @!attribute [rw] name
     #   @return [String]
     #     Optional. The resource name of the monitored resource descriptor:
-    #     +"projects/{project_id}/monitoredResourceDescriptors/{type}"+ where
-    #     {type} is the value of the +type+ field in this object and
-    #     {project_id} is a project ID that provides API-specific context for
+    #     +"projects/\\{project_id}/monitoredResourceDescriptors/\\{type}"+ where
+    #     \\{type} is the value of the +type+ field in this object and
+    #     \\{project_id} is a project ID that provides API-specific context for
     #     accessing the type.  APIs that do not use project information can use the
-    #     resource name format +"monitoredResourceDescriptors/{type}"+.
+    #     resource name format +"monitoredResourceDescriptors/\\{type}"+.
     # @!attribute [rw] type
     #   @return [String]
     #     Required. The monitored resource type. For example, the type

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import logging
 import os
+import re
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -67,3 +68,16 @@ s.replace(
     'lib/google/cloud/logging/v2/credentials.rb',
     'SCOPE = \[[^\]]+\]\.freeze',
     'SCOPE = ["https://www.googleapis.com/auth/logging.admin"].freeze')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/logging/v2/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
@@ -106,7 +106,7 @@ module Google
     #
     #     * +Annotation+ is just a comment if it follows a +UNIT+ and is
     #       equivalent to +1+ if it is used alone. For examples,
-    #       +{requests}/s == 1/s+, +By{transmitted}/s == By/s+.
+    #       +\\{requests}/s == 1/s+, +By\\{transmitted}/s == By/s+.
     #     * +NAME+ is a sequence of non-blank printable ASCII characters not
     #       containing '{' or '}'.
     #     * +1+ represents dimensionless value 1, such as in +1/s+.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
@@ -26,11 +26,11 @@ module Google
     # @!attribute [rw] name
     #   @return [String]
     #     Optional. The resource name of the monitored resource descriptor:
-    #     +"projects/{project_id}/monitoredResourceDescriptors/{type}"+ where
-    #     {type} is the value of the +type+ field in this object and
-    #     {project_id} is a project ID that provides API-specific context for
+    #     +"projects/\\{project_id}/monitoredResourceDescriptors/\\{type}"+ where
+    #     \\{type} is the value of the +type+ field in this object and
+    #     \\{project_id} is a project ID that provides API-specific context for
     #     accessing the type.  APIs that do not use project information can use the
-    #     resource name format +"monitoredResourceDescriptors/{type}"+.
+    #     resource name format +"monitoredResourceDescriptors/\\{type}"+.
     # @!attribute [rw] type
     #   @return [String]
     #     Required. The monitored resource type. For example, the type

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group.rb
@@ -44,17 +44,17 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     Output only. The name of this group. The format is
-      #     +"projects/{project_id_or_number}/groups/{group_id}"+.
+      #     +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
       #     When creating a group, this field is ignored and a new name is created
       #     consisting of the project specified in the call to +CreateGroup+
-      #     and a unique +{group_id}+ that is generated automatically.
+      #     and a unique +\\{group_id}+ that is generated automatically.
       # @!attribute [rw] display_name
       #   @return [String]
       #     A user-assigned name for this group, used only for display purposes.
       # @!attribute [rw] parent_name
       #   @return [String]
       #     The name of the group's parent, if it has one.
-      #     The format is +"projects/{project_id_or_number}/groups/{group_id}"+.
+      #     The format is +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
       #     For groups with no parent, +parentName+ is the empty string, +""+.
       # @!attribute [rw] filter
       #   @return [String]

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group_service.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group_service.rb
@@ -19,22 +19,22 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The project whose groups are to be listed. The format is
-      #     +"projects/{project_id_or_number}"+.
+      #     +"projects/\\{project_id_or_number}"+.
       # @!attribute [rw] children_of_group
       #   @return [String]
-      #     A group name: +"projects/{project_id_or_number}/groups/{group_id}"+.
+      #     A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
       #     Returns groups whose +parentName+ field contains the group
       #     name.  If no groups have this parent, the results are empty.
       # @!attribute [rw] ancestors_of_group
       #   @return [String]
-      #     A group name: +"projects/{project_id_or_number}/groups/{group_id}"+.
+      #     A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
       #     Returns groups that are ancestors of the specified group.
       #     The groups are returned in order, starting with the immediate parent and
       #     ending with the most distant ancestor.  If the specified group has no
       #     immediate parent, the results are empty.
       # @!attribute [rw] descendants_of_group
       #   @return [String]
-      #     A group name: +"projects/{project_id_or_number}/groups/{group_id}"+.
+      #     A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
       #     Returns the descendants of the specified group.  This is a superset of
       #     the results returned by the +childrenOfGroup+ filter, and includes
       #     children-of-children, and so forth.
@@ -63,14 +63,14 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The group to retrieve. The format is
-      #     +"projects/{project_id_or_number}/groups/{group_id}"+.
+      #     +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
       class GetGroupRequest; end
 
       # The +CreateGroup+ request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project in which to create the group. The format is
-      #     +"projects/{project_id_or_number}"+.
+      #     +"projects/\\{project_id_or_number}"+.
       # @!attribute [rw] group
       #   @return [Google::Monitoring::V3::Group]
       #     A group definition. It is an error to define the +name+ field because
@@ -94,14 +94,14 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The group to delete. The format is
-      #     +"projects/{project_id_or_number}/groups/{group_id}"+.
+      #     +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
       class DeleteGroupRequest; end
 
       # The +ListGroupMembers+ request.
       # @!attribute [rw] name
       #   @return [String]
       #     The group whose members are listed. The format is
-      #     +"projects/{project_id_or_number}/groups/{group_id}"+.
+      #     +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     A positive number that is the maximum number of results to return.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric_service.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric_service.rb
@@ -19,7 +19,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     +"projects/{project_id_or_number}"+.
+      #     +"projects/\\{project_id_or_number}"+.
       # @!attribute [rw] filter
       #   @return [String]
       #     An optional [filter](https://cloud.google.com/monitoring/api/v3/filters) describing
@@ -55,8 +55,8 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The monitored resource descriptor to get.  The format is
-      #     +"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"+.
-      #     The +{resource_type}+ is a predefined type, such as
+      #     +"projects/\\{project_id_or_number}/monitoredResourceDescriptors/\\{resource_type}"+.
+      #     The +\\{resource_type}+ is a predefined type, such as
       #     +cloudsql_database+.
       class GetMonitoredResourceDescriptorRequest; end
 
@@ -64,7 +64,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     +"projects/{project_id_or_number}"+.
+      #     +"projects/\\{project_id_or_number}"+.
       # @!attribute [rw] filter
       #   @return [String]
       #     If this field is empty, all custom and
@@ -101,8 +101,8 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The metric descriptor on which to execute the request. The format is
-      #     +"projects/{project_id_or_number}/metricDescriptors/{metric_id}"+.
-      #     An example value of +{metric_id}+ is
+      #     +"projects/\\{project_id_or_number}/metricDescriptors/\\{metric_id}"+.
+      #     An example value of +\\{metric_id}+ is
       #     +"compute.googleapis.com/instance/disk/read_bytes_count"+.
       class GetMetricDescriptorRequest; end
 
@@ -110,7 +110,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     +"projects/{project_id_or_number}"+.
+      #     +"projects/\\{project_id_or_number}"+.
       # @!attribute [rw] metric_descriptor
       #   @return [Google::Api::MetricDescriptor]
       #     The new [custom metric](https://cloud.google.com/monitoring/custom-metrics)
@@ -121,8 +121,8 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The metric descriptor on which to execute the request. The format is
-      #     +"projects/{project_id_or_number}/metricDescriptors/{metric_id}"+.
-      #     An example of +{metric_id}+ is:
+      #     +"projects/\\{project_id_or_number}/metricDescriptors/\\{metric_id}"+.
+      #     An example of +\\{metric_id}+ is:
       #     +"custom.googleapis.com/my_test_metric"+.
       class DeleteMetricDescriptorRequest; end
 
@@ -130,7 +130,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     "projects/{project_id_or_number}".
+      #     "projects/\\{project_id_or_number}".
       # @!attribute [rw] filter
       #   @return [String]
       #     A [monitoring filter](https://cloud.google.com/monitoring/api/v3/filters) that specifies which time
@@ -201,7 +201,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     +"projects/{project_id_or_number}"+.
+      #     +"projects/\\{project_id_or_number}"+.
       # @!attribute [rw] time_series
       #   @return [Array<Google::Monitoring::V3::TimeSeries>]
       #     The new data to be added to a list of time series.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/notification_service.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/notification_service.rb
@@ -56,7 +56,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The channel type for which to execute the request. The format is
-      #     +projects/[PROJECT_ID]/notificationChannelDescriptors/{channel_type}+.
+      #     +projects/[PROJECT_ID]/notificationChannelDescriptors/\\{channel_type}+.
       class GetNotificationChannelDescriptorRequest; end
 
       # The +CreateNotificationChannel+ request.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
@@ -256,19 +256,19 @@ module Google
           #
           # @param name [String]
           #   The project whose groups are to be listed. The format is
-          #   +"projects/{project_id_or_number}"+.
+          #   +"projects/\\{project_id_or_number}"+.
           # @param children_of_group [String]
-          #   A group name: +"projects/{project_id_or_number}/groups/{group_id}"+.
+          #   A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
           #   Returns groups whose +parentName+ field contains the group
           #   name.  If no groups have this parent, the results are empty.
           # @param ancestors_of_group [String]
-          #   A group name: +"projects/{project_id_or_number}/groups/{group_id}"+.
+          #   A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
           #   Returns groups that are ancestors of the specified group.
           #   The groups are returned in order, starting with the immediate parent and
           #   ending with the most distant ancestor.  If the specified group has no
           #   immediate parent, the results are empty.
           # @param descendants_of_group [String]
-          #   A group name: +"projects/{project_id_or_number}/groups/{group_id}"+.
+          #   A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
           #   Returns the descendants of the specified group.  This is a superset of
           #   the results returned by the +childrenOfGroup+ filter, and includes
           #   children-of-children, and so forth.
@@ -332,7 +332,7 @@ module Google
           #
           # @param name [String]
           #   The group to retrieve. The format is
-          #   +"projects/{project_id_or_number}/groups/{group_id}"+.
+          #   +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -363,7 +363,7 @@ module Google
           #
           # @param name [String]
           #   The project in which to create the group. The format is
-          #   +"projects/{project_id_or_number}"+.
+          #   +"projects/\\{project_id_or_number}"+.
           # @param group [Google::Monitoring::V3::Group | Hash]
           #   A group definition. It is an error to define the +name+ field because
           #   the system assigns the name.
@@ -448,7 +448,7 @@ module Google
           #
           # @param name [String]
           #   The group to delete. The format is
-          #   +"projects/{project_id_or_number}/groups/{group_id}"+.
+          #   +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -479,7 +479,7 @@ module Google
           #
           # @param name [String]
           #   The group whose members are listed. The format is
-          #   +"projects/{project_id_or_number}/groups/{group_id}"+.
+          #   +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
@@ -277,7 +277,7 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   +"projects/{project_id_or_number}"+.
+          #   +"projects/\\{project_id_or_number}"+.
           # @param filter [String]
           #   An optional [filter](https://cloud.google.com/monitoring/api/v3/filters) describing
           #   the descriptors to be returned.  The filter can reference
@@ -342,8 +342,8 @@ module Google
           #
           # @param name [String]
           #   The monitored resource descriptor to get.  The format is
-          #   +"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"+.
-          #   The +{resource_type}+ is a predefined type, such as
+          #   +"projects/\\{project_id_or_number}/monitoredResourceDescriptors/\\{resource_type}"+.
+          #   The +\\{resource_type}+ is a predefined type, such as
           #   +cloudsql_database+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -375,7 +375,7 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   +"projects/{project_id_or_number}"+.
+          #   +"projects/\\{project_id_or_number}"+.
           # @param filter [String]
           #   If this field is empty, all custom and
           #   system-defined metric descriptors are returned.
@@ -441,8 +441,8 @@ module Google
           #
           # @param name [String]
           #   The metric descriptor on which to execute the request. The format is
-          #   +"projects/{project_id_or_number}/metricDescriptors/{metric_id}"+.
-          #   An example value of +{metric_id}+ is
+          #   +"projects/\\{project_id_or_number}/metricDescriptors/\\{metric_id}"+.
+          #   An example value of +\\{metric_id}+ is
           #   +"compute.googleapis.com/instance/disk/read_bytes_count"+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -476,7 +476,7 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   +"projects/{project_id_or_number}"+.
+          #   +"projects/\\{project_id_or_number}"+.
           # @param metric_descriptor [Google::Api::MetricDescriptor | Hash]
           #   The new [custom metric](https://cloud.google.com/monitoring/custom-metrics)
           #   descriptor.
@@ -518,8 +518,8 @@ module Google
           #
           # @param name [String]
           #   The metric descriptor on which to execute the request. The format is
-          #   +"projects/{project_id_or_number}/metricDescriptors/{metric_id}"+.
-          #   An example of +{metric_id}+ is:
+          #   +"projects/\\{project_id_or_number}/metricDescriptors/\\{metric_id}"+.
+          #   An example of +\\{metric_id}+ is:
           #   +"custom.googleapis.com/my_test_metric"+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -551,7 +551,7 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   "projects/{project_id_or_number}".
+          #   "projects/\\{project_id_or_number}".
           # @param filter [String]
           #   A [monitoring filter](https://cloud.google.com/monitoring/api/v3/filters) that specifies which time
           #   series should be returned.  The filter must specify a single metric type,
@@ -653,7 +653,7 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   +"projects/{project_id_or_number}"+.
+          #   +"projects/\\{project_id_or_number}"+.
           # @param time_series [Array<Google::Monitoring::V3::TimeSeries | Hash>]
           #   The new data to be added to a list of time series.
           #   Adds at most one data point to each of several time series.  The new data

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
@@ -332,7 +332,7 @@ module Google
           #
           # @param name [String]
           #   The channel type for which to execute the request. The format is
-          #   +projects/[PROJECT_ID]/notificationChannelDescriptors/{channel_type}+.
+          #   +projects/[PROJECT_ID]/notificationChannelDescriptors/\\{channel_type}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -46,3 +46,16 @@ s.replace(
     'google-cloud-monitoring.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"',
     '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.2"')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/monitoring/v3/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -56,6 +56,6 @@ def escape_braces(match):
         if count == 0:
             return content
 s.replace(
-    'lib/google/cloud/monitoring/v3/**/*.rb',
+    'lib/google/cloud/**/*.rb',
     '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
     escape_braces)

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1/doc/google/cloud/oslogin/v1/oslogin.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1/doc/google/cloud/oslogin/v1/oslogin.rb
@@ -38,7 +38,7 @@ module Google
         #   @return [String]
         #     A reference to the POSIX account to update. POSIX accounts are identified
         #     by the project ID they are associated with. A reference to the POSIX
-        #     account is in format +users/{user}/projects/{project}+.
+        #     account is in format +users/\\{user}/projects/\\{project}+.
         class DeletePosixAccountRequest; end
 
         # A request message for deleting an SSH public key.
@@ -46,13 +46,13 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to update. Public keys are identified by
         #     their SHA-256 fingerprint. The fingerprint of the public key is in format
-        #     +users/{user}/sshPublicKeys/{fingerprint}+.
+        #     +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
         class DeleteSshPublicKeyRequest; end
 
         # A request message for retrieving the login profile information for a user.
         # @!attribute [rw] name
         #   @return [String]
-        #     The unique ID for the user in format +users/{user}+.
+        #     The unique ID for the user in format +users/\\{user}+.
         class GetLoginProfileRequest; end
 
         # A request message for retrieving an SSH public key.
@@ -60,13 +60,13 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to retrieve. Public keys are identified
         #     by their SHA-256 fingerprint. The fingerprint of the public key is in
-        #     format +users/{user}/sshPublicKeys/{fingerprint}+.
+        #     format +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
         class GetSshPublicKeyRequest; end
 
         # A request message for importing an SSH public key.
         # @!attribute [rw] parent
         #   @return [String]
-        #     The unique ID for the user in format +users/{user}+.
+        #     The unique ID for the user in format +users/\\{user}+.
         # @!attribute [rw] ssh_public_key
         #   @return [Google::Cloud::Oslogin::Common::SshPublicKey]
         #     The SSH public key and expiration time.
@@ -86,7 +86,7 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to update. Public keys are identified by
         #     their SHA-256 fingerprint. The fingerprint of the public key is in format
-        #     +users/{user}/sshPublicKeys/{fingerprint}+.
+        #     +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
         # @!attribute [rw] ssh_public_key
         #   @return [Google::Cloud::Oslogin::Common::SshPublicKey]
         #     The SSH public key and expiration time.

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1/os_login_service_client.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1/os_login_service_client.rb
@@ -252,7 +252,7 @@ module Google
           # @param name [String]
           #   A reference to the POSIX account to update. POSIX accounts are identified
           #   by the project ID they are associated with. A reference to the POSIX
-          #   account is in format +users/{user}/projects/{project}+.
+          #   account is in format +users/\\{user}/projects/\\{project}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -284,7 +284,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to update. Public keys are identified by
           #   their SHA-256 fingerprint. The fingerprint of the public key is in format
-          #   +users/{user}/sshPublicKeys/{fingerprint}+.
+          #   +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -315,7 +315,7 @@ module Google
           # on Google Compute Engine.
           #
           # @param name [String]
-          #   The unique ID for the user in format +users/{user}+.
+          #   The unique ID for the user in format +users/\\{user}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -347,7 +347,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to retrieve. Public keys are identified
           #   by their SHA-256 fingerprint. The fingerprint of the public key is in
-          #   format +users/{user}/sshPublicKeys/{fingerprint}+.
+          #   format +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -379,7 +379,7 @@ module Google
           # login profile.
           #
           # @param parent [String]
-          #   The unique ID for the user in format +users/{user}+.
+          #   The unique ID for the user in format +users/\\{user}+.
           # @param ssh_public_key [Google::Cloud::Oslogin::Common::SshPublicKey | Hash]
           #   The SSH public key and expiration time.
           #   A hash of the same form as `Google::Cloud::Oslogin::Common::SshPublicKey`
@@ -425,7 +425,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to update. Public keys are identified by
           #   their SHA-256 fingerprint. The fingerprint of the public key is in format
-          #   +users/{user}/sshPublicKeys/{fingerprint}+.
+          #   +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
           # @param ssh_public_key [Google::Cloud::Oslogin::Common::SshPublicKey | Hash]
           #   The SSH public key and expiration time.
           #   A hash of the same form as `Google::Cloud::Oslogin::Common::SshPublicKey`

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta/doc/google/cloud/oslogin/v1beta/oslogin.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta/doc/google/cloud/oslogin/v1beta/oslogin.rb
@@ -38,7 +38,7 @@ module Google
         #   @return [String]
         #     A reference to the POSIX account to update. POSIX accounts are identified
         #     by the project ID they are associated with. A reference to the POSIX
-        #     account is in format +users/{user}/projects/{project}+.
+        #     account is in format +users/\\{user}/projects/\\{project}+.
         class DeletePosixAccountRequest; end
 
         # A request message for deleting an SSH public key.
@@ -46,13 +46,13 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to update. Public keys are identified by
         #     their SHA-256 fingerprint. The fingerprint of the public key is in format
-        #     +users/{user}/sshPublicKeys/{fingerprint}+.
+        #     +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
         class DeleteSshPublicKeyRequest; end
 
         # A request message for retrieving the login profile information for a user.
         # @!attribute [rw] name
         #   @return [String]
-        #     The unique ID for the user in format +users/{user}+.
+        #     The unique ID for the user in format +users/\\{user}+.
         class GetLoginProfileRequest; end
 
         # A request message for retrieving an SSH public key.
@@ -60,13 +60,13 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to retrieve. Public keys are identified
         #     by their SHA-256 fingerprint. The fingerprint of the public key is in
-        #     format +users/{user}/sshPublicKeys/{fingerprint}+.
+        #     format +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
         class GetSshPublicKeyRequest; end
 
         # A request message for importing an SSH public key.
         # @!attribute [rw] parent
         #   @return [String]
-        #     The unique ID for the user in format +users/{user}+.
+        #     The unique ID for the user in format +users/\\{user}+.
         # @!attribute [rw] ssh_public_key
         #   @return [Google::Cloud::Oslogin::Common::SshPublicKey]
         #     The SSH public key and expiration time.
@@ -86,7 +86,7 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to update. Public keys are identified by
         #     their SHA-256 fingerprint. The fingerprint of the public key is in format
-        #     +users/{user}/sshPublicKeys/{fingerprint}+.
+        #     +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
         # @!attribute [rw] ssh_public_key
         #   @return [Google::Cloud::Oslogin::Common::SshPublicKey]
         #     The SSH public key and expiration time.

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta/os_login_service_client.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta/os_login_service_client.rb
@@ -252,7 +252,7 @@ module Google
           # @param name [String]
           #   A reference to the POSIX account to update. POSIX accounts are identified
           #   by the project ID they are associated with. A reference to the POSIX
-          #   account is in format +users/{user}/projects/{project}+.
+          #   account is in format +users/\\{user}/projects/\\{project}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -284,7 +284,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to update. Public keys are identified by
           #   their SHA-256 fingerprint. The fingerprint of the public key is in format
-          #   +users/{user}/sshPublicKeys/{fingerprint}+.
+          #   +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -315,7 +315,7 @@ module Google
           # on Google Compute Engine.
           #
           # @param name [String]
-          #   The unique ID for the user in format +users/{user}+.
+          #   The unique ID for the user in format +users/\\{user}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -347,7 +347,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to retrieve. Public keys are identified
           #   by their SHA-256 fingerprint. The fingerprint of the public key is in
-          #   format +users/{user}/sshPublicKeys/{fingerprint}+.
+          #   format +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -379,7 +379,7 @@ module Google
           # login profile.
           #
           # @param parent [String]
-          #   The unique ID for the user in format +users/{user}+.
+          #   The unique ID for the user in format +users/\\{user}+.
           # @param ssh_public_key [Google::Cloud::Oslogin::Common::SshPublicKey | Hash]
           #   The SSH public key and expiration time.
           #   A hash of the same form as `Google::Cloud::Oslogin::Common::SshPublicKey`
@@ -425,7 +425,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to update. Public keys are identified by
           #   their SHA-256 fingerprint. The fingerprint of the public key is in format
-          #   +users/{user}/sshPublicKeys/{fingerprint}+.
+          #   +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
           # @param ssh_public_key [Google::Cloud::Oslogin::Common::SshPublicKey | Hash]
           #   The SSH public key and expiration time.
           #   A hash of the same form as `Google::Cloud::Oslogin::Common::SshPublicKey`

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -82,9 +82,6 @@ def escape_braces(match):
         if count == 0:
             return content
 s.replace(
-    [
-      'lib/google/cloud/os_login/v1/**/*.rb',
-      'lib/google/cloud/os_login/v1beta/**/*.rb'
-    ],
+    'lib/google/cloud/**/*.rb',
     '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
     escape_braces)

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -72,3 +72,19 @@ s.replace(
     ],
     '\\[Product Documentation\\]: https://cloud\\.google\\.com/os-login\n',
     '[Product Documentation]: https://cloud.google.com/compute/docs/oslogin/rest/\n')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    [
+      'lib/google/cloud/os_login/v1/**/*.rb',
+      'lib/google/cloud/os_login/v1beta/**/*.rb'
+    ],
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/iam_policy.rb
@@ -20,7 +20,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
       #     REQUIRED: The complete policy to be applied to the +resource+. The size of
@@ -34,7 +34,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       class GetIamPolicyRequest; end
 
       # Request message for +TestIamPermissions+ method.
@@ -42,7 +42,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
       #     The set of permissions to check for the +resource+. Permissions with

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/policy.rb
@@ -85,17 +85,17 @@ module Google
       #     * +allAuthenticatedUsers+: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:{emailid}+: An email address that represents a specific Google
+      #     * +user:\\{emailid}+: An email address that represents a specific Google
       #       account. For example, +alice@gmail.com+ or +joe@example.com+.
       #
       #
-      #     * +serviceAccount:{emailid}+: An email address that represents a service
+      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
       #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
       #
-      #     * +group:{emailid}+: An email address that represents a Google group.
+      #     * +group:\\{emailid}+: An email address that represents a Google group.
       #       For example, +admins@example.com+.
       #
-      #     * +domain:{domain}+: A Google Apps domain name that represents all the
+      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
       #       users of that domain. For example, +google.com+ or +example.com+.
       class Binding; end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
@@ -29,7 +29,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The name of the topic. It must have the format
-      #     +"projects/{project}/topics/{topic}"+. +{topic}+ must start with a letter,
+      #     +"projects/\\{project}/topics/\\{topic}"+. +\\{topic}+ must start with a letter,
       #     and contain only letters (+[A-Za-z]+), numbers (+[0-9]+), dashes (+-+),
       #     underscores (+_+), periods (+.+), tildes (+~+), plus (+++) or percent
       #     signs (+%+). It must be between 3 and 255 characters in length, and it
@@ -72,7 +72,7 @@ module Google
       # @!attribute [rw] topic
       #   @return [String]
       #     The name of the topic to get.
-      #     Format is +projects/{project}/topics/{topic}+.
+      #     Format is +projects/\\{project}/topics/\\{topic}+.
       class GetTopicRequest; end
 
       # Request for the UpdateTopic method.
@@ -92,7 +92,7 @@ module Google
       # @!attribute [rw] topic
       #   @return [String]
       #     The messages in the request will be published on this topic.
-      #     Format is +projects/{project}/topics/{topic}+.
+      #     Format is +projects/\\{project}/topics/\\{topic}+.
       # @!attribute [rw] messages
       #   @return [Array<Google::Pubsub::V1::PubsubMessage>]
       #     The messages to publish.
@@ -110,7 +110,7 @@ module Google
       # @!attribute [rw] project
       #   @return [String]
       #     The name of the cloud project that topics belong to.
-      #     Format is +projects/{project}+.
+      #     Format is +projects/\\{project}+.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of topics to return.
@@ -135,7 +135,7 @@ module Google
       # @!attribute [rw] topic
       #   @return [String]
       #     The name of the topic that subscriptions are attached to.
-      #     Format is +projects/{project}/topics/{topic}+.
+      #     Format is +projects/\\{project}/topics/\\{topic}+.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of subscription names to return.
@@ -164,7 +164,7 @@ module Google
       # @!attribute [rw] topic
       #   @return [String]
       #     The name of the topic that snapshots are attached to.
-      #     Format is +projects/{project}/topics/{topic}+.
+      #     Format is +projects/\\{project}/topics/\\{topic}+.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of snapshot names to return.
@@ -193,14 +193,14 @@ module Google
       # @!attribute [rw] topic
       #   @return [String]
       #     Name of the topic to delete.
-      #     Format is +projects/{project}/topics/{topic}+.
+      #     Format is +projects/\\{project}/topics/\\{topic}+.
       class DeleteTopicRequest; end
 
       # A subscription resource.
       # @!attribute [rw] name
       #   @return [String]
       #     The name of the subscription. It must have the format
-      #     +"projects/{project}/subscriptions/{subscription}"+. +{subscription}+ must
+      #     +"projects/\\{project}/subscriptions/\\{subscription}"+. +\\{subscription}+ must
       #     start with a letter, and contain only letters (+[A-Za-z]+), numbers
       #     (+[0-9]+), dashes (+-+), underscores (+_+), periods (+.+), tildes (+~+),
       #     plus (+++) or percent signs (+%+). It must be between 3 and 255 characters
@@ -208,7 +208,7 @@ module Google
       # @!attribute [rw] topic
       #   @return [String]
       #     The name of the topic from which this subscription is receiving messages.
-      #     Format is +projects/{project}/topics/{topic}+.
+      #     Format is +projects/\\{project}/topics/\\{topic}+.
       #     The value of this field will be +_deleted-topic_+ if the topic has been
       #     deleted.
       # @!attribute [rw] push_config
@@ -306,7 +306,7 @@ module Google
       # @!attribute [rw] subscription
       #   @return [String]
       #     The name of the subscription to get.
-      #     Format is +projects/{project}/subscriptions/{sub}+.
+      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
       class GetSubscriptionRequest; end
 
       # Request for the UpdateSubscription method.
@@ -323,7 +323,7 @@ module Google
       # @!attribute [rw] project
       #   @return [String]
       #     The name of the cloud project that subscriptions belong to.
-      #     Format is +projects/{project}+.
+      #     Format is +projects/\\{project}+.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of subscriptions to return.
@@ -349,14 +349,14 @@ module Google
       # @!attribute [rw] subscription
       #   @return [String]
       #     The subscription to delete.
-      #     Format is +projects/{project}/subscriptions/{sub}+.
+      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
       class DeleteSubscriptionRequest; end
 
       # Request for the ModifyPushConfig method.
       # @!attribute [rw] subscription
       #   @return [String]
       #     The name of the subscription.
-      #     Format is +projects/{project}/subscriptions/{sub}+.
+      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
       # @!attribute [rw] push_config
       #   @return [Google::Pubsub::V1::PushConfig]
       #     The push configuration for future deliveries.
@@ -371,7 +371,7 @@ module Google
       # @!attribute [rw] subscription
       #   @return [String]
       #     The subscription from which messages should be pulled.
-      #     Format is +projects/{project}/subscriptions/{sub}+.
+      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
       # @!attribute [rw] return_immediately
       #   @return [true, false]
       #     If this field set to true, the system will respond immediately even if
@@ -399,7 +399,7 @@ module Google
       # @!attribute [rw] subscription
       #   @return [String]
       #     The name of the subscription.
-      #     Format is +projects/{project}/subscriptions/{sub}+.
+      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
       # @!attribute [rw] ack_ids
       #   @return [Array<String>]
       #     List of acknowledgment IDs.
@@ -418,7 +418,7 @@ module Google
       # @!attribute [rw] subscription
       #   @return [String]
       #     The subscription whose message is being acknowledged.
-      #     Format is +projects/{project}/subscriptions/{sub}+.
+      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
       # @!attribute [rw] ack_ids
       #   @return [Array<String>]
       #     The acknowledgment ID for the messages being acknowledged that was returned
@@ -433,7 +433,7 @@ module Google
       #     The subscription for which to initialize the new stream. This must be
       #     provided in the first request on the stream, and must not be set in
       #     subsequent requests from client to server.
-      #     Format is +projects/{project}/subscriptions/{sub}+.
+      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
       # @!attribute [rw] ack_ids
       #   @return [Array<String>]
       #     List of acknowledgement IDs for acknowledging previously received messages
@@ -486,7 +486,7 @@ module Google
       #     If the name is not provided in the request, the server will assign a random
       #     name for this snapshot on the same project as the subscription.
       #     Note that for REST API requests, you must specify a name.
-      #     Format is +projects/{project}/snapshots/{snap}+.
+      #     Format is +projects/\\{project}/snapshots/\\{snap}+.
       # @!attribute [rw] subscription
       #   @return [String]
       #     The subscription whose backlog the snapshot retains.
@@ -497,7 +497,7 @@ module Google
       #          +CreateSnapshot+ request; as well as:
       #      (b) Any messages published to the subscription's topic following the
       #          successful completion of the CreateSnapshot request.
-      #     Format is +projects/{project}/subscriptions/{sub}+.
+      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
       # @!attribute [rw] labels
       #   @return [Hash{String => String}]
       #     User labels.
@@ -550,7 +550,7 @@ module Google
       # @!attribute [rw] snapshot
       #   @return [String]
       #     The name of the snapshot to get.
-      #     Format is +projects/{project}/snapshots/{snap}+.
+      #     Format is +projects/\\{project}/snapshots/\\{snap}+.
       class GetSnapshotRequest; end
 
       # Request for the +ListSnapshots+ method.<br><br>
@@ -560,7 +560,7 @@ module Google
       # @!attribute [rw] project
       #   @return [String]
       #     The name of the cloud project that snapshots belong to.
-      #     Format is +projects/{project}+.
+      #     Format is +projects/\\{project}+.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of snapshots to return.
@@ -591,7 +591,7 @@ module Google
       # @!attribute [rw] snapshot
       #   @return [String]
       #     The name of the snapshot to delete.
-      #     Format is +projects/{project}/snapshots/{snap}+.
+      #     Format is +projects/\\{project}/snapshots/\\{snap}+.
       class DeleteSnapshotRequest; end
 
       # Request for the +Seek+ method.<br><br>
@@ -618,7 +618,7 @@ module Google
       #   @return [String]
       #     The snapshot to seek to. The snapshot's topic must be the same as that of
       #     the provided subscription.
-      #     Format is +projects/{project}/snapshots/{snap}+.
+      #     Format is +projects/\\{project}/snapshots/\\{snap}+.
       class SeekRequest; end
 
       class SeekResponse; end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
@@ -291,7 +291,7 @@ module Google
           #
           # @param name [String]
           #   The name of the topic. It must have the format
-          #   +"projects/{project}/topics/{topic}"+. +{topic}+ must start with a letter,
+          #   +"projects/\\{project}/topics/\\{topic}"+. +\\{topic}+ must start with a letter,
           #   and contain only letters (+[A-Za-z]+), numbers (+[0-9]+), dashes (+-+),
           #   underscores (+_+), periods (+.+), tildes (+~+), plus (+++) or percent
           #   signs (+%+). It must be between 3 and 255 characters in length, and it
@@ -391,7 +391,7 @@ module Google
           #
           # @param topic [String]
           #   The messages in the request will be published on this topic.
-          #   Format is +projects/{project}/topics/{topic}+.
+          #   Format is +projects/\\{project}/topics/\\{topic}+.
           # @param messages [Array<Google::Pubsub::V1::PubsubMessage | Hash>]
           #   The messages to publish.
           #   A hash of the same form as `Google::Pubsub::V1::PubsubMessage`
@@ -431,7 +431,7 @@ module Google
           #
           # @param topic [String]
           #   The name of the topic to get.
-          #   Format is +projects/{project}/topics/{topic}+.
+          #   Format is +projects/\\{project}/topics/\\{topic}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -462,7 +462,7 @@ module Google
           #
           # @param project [String]
           #   The name of the cloud project that topics belong to.
-          #   Format is +projects/{project}+.
+          #   Format is +projects/\\{project}+.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -517,7 +517,7 @@ module Google
           #
           # @param topic [String]
           #   The name of the topic that subscriptions are attached to.
-          #   Format is +projects/{project}/topics/{topic}+.
+          #   Format is +projects/\\{project}/topics/\\{topic}+.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -576,7 +576,7 @@ module Google
           #
           # @param topic [String]
           #   Name of the topic to delete.
-          #   Format is +projects/{project}/topics/{topic}+.
+          #   Format is +projects/\\{project}/topics/\\{topic}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -609,7 +609,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being specified.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param policy [Google::Iam::V1::Policy | Hash]
           #   REQUIRED: The complete policy to be applied to the +resource+. The size of
           #   the policy is limited to a few 10s of KB. An empty policy is a
@@ -655,7 +655,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -689,7 +689,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy detail is being requested.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param permissions [Array<String>]
           #   The set of permissions to check for the +resource+. Permissions with
           #   wildcards (such as '*' or 'storage.*') are not allowed. For more

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
@@ -363,14 +363,14 @@ module Google
           #
           # @param name [String]
           #   The name of the subscription. It must have the format
-          #   +"projects/{project}/subscriptions/{subscription}"+. +{subscription}+ must
+          #   +"projects/\\{project}/subscriptions/\\{subscription}"+. +\\{subscription}+ must
           #   start with a letter, and contain only letters (+[A-Za-z]+), numbers
           #   (+[0-9]+), dashes (+-+), underscores (+_+), periods (+.+), tildes (+~+),
           #   plus (+++) or percent signs (+%+). It must be between 3 and 255 characters
           #   in length, and it must not start with +"goog"+
           # @param topic [String]
           #   The name of the topic from which this subscription is receiving messages.
-          #   Format is +projects/{project}/topics/{topic}+.
+          #   Format is +projects/\\{project}/topics/\\{topic}+.
           #   The value of this field will be +_deleted-topic_+ if the topic has been
           #   deleted.
           # @param push_config [Google::Pubsub::V1::PushConfig | Hash]
@@ -465,7 +465,7 @@ module Google
           #
           # @param subscription [String]
           #   The name of the subscription to get.
-          #   Format is +projects/{project}/subscriptions/{sub}+.
+          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -540,7 +540,7 @@ module Google
           #
           # @param project [String]
           #   The name of the cloud project that subscriptions belong to.
-          #   Format is +projects/{project}+.
+          #   Format is +projects/\\{project}+.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -599,7 +599,7 @@ module Google
           #
           # @param subscription [String]
           #   The subscription to delete.
-          #   Format is +projects/{project}/subscriptions/{sub}+.
+          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -634,7 +634,7 @@ module Google
           #
           # @param subscription [String]
           #   The name of the subscription.
-          #   Format is +projects/{project}/subscriptions/{sub}+.
+          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
           # @param ack_ids [Array<String>]
           #   List of acknowledgment IDs.
           # @param ack_deadline_seconds [Integer]
@@ -691,7 +691,7 @@ module Google
           #
           # @param subscription [String]
           #   The subscription whose message is being acknowledged.
-          #   Format is +projects/{project}/subscriptions/{sub}+.
+          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
           # @param ack_ids [Array<String>]
           #   The acknowledgment ID for the messages being acknowledged that was returned
           #   by the Pub/Sub system in the +Pull+ response. Must not be empty.
@@ -733,7 +733,7 @@ module Google
           #
           # @param subscription [String]
           #   The subscription from which messages should be pulled.
-          #   Format is +projects/{project}/subscriptions/{sub}+.
+          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
           # @param max_messages [Integer]
           #   The maximum number of messages returned for this request. The Pub/Sub
           #   system may return fewer than the number specified.
@@ -830,7 +830,7 @@ module Google
           #
           # @param subscription [String]
           #   The name of the subscription.
-          #   Format is +projects/{project}/subscriptions/{sub}+.
+          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
           # @param push_config [Google::Pubsub::V1::PushConfig | Hash]
           #   The push configuration for future deliveries.
           #
@@ -878,7 +878,7 @@ module Google
           #
           # @param project [String]
           #   The name of the cloud project that snapshots belong to.
-          #   Format is +projects/{project}+.
+          #   Format is +projects/\\{project}+.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -950,7 +950,7 @@ module Google
           #   If the name is not provided in the request, the server will assign a random
           #   name for this snapshot on the same project as the subscription.
           #   Note that for REST API requests, you must specify a name.
-          #   Format is +projects/{project}/snapshots/{snap}+.
+          #   Format is +projects/\\{project}/snapshots/\\{snap}+.
           # @param subscription [String]
           #   The subscription whose backlog the snapshot retains.
           #   Specifically, the created snapshot is guaranteed to retain:
@@ -960,7 +960,7 @@ module Google
           #        +CreateSnapshot+ request; as well as:
           #    (b) Any messages published to the subscription's topic following the
           #        successful completion of the CreateSnapshot request.
-          #   Format is +projects/{project}/subscriptions/{sub}+.
+          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
           # @param labels [Hash{String => String}]
           #   User labels.
           # @param options [Google::Gax::CallOptions]
@@ -1053,7 +1053,7 @@ module Google
           #
           # @param snapshot [String]
           #   The name of the snapshot to delete.
-          #   Format is +projects/{project}/snapshots/{snap}+.
+          #   Format is +projects/\\{project}/snapshots/\\{snap}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1105,7 +1105,7 @@ module Google
           # @param snapshot [String]
           #   The snapshot to seek to. The snapshot's topic must be the same as that of
           #   the provided subscription.
-          #   Format is +projects/{project}/snapshots/{snap}+.
+          #   Format is +projects/\\{project}/snapshots/\\{snap}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1142,7 +1142,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being specified.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param policy [Google::Iam::V1::Policy | Hash]
           #   REQUIRED: The complete policy to be applied to the +resource+. The size of
           #   the policy is limited to a few 10s of KB. An empty policy is a
@@ -1188,7 +1188,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1222,7 +1222,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy detail is being requested.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param permissions [Array<String>]
           #   The set of permissions to check for the +resource+. Permissions with
           #   wildcards (such as '*' or 'storage.*') are not allowed. For more

--- a/google-cloud-pubsub/synth.py
+++ b/google-cloud-pubsub/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import logging
 import os
+import re
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -43,3 +44,16 @@ s.replace(
     'lib/google/cloud/pubsub/v1/credentials.rb',
     'SCOPE = \[[^\]]+\]\.freeze',
     'SCOPE = ["https://www.googleapis.com/auth/pubsub"].freeze')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/pubsub/v1/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-redis/lib/google/cloud/redis.rb
+++ b/google-cloud-redis/lib/google/cloud/redis.rb
@@ -93,7 +93,7 @@ module Google
       # * Each project has a collection of available locations, named: +/locations/*+
       # * Each location has a collection of Redis instances, named: +/instances/*+
       # * As such, Redis instances are resources of the form:
-      #   +/projects/{project_id}/locations/{location_id}/instances/{instance_id}+
+      #   +/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
       #
       # Note that location_id must be refering to a GCP +region+; for example:
       # * +projects/redpepper-1290/locations/us-central1/instances/my-redis+

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
@@ -86,7 +86,7 @@ module Google
         # * Each project has a collection of available locations, named: +/locations/*+
         # * Each location has a collection of Redis instances, named: +/instances/*+
         # * As such, Redis instances are resources of the form:
-        #   +/projects/{project_id}/locations/{location_id}/instances/{instance_id}+
+        #   +/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
         #
         # Note that location_id must be refering to a GCP +region+; for example:
         # * +projects/redpepper-1290/locations/us-central1/instances/my-redis+

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_client.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_client.rb
@@ -44,7 +44,7 @@ module Google
         # * Each project has a collection of available locations, named: +/locations/*+
         # * Each location has a collection of Redis instances, named: +/instances/*+
         # * As such, Redis instances are resources of the form:
-        #   +/projects/{project_id}/locations/{location_id}/instances/{instance_id}+
+        #   +/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
         #
         # Note that location_id must be refering to a GCP +region+; for example:
         # * +projects/redpepper-1290/locations/us-central1/instances/my-redis+
@@ -267,14 +267,14 @@ module Google
           # location (region) or all locations.
           #
           # The location should have the following format:
-          # * +projects/{project_id}/locations/{location_id}+
+          # * +projects/\\{project_id}/locations/\\{location_id}+
           #
           # If +location_id+ is specified as +-+ (wildcard), then all regions
           # available to the project are queried, and the results are aggregated.
           #
           # @param parent [String]
           #   Required. The resource name of the instance location using the form:
-          #       +projects/{project_id}/locations/{location_id}+
+          #       +projects/\\{project_id}/locations/\\{location_id}+
           #   where +location_id+ refers to a GCP region
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
@@ -330,7 +330,7 @@ module Google
           #
           # @param name [String]
           #   Required. Redis instance resource name using the form:
-          #       +projects/{project_id}/locations/{location_id}/instances/{instance_id}+
+          #       +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
           #   where +location_id+ refers to a GCP region
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -373,7 +373,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The resource name of the instance location using the form:
-          #       +projects/{project_id}/locations/{location_id}+
+          #       +projects/\\{project_id}/locations/\\{location_id}+
           #   where +location_id+ refers to a GCP region
           # @param instance_id [String]
           #   Required. The logical name of the Redis instance in the customer project
@@ -542,7 +542,7 @@ module Google
           #
           # @param name [String]
           #   Required. Redis instance resource name using the form:
-          #       +projects/{project_id}/locations/{location_id}/instances/{instance_id}+
+          #       +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
           #   where +location_id+ refers to a GCP region
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_services_pb.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_services_pb.rb
@@ -35,7 +35,7 @@ module Google
           # * Each project has a collection of available locations, named: `/locations/*`
           # * Each location has a collection of Redis instances, named: `/instances/*`
           # * As such, Redis instances are resources of the form:
-          #   `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+          #   `/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}`
           #
           # Note that location_id must be refering to a GCP `region`; for example:
           # * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
@@ -51,7 +51,7 @@ module Google
             # location (region) or all locations.
             #
             # The location should have the following format:
-            # * `projects/{project_id}/locations/{location_id}`
+            # * `projects/\\{project_id}/locations/\\{location_id}`
             #
             # If `location_id` is specified as `-` (wildcard), then all regions
             # available to the project are queried, and the results are aggregated.

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/cloud/redis/v1beta1/cloud_redis.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/cloud/redis/v1beta1/cloud_redis.rb
@@ -21,7 +21,7 @@ module Google
         #   @return [String]
         #     Required. Unique name of the resource in this scope including project and
         #     location using the form:
-        #         +projects/{project_id}/locations/{location_id}/instances/{instance_id}+
+        #         +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
         #
         #     Note: Redis instances are managed and addressed at regional level so
         #     location_id here refers to a GCP region; however, users get to choose which
@@ -144,7 +144,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the instance location using the form:
-        #         +projects/{project_id}/locations/{location_id}+
+        #         +projects/\\{project_id}/locations/\\{location_id}+
         #     where +location_id+ refers to a GCP region
         # @!attribute [rw] page_size
         #   @return [Integer]
@@ -171,7 +171,7 @@ module Google
         #     available to the project are queried, and the results aggregated.
         #     If in such an aggregated query a location is unavailable, a dummy Redis
         #     entry is included in the response with the "name" field set to a value of
-        #     the form projects/{project_id}/locations/{location_id}/instances/- and the
+        #     the form projects/\\{project_id}/locations/\\{location_id}/instances/- and the
         #     "status" field set to ERROR and "status_message" field set to "location not
         #     available for ListInstances".
         # @!attribute [rw] next_page_token
@@ -184,7 +184,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. Redis instance resource name using the form:
-        #         +projects/{project_id}/locations/{location_id}/instances/{instance_id}+
+        #         +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
         #     where +location_id+ refers to a GCP region
         class GetInstanceRequest; end
 
@@ -192,7 +192,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the instance location using the form:
-        #         +projects/{project_id}/locations/{location_id}+
+        #         +projects/\\{project_id}/locations/\\{location_id}+
         #     where +location_id+ refers to a GCP region
         # @!attribute [rw] instance_id
         #   @return [String]
@@ -229,7 +229,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. Redis instance resource name using the form:
-        #         +projects/{project_id}/locations/{location_id}/instances/{instance_id}+
+        #         +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
         #     where +location_id+ refers to a GCP region
         class DeleteInstanceRequest; end
 

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -51,3 +51,16 @@ s.replace(
     'lib/google/cloud/redis/v1beta1/cloud_redis_client.rb',
     '\n\n(\\s+)class OperationsClient < Google::Longrunning::OperationsClient',
     '\n\n\\1# @private\n\\1class OperationsClient < Google::Longrunning::OperationsClient')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
@@ -574,7 +574,7 @@ module Google
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being specified.
               #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/{project}+.
+              #   resource is specified as +projects/\\{project}+.
               # @param policy [Google::Iam::V1::Policy | Hash]
               #   REQUIRED: The complete policy to be applied to the +resource+. The size of
               #   the policy is limited to a few 10s of KB. An empty policy is a
@@ -616,7 +616,7 @@ module Google
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being requested.
               #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/{project}+.
+              #   resource is specified as +projects/\\{project}+.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -649,7 +649,7 @@ module Google
               # @param resource [String]
               #   REQUIRED: The resource for which the policy detail is being requested.
               #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/{project}+.
+              #   resource is specified as +projects/\\{project}+.
               # @param permissions [Array<String>]
               #   The set of permissions to check for the +resource+. Permissions with
               #   wildcards (such as '*' or 'storage.*') are not allowed. For more

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
@@ -85,17 +85,17 @@ module Google
       #     * +allAuthenticatedUsers+: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:{emailid}+: An email address that represents a specific Google
+      #     * +user:\\{emailid}+: An email address that represents a specific Google
       #       account. For example, +alice@gmail.com+ or +joe@example.com+.
       #
       #
-      #     * +serviceAccount:{emailid}+: An email address that represents a service
+      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
       #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
       #
-      #     * +group:{emailid}+: An email address that represents a Google group.
+      #     * +group:\\{emailid}+: An email address that represents a Google group.
       #       For example, +admins@example.com+.
       #
-      #     * +domain:{domain}+: A Google Apps domain name that represents all the
+      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
       #       users of that domain. For example, +google.com+ or +example.com+.
       class Binding; end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
@@ -85,17 +85,17 @@ module Google
       #     * +allAuthenticatedUsers+: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:{emailid}+: An email address that represents a specific Google
+      #     * +user:\\{emailid}+: An email address that represents a specific Google
       #       account. For example, +alice@gmail.com+ or +joe@example.com+.
       #
       #
-      #     * +serviceAccount:{emailid}+: An email address that represents a service
+      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
       #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
       #
-      #     * +group:{emailid}+: An email address that represents a Google group.
+      #     * +group:\\{emailid}+: An email address that represents a Google group.
       #       For example, +admins@example.com+.
       #
-      #     * +domain:{domain}+: A Google Apps domain name that represents all the
+      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
       #       users of that domain. For example, +google.com+ or +example.com+.
       class Binding; end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
@@ -739,7 +739,7 @@ module Google
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being specified.
               #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/{project}+.
+              #   resource is specified as +projects/\\{project}+.
               # @param policy [Google::Iam::V1::Policy | Hash]
               #   REQUIRED: The complete policy to be applied to the +resource+. The size of
               #   the policy is limited to a few 10s of KB. An empty policy is a
@@ -781,7 +781,7 @@ module Google
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being requested.
               #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/{project}+.
+              #   resource is specified as +projects/\\{project}+.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -814,7 +814,7 @@ module Google
               # @param resource [String]
               #   REQUIRED: The resource for which the policy detail is being requested.
               #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/{project}+.
+              #   resource is specified as +projects/\\{project}+.
               # @param permissions [Array<String>]
               #   The set of permissions to check for the +resource+. Permissions with
               #   wildcards (such as '*' or 'storage.*') are not allowed. For more

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import logging
 import os
+import re
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -46,3 +47,19 @@ s.replace(
     ],
     '\n\n(\\s+)class OperationsClient < Google::Longrunning::OperationsClient',
     '\n\n\\1# @private\n\\1class OperationsClient < Google::Longrunning::OperationsClient')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    [
+      'lib/google/cloud/spanner/v1/**/*.rb',
+      'lib/google/cloud/spanner/admin/**/*.rb'
+    ],
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/cloud_tasks_client.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/cloud_tasks_client.rb
@@ -815,7 +815,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -857,7 +857,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being specified.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param policy [Google::Iam::V1::Policy | Hash]
           #   REQUIRED: The complete policy to be applied to the +resource+. The size of
           #   the policy is limited to a few 10s of KB. An empty policy is a
@@ -907,7 +907,7 @@ module Google
           # @param resource [String]
           #   REQUIRED: The resource for which the policy detail is being requested.
           #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/{project}+.
+          #   resource is specified as +projects/\\{project}+.
           # @param permissions [Array<String>]
           #   The set of permissions to check for the +resource+. Permissions with
           #   wildcards (such as '*' or 'storage.*') are not allowed. For more

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/iam_policy.rb
@@ -20,7 +20,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
       #     REQUIRED: The complete policy to be applied to the +resource+. The size of
@@ -34,7 +34,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       class GetIamPolicyRequest; end
 
       # Request message for +TestIamPermissions+ method.
@@ -42,7 +42,7 @@ module Google
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
       #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/{project}+.
+      #     resource is specified as +projects/\\{project}+.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
       #     The set of permissions to check for the +resource+. Permissions with

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/policy.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/policy.rb
@@ -85,17 +85,17 @@ module Google
       #     * +allAuthenticatedUsers+: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:{emailid}+: An email address that represents a specific Google
+      #     * +user:\\{emailid}+: An email address that represents a specific Google
       #       account. For example, +alice@gmail.com+ or +joe@example.com+.
       #
       #
-      #     * +serviceAccount:{emailid}+: An email address that represents a service
+      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
       #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
       #
-      #     * +group:{emailid}+: An email address that represents a Google group.
+      #     * +group:\\{emailid}+: An email address that represents a Google group.
       #       For example, +admins@example.com+.
       #
-      #     * +domain:{domain}+: A Google Apps domain name that represents all the
+      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
       #       users of that domain. For example, +google.com+ or +example.com+.
       class Binding; end
 

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -41,3 +41,16 @@ s.replace(
     'google-cloud-tasks.gemspec',
     '\n  gem\\.add_dependency "google-gax", "~> ([\\d\\.]+)"\n\n',
     '\n  gem.add_dependency "google-gax", "~> \\1"\n  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"\n\n')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^\n#\\$\\\\])\\{([\\w,]+|\\.+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    'lib/google/cloud/**/*.rb',
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/timestamp.rb
@@ -72,9 +72,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required, though only UTC (as indicated by "Z") is presently supported.

--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import logging
 import os
+import re
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -65,3 +66,19 @@ s.replace(
     ],
     '\\{% dynamic print site_values.console_name %\\}',
     'Google Cloud Platform Console')
+
+# https://github.com/googleapis/gapic-generator/issues/2242
+def escape_braces(match):
+    expr = re.compile('([^\n#\\$\\\\])\\{([\\w,]+|\\.+)\\}')
+    content = match.group(0)
+    while True:
+        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        if count == 0:
+            return content
+s.replace(
+    [
+      'lib/google/cloud/trace/v1/**/*.rb',
+      'lib/google/cloud/trace/v2/**/*.rb'
+    ],
+    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    escape_braces)


### PR DESCRIPTION
Escape most literal braces that are coming from proto documentation and showing up in generated yardoc comments (and confusing the yard parser). Partial fix for https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/2265