### PR TITLE
Update google-cloud-* auto-loading

### DIFF
--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -194,10 +194,11 @@ module Google
     #
     def self.auto_load_gems
       previously_loaded_files = Array(caller).map do |backtrace_line|
-        backtrace_line.split(":").first
+        File.realpath backtrace_line.split(":").first
       end.uniq
 
       auto_load_files.each do |auto_load_file|
+        auto_load_file = File.realpath auto_load_file
         next if previously_loaded_files.include? auto_load_file
         require auto_load_file
       end

--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -193,12 +193,14 @@ module Google
     # @private
     #
     def self.auto_load_gems
-      original_verbosity = $VERBOSE
-      $VERBOSE = nil
+      previously_loaded_files = Array(caller).map do |backtrace_line|
+        backtrace_line.split(":").first
+      end.uniq
 
-      auto_load_files.each { |auto_load_file| require auto_load_file }
-
-      $VERBOSE = original_verbosity
+      auto_load_files.each do |auto_load_file|
+        next if previously_loaded_files.include? auto_load_file
+        require auto_load_file
+      end
     end
 
     ##


### PR DESCRIPTION
Avoid loading a gem twice by tracking what is already loaded and skipping files already in the process of being required. This allows for the removal of swallowing warnings for circular requires. It also fixed configuration warnings when being loaded from a symlink, and the real paths for the files are used.

[fixes #2350]