### PR TITLE
Update synth scripts to remove jsondoc from rakefiles

### DIFF
--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -67,3 +67,13 @@ s.replace(
     'lib/google/cloud/asset/v1beta1/asset_service_client.rb',
     '\n\n(\\s+)class OperationsClient < Google::Longrunning::OperationsClient',
     '\n\n\\1# @private\n\\1class OperationsClient < Google::Longrunning::OperationsClient')
+
+# https://github.com/googleapis/gapic-generator/issues/2278
+s.replace(
+    'Rakefile',
+    '\ndesc[^\n]+\ntask :jsondoc [^\n]+\n+(  [^\n]+\n+)*end\n',
+    '')
+s.replace(
+    'Rakefile',
+    '\n\\s*header "google-cloud-\\S+ jsondoc", "\\*"\n\\s*sh "bundle exec rake jsondoc"\n',
+    '\n')

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -89,3 +89,13 @@ s.replace(
     'lib/google/cloud/bigquery/data_transfer/*/*_client.rb',
     '(\n\\s+class \\w+Client\n)(\\s+)(attr_reader :\\w+_stub)',
     '\\1\\2# @private\n\\2\\3')
+
+# https://github.com/googleapis/gapic-generator/issues/2278
+s.replace(
+    'Rakefile',
+    '\ndesc[^\n]+\ntask :jsondoc [^\n]+\n+(  [^\n]+\n+)*end\n',
+    '')
+s.replace(
+    'Rakefile',
+    '\n\\s*header "google-cloud-\\S+ jsondoc", "\\*"\n\\s*sh "bundle exec rake jsondoc"\n',
+    '\n')

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -82,3 +82,13 @@ s.replace(
     'lib/google/cloud/container/*/*_client.rb',
     '(\n\\s+class \\w+Client\n)(\\s+)(attr_reader :\\w+_stub)',
     '\\1\\2# @private\n\\2\\3')
+
+# https://github.com/googleapis/gapic-generator/issues/2278
+s.replace(
+    'Rakefile',
+    '\ndesc[^\n]+\ntask :jsondoc [^\n]+\n+(  [^\n]+\n+)*end\n',
+    '')
+s.replace(
+    'Rakefile',
+    '\n\\s*header "google-cloud-\\S+ jsondoc", "\\*"\n\\s*sh "bundle exec rake jsondoc"\n',
+    '\n')

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -90,3 +90,13 @@ s.replace(
     'lib/google/cloud/dataproc/*/*_client.rb',
     '(\n\\s+class \\w+Client\n)(\\s+)(attr_reader :\\w+_stub)',
     '\\1\\2# @private\n\\2\\3')
+
+# https://github.com/googleapis/gapic-generator/issues/2278
+s.replace(
+    'Rakefile',
+    '\ndesc[^\n]+\ntask :jsondoc [^\n]+\n+(  [^\n]+\n+)*end\n',
+    '')
+s.replace(
+    'Rakefile',
+    '\n\\s*header "google-cloud-\\S+ jsondoc", "\\*"\n\\s*sh "bundle exec rake jsondoc"\n',
+    '\n')

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -65,3 +65,13 @@ s.replace(
     'lib/google/cloud/dialogflow/*/*_client.rb',
     '(\n\\s+class \\w+Client\n)(\\s+)(attr_reader :\\w+_stub)',
     '\\1\\2# @private\n\\2\\3')
+
+# https://github.com/googleapis/gapic-generator/issues/2278
+s.replace(
+    'Rakefile',
+    '\ndesc[^\n]+\ntask :jsondoc [^\n]+\n+(  [^\n]+\n+)*end\n',
+    '')
+s.replace(
+    'Rakefile',
+    '\n\\s*header "google-cloud-\\S+ jsondoc", "\\*"\n\\s*sh "bundle exec rake jsondoc"\n',
+    '\n')

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -61,3 +61,13 @@ s.replace(
     'lib/google/cloud/kms/*/*_client.rb',
     '(\n\\s+class \\w+Client\n)(\\s+)(attr_reader :\\w+_stub)',
     '\\1\\2# @private\n\\2\\3')
+
+# https://github.com/googleapis/gapic-generator/issues/2278
+s.replace(
+    'Rakefile',
+    '\ndesc[^\n]+\ntask :jsondoc [^\n]+\n+(  [^\n]+\n+)*end\n',
+    '')
+s.replace(
+    'Rakefile',
+    '\n\\s*header "google-cloud-\\S+ jsondoc", "\\*"\n\\s*sh "bundle exec rake jsondoc"\n',
+    '\n')

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -96,3 +96,13 @@ s.replace(
     'lib/google/cloud/language/*/*_client.rb',
     '(\n\\s+class \\w+Client\n)(\\s+)(attr_reader :\\w+_stub)',
     '\\1\\2# @private\n\\2\\3')
+
+# https://github.com/googleapis/gapic-generator/issues/2278
+s.replace(
+    'Rakefile',
+    '\ndesc[^\n]+\ntask :jsondoc [^\n]+\n+(  [^\n]+\n+)*end\n',
+    '')
+s.replace(
+    'Rakefile',
+    '\n\\s*header "google-cloud-\\S+ jsondoc", "\\*"\n\\s*sh "bundle exec rake jsondoc"\n',
+    '\n')

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -70,3 +70,13 @@ s.replace(
     'lib/google/cloud/redis/*/*_client.rb',
     '(\n\\s+class \\w+Client\n)(\\s+)(attr_reader :\\w+_stub)',
     '\\1\\2# @private\n\\2\\3')
+
+# https://github.com/googleapis/gapic-generator/issues/2278
+s.replace(
+    'Rakefile',
+    '\ndesc[^\n]+\ntask :jsondoc [^\n]+\n+(  [^\n]+\n+)*end\n',
+    '')
+s.replace(
+    'Rakefile',
+    '\n\\s*header "google-cloud-\\S+ jsondoc", "\\*"\n\\s*sh "bundle exec rake jsondoc"\n',
+    '\n')

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -60,3 +60,13 @@ s.replace(
     'lib/google/cloud/tasks/*/*_client.rb',
     '(\n\\s+class \\w+Client\n)(\\s+)(attr_reader :\\w+_stub)',
     '\\1\\2# @private\n\\2\\3')
+
+# https://github.com/googleapis/gapic-generator/issues/2278
+s.replace(
+    'Rakefile',
+    '\ndesc[^\n]+\ntask :jsondoc [^\n]+\n+(  [^\n]+\n+)*end\n',
+    '')
+s.replace(
+    'Rakefile',
+    '\n\\s*header "google-cloud-\\S+ jsondoc", "\\*"\n\\s*sh "bundle exec rake jsondoc"\n',
+    '\n')


### PR DESCRIPTION
These are the synth scripts that generate Rakefiles. Include a transform that removes the jsondoc related tasks.