### PR TITLE
Remove synth references to overview.rb file that is no longer generated

### DIFF
--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -51,6 +51,8 @@ s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-bigquery-data_transfer.gemspec', merge=merge_gemspec)
 
+print(str(v1_library))
+
 # PERMANENT: Use custom credentials env variable names
 s.replace(
     'lib/google/cloud/bigquery/data_transfer/v1/credentials.rb',
@@ -65,8 +67,7 @@ s.replace(
     [
       'README.md',
       'lib/google/cloud/bigquery/data_transfer.rb',
-      'lib/google/cloud/bigquery/data_transfer/v1.rb',
-      'lib/google/cloud/bigquery/data_transfer/v1/doc/overview.rb'
+      'lib/google/cloud/bigquery/data_transfer/v1.rb'
     ],
     '\\[Product Documentation\\]: https://cloud\\.google\\.com/bigquerydatatransfer\n',
     '[Product Documentation]: https://cloud.google.com/bigquery/transfer/\n')

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -51,8 +51,6 @@ s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-bigquery-data_transfer.gemspec', merge=merge_gemspec)
 
-print(str(v1_library))
-
 # PERMANENT: Use custom credentials env variable names
 s.replace(
     'lib/google/cloud/bigquery/data_transfer/v1/credentials.rb',

--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 import re
 
 logging.basicConfig(level=logging.DEBUG)
@@ -43,11 +42,6 @@ s.copy(v2_admin_library / 'lib/google/cloud/bigtable/admin/v2.rb')
 s.copy(v2_admin_library / 'lib/google/cloud/bigtable/admin.rb')
 s.copy(v2_admin_library / 'lib/google/bigtable/admin/v2')
 s.copy(v2_admin_library / 'test/google/cloud/bigtable/admin/v2')
-
-# PERMANENT: We don't want the generated overview.rb files because we have our
-# own toplevel docs for the handwritten layer.
-os.remove('lib/google/cloud/bigtable/v2/doc/overview.rb')
-os.remove('lib/google/cloud/bigtable/admin/v2/doc/overview.rb')
 
 # PERMANENT: We're combining bigtable and bigtable-admin into one gem.
 s.replace(

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -56,8 +56,7 @@ s.replace(
     [
       'README.md',
       'lib/google/cloud/container.rb',
-      'lib/google/cloud/container/v1.rb',
-      'lib/google/cloud/container/v1/doc/overview.rb'
+      'lib/google/cloud/container/v1.rb'
     ],
     '\\[Product Documentation\\]: https://cloud\\.google\\.com/container\n',
     '[Product Documentation]: https://cloud.google.com/kubernetes-engine\n')

--- a/google-cloud-datastore/synth.py
+++ b/google-cloud-datastore/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -33,10 +32,6 @@ s.copy(v1_library / 'lib/google/datastore/v1')
 
 # Omitting lib/google/cloud/datastore/v1.rb for now because we are not exposing
 # the low-level API.
-
-# PERMANENT: We don't want the generated overview.rb file because we have our
-# own toplevel docs for the handwritten layer.
-os.remove('lib/google/cloud/datastore/v1/doc/overview.rb')
 
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(

--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 import re
 
 logging.basicConfig(level=logging.DEBUG)
@@ -33,10 +32,6 @@ s.copy(v2_library / 'lib/google/cloud/debugger/v2')
 s.copy(v2_library / 'lib/google/cloud/debugger/v2.rb')
 s.copy(v2_library / 'lib/google/devtools')
 s.copy(v2_library / 'test/google/cloud/debugger/v2')
-
-# PERMANENT: We don't want the generated overview.rb file because we have our
-# own toplevel docs for the handwritten layer.
-os.remove('lib/google/cloud/debugger/v2/doc/overview.rb')
 
 # PERMANENT: Handwritten layer owns Debugger.new so low-level clients need to
 # use Debugger::V2.new instead of Debugger.new(version: :v2). Update the

--- a/google-cloud-error_reporting/synth.py
+++ b/google-cloud-error_reporting/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 import re
 
 logging.basicConfig(level=logging.DEBUG)
@@ -34,10 +33,6 @@ s.copy(v1beta1_library / 'lib/google/devtools/clouderrorreporting/v1beta1')
 
 # Omitting lib/google/cloud/error_reporting/v1beta1.rb for now because we are
 # not exposing the low-level API.
-
-# PERMANENT: We don't want the generated overview.rb file because we have our
-# own toplevel docs for the handwritten layer.
-os.remove('lib/google/cloud/error_reporting/v1beta1/doc/overview.rb')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 import re
 
 logging.basicConfig(level=logging.DEBUG)
@@ -33,10 +32,6 @@ s.copy(v1beta1_library / 'lib/google/cloud/firestore/v1beta1')
 s.copy(v1beta1_library / 'lib/google/cloud/firestore/v1beta1.rb')
 s.copy(v1beta1_library / 'lib/google/firestore/v1beta1')
 s.copy(v1beta1_library / 'test/google/cloud/firestore/v1beta1')
-
-# PERMANENT: We don't want the generated overview.rb file because we have our
-# own toplevel docs for the handwritten layer.
-os.remove('lib/google/cloud/firestore/v1beta1/doc/overview.rb')
 
 # PERMANENT: Handwritten layer owns Firestore.new so low-level clients need to
 # use Firestore::V1beta1.new instead of Firestore.new(version: :v1beta1).

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -38,8 +38,7 @@ s.replace(
     [
       'README.md',
       'lib/google/cloud/kms.rb',
-      'lib/google/cloud/kms/v1.rb',
-      'lib/google/cloud/kms/v1/doc/overview.rb'
+      'lib/google/cloud/kms/v1.rb'
     ],
     '/kms\\.googleapis\\.com', '/cloudkms.googleapis.com')
 

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -69,9 +69,7 @@ s.replace(
       'README.md',
       'lib/google/cloud/language.rb',
       'lib/google/cloud/language/v1.rb',
-      'lib/google/cloud/language/v1beta2.rb',
-      'lib/google/cloud/language/v1/doc/overview.rb',
-      'lib/google/cloud/language/v1beta2/doc/overview.rb'
+      'lib/google/cloud/language/v1beta2.rb'
     ],
     '\\[Product Documentation\\]: https://cloud\\.google\\.com/language\n',
     '[Product Documentation]: https://cloud.google.com/natural-language\n')

--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 import re
 
 logging.basicConfig(level=logging.DEBUG)
@@ -34,10 +33,6 @@ s.copy(v2_library / 'lib/google/logging/v2')
 
 # Omitting lib/google/cloud/logging/v2.rb for now because we are not exposing
 # the low-level API.
-
-# PERMANENT: We don't want the generated overview.rb file because we have our
-# own toplevel docs for the handwritten layer.
-os.remove('lib/google/cloud/logging/v2/doc/overview.rb')
 
 # PERMANENT: Handwritten layer owns Logging.new so low-level clients need to
 # use Logging::V2.new instead of Logging.new(version: :v2). Update the

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -54,9 +54,7 @@ s.replace(
       'README.md',
       'lib/google/cloud/os_login.rb',
       'lib/google/cloud/os_login/v1.rb',
-      'lib/google/cloud/os_login/v1beta.rb',
-      'lib/google/cloud/os_login/v1/doc/overview.rb',
-      'lib/google/cloud/os_login/v1beta/doc/overview.rb'
+      'lib/google/cloud/os_login/v1beta.rb'
     ],
     '/os-login\\.googleapis\\.com', '/oslogin.googleapis.com')
 
@@ -66,9 +64,7 @@ s.replace(
       'README.md',
       'lib/google/cloud/os_login.rb',
       'lib/google/cloud/os_login/v1.rb',
-      'lib/google/cloud/os_login/v1beta.rb',
-      'lib/google/cloud/os_login/v1/doc/overview.rb',
-      'lib/google/cloud/os_login/v1beta/doc/overview.rb'
+      'lib/google/cloud/os_login/v1beta.rb'
     ],
     '\\[Product Documentation\\]: https://cloud\\.google\\.com/os-login\n',
     '[Product Documentation]: https://cloud.google.com/compute/docs/oslogin/rest/\n')

--- a/google-cloud-pubsub/synth.py
+++ b/google-cloud-pubsub/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 import re
 
 logging.basicConfig(level=logging.DEBUG)
@@ -34,10 +33,6 @@ s.copy(v1_library / 'lib/google/pubsub/v1')
 
 # Omitting lib/google/cloud/pusbusb/v1.rb for now because we are not exposing
 # the low-level API.
-
-# PERMANENT: We don't want the generated overview.rb file because we have our
-# own toplevel docs for the handwritten layer.
-os.remove('lib/google/cloud/pubsub/v1/doc/overview.rb')
 
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -40,8 +40,7 @@ s.replace(
     [
       'README.md',
       'lib/google/cloud/redis.rb',
-      'lib/google/cloud/redis/v1beta1.rb',
-      'lib/google/cloud/redis/v1beta1/doc/overview.rb'
+      'lib/google/cloud/redis/v1beta1.rb'
     ],
     '\\[Product Documentation\\]: https://cloud\\.google\\.com/redis\n',
     '[Product Documentation]: https://cloud.google.com/memorystore\n')

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 import re
 
 logging.basicConfig(level=logging.DEBUG)
@@ -55,12 +54,6 @@ s.copy(v1_instance_library / 'test/google/cloud/spanner/admin/instance/v1')
 
 # Omitting lib/google/cloud/spanner/v1.rb for now because we are not exposing
 # the low-level API.
-
-# PERMANENT: We don't want the generated overview.rb file because we have our
-# own toplevel docs for the handwritten layer.
-os.remove('lib/google/cloud/spanner/v1/doc/overview.rb')
-os.remove('lib/google/cloud/spanner/admin/database/v1/doc/overview.rb')
-os.remove('lib/google/cloud/spanner/admin/instance/v1/doc/overview.rb')
 
 # PERMANENT: We're combining three APIs into one gem.
 s.replace(

--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 import re
 
 logging.basicConfig(level=logging.DEBUG)
@@ -42,11 +41,6 @@ s.copy(v2_library / 'lib/google/devtools/cloudtrace/v2')
 
 # Omitting lib/google/cloud/trace/v{1,2}.rb for now because we are not exposing
 # the low-level API.
-
-# PERMANENT: We don't want the generated overview.rb files because we have our
-# own toplevel docs for the handwritten layer.
-os.remove('lib/google/cloud/trace/v1/doc/overview.rb')
-os.remove('lib/google/cloud/trace/v2/doc/overview.rb')
 
 # https://github.com/googleapis/gapic-generator/issues/2124
 s.replace(

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -77,10 +77,7 @@ s.replace(
       'lib/google/cloud/video_intelligence.rb',
       'lib/google/cloud/video_intelligence/v1.rb',
       'lib/google/cloud/video_intelligence/v1beta1.rb',
-      'lib/google/cloud/video_intelligence/v1beta2.rb',
-      'lib/google/cloud/video_intelligence/v1/doc/overview.rb',
-      'lib/google/cloud/video_intelligence/v1beta1/doc/overview.rb',
-      'lib/google/cloud/video_intelligence/v1beta2/doc/overview.rb'
+      'lib/google/cloud/video_intelligence/v1beta2.rb'
     ],
     '/video-intelligence\\.googleapis\\.com', '/videointelligence.googleapis.com')
 

--- a/google-cloud-vision/synth.py
+++ b/google-cloud-vision/synth.py
@@ -17,7 +17,6 @@
 import synthtool as s
 import synthtool.gcp as gcp
 import logging
-import os
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -30,11 +29,6 @@ v1_library = gapic.ruby_library(
 s.copy(v1_library / 'lib/google/cloud/vision/v1')
 s.copy(v1_library / 'lib/google/cloud/vision/v1.rb')
 s.copy(v1_library / 'test/google/cloud/vision/v1')
-
-# PERMANENT: We don't want the generated overview.rb file because we have our
-# own toplevel docs for the handwritten layer.
-# REMOVE when we migrate to gapic-only.
-os.remove('lib/google/cloud/vision/v1/doc/overview.rb')
 
 # PERMANENT: Handwritten layer owns Vision.new so low-level clients need to
 # use Vision::V1.new instead of Vision.new(version: :v1). Update the examples


### PR DESCRIPTION
I discovered that a bunch of synth scripts are currently erroring out because they're expecting to find overview.rb which gapic is no longer generating. Fixing by removing references to overview.rb. This should unlock several synth scripts that need to run.

Do not merge until https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/2374 has also been merged.