### PR TITLE
Add Object Lifecycle Management to Storage Bucket

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket/cors.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/cors.rb
@@ -46,6 +46,19 @@ module Google
         #                max_age: 3600
         #   end
         #
+        # @example Retrieving the bucket's CORS rules.
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.bucket "my-bucket"
+        #   bucket.cors.size #=> 2
+        #   rule = bucket.cors.first
+        #   rule.origin #=> ["http://example.org"]
+        #   rule.methods #=> ["GET","POST","DELETE"]
+        #   rule.headers #=> ["X-My-Custom-Header"]
+        #   rule.max_age #=> 3600
+        #
         class Cors < DelegateClass(::Array)
           ##
           # @private Initialize a new CORS rules builder with existing CORS
@@ -118,9 +131,50 @@ module Google
             super
           end
 
+          ##
+          # # Bucket Cors Rule
+          #
+          # Represents a website CORS rule for a bucket. Accessed via
+          # {Bucket#cors}.
+          #
+          # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
+          #   Resource Sharing (CORS)
+          #
+          # @attr [String] origin The [origin](http://tools.ietf.org/html/rfc6454)
+          #   or origins permitted for cross origin resource sharing with the
+          #   bucket. Note: "*" is permitted in the list of origins, and means
+          #   "any Origin".
+          # @attr [String] methods The list of HTTP methods permitted in cross
+          #   origin resource sharing with the bucket. (GET, OPTIONS, POST, etc)
+          #   Note: "*" is permitted in the list of methods, and means
+          #   "any method".
+          # @attr [String] headers The list of header field names to send in the
+          #   Access-Control-Allow-Headers header in the preflight response.
+          #   Indicates the custom request headers that may be used in the
+          #   actual request.
+          # @attr [String] max_age The value to send in the
+          #   Access-Control-Max-Age header in the preflight response. Indicates
+          #   how many seconds the results of a preflight request can be cached
+          #   in a preflight result cache. The default value is `1800` (30
+          #   minutes.)
+          #
+          # @example Retrieving the bucket's CORS rules.
+          #   require "google/cloud/storage"
+          #
+          #   storage = Google::Cloud::Storage.new
+          #
+          #   bucket = storage.bucket "my-bucket"
+          #   bucket.cors.size #=> 2
+          #   rule = bucket.cors.first
+          #   rule.origin #=> ["http://example.org"]
+          #   rule.methods #=> ["GET","POST","DELETE"]
+          #   rule.headers #=> ["X-My-Custom-Header"]
+          #   rule.max_age #=> 3600
+          #
           class Rule
             attr_accessor :origin, :methods, :headers, :max_age
 
+            # @private
             def initialize origin, methods, headers: nil, max_age: nil
               @origin = Array(origin)
               @methods = Array(methods)
@@ -128,6 +182,7 @@ module Google
               @max_age = (max_age || 1800)
             end
 
+            # @private
             def to_gapi
               Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
                 origin: Array(origin).dup, http_method: Array(methods).dup,
@@ -135,12 +190,14 @@ module Google
               )
             end
 
+            # @private
             def self.from_gapi gapi
               new gapi.origin.dup, gapi.http_method.dup, \
                   headers: gapi.response_header.dup,
                   max_age: gapi.max_age_seconds
             end
 
+            # @private
             def freeze
               @origin.freeze
               @methods.freeze

