### PR TITLE
Remove unwanted synth transform for monitoring rubocop config

### DIFF
--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -34,12 +34,6 @@ s.copy(v3_library / '.gitignore')
 s.copy(v3_library / '.yardopts')
 s.copy(v3_library / 'google-cloud-monitoring.gemspec', merge=merge_gemspec)
 
-# PERMANENT: Because lib/google-cloud-monitoring.rb is present and handwritten.
-s.replace(
-    '.rubocop.yml',
-    '\\Z',
-    '\nNaming/FileName:\n  Exclude:\n    - "lib/google-cloud-monitoring.rb"\n')
-
 # PERMANENT: Use a compatible version of googleapis-common-protos-types
 s.replace(
     'google-cloud-monitoring.gemspec',


### PR DESCRIPTION
We stopped auto-updating rubocop configs from synth, but I forgot to remove this transform from the monitoring synth script, with the result that autosynth was incorrectly creating PRs like https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/2396 that continually add extra lines to the existing config.