### PR TITLE
Releases for Sept 10, 2018

### DIFF
--- a/gcloud/CHANGELOG.md
+++ b/gcloud/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.23.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.23.0 / 2016-12-8
 
 * Update dependency on `google-cloud` gem to 0.23 or greater.

--- a/gcloud/lib/gcloud/version.rb
+++ b/gcloud/lib/gcloud/version.rb
@@ -14,5 +14,5 @@
 
 
 module Gcloud
-  GCLOUD_VERSION = "0.23.0".freeze
+  GCLOUD_VERSION = "0.23.1".freeze
 end

--- a/google-cloud-bigquery-data_transfer/CHANGELOG.md
+++ b/google-cloud-bigquery-data_transfer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.2 / 2018-09-10
+
+* Update documentation.
+
 ### 0.2.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
+++ b/google-cloud-bigquery-data_transfer/google-cloud-bigquery-data_transfer.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-bigquery-data_transfer"
-  gem.version       = "0.2.1"
+  gem.version       = "0.2.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-bigquery/CHANGELOG.md
+++ b/google-cloud-bigquery/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.8.0 / 2018-09-10
+
+* Add support for OCR format.
+* Update documentation.
+
 ### 1.7.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigquery
-      VERSION = "1.7.1".freeze
+      VERSION = "1.8.0".freeze
     end
   end
 end

--- a/google-cloud-bigtable/CHANGELOG.md
+++ b/google-cloud-bigtable/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
+### 0.1.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.1.0 / 2018-08-16
 
 * Initial release
-

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Bigtable
-      VERSION = "0.1.0".freeze
+      VERSION = "0.1.1".freeze
     end
   end
 end

--- a/google-cloud-container/CHANGELOG.md
+++ b/google-cloud-container/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.2.0 / 2018-08-21
 
 * Move Credentials location:

--- a/google-cloud-container/google-cloud-container.gemspec
+++ b/google-cloud-container/google-cloud-container.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-container"
-  gem.version       = "0.2.0"
+  gem.version       = "0.2.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-core/CHANGELOG.md
+++ b/google-cloud-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.2.4 / 2018-09-10
+
+* Update documentation.
+
 ### 1.2.3 / 2018-08-21
 
 * Update (deprecated) Credentials authentication URLs.

--- a/google-cloud-core/lib/google/cloud/core/version.rb
+++ b/google-cloud-core/lib/google/cloud/core/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Core
-      VERSION = "1.2.3".freeze
+      VERSION = "1.2.4".freeze
     end
   end
 end

--- a/google-cloud-dataproc/CHANGELOG.md
+++ b/google-cloud-dataproc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.2.0 / 2018-08-21
 
 * Update dependencies.

--- a/google-cloud-dataproc/google-cloud-dataproc.gemspec
+++ b/google-cloud-dataproc/google-cloud-dataproc.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dataproc"
-  gem.version       = "0.2.0"
+  gem.version       = "0.2.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-datastore/CHANGELOG.md
+++ b/google-cloud-datastore/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 1.4.2 / 2018-09-10
+
+* Fix issue where client_config was not being passed when connecting to the
+  datastore emulator.
+* Update documentation.
+
 ### 1.4.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-datastore/lib/google/cloud/datastore/version.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Datastore
-      VERSION = "1.4.1".freeze
+      VERSION = "1.4.2".freeze
     end
   end
 end

--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.32.3 / 2018-09-10
+
+* Update documentation.
+
 ### 0.32.2 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Debugger
-      VERSION = "0.32.2".freeze
+      VERSION = "0.32.3".freeze
     end
   end
 end

--- a/google-cloud-dialogflow/CHANGELOG.md
+++ b/google-cloud-dialogflow/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.2.0 / 2018-08-21
 
 * Move Credentials location:

--- a/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
+++ b/google-cloud-dialogflow/google-cloud-dialogflow.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dialogflow"
-  gem.version       = "0.2.0"
+  gem.version       = "0.2.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-dlp/CHANGELOG.md
+++ b/google-cloud-dlp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.6.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.6.0 / 2018-08-21
 
 * Update V2 API.

--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-dlp"
-  gem.version       = "0.6.0"
+  gem.version       = "0.6.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-dns/CHANGELOG.md
+++ b/google-cloud-dns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.29.2 / 2018-09-10
+
+* Update documentation.
+
 ### 0.29.1 / 2018-08-21
 
 * Reduce memory usage.

--- a/google-cloud-dns/lib/google/cloud/dns/version.rb
+++ b/google-cloud-dns/lib/google/cloud/dns/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Dns
-      VERSION = "0.29.1".freeze
+      VERSION = "0.29.2".freeze
     end
   end
 end

--- a/google-cloud-env/CHANGELOG.md
+++ b/google-cloud-env/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.3 / 2018-09-10
+
+* Update documentation.
+
 ### 1.0.2 / 2018-06-28
 
 * Use Kubernetes Engine names.

--- a/google-cloud-env/lib/google/cloud/env/version.rb
+++ b/google-cloud-env/lib/google/cloud/env/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     class Env
-      VERSION = "1.0.2".freeze
+      VERSION = "1.0.3".freeze
     end
   end
 end