--- a/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb
@@ -1,0 +1,355 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "delegate"
+require "google/cloud/storage/convert"
+
+module Google
+  module Cloud
+    module Storage
+      class Bucket
+        ##
+        # # Bucket Lifecycle
+        #
+        # A special-case Array for managing the Object Lifecycle Management
+        # rules for a bucket. Accessed via {Bucket#lifecycle}.
+        #
+        # @see https://cloud.google.com/storage/docs/lifecycle Object
+        #   Lifecycle Management
+        # @see https://cloud.google.com/storage/docs/managing-lifecycles
+        #   Managing Object Lifecycles
+        #
+        # @example Specifying the lifecycle management rules for a new bucket.
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   bucket = storage.create_bucket "my-bucket" do |b|
+        #     b.lifecycle.add_set_storage_class_rule "COLDLINE", age: 10
+        #     b.lifecycle.add_delete_rule age: 30, is_live: false
+        #   end
+        #
+        # @example Retrieving a bucket's lifecycle management rules.
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   bucket.lifecycle.size #=> 2
+        #   rule = bucket.lifecycle.first
+        #   rule.action #=> "SetStorageClass"
+        #   rule.storage_class #=> "COLDLINE"
+        #   rule.age #=> 10
+        #   rule.matches_storage_class #=> ["MULTI_REGIONAL", "REGIONAL"]
+        #
+        # @example Updating the bucket's lifecycle management rules in a block.
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #   bucket = storage.bucket "my-bucket"
+        #
+        #   bucket.lifecycle do |l|
+        #     # Remove the last rule from the array
+        #     l.pop
+        #     # Remove all rules with the given condition
+        #     l.delete_if do |r|
+        #       r.matches_storage_class.include? "NEARLINE"
+        #     end
+        #     l.add_set_storage_class_rule "COLDLINE", age: 10, is_live: true
+        #     l.add_delete_rule age: 30, is_live: false
+        #   end
+        #
+        class Lifecycle < DelegateClass(::Array)
+          include Convert
+          ##
+          # @private Initialize a new lifecycle rules builder with existing
+          # lifecycle rules, if any.
+          def initialize rules = []
+            super rules
+            @original = to_gapi.rule.map(&:to_json)
+          end
+
+          # @private
+          def changed?
+            @original != to_gapi.rule.map(&:to_json)
+          end
+
+          ##
+          # Adds a SetStorageClass lifecycle rule to the Object Lifecycle
+          # Management rules for a bucket.
+          #
+          # @see https://cloud.google.com/storage/docs/lifecycle Object
+          #   Lifecycle Management
+          # @see https://cloud.google.com/storage/docs/managing-lifecycles
+          #   Managing Object Lifecycles
+          #
+          # @param [String,Symbol] storage_class The target storage class.
+          #   Required if the type of the action is `SetStorageClass`. The
+          #   argument will be converted from symbols and lower-case to
+          #   upper-case strings.
+          # @param [Integer] age The age of a file (in days). This condition is
+          #   satisfied when a file reaches the specified age.
+          # @param [String,Date] created_before A date in RFC 3339 format with
+          #   only the date part (for instance, "2013-01-15"). This condition is
+          #   satisfied when a file is created before midnight of the specified
+          #   date in UTC.
+          # @param [Boolean] is_live Relevant only for versioned files. If the
+          #   value is `true`, this condition matches live files; if the value
+          #   is `false`, it matches archived files.
+          # @param [String,Symbol,Array<String,Symbol>] matches_storage_class
+          #   Files having any of the storage classes specified by this
+          #   condition will be matched. Values include `MULTI_REGIONAL`,
+          #   `REGIONAL`, `NEARLINE`, `COLDLINE`, `STANDARD`, and
+          #   `DURABLE_REDUCED_AVAILABILITY`. Arguments will be converted from
+          #   symbols and lower-case to upper-case strings.
+          # @param [Integer] num_newer_versions Relevant only for versioned
+          #   files. If the value is N, this condition is satisfied when there
+          #   are at least N versions (including the live version) newer than
+          #   this version of the file.
+          #
+          # @example
+          #   require "google/cloud/storage"
+          #
+          #   storage = Google::Cloud::Storage.new
+          #
+          #   bucket = storage.create_bucket "my-bucket" do |b|
+          #     b.lifecycle.add_set_storage_class_rule "COLDLINE", age: 10
+          #   end
+          #
+          def add_set_storage_class_rule storage_class, age: nil,
+                                         created_before: nil, is_live: nil,
+                                         matches_storage_class: nil,
+                                         num_newer_versions: nil
+            push Rule.new \
+              "SetStorageClass",
+              storage_class: storage_class_for(storage_class),
+              age: age, created_before: created_before, is_live: is_live,
+              matches_storage_class: storage_class_for(matches_storage_class),
+              num_newer_versions: num_newer_versions
+          end
+
+          ##
+          # Adds a SetStorageClass lifecycle rule to the Object Lifecycle
+          # Management rules for a bucket.
+          #
+          # @see https://cloud.google.com/storage/docs/lifecycle Object
+          #   Lifecycle Management
+          # @see https://cloud.google.com/storage/docs/managing-lifecycles
+          #   Managing Object Lifecycles
+          #
+          # @param [Integer] age The age of a file (in days). This condition is
+          #   satisfied when a file reaches the specified age.
+          # @param [String,Date] created_before A date in RFC 3339 format with
+          #   only the date part (for instance, "2013-01-15"). This condition is
+          #   satisfied when a file is created before midnight of the specified
+          #   date in UTC.
+          # @param [Boolean] is_live Relevant only for versioned files. If the
+          #   value is `true`, this condition matches live files; if the value
+          #   is `false`, it matches archived files.
+          # @param [String,Symbol,Array<String,Symbol>] matches_storage_class
+          #   Files having any of the storage classes specified by this
+          #   condition will be matched. Values include `MULTI_REGIONAL`,
+          #   `REGIONAL`, `NEARLINE`, `COLDLINE`, `STANDARD`, and
+          #   `DURABLE_REDUCED_AVAILABILITY`. Arguments will be converted from
+          #   symbols and lower-case to upper-case strings.
+          # @param [Integer] num_newer_versions Relevant only for versioned
+          #   files. If the value is N, this condition is satisfied when there
+          #   are at least N versions (including the live version) newer than
+          #   this version of the file.
+          #
+          # @example
+          #   require "google/cloud/storage"
+          #
+          #   storage = Google::Cloud::Storage.new
+          #
+          #   bucket = storage.create_bucket "my-bucket" do |b|
+          #     b.lifecycle.add_delete_rule age: 30, is_live: false
+          #   end
+          #
+          def add_delete_rule age: nil, created_before: nil, is_live: nil,
+                              matches_storage_class: nil,
+                              num_newer_versions: nil
+            push Rule.new \
+              "Delete",
+              age: age, created_before: created_before, is_live: is_live,
+              matches_storage_class: storage_class_for(matches_storage_class),
+              num_newer_versions: num_newer_versions
+          end
+
+          # @private
+          def to_gapi
+            Google::Apis::StorageV1::Bucket::Lifecycle.new(
+              rule: map(&:to_gapi)
+            )
+          end
+
+          # @private
+          def self.from_gapi gapi
+            gapi_list = gapi.rule if gapi
+            rules = Array(gapi_list).map do |rule_gapi|
+              Rule.from_gapi rule_gapi
+            end
+            new rules
+          end
+
+          # @private
+          def freeze
+            each(&:freeze)
+            super
+          end
+
+          ##
+          # # Bucket Lifecycle Rule
+          #
+          # Represents an Object Lifecycle Management rule for a bucket. The
+          # action for the rule will be taken when its conditions are met.
+          # Accessed via {Bucket#lifecycle}.
+          #
+          # @see https://cloud.google.com/storage/docs/lifecycle Object
+          #   Lifecycle Management
+          # @see https://cloud.google.com/storage/docs/managing-lifecycles
+          #   Managing Object Lifecycles
+          #
+          # @attr [String] action The type of action taken when the rule's
+          #   conditions are met. Currently, only `Delete` and `SetStorageClass`
+          #   are supported.
+          # @attr [String] storage_class The target storage class for the
+          #   action. Required only if the action is `SetStorageClass`.
+          # @attr [Integer] age The age of a file (in days). This condition is
+          #   satisfied when a file reaches the specified age.
+          # @attr [String,Date] created_before A date in RFC 3339 format with
+          #   only the date part (for instance, "2013-01-15"). This condition is
+          #   satisfied when a file is created before midnight of the specified
+          #   date in UTC.
+          # @attr [Boolean] is_live Relevant only for versioned files. If the
+          #   value is `true`, this condition matches live files; if the value
+          #   is `false`, it matches archived files.
+          # @attr [Array<String>] matches_storage_class Files having any of the
+          #   storage classes specified by this condition will be matched.
+          #   Values include `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`,
+          #   `COLDLINE`, `STANDARD`, and `DURABLE_REDUCED_AVAILABILITY`.
+          # @attr [Integer] num_newer_versions Relevant only for versioned
+          #   files. If the value is N, this condition is satisfied when there
+          #   are at least N versions (including the live version) newer than
+          #   this version of the file.
+          #
+          # @example Retrieving a bucket's lifecycle management rules.
+          #   require "google/cloud/storage"
+          #
+          #   storage = Google::Cloud::Storage.new
+          #   bucket = storage.bucket "my-bucket"
+          #
+          #   bucket.lifecycle.size #=> 2
+          #   rule = bucket.lifecycle.first
+          #   rule.action #=> "SetStorageClass"
+          #   rule.storage_class #=> "COLDLINE"
+          #   rule.age #=> 10
+          #   rule.matches_storage_class #=> ["MULTI_REGIONAL", "REGIONAL"]
+          #
+          # @example Updating the bucket's lifecycle rules in a block.
+          #   require "google/cloud/storage"
+          #
+          #   storage = Google::Cloud::Storage.new
+          #   bucket = storage.bucket "my-bucket"
+          #
+          #   bucket.update do |b|
+          #     b.lifecycle do |l|
+          #       # Remove the last rule from the array
+          #       l.pop
+          #       # Remove rules with the given condition
+          #       l.delete_if do |r|
+          #         r.matches_storage_class.include? "NEARLINE"
+          #       end
+          #       # Update rules
+          #       l.each do |r|
+          #         r.age = 90 if r.action == "Delete"
+          #       end
+          #       # Add a rule
+          #       l.add_set_storage_class_rule "COLDLINE", age: 10
+          #     end
+          #   end
+          #
+          class Rule
+            attr_accessor :action, :storage_class, :age, :created_before,
+                          :is_live, :matches_storage_class, :num_newer_versions
+
+            # @private
+            def initialize action, storage_class: nil, age: nil,
+                           created_before: nil, is_live: nil,
+                           matches_storage_class: nil, num_newer_versions: nil
+              @action = action
+              @storage_class = storage_class
+              @age = age
+              @created_before = created_before
+              @is_live = is_live
+              @matches_storage_class = Array(matches_storage_class)
+              @num_newer_versions = num_newer_versions
+            end
+
+            # @private
+            # @return [Google::Apis::StorageV1::Bucket::Lifecycle]
+            def to_gapi
+              condition = condition_gapi(age, created_before, is_live,
+                                         matches_storage_class,
+                                         num_newer_versions)
+              Google::Apis::StorageV1::Bucket::Lifecycle::Rule.new(
+                action: action_gapi(action, storage_class),
+                condition: condition
+              )
+            end
+
+            # @private
+            def action_gapi action, storage_class
+              Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action.new(
+                type: action, storage_class: storage_class
+              )
+            end
+
+            # @private
+            def condition_gapi age, created_before, is_live,
+                               matches_storage_class, num_newer_versions
+              Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition.new(
+                age: age,
+                created_before: created_before,
+                is_live: is_live,
+                matches_storage_class: Array(matches_storage_class),
+                num_newer_versions: num_newer_versions
+              )
+            end
+
+            # @private
+            # @param [Google::Apis::StorageV1::Bucket::Rule] gapi
+            def self.from_gapi gapi
+              action = gapi.action
+              c = gapi.condition
+              new action.type, storage_class: action.storage_class,
+                               age: c.age,
+                               created_before: c.created_before,
+                               is_live: c.is_live,
+                               matches_storage_class: c.matches_storage_class,
+                               num_newer_versions: c.num_newer_versions
+            end
+
+            # @private
+            def freeze
+              @matches_storage_class.freeze
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-storage/lib/google/cloud/storage/convert.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/convert.rb
@@ -1,0 +1,40 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Storage
+      ##
+      # @private
+      #
+      # Internal conversion of raw data values to/from Storage values
+      module Convert
+        # @param [String,Symbol,Array<String,Symbol>] str
+        def storage_class_for str
+          return nil if str.nil?
+          return str.map { |s| storage_class_for s } if str.is_a? Array
+          { "durable_reduced_availability" => "DURABLE_REDUCED_AVAILABILITY",
+            "dra" => "DURABLE_REDUCED_AVAILABILITY",
+            "durable" => "DURABLE_REDUCED_AVAILABILITY",
+            "nearline" => "NEARLINE",
+            "coldline" => "COLDLINE",
+            "multi_regional" => "MULTI_REGIONAL",
+            "regional" => "REGIONAL",
+            "standard" => "STANDARD" }[str.to_s.downcase] || str.to_s
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+require "google/cloud/storage/convert"
 require "google/cloud/storage/file/acl"
 require "google/cloud/storage/file/list"
 require "google/cloud/storage/file/verifier"
