### PR TITLE
Remove verbose flag from test rake tasks

### DIFF
--- a/google-cloud-bigquery-data_transfer/Rakefile
+++ b/google-cloud-bigquery-data_transfer/Rakefile
@@ -41,7 +41,6 @@ end
 desc "Runs the smoke tests."
 Rake::TestTask.new :smoke_test do |t|
   t.test_files = FileList["acceptance/**/*smoke_test.rb"]
-  t.verbose = true
   t.warning = false
 end
 

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -114,7 +114,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-bigtable/Rakefile
+++ b/google-cloud-bigtable/Rakefile
@@ -80,7 +80,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 

--- a/google-cloud-container/Rakefile
+++ b/google-cloud-container/Rakefile
@@ -41,7 +41,6 @@ end
 desc "Runs the smoke tests."
 Rake::TestTask.new :smoke_test do |t|
   t.test_files = FileList["acceptance/**/*smoke_test.rb"]
-  t.verbose = true
   t.warning = false
 end
 

--- a/google-cloud-dataproc/Rakefile
+++ b/google-cloud-dataproc/Rakefile
@@ -41,7 +41,6 @@ end
 desc "Runs the smoke tests."
 Rake::TestTask.new :smoke_test do |t|
   t.test_files = FileList["acceptance/**/*smoke_test.rb"]
-  t.verbose = true
   t.warning = false
 end
 

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -76,7 +76,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 

--- a/google-cloud-debugger/Rakefile
+++ b/google-cloud-debugger/Rakefile
@@ -102,7 +102,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-dlp/Rakefile
+++ b/google-cloud-dlp/Rakefile
@@ -63,7 +63,6 @@ namespace :smoke_test do
 
   Rake::TestTask.new :run do |t|
     t.test_files = FileList["acceptance/**/*smoke_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -106,7 +106,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-error_reporting/Rakefile
+++ b/google-cloud-error_reporting/Rakefile
@@ -82,7 +82,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-firestore/Rakefile
+++ b/google-cloud-firestore/Rakefile
@@ -135,7 +135,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -41,7 +41,6 @@ end
 desc "Runs the smoke tests."
 Rake::TestTask.new :smoke_test do |t|
   t.test_files = FileList["acceptance/**/*smoke_test.rb"]
-  t.verbose = true
   t.warning = false
 end
 

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -110,7 +110,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-monitoring/Rakefile
+++ b/google-cloud-monitoring/Rakefile
@@ -63,7 +63,6 @@ namespace :smoke_test do
 
   Rake::TestTask.new :run do |t|
     t.test_files = FileList["acceptance/**/*smoke_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -104,7 +104,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-spanner/Rakefile
+++ b/google-cloud-spanner/Rakefile
@@ -111,7 +111,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -42,7 +42,6 @@ desc "Runs the smoke tests."
 desc "Runs the smoke tests."
 Rake::TestTask.new :smoke_test do |t|
   t.test_files = FileList["acceptance/**/*smoke_test.rb"]
-  t.verbose = true
   t.warning = false
 end
 
@@ -97,7 +96,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -118,7 +118,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-trace/Rakefile
+++ b/google-cloud-trace/Rakefile
@@ -85,7 +85,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -102,7 +102,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-video_intelligence/Rakefile
+++ b/google-cloud-video_intelligence/Rakefile
@@ -63,7 +63,6 @@ namespace :smoke_test do
 
   Rake::TestTask.new :run do |t|
     t.test_files = FileList["acceptance/**/*smoke_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -78,7 +78,6 @@ namespace :acceptance do
   Rake::TestTask.new :run do |t|
     t.libs << "acceptance"
     t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.verbose = true
     t.warning = false
   end
 end


### PR DESCRIPTION
It was thought this setting would set the test output to verbose,
but it doesn't. Remove to make the CI output less... verbose.