### PR TITLE
Release google-cloud-bigquery 1.8.0

### DIFF
--- a/google-cloud-bigquery/CHANGELOG.md
+++ b/google-cloud-bigquery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.8.0 / 2018-08-31
+
+* Add ORC support to BigQuery (#2372)
+
 ### 1.7.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigquery
-      VERSION = "1.7.1".freeze
+      VERSION = "1.8.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add ORC support to BigQuery (#2372)

This pull request was generated using releasetool. See GoogleCloudPlatform/releasetool#37.