--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.30.3 / 2018-09-10
+
+* Update documentation.
+
 ### 0.30.2 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.30.2".freeze
+      VERSION = "0.30.3".freeze
     end
   end
 end

--- a/google-cloud-firestore/CHANGELOG.md
+++ b/google-cloud-firestore/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+### 0.24.0 / 2018-09-10
+
+* Add array_union and array_delete FieldValue configuration.
+* Add array-contains as an operator to the Query#where method.
+* Update documentation.
+
 ### 0.23.0 / 2018-08-17
 
 * Add Firestore Watch

--- a/google-cloud-firestore/lib/google/cloud/firestore/version.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Firestore
-      VERSION = "0.23.0".freeze
+      VERSION = "0.24.0".freeze
     end
   end
 end

--- a/google-cloud-kms/CHANGELOG.md
+++ b/google-cloud-kms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.2 / 2018-09-10
+
+* Update documentation.
+
 ### 0.2.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-kms/google-cloud-kms.gemspec
+++ b/google-cloud-kms/google-cloud-kms.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-kms"
-  gem.version       = "0.2.1"
+  gem.version       = "0.2.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-language/CHANGELOG.md
+++ b/google-cloud-language/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.31.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.31.0 / 2018-08-21
 
 * Move Credentials location:

--- a/google-cloud-language/google-cloud-language.gemspec
+++ b/google-cloud-language/google-cloud-language.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-language"
-  gem.version       = "0.31.0"
+  gem.version       = "0.31.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.5.3 / 2018-09-10
+
+* Update documentation.
+
 ### 1.5.2 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-logging/lib/google/cloud/logging/version.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Logging
-      VERSION = "1.5.2".freeze
+      VERSION = "1.5.3".freeze
     end
   end
 end

--- a/google-cloud-monitoring/CHANGELOG.md
+++ b/google-cloud-monitoring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.29.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.29.0 / 2018-08-21
 
 * Move Credentials location:

--- a/google-cloud-monitoring/google-cloud-monitoring.gemspec
+++ b/google-cloud-monitoring/google-cloud-monitoring.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-monitoring"
-  gem.version       = "0.29.0"
+  gem.version       = "0.29.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-os_login/CHANGELOG.md
+++ b/google-cloud-os_login/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.2 / 2018-09-10
+
+* Update documentation.
+
 ### 0.2.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-os_login/google-cloud-os_login.gemspec
+++ b/google-cloud-os_login/google-cloud-os_login.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-os_login"
-  gem.version       = "0.2.1"
+  gem.version       = "0.2.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-pubsub/CHANGELOG.md
+++ b/google-cloud-pubsub/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.32.1 / 2018-09-10
+
+* Fix issue where client_config was not being used on publisher API calls.
+* Update documentation.
+
 ### 0.32.0 / 2018-08-14
 
 * Updated Subscriber implementation

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Pubsub
-      VERSION = "0.32.0".freeze
+      VERSION = "0.32.1".freeze
     end
   end
 end

--- a/google-cloud-redis/CHANGELOG.md
+++ b/google-cloud-redis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.2.0 / 2018-08-21
 
 * Move Credentials location:

--- a/google-cloud-redis/google-cloud-redis.gemspec
+++ b/google-cloud-redis/google-cloud-redis.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-redis"
-  gem.version       = "0.2.0"
+  gem.version       = "0.2.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-resource_manager/CHANGELOG.md
+++ b/google-cloud-resource_manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.30.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.30.0 / 2018-06-22
 
 * Update Policy, protect from role duplication.

--- a/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
+++ b/google-cloud-resource_manager/lib/google/cloud/resource_manager/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ResourceManager
-      VERSION = "0.30.0".freeze
+      VERSION = "0.30.1".freeze
     end
   end
 end

--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.6.2 / 2018-09-10
+
+* Update documentation.
+
 ### 1.6.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "1.6.1".freeze
+      VERSION = "1.6.2".freeze
     end
   end
 end

--- a/google-cloud-speech/CHANGELOG.md
+++ b/google-cloud-speech/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 0.31.0 / 2018-09-10
+
+* Add get_operation to retrieve long running operation resource.
+* Update documentation.
+
 ### 0.30.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-speech/google-cloud-speech.gemspec
+++ b/google-cloud-speech/google-cloud-speech.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-speech"
-  gem.version       = "0.30.1"
+  gem.version       = "0.31.0"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 1.14.0 / 2018-09-10
+
+* Add Object Lifecycle Management:
+  * Add Bucket#lifecycle.
+  * Add Bucket::Lifecycle and Bucket::Lifecycle::Rule.
+* Update documentation.
+
 ### 1.13.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Storage
-      VERSION = "1.13.1".freeze
+      VERSION = "1.14.0".freeze
     end
   end
 end

--- a/google-cloud-tasks/CHANGELOG.md
+++ b/google-cloud-tasks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.3 / 2018-09-10
+
+* Update documentation.
+
 ### 0.2.2 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-tasks/google-cloud-tasks.gemspec
