### PR TITLE
Set evaluation_time_limit in Evaluator tests

### DIFF
--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/class_c_methods_whitelist_test.rb
@@ -18,6 +18,14 @@ require "helper"
 describe Google::Cloud::Debugger::Breakpoint::Evaluator do
   let(:evaluator) { Google::Cloud::Debugger::Breakpoint::Evaluator }
 
+  before do
+    if ENV["GCLOUD_TEST_COVERAGE_DEBUGGER_TIMEOUT"]
+      # Have to set it here because configure gets reset by some tests.
+      eval_time_limit = Float ENV["GCLOUD_TEST_COVERAGE_DEBUGGER_TIMEOUT"]
+      Google::Cloud::Debugger.configure.evaluation_time_limit = eval_time_limit
+    end
+  end
+
   describe "Array" do
     it "allows .new" do
       expression_must_be_kind_of "Array.new 2, nil", Array

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/immutable_classes_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/immutable_classes_test.rb
@@ -19,6 +19,14 @@ require_relative "expression_test_helper"
 describe Google::Cloud::Debugger::Breakpoint::Evaluator do
   let(:evaluator) { Google::Cloud::Debugger::Breakpoint::Evaluator }
 
+  before do
+    if ENV["GCLOUD_TEST_COVERAGE_DEBUGGER_TIMEOUT"]
+      # Have to set it here because configure gets reset by some tests.
+      eval_time_limit = Float ENV["GCLOUD_TEST_COVERAGE_DEBUGGER_TIMEOUT"]
+      Google::Cloud::Debugger.configure.evaluation_time_limit = eval_time_limit
+    end
+  end
+
   describe "Bignum" do
     it "allows #multiplication" do
       expression_must_equal "123123123123123123123 * 3",

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
@@ -19,6 +19,14 @@ require_relative "expression_test_helper"
 describe Google::Cloud::Debugger::Breakpoint::Evaluator do
   let(:evaluator) { Google::Cloud::Debugger::Breakpoint::Evaluator }
 
+  before do
+    if ENV["GCLOUD_TEST_COVERAGE_DEBUGGER_TIMEOUT"]
+      # Have to set it here because configure gets reset by some tests.
+      eval_time_limit = Float ENV["GCLOUD_TEST_COVERAGE_DEBUGGER_TIMEOUT"]
+      Google::Cloud::Debugger.configure.evaluation_time_limit = eval_time_limit
+    end
+  end
+
   describe "Array" do
     it "allows #size" do
       expression_must_equal "[1,2,3].size", 3

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -52,6 +52,14 @@ end
 describe Google::Cloud::Debugger::Breakpoint::Evaluator do
   let(:evaluator) { Google::Cloud::Debugger::Breakpoint::Evaluator }
 
+  before do
+    if ENV["GCLOUD_TEST_COVERAGE_DEBUGGER_TIMEOUT"]
+      # Have to set it here because configure gets reset by some tests.
+      eval_time_limit = Float ENV["GCLOUD_TEST_COVERAGE_DEBUGGER_TIMEOUT"]
+      Google::Cloud::Debugger.configure.evaluation_time_limit = eval_time_limit
+    end
+  end
+
   describe ".readonly_eval_expression" do
     after do
       Google::Cloud::Debugger.configure.allow_mutating_methods = false


### PR DESCRIPTION
This extends a fix to the Debugger tests when running in the coverage task.
We see frequent failures on CI because debugger tests fail during coverage.
We think this is due to the increased overhead by the coverage reporting.
We tried to extend this time limit before, but it was being reset by
some of the other tests.
Add the time limit extension to the Evaluator tests, which do not share the
same test setup as most of the other Debugger tests.