@@ -62,6 +63,7 @@ module Google
       #   downloaded.read #=> "Hello world!"
       #
       class File
+        include Convert
         ##
         # @private The Connection object.
         attr_accessor :service
@@ -1484,18 +1486,6 @@ module Google
             gz = Zlib::GzipReader.new StringIO.new(local_file.read)
             StringIO.new gz.read
           end
-        end
-
-        def storage_class_for str
-          return nil if str.nil?
-          { "durable_reduced_availability" => "DURABLE_REDUCED_AVAILABILITY",
-            "dra" => "DURABLE_REDUCED_AVAILABILITY",
-            "durable" => "DURABLE_REDUCED_AVAILABILITY",
-            "nearline" => "NEARLINE",
-            "coldline" => "COLDLINE",
-            "multi_regional" => "MULTI_REGIONAL",
-            "regional" => "REGIONAL",
-            "standard" => "STANDARD" }[str.to_s.downcase] || str.to_s
         end
 
         ##

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -28,6 +28,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
                          "method" => ["*"],
                          "origin" => ["http://example.org", "https://example.org"],
                          "responseHeader" => ["X-My-Custom-Header"] }] }
+  let(:bucket_lifecycle) { {"rule" => [{"action" => {"storageClass" => "NEARLINE","type" => "SetStorageClass"},"condition" => {"age" => 32}}]} }
   let(:bucket_location) { "US" }
   let(:bucket_logging_bucket) { "bucket-name-logging" }
   let(:bucket_logging_prefix) { "AccessLog" }