+++ b/google-cloud-tasks/google-cloud-tasks.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-tasks"
-  gem.version       = "0.2.2"
+  gem.version       = "0.2.3"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-text_to_speech/CHANGELOG.md
+++ b/google-cloud-text_to_speech/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.1.2 / 2018-09-10
+
+* Update documentation.
+
 ### 0.1.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
+++ b/google-cloud-text_to_speech/google-cloud-text_to_speech.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-text_to_speech"
-  gem.version       = "0.1.1"
+  gem.version       = "0.1.2"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.33.3 / 2018-09-10
+
+* Update documentation.
+
 ### 0.33.2 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.33.2".freeze
+      VERSION = "0.33.3".freeze
     end
   end
 end

--- a/google-cloud-translate/CHANGELOG.md
+++ b/google-cloud-translate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.2.2 / 2018-09-10
+
+* Update documentation.
+
 ### 1.2.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-translate/lib/google/cloud/translate/version.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Translate
-      VERSION = "1.2.1".freeze
+      VERSION = "1.2.2".freeze
     end
   end
 end

--- a/google-cloud-video_intelligence/CHANGELOG.md
+++ b/google-cloud-video_intelligence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.1.1 / 2018-09-10
+
+* Update documentation.
+
 ### 1.1.0 / 2018-08-21
 
 * Deprecate Google::Cloud::VideoIntelligence::Credentials.

--- a/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
+++ b/google-cloud-video_intelligence/google-cloud-video_intelligence.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-video_intelligence"
-  gem.version       = "1.1.0"
+  gem.version       = "1.1.1"
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-vision/CHANGELOG.md
+++ b/google-cloud-vision/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.30.2 / 2018-09-10
+
+* Update documentation.
+
 ### 0.30.1 / 2018-08-21
 
 * Update documentation.

--- a/google-cloud-vision/lib/google/cloud/vision/version.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Vision
-      VERSION = "0.30.1".freeze
+      VERSION = "0.30.2".freeze
     end
   end
 end

--- a/google-cloud/CHANGELOG.md
+++ b/google-cloud/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.56.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.56.0 / 2018-08-16
 
 * Add Cloud Bigtable

--- a/google-cloud/lib/google/cloud/version.rb
+++ b/google-cloud/lib/google/cloud/version.rb
@@ -15,6 +15,6 @@
 
 module Google
   module Cloud
-    VERSION = "0.56.0".freeze
+    VERSION = "0.56.1".freeze
   end
 end

--- a/stackdriver-core/CHANGELOG.md
+++ b/stackdriver-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.3.1 / 2018-09-10
+
+* Update documentation.
+
 ### 1.3.0 / 2018-02-27
 
 * Use Google Cloud Shared Configuration.

--- a/stackdriver-core/lib/stackdriver/core/version.rb
+++ b/stackdriver-core/lib/stackdriver/core/version.rb
@@ -15,6 +15,6 @@
 
 module Stackdriver
   module Core
-    VERSION = "1.3.0".freeze
+    VERSION = "1.3.1".freeze
   end
 end

--- a/stackdriver/CHANGELOG.md
+++ b/stackdriver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.15.1 / 2018-09-10
+
+* Update documentation.
+
 ### 0.15.0 / 2018-05-24
 
 * Debugger 0.32.0

--- a/stackdriver/lib/stackdriver/version.rb
+++ b/stackdriver/lib/stackdriver/version.rb
@@ -14,5 +14,5 @@
 
 
 module Stackdriver
-  VERSION = "0.15.0".freeze
+  VERSION = "0.15.1".freeze
 end


### PR DESCRIPTION
This PR bumps all gems in preparation of a release. Here are all the releases that this PR contains:

gcloud/v0.23.1
google-cloud/v0.56.1
google-cloud-bigquery/v1.8.0
google-cloud-bigquery-data_transfer/v0.2.2
google-cloud-bigtable/v0.1.1
google-cloud-container/v0.2.1
google-cloud-core/v1.2.4
google-cloud-dataproc/v0.2.1
google-cloud-datastore/v1.4.2
google-cloud-debugger/v0.32.3
google-cloud-dialogflow/v0.2.1
google-cloud-dlp/v0.6.1
google-cloud-dns/v0.29.2
google-cloud-env/v1.0.3
google-cloud-error_reporting/v0.30.3
google-cloud-firestore/v0.24.0
google-cloud-kms/v0.2.2
google-cloud-language/v0.31.1
google-cloud-logging/v1.5.3
google-cloud-monitoring/v0.29.1
google-cloud-os_login/v0.2.2
google-cloud-pubsub/v0.32.1
google-cloud-redis/v0.2.1
google-cloud-resource_manager/v0.30.1
google-cloud-spanner/v1.6.2
google-cloud-speech/v0.31.0
google-cloud-storage/v1.14.0
google-cloud-tasks/v0.2.3
google-cloud-text_to_speech/v0.1.2
google-cloud-trace/v0.33.3
google-cloud-translate/v1.2.2
google-cloud-video_intelligence/v1.1.1
google-cloud-vision/v0.30.2
stackdriver/v0.15.1
stackdriver-core/v1.3.1
