### PR TITLE
Add missing standard types to Datastore docs

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/struct.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/struct.rb
@@ -1,0 +1,74 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Protobuf
+    # `Struct` represents a structured data value, consisting of fields
+    # which map to dynamically typed values. In some languages, `Struct`
+    # might be supported by a native representation. For example, in
+    # scripting languages like JS a struct is represented as an
+    # object. The details of that representation are described together
+    # with the proto support for the language.
+    #
+    # The JSON representation for `Struct` is JSON object.
+    # @!attribute [rw] fields
+    #   @return [Hash{String => Google::Protobuf::Value}]
+    #     Unordered map of dynamically typed values.
+    class Struct; end
+
+    # `Value` represents a dynamically typed value which can be either
+    # null, a number, a string, a boolean, a recursive struct value, or a
+    # list of values. A producer of value is expected to set one of that
+    # variants, absence of any variant indicates an error.
+    #
+    # The JSON representation for `Value` is JSON value.
+    # @!attribute [rw] null_value
+    #   @return [Google::Protobuf::NullValue]
+    #     Represents a null value.
+    # @!attribute [rw] number_value
+    #   @return [Float]
+    #     Represents a double value.
+    # @!attribute [rw] string_value
+    #   @return [String]
+    #     Represents a string value.
+    # @!attribute [rw] bool_value
+    #   @return [true, false]
+    #     Represents a boolean value.
+    # @!attribute [rw] struct_value
+    #   @return [Google::Protobuf::Struct]
+    #     Represents a structured value.
+    # @!attribute [rw] list_value
+    #   @return [Google::Protobuf::ListValue]
+    #     Represents a repeated +Value+.
+    class Value; end
+
+    # `ListValue` is a wrapper around a repeated field of values.
+    #
+    # The JSON representation for `ListValue` is JSON array.
+    # @!attribute [rw] values
+    #   @return [Array<Google::Protobuf::Value>]
+    #     Repeated field of dynamically typed values.
+    class ListValue; end
+
+    # `NullValue` is a singleton enumeration to represent the null value for the
+    # `Value` type union.
+    #
+    #  The JSON representation for `NullValue` is JSON +null+.
+    module NullValue
+      # Null value.
+      NULL_VALUE = 0
+    end
+  end
+end

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/timestamp.rb
@@ -1,0 +1,109 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Protobuf
+    # A Timestamp represents a point in time independent of any time zone
+    # or calendar, represented as seconds and fractions of seconds at
+    # nanosecond resolution in UTC Epoch time. It is encoded using the
+    # Proleptic Gregorian Calendar which extends the Gregorian calendar
+    # backwards to year one. It is encoded assuming all minutes are 60
+    # seconds long, i.e. leap seconds are "smeared" so that no leap second
+    # table is needed for interpretation. Range is from
+    # 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+    # By restricting to that range, we ensure that we can convert to
+    # and from  RFC 3339 date strings.
+    # See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+    #
+    # = Examples
+    #
+    # Example 1: Compute Timestamp from POSIX `time()`.
+    #
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds(time(NULL));
+    #     timestamp.set_nanos(0);
+    #
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+    #
+    #     struct timeval tv;
+    #     gettimeofday(&tv, NULL);
+    #
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds(tv.tv_sec);
+    #     timestamp.set_nanos(tv.tv_usec * 1000);
+    #
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+    #
+    #     FILETIME ft;
+    #     GetSystemTimeAsFileTime(&ft);
+    #     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+    #
+    #     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+    #     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+    #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+    #
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+    #
+    #     long millis = System.currentTimeMillis();
+    #
+    #     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+    #         .setNanos((int) ((millis % 1000) * 1000000)).build();
+    #
+    #
+    # Example 5: Compute Timestamp from current time in Python.
+    #
+    #     timestamp = Timestamp()
+    #     timestamp.GetCurrentTime()
+    #
+    # = JSON Mapping
+    #
+    # In JSON format, the Timestamp type is encoded as a string in the
+    # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+    # format is "\\{year}-\\{month}-\\{day}T\\{hour}:\\{min}:\\{sec}[.\\{frac_sec}]Z"
+    # where \\{year} is always expressed using four digits while \\{month}, \\{day},
+    # \\{hour}, \\{min}, and \\{sec} are zero-padded to two digits each. The fractional
+    # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+    # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+    # is required. A proto3 JSON serializer should always use UTC (as indicated by
+    # "Z") when printing the Timestamp type and a proto3 JSON parser should be
+    # able to accept both UTC and other timezones (as indicated by an offset).
+    #
+    # For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+    # 01:30 UTC on January 15, 2017.
+    #
+    # In JavaScript, one can convert a Date object to this format using the
+    # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
+    # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
+    # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
+    # ) to obtain a formatter capable of generating timestamps in this format.
+    # @!attribute [rw] seconds
+    #   @return [Integer]
+    #     Represents seconds of UTC time since Unix epoch
+    #     1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+    #     9999-12-31T23:59:59Z inclusive.
+    # @!attribute [rw] nanos
+    #   @return [Integer]
+    #     Non-negative fractions of a second at nanosecond resolution. Negative
+    #     second values with fractions must still have non-negative nanos values
+    #     that count forward in time. Must be from 0 to 999,999,999
+    #     inclusive.
+    class Timestamp; end
+  end
+end

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/type/latlng.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/type/latlng.rb
@@ -1,0 +1,65 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Type
+    # An object representing a latitude/longitude pair. This is expressed as a pair
+    # of doubles representing degrees latitude and degrees longitude. Unless
+    # specified otherwise, this must conform to the
+    # <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
+    # standard</a>. Values must be within normalized ranges.
+    #
+    # Example of normalization code in Python:
+    #
+    #     def NormalizeLongitude(longitude):
+    #       """Wraps decimal degrees longitude to [-180.0, 180.0]."""
+    #       q, r = divmod(longitude, 360.0)
+    #       if r > 180.0 or (r == 180.0 and q <= -1.0):
+    #         return r - 360.0
+    #       return r
+    #
+    #     def NormalizeLatLng(latitude, longitude):
+    #       """Wraps decimal degrees latitude and longitude to
+    #       [-90.0, 90.0] and [-180.0, 180.0], respectively."""
+    #       r = latitude % 360.0
+    #       if r <= 90.0:
+    #         return r, NormalizeLongitude(longitude)
+    #       elif r >= 270.0:
+    #         return r - 360, NormalizeLongitude(longitude)
+    #       else:
+    #         return 180 - r, NormalizeLongitude(longitude + 180.0)
+    #
+    #     assert 180.0 == NormalizeLongitude(180.0)
+    #     assert -180.0 == NormalizeLongitude(-180.0)
+    #     assert -179.0 == NormalizeLongitude(181.0)
+    #     assert (0.0, 0.0) == NormalizeLatLng(360.0, 0.0)
+    #     assert (0.0, 0.0) == NormalizeLatLng(-360.0, 0.0)
+    #     assert (85.0, 180.0) == NormalizeLatLng(95.0, 0.0)
+    #     assert (-85.0, -170.0) == NormalizeLatLng(-95.0, 10.0)
+    #     assert (90.0, 10.0) == NormalizeLatLng(90.0, 10.0)
+    #     assert (-90.0, -10.0) == NormalizeLatLng(-90.0, -10.0)
+    #     assert (0.0, -170.0) == NormalizeLatLng(-180.0, 10.0)
+    #     assert (0.0, -170.0) == NormalizeLatLng(180.0, 10.0)
+    #     assert (-90.0, 10.0) == NormalizeLatLng(270.0, 10.0)
+    #     assert (90.0, 10.0) == NormalizeLatLng(-270.0, 10.0)
+    # @!attribute [rw] latitude
+    #   @return [Float]
+    #     The latitude in degrees. It must be in the range `[-90.0, +90.0]`.
+    # @!attribute [rw] longitude
+    #   @return [Float]
+    #     The longitude in degrees. It must be in the range `[-180.0, +180.0]`.
+    class LatLng; end
+  end
+end


### PR DESCRIPTION
Patch for https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/2233 (files copied from generated files in other gems). Ideally we'd like these files to be generated, but we can add the files manually to fix the problem for now, and figure out later what's going on with generation.