### PR TITLE
Update Storage notification tests and examples to use Project#service_account_email

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_notification_test.rb
@@ -15,7 +15,7 @@
 require "storage_helper"
 
 describe Google::Cloud::Storage::Bucket, :notification, :storage do
-  let(:project_email) { "serviceAccount:#{storage.project}@gs-project-accounts.iam.gserviceaccount.com" }
+  let(:project_email) { "serviceAccount:#{storage.service_account_email}" }
   let(:bucket_name) { $bucket_names.first }
   let :bucket do
     storage.bucket(bucket_name) ||

--- a/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_requester_pays_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Storage::Bucket, :requester_pays, :storage do
   end
 
   # Pub/Sub subscription notification fixtures
-  let(:project_email) { "serviceAccount:#{storage_2.project}@gs-project-accounts.iam.gserviceaccount.com" }
+  let(:project_email) { "serviceAccount:#{storage_2.service_account_email}" }
   let(:topic_name) { "#{prefix}_bucket_notification_topic" }
   let(:topic_name_full_path) { "//pubsub.googleapis.com/projects/#{storage.project}/topics/#{topic_name}" }
   let(:custom_attrs) { { "foo" => "bar" } }

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -594,14 +594,14 @@ module Google
     # require "google/cloud/storage"
     #
     # pubsub = Google::Cloud::Pubsub.new
+    # storage = Google::Cloud::Storage.new
+    #
     # topic = pubsub.create_topic "my-topic"
     # topic.policy do |p|
     #   p.add "roles/pubsub.publisher",
-    #         "serviceAccount:my-project" \
-    #         "@gs-project-accounts.iam.gserviceaccount.com"
+    #         "serviceAccount:#{storage.service_account_email}"
     # end
     #
-    # storage = Google::Cloud::Storage.new
     # bucket = storage.bucket "my-bucket"
     #
     # notification = bucket.create_notification topic.name

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1519,14 +1519,14 @@ module Google
         #   require "google/cloud/storage"
         #
         #   pubsub = Google::Cloud::Pubsub.new
+        #   storage = Google::Cloud::Storage.new
+        #
         #   topic = pubsub.create_topic "my-topic"
         #   topic.policy do |p|
         #     p.add "roles/pubsub.publisher",
-        #           "serviceAccount:my-project" \
-        #           "@gs-project-accounts.iam.gserviceaccount.com"
+        #           "serviceAccount:#{storage.service_account_email}"
         #   end
         #
-        #   storage = Google::Cloud::Storage.new
         #   bucket = storage.bucket "my-bucket"
         #
         #   notification = bucket.create_notification topic.name

--- a/google-cloud-storage/lib/google/cloud/storage/notification.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/notification.rb
@@ -38,14 +38,14 @@ module Google
       #   require "google/cloud/storage"
       #
       #   pubsub = Google::Cloud::Pubsub.new
+      #   storage = Google::Cloud::Storage.new
+      #
       #   topic = pubsub.create_topic "my-topic"
       #   topic.policy do |p|
       #     p.add "roles/pubsub.publisher",
-      #           "serviceAccount:my-project" \
-      #           "@gs-project-accounts.iam.gserviceaccount.com"
+      #           "serviceAccount:#{storage.service_account_email}"
       #   end
       #
-      #   storage = Google::Cloud::Storage.new
       #   bucket = storage.bucket "my-bucket"
       #
       #   notification = bucket.create_notification topic.name

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -258,6 +258,7 @@ YARD::Doctest.configure do |doctest|
     end
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_project_service_account, OpenStruct.new(email_address: "my_service_account@gs-project-accounts.iam.gserviceaccount.com"), ["my-project"]
       mock.expect :insert_notification, notification_gapi, ["my-bucket", Google::Apis::StorageV1::Notification, Hash]
     end
   end
@@ -887,6 +888,7 @@ YARD::Doctest.configure do |doctest|
     end
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
+      mock.expect :get_project_service_account, OpenStruct.new(email_address: "my_service_account@gs-project-accounts.iam.gserviceaccount.com"), ["my-project"]
       mock.expect :insert_notification, notification_gapi, ["my-bucket", Google::Apis::StorageV1::Notification, Hash]
     end
   end


### PR DESCRIPTION
Replace hardcoded email pattern with `Project#service_account_email`.

This change is intended to fix the Error 2 problem encountered in #2339:

```rb
Google::Cloud::Storage::Bucket::notification::storage#test_0001_creates a Pub/Sub subscription notification:
Google::Cloud::InvalidArgumentError: 3:Service account secure-gcp-test-project9@gs-project-accounts.iam.gserviceaccount.com does not exist.
```

[refs #2339]