### PR TITLE
Fix for auto loading files

### DIFF
--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -189,15 +189,26 @@ module Google
     # @private
     #
     def self.auto_load_gems
-      previously_loaded_files = Array(caller).map do |backtrace_line|
-        File.realpath backtrace_line.split(":").first
-      end.uniq
+      currently_loaded_files = loaded_files
 
       auto_load_files.each do |auto_load_file|
         auto_load_file = File.realpath auto_load_file
-        next if previously_loaded_files.include? auto_load_file
+        next if currently_loaded_files.include? auto_load_file
         require auto_load_file
       end
+    end
+
+    ##
+    # Find files that are currently loaded.
+    # @private
+    #
+    def self.loaded_files
+      files = Array(caller).map do |backtrace_line|
+        backtrace_line.split(":").first
+      end
+      files.uniq!
+      files.select! { |file| File.file? file }
+      files.map { |file| File.realpath file }
     end
 
     ##

--- a/google-cloud-core/test/google/cloud/loaded_files_test.rb
+++ b/google-cloud-core/test/google/cloud/loaded_files_test.rb
@@ -1,0 +1,37 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud, :loaded_files do
+  let :loaded_files do
+    [
+      "lib/google/cloud.rb:123:in `require'",
+      "../google-cloud-core/lib/google/cloud/config.rb:123:in `require'",
+      File.realpath("lib/google/cloud/credentials.rb") + ":123:in `require'",
+      "-e:1:in `<main>'"
+    ]
+  end
+
+  it "gives real paths of files that exist" do
+    Google::Cloud.stub :caller, loaded_files do
+      Google::Cloud.loaded_files.must_equal [
+        File.realpath("lib/google/cloud.rb"),
+        File.realpath("lib/google/cloud/config.rb"),
+        File.realpath("lib/google/cloud/credentials.rb")
+      ]
+    end
+  end
+end


### PR DESCRIPTION
The caller information can contain entries that are not files.
This can cause an error when loading the gems.
Ensure that all currently loaded files exist before calling realpath.

[fixes #2423]