### PR TITLE
Release google-cloud-core 1.2.6

### DIFF
--- a/google-cloud-core/CHANGELOG.md
+++ b/google-cloud-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.2.6 / 2018-09-12
+
+* Add missing documentation files to package.
+
 ### 1.2.5 / 2018-09-11
 
 * Fix for issue when auto-loading google-cloud-* gem.

--- a/google-cloud-core/google-cloud-core.gemspec
+++ b/google-cloud-core/google-cloud-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.license       = "Apache-2.0"
 
   gem.files         = `git ls-files -- lib/*`.split("\n") +
-                      ["README.md", "LICENSE", ".yardopts"]
+                      ["README.md", "AUTHENTICATION.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
   gem.required_ruby_version = ">= 2.0.0"

--- a/google-cloud-core/lib/google/cloud/core/version.rb
+++ b/google-cloud-core/lib/google/cloud/core/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Core
-      VERSION = "1.2.5".freeze
+      VERSION = "1.2.6".freeze
     end
   end
 end


### PR DESCRIPTION
* Add missing documentation files to package.