### PR TITLE
Don't auto-update rubocop configs from gapic

### DIFF
--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -46,7 +46,6 @@ s.copy(v1beta1_library / 'Rakefile')
 s.copy(v1beta1_library / 'README.md')
 s.copy(v1beta1_library / 'LICENSE')
 s.copy(v1beta1_library / '.gitignore')
-s.copy(v1beta1_library / '.rubocop.yml')
 s.copy(v1beta1_library / '.yardopts')
 s.copy(v1beta1_library / 'google-cloud-asset.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -47,7 +47,6 @@ s.copy(v1_library / 'Rakefile')
 s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
-s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-bigquery-data_transfer.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-container/synth.py
+++ b/google-cloud-container/synth.py
@@ -47,7 +47,6 @@ s.copy(v1_library / 'Rakefile')
 s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
-s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-container.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -47,7 +47,6 @@ s.copy(v1_library / 'Rakefile')
 s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
-s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-dataproc.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -46,7 +46,6 @@ s.copy(v2_library / 'Rakefile')
 s.copy(v2_library / 'README.md')
 s.copy(v2_library / 'LICENSE')
 s.copy(v2_library / '.gitignore')
-s.copy(v2_library / '.rubocop.yml')
 s.copy(v2_library / '.yardopts')
 s.copy(v2_library / 'google-cloud-dialogflow.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -44,7 +44,6 @@ s.copy(v2_library / 'test')
 s.copy(v2_library / 'README.md')
 s.copy(v2_library / 'LICENSE')
 s.copy(v2_library / '.gitignore')
-s.copy(v2_library / '.rubocop.yml')
 s.copy(v2_library / '.yardopts')
 s.copy(v2_library / 'google-cloud-dlp.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -29,7 +29,6 @@ s.copy(v1_library / 'Rakefile')
 s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
-s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-kms.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-language/synth.py
+++ b/google-cloud-language/synth.py
@@ -50,7 +50,6 @@ s.copy(v1_library / 'Rakefile')
 s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
-s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-language.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -31,7 +31,6 @@ s.copy(v3_library / 'test')
 s.copy(v3_library / 'README.md')
 s.copy(v3_library / 'LICENSE')
 s.copy(v3_library / '.gitignore')
-s.copy(v3_library / '.rubocop.yml')
 s.copy(v3_library / '.yardopts')
 s.copy(v3_library / 'google-cloud-monitoring.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -34,7 +34,6 @@ s.copy(v1_library / 'test/google/cloud/os_login/v1')
 s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
-s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-os_login.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -31,7 +31,6 @@ s.copy(v1beta1_library / 'Rakefile')
 s.copy(v1beta1_library / 'README.md')
 s.copy(v1beta1_library / 'LICENSE')
 s.copy(v1beta1_library / '.gitignore')
-s.copy(v1beta1_library / '.rubocop.yml')
 s.copy(v1beta1_library / '.yardopts')
 s.copy(v1beta1_library / 'google-cloud-redis.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-speech/synth.py
+++ b/google-cloud-speech/synth.py
@@ -48,7 +48,6 @@ s.copy(v1_library / 'lib/google/cloud/speech.rb')
 s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
-s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-speech.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -46,7 +46,6 @@ s.copy(v2beta2_library / 'Rakefile')
 s.copy(v2beta2_library / 'README.md')
 s.copy(v2beta2_library / 'LICENSE')
 s.copy(v2beta2_library / '.gitignore')
-s.copy(v2beta2_library / '.rubocop.yml')
 s.copy(v2beta2_library / '.yardopts')
 s.copy(v2beta2_library / 'google-cloud-tasks.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-text_to_speech/synth.py
+++ b/google-cloud-text_to_speech/synth.py
@@ -44,7 +44,6 @@ s.copy(v1_library / 'test')
 s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
-s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-text_to_speech.gemspec', merge=merge_gemspec)
 

--- a/google-cloud-video_intelligence/synth.py
+++ b/google-cloud-video_intelligence/synth.py
@@ -48,7 +48,6 @@ s.copy(v1_library / 'test/google/cloud/video_intelligence/v1')
 s.copy(v1_library / 'README.md')
 s.copy(v1_library / 'LICENSE')
 s.copy(v1_library / '.gitignore')
-s.copy(v1_library / '.rubocop.yml')
 s.copy(v1_library / '.yardopts')
 s.copy(v1_library / 'google-cloud-video_intelligence.gemspec', merge=merge_gemspec)
 


### PR DESCRIPTION
Prevents autosynth from breaking rubocop configs, as in https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/2393