### PR TITLE
Update YARD excludes of protobuf files

### DIFF
--- a/google-cloud-datastore/.yardopts
+++ b/google-cloud-datastore/.yardopts
@@ -1,6 +1,6 @@
 --no-private
 --title=Google Cloud Datastore
---exclude lib/google/datastore/v1
+--exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet
 

--- a/google-cloud-debugger/.yardopts
+++ b/google-cloud-debugger/.yardopts
@@ -1,6 +1,6 @@
 --no-private
 --title=Stackdriver Debugger
---exclude lib/google/devtools
+--exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet
 

--- a/google-cloud-error_reporting/.yardopts
+++ b/google-cloud-error_reporting/.yardopts
@@ -1,6 +1,6 @@
 --no-private
 --title=Stackdriver Error Reporting
---exclude lib/google/devtools/clouderrorreporting/v1beta1
+--exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet
 

--- a/google-cloud-firestore/.yardopts
+++ b/google-cloud-firestore/.yardopts
@@ -1,6 +1,6 @@
 --no-private
 --title=Google Cloud Firestore API
---exclude lib/google/firestore/v1beta1
+--exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet
 

--- a/google-cloud-logging/.yardopts
+++ b/google-cloud-logging/.yardopts
@@ -1,6 +1,6 @@
 --no-private
 --title=Stackdriver Logging
---exclude lib/google/logging/v2
+--exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet
 

--- a/google-cloud-pubsub/.yardopts
+++ b/google-cloud-pubsub/.yardopts
@@ -1,6 +1,6 @@
 --no-private
 --title=Google Cloud Pub/Sub
---exclude lib/google/pubsub/v1
+--exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet
 

--- a/google-cloud-spanner/.yardopts
+++ b/google-cloud-spanner/.yardopts
@@ -1,8 +1,6 @@
 --no-private
 --title=Google Cloud Spanner
---exclude lib/google/spanner
---exclude lib/google/cloud/spanner/admin/database/v1.rb
---exclude lib/google/cloud/spanner/admin/instance/v1.rb
+--exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet
 

--- a/google-cloud-trace/.yardopts
+++ b/google-cloud-trace/.yardopts
@@ -1,6 +1,6 @@
 --no-private
 --title=Stackdriver Trace
---exclude lib/google/devtools/cloudtrace/v1
+--exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet
 

--- a/google-cloud-vision/.yardopts
+++ b/google-cloud-vision/.yardopts
@@ -1,6 +1,6 @@
 --no-private
 --title=Google Cloud Vision
---exclude lib/google/cloud/vision/v1.rb
+--exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet
 


### PR DESCRIPTION
Protobuf files and GAPIC documentation can live in the same directories.
Instead of excluding a directory, exclude the generated protobuf ruby files.

[closes #2298, refs #2326, #2328]