@@ -41,7 +42,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     h = random_bucket_hash bucket_name, bucket_url_root,
                            bucket_location, bucket_storage_class, bucket_versioning,
                            bucket_logging_bucket, bucket_logging_prefix, bucket_website_main,
-                           bucket_website_404, bucket_cors, bucket_requester_pays
+                           bucket_website_404, bucket_cors, bucket_requester_pays, bucket_lifecycle
     h[:labels] = bucket_labels
     h
   end
@@ -71,12 +72,20 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     bucket_complete.labels.must_equal bucket_labels
   end
 
-  it "return frozen cors" do
+  it "returns frozen cors" do
     bucket_complete.cors.each do |cors|
       cors.must_be_kind_of Google::Cloud::Storage::Bucket::Cors::Rule
       cors.frozen?.must_equal true
     end
     bucket_complete.cors.frozen?.must_equal true
+  end
+
+  it "returns frozen lifecycle (Object Lifecycle Management)" do
+    bucket_complete.lifecycle.each do |r|
+      r.must_be_kind_of Google::Cloud::Storage::Bucket::Lifecycle::Rule
+      r.frozen?.must_equal true
+    end
+    bucket_complete.lifecycle.frozen?.must_equal true
   end
 
   it "can delete itself" do

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -31,13 +31,23 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     http_method: ["*"],
     response_header: ["X-My-Custom-Header"]) }
   let(:bucket_cors_hash) { JSON.parse bucket_cors_gapi.to_json }
+  let(:bucket_lifecycle_gapi) do
+    lifecycle_gapi lifecycle_rule_gapi("SetStorageClass",
+                                       storage_class: "NEARLINE",
+                                       age: 32,
+                                       created_before: "2013-01-15",
+                                       is_live: true,
+                                       matches_storage_class: ["MULTI_REGIONAL"],
+                                       num_newer_versions: 3)
+  end
+  let(:bucket_lifecycle_hash) { JSON.parse bucket_lifecycle_gapi.to_json }
 
   let(:bucket_hash) { random_bucket_hash bucket_name, bucket_url_root, bucket_location, bucket_storage_class }
   let(:bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json bucket_hash.to_json }
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
 
   let(:bucket_with_cors_hash) { random_bucket_hash bucket_name, bucket_url_root, bucket_location, bucket_storage_class,
-                                                   nil, nil, nil, nil, nil, [bucket_cors_hash] }
+                                                   nil, nil, nil, nil, nil, [bucket_cors_hash], nil, bucket_lifecycle_hash }
   let(:bucket_with_cors_gapi) { Google::Apis::StorageV1::Bucket.from_json bucket_with_cors_hash.to_json }
   let(:bucket_with_cors) { Google::Cloud::Storage::Bucket.from_gapi bucket_with_cors_gapi, storage.service }
 
@@ -307,88 +317,124 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     mock.verify
   end
 
-  it "sets the cors rules" do
-    mock = Minitest::Mock.new
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [bucket_cors_gapi]
-    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
-      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
-    bucket.service.mocked_service = mock
+  describe "CORS" do
 
-    bucket.cors.must_equal []
-    bucket.cors do |c|
-      c.add_rule ["http://example.org", "https://example.org"],
-                 "*",
-                 headers: ["X-My-Custom-Header"],
-                 max_age: 300
+    it "sets the cors rules" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [bucket_cors_gapi]
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+        [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      bucket.cors.must_equal []
+      bucket.cors do |c|
+        c.add_rule ["http://example.org", "https://example.org"],
+                   "*",
+                   headers: ["X-My-Custom-Header"],
+                   max_age: 300
+      end
+
+      mock.verify
     end
 
-    mock.verify
-  end
-
-  it "can't update cors outside of a block" do
-    err = expect {
-      bucket_with_cors.cors.first.max_age = 600
-    }.must_raise RuntimeError
-    err.message.must_match "can't modify frozen"
-  end
-
-  it "can update cors inside of a block" do
-    mock = Minitest::Mock.new
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 600, http_method: ["PUT"], origin: ["http://example.org", "https://example.org", "https://example.com"], response_header: ["X-My-Custom-Header", "X-Another-Custom-Header"]
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: [], origin: [], response_header: []
-      )
-    ]
-    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
-      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
-    bucket_with_cors.service.mocked_service = mock
-
-    bucket_with_cors.cors.must_be :frozen?
-    bucket_with_cors.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
-    bucket_with_cors.update do |b|
-      b.cors.wont_be :frozen?
-      b.cors.first.class.must_equal Google::Cloud::Storage::Bucket::Cors::Rule
-      b.cors.first.wont_be :frozen?
-      b.cors.first.max_age = 600
-      b.cors.first.origin << "https://example.com"
-      b.cors.first.methods = ["PUT"]
-      b.cors.first.headers << "X-Another-Custom-Header"
-      # Add a second rule
-      b.cors << Google::Cloud::Storage::Bucket::Cors::Rule.new(nil, nil)
+    it "can't update cors outside of a block" do
+      err = expect {
+        bucket_with_cors.cors.first.max_age = 600
+      }.must_raise RuntimeError
+      err.message.must_match "can't modify frozen"
     end
 
