### PR TITLE
Add missing client_config in Pubsub publisher instantiation

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -78,6 +78,7 @@ module Google
             V1::PublisherClient.new(
               credentials: channel,
               timeout: timeout,
+              client_config: client_config,
               lib_name: "gccl",
               lib_version: Google::Cloud::Pubsub::VERSION
             )


### PR DESCRIPTION
Possible fix of #2406.

When GAX was introduced in Pubsub, the possibility of passing a `client_config` value from `Google::Cloud::Pubsub.new` was given. The point is that such config should be propagated to the subscriber and publisher objects. That's right for the subscriber (lines 61 to 72). But it seems like publisher was not also updated in commit 580b8feb16e980f50327cba20d88a325712e689e. 

The fix is as simple as passing the `client_config` value while calling to `PublisherClient.new`.