### PR TITLE
Use bigquery-public-data project for tests

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -15,7 +15,7 @@
 require "bigquery_helper"
 
 describe Google::Cloud::Bigquery, :bigquery do
-  let(:publicdata_query) { "SELECT url FROM publicdata.samples.github_nested LIMIT 100" }
+  let(:publicdata_query) { "SELECT url FROM `bigquery-public-data.samples.github_nested` LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id
@@ -109,13 +109,13 @@ describe Google::Cloud::Bigquery, :bigquery do
   end
 
   it "should run an query without legacy SQL syntax" do
-    rows = bigquery.query "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100", legacy_sql: false
+    rows = bigquery.query publicdata_query, legacy_sql: false
     rows.class.must_equal Google::Cloud::Bigquery::Data
     rows.count.must_equal 100
   end
 
   it "should run an query with standard SQL syntax" do
-    rows = bigquery.query "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100", standard_sql: true
+    rows = bigquery.query publicdata_query, standard_sql: true
     rows.class.must_equal Google::Cloud::Bigquery::Data
     rows.count.must_equal 100
   end

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_access_test.rb
@@ -15,7 +15,7 @@
 require "bigquery_helper"
 
 describe Google::Cloud::Bigquery::Dataset, :access, :bigquery do
-  let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
+  let(:publicdata_query) { "SELECT url FROM `bigquery-public-data.samples.github_nested` LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -15,7 +15,7 @@
 require "bigquery_helper"
 
 describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
-  let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
+  let(:publicdata_query) { "SELECT url FROM `bigquery-public-data.samples.github_nested` LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -15,7 +15,7 @@
 require "bigquery_helper"
 
 describe Google::Cloud::Bigquery::Dataset, :bigquery do
-  let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
+  let(:publicdata_query) { "SELECT url FROM `bigquery-public-data.samples.github_nested` LIMIT 100" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id

--- a/google-cloud-bigquery/acceptance/bigquery/view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/view_test.rb
@@ -15,8 +15,8 @@
 require "bigquery_helper"
 
 describe Google::Cloud::Bigquery::Table, :view, :bigquery do
-  let(:publicdata_query) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 100" }
-  let(:publicdata_query_2) { "SELECT url FROM `publicdata.samples.github_nested` LIMIT 50" }
+  let(:publicdata_query) { "SELECT url FROM `bigquery-public-data.samples.github_nested` LIMIT 100" }
+  let(:publicdata_query_2) { "SELECT url FROM `bigquery-public-data.samples.github_nested` LIMIT 50" }
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_test.rb
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
     step.kind.must_equal "READ"
     step.substeps.wont_be_nil
     step.substeps.must_be_kind_of Array
-    step.substeps.must_equal [ "word", "FROM publicdata:samples.shakespeare" ]
+    step.substeps.must_equal [ "word", "FROM bigquery-public-data:samples.shakespeare" ]
   end
 
   it "knows its user defined function resources" do
@@ -181,7 +181,7 @@ describe Google::Cloud::Bigquery::QueryJob, :mock_bigquery do
               kind: "READ",
               substeps: [
                 "word",
-                "FROM publicdata:samples.shakespeare"
+                "FROM bigquery-public-data:samples.shakespeare"
               ]
             )
           ],


### PR DESCRIPTION
The publicdata project is deprecated.

```
$ bundle exec rake acceptance[swast-scratch,/Users/swast/keys/swast-scratch-6747200734a1.json]
/Users/swast/.rbenv/versions/2.3.6/bin/ruby -I"lib:acceptance" -I"/Users/swast/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/rake-12.3.1/lib" "/Users/swast/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/rake-12.3.1/lib/rake/rake_test_loader.rb" "acceptance/bigquery/advanced_test.rb" "acceptance/bigquery/bigquery_test.rb" "acceptance/bigquery/dataset_access_test.rb" "acceptance/bigquery/dataset_ddl_test.rb" "acceptance/bigquery/dataset_reference_test.rb" "acceptance/bigquery/dataset_test.rb" "acceptance/bigquery/legacy_query_test.rb" "acceptance/bigquery/location_test.rb" "acceptance/bigquery/named_params_test.rb" "acceptance/bigquery/positional_params_test.rb" "acceptance/bigquery/query_destination_test.rb" "acceptance/bigquery/query_external_test.rb" "acceptance/bigquery/standard_query_test.rb" "acceptance/bigquery/table_external_test.rb" "acceptance/bigquery/table_reference_test.rb" "acceptance/bigquery/table_test.rb" "acceptance/bigquery/view_test.rb"
WARNING: You are running Ruby 2.3.6, which is nearing end-of-life.
The Google Cloud API clients work best on supported versions of Ruby. Consider upgrading to Ruby 2.4 or later.
See https://www.ruby-lang.org/en/downloads/branches/ for more info on the Ruby maintenance schedule.
To suppress this message, set the GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable.
Run options: --seed 16616

# Running:

....................................................................S.......................................................................................................

Finished in 731.314613s, 0.2352 runs/s, 3.6496 assertions/s.

172 runs, 2669 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
Cleaning up bigquery datasets after tests.
Cleaning up bigquery bucket after tests.
```

```
$ bundle exec rake ci

######################################
### BUILDING google-cloud-bigquery ###
######################################


*************************************
*** google-cloud-bigquery rubocop ***
*************************************

Running RuboCop...
Inspecting 28 files
............................

28 files inspected, no offenses detected

**********************************
*** google-cloud-bigquery yard ***
**********************************

Files:          26
Modules:         4 (    2 undocumented)
Classes:        38 (    0 undocumented)
Constants:       5 (    5 undocumented)
Attributes:     34 (    0 undocumented)
Methods:       505 (    4 undocumented)
 98.12% documented

*************************************
*** google-cloud-bigquery doctest ***
*************************************

bundle exec yard config load_plugins true && bundle exec yard doctest
WARNING: You are running Ruby 2.3.6, which is nearing end-of-life.
The Google Cloud API clients work best on supported versions of Ruby. Consider upgrading to Ruby 2.4 or later.
See https://www.ruby-lang.org/en/downloads/branches/ for more info on the Ruby maintenance schedule.
To suppress this message, set the GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable.
Run options: --seed 22889

# Running:

Table Name
......

Finished in 2.216050s, 154.3286 runs/s, 39.7103 assertions/s.

342 runs, 88 assertions, 0 failures, 0 errors, 11 skips

You have skipped tests. Run with --verbose for details.

**********************************
*** google-cloud-bigquery test ***
**********************************

WARNING: You are running Ruby 2.3.6, which is nearing end-of-life.
The Google Cloud API clients work best on supported versions of Ruby. Consider upgrading to Ruby 2.4 or later.
See https://www.ruby-lang.org/en/downloads/branches/ for more info on the Ruby maintenance schedule.
To suppress this message, set the GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable.
Run options: --seed 50567

# Running:

...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 8.693951s, 95.5837 runs/s, 507.9394 assertions/s.

831 runs, 4416 assertions, 0 failures, 0 errors, 0 skips
```