-    mock.verify
-  end
+    it "can update cors inside of a block" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 600, http_method: ["PUT"], origin: ["http://example.org", "https://example.org", "https://example.com"], response_header: ["X-My-Custom-Header", "X-Another-Custom-Header"]
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: [], origin: [], response_header: []
+        )
+      ]
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+        [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket_with_cors.service.mocked_service = mock
 
-  it "adds CORS rules in a nested block in update" do
-    mock = Minitest::Mock.new
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.org"], response_header: []
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 300, http_method: ["PUT", "DELETE"], origin: ["http://example.org", "https://example.org"], response_header: ["X-My-Custom-Header"]
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: ["*"], origin: ["http://example.com"], response_header: ["X-Another-Custom-Header"]
-      )
-    ]
-    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
-      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
-    bucket_with_cors.service.mocked_service = mock
+      bucket_with_cors.cors.must_be :frozen?
+      bucket_with_cors.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
+      bucket_with_cors.update do |b|
+        b.cors.wont_be :frozen?
+        b.cors.first.class.must_equal Google::Cloud::Storage::Bucket::Cors::Rule
+        b.cors.first.wont_be :frozen?
+        b.cors.first.max_age = 600
+        b.cors.first.origin << "https://example.com"
+        b.cors.first.methods = ["PUT"]
+        b.cors.first.headers << "X-Another-Custom-Header"
+        # Add a second rule
+        b.cors << Google::Cloud::Storage::Bucket::Cors::Rule.new(nil, nil)
+      end
 
-    bucket_with_cors.update do |b|
-      b.cors.delete_if { |c| c.max_age = 300 }
-      b.cors do |c|
+      mock.verify
+    end
+
+    it "adds CORS rules in a nested block in update" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.org"], response_header: []
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 300, http_method: ["PUT", "DELETE"], origin: ["http://example.org", "https://example.org"], response_header: ["X-My-Custom-Header"]
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: ["*"], origin: ["http://example.com"], response_header: ["X-Another-Custom-Header"]
+        )
+      ]
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+        [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket_with_cors.service.mocked_service = mock
+
+      bucket_with_cors.update do |b|
+        b.cors.delete_if { |c| c.max_age = 300 }
+        b.cors do |c|
+          c.add_rule "http://example.org", "GET"
+          c.add_rule ["http://example.org", "https://example.org"],
+                     ["PUT", "DELETE"],
+                     headers: ["X-My-Custom-Header"],
+                     max_age: 300
+          c.add_rule "http://example.com",
+                     "*",
+                     headers: "X-Another-Custom-Header"
+        end
+      end
+
+      mock.verify
+    end
+
+    it "adds CORS rules in a block to cors" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.org"], response_header: []
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 300, http_method: ["PUT", "DELETE"], origin: ["http://example.org", "https://example.org"], response_header: ["X-My-Custom-Header"]
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: ["*"], origin: ["http://example.com"], response_header: ["X-Another-Custom-Header"]
+        )
+      ]
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+        [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      returned_cors = bucket.cors do |c|
         c.add_rule "http://example.org", "GET"
         c.add_rule ["http://example.org", "https://example.org"],
                    ["PUT", "DELETE"],
@@ -398,70 +444,205 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                    "*",
                    headers: "X-Another-Custom-Header"
       end
+      returned_cors.frozen?.must_equal true
+      returned_cors.first.frozen?.must_equal true
+
+      mock.verify
     end
 
-    mock.verify
+    it "updates CORS rules in a block to cors" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.net"], response_header: []
+        )
+      ]
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+        [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      bucket_with_cors.cors.size.must_equal 1
+      bucket_with_cors.cors[0].origin.must_equal ["http://example.org", "https://example.org"]
+      bucket_with_cors.cors do |c|
+        c.add_rule "http://example.net", "GET"
+        c.add_rule "http://example.net", "POST"
+        # Remove the last CORS rule from the array
+        c.pop
+        # Remove all existing rules with the https protocol
+        c.delete_if { |r| r.origin.include? "http://example.org" }
+      end
+
+      mock.verify
+    end
   end
 
-  it "adds CORS rules in a block to cors" do
-    mock = Minitest::Mock.new
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.org"], response_header: []
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 300, http_method: ["PUT", "DELETE"], origin: ["http://example.org", "https://example.org"], response_header: ["X-My-Custom-Header"]
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: ["*"], origin: ["http://example.com"], response_header: ["X-Another-Custom-Header"]
-      )
-    ]
-    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
-      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
-    bucket.service.mocked_service = mock
+  describe "lifecycle (Object Lifecycle Management)" do
 
-    returned_cors = bucket.cors do |c|
-      c.add_rule "http://example.org", "GET"
-      c.add_rule ["http://example.org", "https://example.org"],
-                 ["PUT", "DELETE"],
-                 headers: ["X-My-Custom-Header"],
-                 max_age: 300
-      c.add_rule "http://example.com",
-                 "*",
-                 headers: "X-Another-Custom-Header"
-    end
-    returned_cors.frozen?.must_equal true
-    returned_cors.first.frozen?.must_equal true
+    it "sets the lifecycle rules" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new lifecycle: bucket_lifecycle_gapi
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
 
-    mock.verify
-  end
+      bucket.lifecycle.must_equal []
+      lifecycle = bucket.lifecycle do |l|
+        l.add_set_storage_class_rule "NEARLINE",
+                                     age: 32,
+                                     created_before: "2013-01-15",
+                                     is_live: true,
+                                     matches_storage_class: ["MULTI_REGIONAL"],
+                                     num_newer_versions: 3
+      end
 
-  it "updates CORS rules in a block to cors" do
-    mock = Minitest::Mock.new
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.net"], response_header: []
-      )
-    ]
-    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
-      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
-    bucket.service.mocked_service = mock
+      mock.verify
 
-    bucket_with_cors.cors.size.must_equal 1
-    bucket_with_cors.cors[0].origin.must_equal ["http://example.org", "https://example.org"]
-    bucket_with_cors.cors do |c|
-      c.add_rule "http://example.net", "GET"
-      c.add_rule "http://example.net", "POST"
-      # Remove the last CORS rule from the array
-      c.pop
-      # Remove all existing rules with the https protocol
-      c.delete_if { |r| r.origin.include? "http://example.org" }
+      rule = lifecycle.first
+
+      rule.action.must_equal "SetStorageClass"
+      rule.storage_class.must_equal "NEARLINE"
+      rule.age.must_equal 32
+      rule.created_before.must_equal "2013-01-15"
+      rule.is_live.must_equal true
+      rule.matches_storage_class.must_equal ["MULTI_REGIONAL"]
+      rule.num_newer_versions.must_equal 3
     end
 
-    mock.verify
+    it "can't update lifecycle outside of a block" do
+      err = expect {
+        bucket_with_cors.lifecycle.first.age = 600
+      }.must_raise RuntimeError
+      err.message.must_match "can't modify frozen"
+    end
+
+    it "can update lifecycle inside of a block" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(
+        lifecycle: lifecycle_gapi(
+          lifecycle_rule_gapi("SetStorageClass",
+                              storage_class: "COLDLINE",
+                              age: 32,
+                              created_before: "2013-01-15",
+                              is_live: true,
+                              matches_storage_class: ["MULTI_REGIONAL"],
+                              num_newer_versions: 3),
+          lifecycle_rule_gapi("Delete", age: 40, is_live: false)
+        )
+      )
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket_with_cors.service.mocked_service = mock
+
+      bucket_with_cors.lifecycle.must_be :frozen?
+      bucket_with_cors.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      bucket_with_cors.update do |b|
+        b.lifecycle.wont_be :frozen?
+        b.lifecycle.first.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle::Rule
+        b.lifecycle.first.wont_be :frozen?
+        b.lifecycle.first.storage_class = "COLDLINE"
+        # Add a second rule
+        b.lifecycle.add_delete_rule age: 40, is_live: false
+      end
+
+      mock.verify
+    end
+
+    it "adds Lifecycle rules in a nested block in update" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(
+          lifecycle: lifecycle_gapi(
+              lifecycle_rule_gapi("Delete", age: 40, is_live: false)
+          )
+      )
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket_with_cors.service.mocked_service = mock
+
+      bucket_with_cors.update do |b|
+        b.lifecycle.delete_if { |r| r.age == 32 }
+        b.lifecycle do |l|
+          l.add_delete_rule age: 40, is_live: false
+        end
+      end
+
+      mock.verify
+    end
+
+    it "adds Lifecycle rules in a block to lifecycle" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(
+          lifecycle: lifecycle_gapi(
+            lifecycle_rule_gapi("SetStorageClass",
+                                storage_class: "NEARLINE",
+                                age: 32,
+                                created_before: "2013-01-15",
+                                is_live: true,
+                                matches_storage_class: ["MULTI_REGIONAL"],
+                                num_newer_versions: 3),
+              lifecycle_rule_gapi("Delete", age: 40, is_live: false),
+              lifecycle_rule_gapi("Delete", is_live: false, num_newer_versions: 8),
+              lifecycle_rule_gapi("SetStorageClass", storage_class: "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"])
+          )
+      )
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket_with_cors.service.mocked_service = mock
+
+      bucket_with_cors.lifecycle.must_be :frozen?
+      bucket_with_cors.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      bucket_with_cors.update do |b|
+        b.lifecycle.add_delete_rule age: 40, is_live: false
+        b.lifecycle.add_delete_rule is_live: false, num_newer_versions: 8
+        b.lifecycle.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"]
+      end
+
+      mock.verify
+    end
+
+    it "updates Lifecycle rules in a block to lifecycle" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(
+          lifecycle: lifecycle_gapi(
+            lifecycle_rule_gapi("SetStorageClass",
+                                storage_class: "NEARLINE",
+                                age: 32,
+                                created_before: "2013-01-15",
+                                is_live: true,
+                                matches_storage_class: ["MULTI_REGIONAL"],
+                                num_newer_versions: 3),
+              lifecycle_rule_gapi("Delete", age: 40, is_live: false)
+          )
+      )
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket_with_cors.service.mocked_service = mock
+
+      bucket_with_cors.lifecycle.must_be :frozen?
+      bucket_with_cors.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      bucket_with_cors.lifecycle do |l|
+        l.add_set_storage_class_rule :coldline, created_before: "2013-01-15", matches_storage_class: [:MULTI_REGIONAL, :regional]  # alias: set_storage_class
+        l.add_delete_rule age: 40, is_live: false
+        l.add_delete_rule is_live: false, num_newer_versions: 8
+
+        # Remove the last Lifecycle rule from the array
+        l.pop
+        # Remove all existing rules that match predicate
+        l.delete_if { |r| r.matches_storage_class.include? "REGIONAL" }
+      end
+
+      mock.verify
+    end
   end
 end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
@@ -31,6 +31,8 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
     http_method: ["*"],
     response_header: ["X-My-Custom-Header"]) }
   let(:bucket_cors_hash) { JSON.parse bucket_cors_gapi.to_json }
+  let(:bucket_lifecycle_gapi) { lifecycle_gapi lifecycle_rule_gapi("SetStorageClass", storage_class: "NEARLINE", age: 32) }
+  let(:bucket_lifecycle_hash) { JSON.parse bucket_lifecycle_gapi.to_json }
 
   let(:bucket) { Google::Cloud::Storage::Bucket.new_lazy bucket_name, storage.service }
 
@@ -300,90 +302,126 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
     mock.verify
   end
 
-  it "sets the cors rules" do
-    mock = Minitest::Mock.new
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [bucket_cors_gapi]
-    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
-      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
-    bucket.service.mocked_service = mock
+  describe "CORS" do
 
-    bucket.cors.must_equal []
-    bucket.cors do |c|
-      c.add_rule ["http://example.org", "https://example.org"],
-                 "*",
-                 headers: ["X-My-Custom-Header"],
-                 max_age: 300
+    it "sets the cors rules" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [bucket_cors_gapi]
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+        [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      bucket.cors.must_equal []
+      bucket.cors do |c|
+        c.add_rule ["http://example.org", "https://example.org"],
+                   "*",
+                   headers: ["X-My-Custom-Header"],
+                   max_age: 300
+      end
+
+      mock.verify
     end
 
-    mock.verify
-  end
-
-  it "can't update cors outside of a block" do
-    err = expect {
-      bucket.cors.add_rule ["http://example.org", "https://example.org"],
-                            "*",
-                            headers: ["X-My-Custom-Header"],
-                            max_age: 300
-    }.must_raise RuntimeError
-    err.message.must_match "can't modify frozen"
-  end
-
-  it "can update cors inside of a block" do
-    mock = Minitest::Mock.new
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 600, http_method: ["PUT"], origin: ["http://example.org", "https://example.org", "https://example.com"], response_header: ["X-My-Custom-Header", "X-Another-Custom-Header"]
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: [], origin: [], response_header: []
-      )
-    ]
-    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
-      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
-    bucket.service.mocked_service = mock
-
-    bucket.cors.must_be :frozen?
-    bucket.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
-    bucket.update do |b|
-      b.cors.wont_be :frozen?
-      b.cors.must_be :empty?
-      b.cors.add_rule ["http://example.org", "https://example.org", "https://example.com"],
-                       "PUT",
-                       headers: ["X-My-Custom-Header", "X-Another-Custom-Header"],
-                       max_age: 600
-      # Add a rule
-      b.cors << Google::Cloud::Storage::Bucket::Cors::Rule.new(nil, nil)
+    it "can't update cors outside of a block" do
+      err = expect {
+        bucket.cors.add_rule ["http://example.org", "https://example.org"],
+                              "*",
+                              headers: ["X-My-Custom-Header"],
+                              max_age: 300
+      }.must_raise RuntimeError
+      err.message.must_match "can't modify frozen"
     end
 
-    mock.verify
-  end
+    it "can update cors inside of a block" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 600, http_method: ["PUT"], origin: ["http://example.org", "https://example.org", "https://example.com"], response_header: ["X-My-Custom-Header", "X-Another-Custom-Header"]
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: [], origin: [], response_header: []
+        )
+      ]
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+        [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
 
-  it "adds CORS rules in a nested block in update" do
-    mock = Minitest::Mock.new
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.org"], response_header: []
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 300, http_method: ["PUT", "DELETE"], origin: ["http://example.org", "https://example.org"], response_header: ["X-My-Custom-Header"]
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: ["*"], origin: ["http://example.com"], response_header: ["X-Another-Custom-Header"]
-      )
-    ]
-    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
-      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
-    bucket.service.mocked_service = mock
+      bucket.cors.must_be :frozen?
+      bucket.cors.class.must_equal Google::Cloud::Storage::Bucket::Cors
+      bucket.update do |b|
+        b.cors.wont_be :frozen?
+        b.cors.must_be :empty?
+        b.cors.add_rule ["http://example.org", "https://example.org", "https://example.com"],
+                         "PUT",
+                         headers: ["X-My-Custom-Header", "X-Another-Custom-Header"],
+                         max_age: 600
+        # Add a rule
+        b.cors << Google::Cloud::Storage::Bucket::Cors::Rule.new(nil, nil)
+      end
 
-    bucket.update do |b|
-      b.cors.delete_if { |c| c.max_age = 300 }
-      b.cors do |c|
+      mock.verify
+    end
+
+    it "adds CORS rules in a nested block in update" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.org"], response_header: []
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 300, http_method: ["PUT", "DELETE"], origin: ["http://example.org", "https://example.org"], response_header: ["X-My-Custom-Header"]
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: ["*"], origin: ["http://example.com"], response_header: ["X-Another-Custom-Header"]
+        )
+      ]
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+        [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      bucket.update do |b|
+        b.cors.delete_if { |c| c.max_age = 300 }
+        b.cors do |c|
+          c.add_rule "http://example.org", "GET"
+          c.add_rule ["http://example.org", "https://example.org"],
+                     ["PUT", "DELETE"],
+                     headers: ["X-My-Custom-Header"],
+                     max_age: 300
+          c.add_rule "http://example.com",
+                     "*",
+                     headers: "X-Another-Custom-Header"
+        end
+      end
+
+      mock.verify
+    end
+
+    it "adds CORS rules in a block to cors" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.org"], response_header: []
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 300, http_method: ["PUT", "DELETE"], origin: ["http://example.org", "https://example.org"], response_header: ["X-My-Custom-Header"]
+        ),
+        Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
+          max_age_seconds: 1800, http_method: ["*"], origin: ["http://example.com"], response_header: ["X-Another-Custom-Header"]
+        )
+      ]
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+        [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      returned_cors = bucket.cors do |c|
         c.add_rule "http://example.org", "GET"
         c.add_rule ["http://example.org", "https://example.org"],
                    ["PUT", "DELETE"],
@@ -393,43 +431,143 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
                    "*",
                    headers: "X-Another-Custom-Header"
       end
-    end
+      returned_cors.frozen?.must_equal true
+      returned_cors.first.frozen?.must_equal true
 
-    mock.verify
+      mock.verify
+    end
   end
 
-  it "adds CORS rules in a block to cors" do
-    mock = Minitest::Mock.new
-    patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new cors_configurations: [
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: ["GET"], origin: ["http://example.org"], response_header: []
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 300, http_method: ["PUT", "DELETE"], origin: ["http://example.org", "https://example.org"], response_header: ["X-My-Custom-Header"]
-      ),
-      Google::Apis::StorageV1::Bucket::CorsConfiguration.new(
-        max_age_seconds: 1800, http_method: ["*"], origin: ["http://example.com"], response_header: ["X-Another-Custom-Header"]
+  describe "lifecycle (Object Lifecycle Management)" do
+
+    it "sets the lifecycle rules" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(
+          lifecycle: lifecycle_gapi(
+              lifecycle_rule_gapi("SetStorageClass", storage_class: "NEARLINE", age: 32)
+          )
       )
-    ]
-    returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
-      random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, [bucket_cors_hash]).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi,
-      [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
-    bucket.service.mocked_service = mock
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
 
-    returned_cors = bucket.cors do |c|
-      c.add_rule "http://example.org", "GET"
-      c.add_rule ["http://example.org", "https://example.org"],
-                 ["PUT", "DELETE"],
-                 headers: ["X-My-Custom-Header"],
-                 max_age: 300
-      c.add_rule "http://example.com",
-                 "*",
-                 headers: "X-Another-Custom-Header"
+      bucket.lifecycle.must_equal []
+      bucket.lifecycle do |l|
+        l.add_set_storage_class_rule "NEARLINE", age: 32
+      end
+
+      mock.verify
     end
-    returned_cors.frozen?.must_equal true
-    returned_cors.first.frozen?.must_equal true
 
-    mock.verify
+    it "can't update lifecycle outside of a block" do
+      err = expect {
+        bucket.lifecycle.add_set_storage_class_rule "NEARLINE", age: 32
+      }.must_raise RuntimeError
+      err.message.must_match "can't modify frozen"
+    end
+
+    it "can update lifecycle inside of a block" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(
+          lifecycle: lifecycle_gapi(
+              lifecycle_rule_gapi("Delete", age: 40, is_live: false)
+          )
+      )
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      bucket.lifecycle.must_be :frozen?
+      bucket.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      bucket.update do |b|
+        b.lifecycle.wont_be :frozen?
+        b.lifecycle.must_be :empty?
+        b.lifecycle.add_delete_rule age: 40, is_live: false
+      end
+
+      mock.verify
+    end
+
+    it "adds Lifecycle rules in a nested block in update" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(
+          lifecycle: lifecycle_gapi(
+              lifecycle_rule_gapi("Delete", age: 40, is_live: false)
+          )
+      )
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      bucket.update do |b|
+        b.lifecycle.delete_if { |r| r.age == 32 }
+        b.lifecycle do |l|
+          l.add_delete_rule age: 40, is_live: false
+        end
+      end
+
+      mock.verify
+    end
+
+    it "adds Lifecycle rules in a block to lifecycle" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(
+          lifecycle: lifecycle_gapi(
+              lifecycle_rule_gapi("Delete", age: 40, is_live: false),
+              lifecycle_rule_gapi("Delete", is_live: false, num_newer_versions: 8),
+              lifecycle_rule_gapi("SetStorageClass", storage_class: "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"])
+          )
+      )
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      bucket.lifecycle.must_be :frozen?
+      bucket.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      bucket.update do |b|
+        b.lifecycle.add_delete_rule age: 40, is_live: false
+        b.lifecycle.add_delete_rule is_live: false, num_newer_versions: 8
+        b.lifecycle.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"]
+      end
+
+      mock.verify
+    end
+
+    it "updates Lifecycle rules in a block to lifecycle" do
+      mock = Minitest::Mock.new
+      patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new(
+          lifecycle: lifecycle_gapi(
+              lifecycle_rule_gapi("Delete", age: 40, is_live: false)
+          )
+      )
+      returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
+        random_bucket_hash(bucket_name, bucket_url, bucket_location, bucket_storage_class, nil, nil, nil, nil, nil, nil, nil, bucket_lifecycle_hash).to_json
+      mock.expect :patch_bucket, returned_bucket_gapi,
+                  [bucket_name, patch_bucket_gapi, predefined_acl: nil, predefined_default_object_acl: nil, user_project: nil]
+      bucket.service.mocked_service = mock
+
+      bucket.lifecycle.must_be :frozen?
+      bucket.lifecycle.class.must_equal Google::Cloud::Storage::Bucket::Lifecycle
+      bucket.lifecycle do |l|
+        l.add_set_storage_class_rule "COLDLINE", created_before: "2013-01-15", matches_storage_class: ["MULTI_REGIONAL", "REGIONAL"]
+        l.add_delete_rule age: 40, is_live: false
+        l.add_delete_rule is_live: false, num_newer_versions: 8
+
+        # Remove the last Lifecycle rule from the array
+        l.pop
+        # Remove all existing rules that match predicate
+        l.delete_if { |r| r.matches_storage_class.include? "MULTI_REGIONAL" }
+      end
+
+      mock.verify
+    end
   end
 end

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -49,7 +49,8 @@ class MockStorage < Minitest::Spec
   def random_bucket_hash(name=random_bucket_name,
     url_root="https://www.googleapis.com/storage/v1", location="US",
     storage_class="STANDARD", versioning=nil, logging_bucket=nil,
-    logging_prefix=nil, website_main=nil, website_404=nil, cors=[], requester_pays=nil)
+    logging_prefix=nil, website_main=nil, website_404=nil, cors=[], requester_pays=nil,
+    lifecycle=nil)
     versioning_config = { "enabled" => versioning } if versioning
     { "kind" => "storage#bucket",
       "id" => name,
@@ -61,6 +62,7 @@ class MockStorage < Minitest::Spec
       "owner" => { "entity" => "project-owners-1234567890" },
       "location" => location,
       "cors" => cors,
+      "lifecycle" => lifecycle,
       "logging" => logging_hash(logging_bucket, logging_prefix),
       "storageClass" => storage_class,
       "versioning" => versioning_config,
@@ -150,5 +152,27 @@ class MockStorage < Minitest::Spec
 
   def encryption_gapi key_name
     Google::Apis::StorageV1::Bucket::Encryption.new default_kms_key_name: key_name
+  end
+
+  def lifecycle_gapi *rules
+    Google::Apis::StorageV1::Bucket::Lifecycle.new rule: Array(rules)
+  end
+
+  def lifecycle_rule_gapi action, storage_class: nil, age: nil,
+                     created_before: nil, is_live: nil,
+                     matches_storage_class: nil, num_newer_versions: nil
+    Google::Apis::StorageV1::Bucket::Lifecycle::Rule.new(
+      action: Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action.new(
+        storage_class: storage_class,
+        type: action
+      ),
+      condition: Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition.new(
+        age: age,
+        created_before: created_before,
+        is_live: is_live,
+        matches_storage_class: Array(matches_storage_class),
+        num_newer_versions: num_newer_versions
+      )
+    )
   end
 end


### PR DESCRIPTION
* Add `Bucket::Lifecycle` and `Bucket::Lifecycle::Rule`
* Add `Bucket#lifecycle`
* Extract `#storage_class_for` to new module `Convert`
* Update `Project#create_bucket` documentation
* Add `Bucket::Cors::Rule` documentation

[fixes #2403]