### PR TITLE
Add labels to Pub/Sub Snapshot, Subscription and Topic

### DIFF
--- a/google-cloud-pubsub/.rubocop.yml
+++ b/google-cloud-pubsub/.rubocop.yml
@@ -30,7 +30,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Enabled: false
 Metrics/MethodLength:
-  Max: 20
+  Max: 25
   Exclude:
     - "lib/google/cloud/pubsub.rb"
 Metrics/ParameterLists:

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -186,11 +186,13 @@ describe Google::Cloud::Pubsub, :pubsub do
     end
 
     it "should allow creation of a subscription with options" do
-      subscription = topic.subscribe "#{$topic_prefix}-sub3", retain_acked: true, retention: 600
+      subscription = topic.subscribe "#{$topic_prefix}-sub3", retain_acked: true, retention: 600, labels: labels
       subscription.wont_be :nil?
       subscription.must_be_kind_of Google::Cloud::Pubsub::Subscription
       assert subscription.retain_acked
       subscription.retention.must_equal 600
+      subscription.labels.must_equal labels
+      subscription.labels.must_be :frozen?
       subscription.delete
     end
 

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -34,6 +34,7 @@ describe Google::Cloud::Pubsub, :pubsub do
   let(:new_topic_name)  {  $topic_names[0] }
   let(:topic_names)     {  $topic_names[3..6] }
   let(:lazy_topic_name) {  $topic_names[7] }
+  let(:labels) { { "foo" => "bar" } }
 
   before do
     # create all topics
@@ -72,6 +73,17 @@ describe Google::Cloud::Pubsub, :pubsub do
       topic = pubsub.create_topic new_topic_name
       topic.must_be_kind_of Google::Cloud::Pubsub::Topic
       pubsub.topic(topic.name).wont_be :nil?
+      topic.delete
+      pubsub.topic(topic.name).must_be :nil?
+    end
+
+    it "should be created and fetched and deleted with labels" do
+      topic = pubsub.create_topic new_topic_name, labels: labels
+      topic.must_be_kind_of Google::Cloud::Pubsub::Topic
+      topic = pubsub.topic(topic.name)
+      topic.wont_be :nil?
+      topic.labels.must_equal labels
+      topic.labels.must_be :frozen?
       topic.delete
       pubsub.topic(topic.name).must_be :nil?
     end

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -70,14 +70,6 @@ describe Google::Cloud::Pubsub, :pubsub do
     end
 
     it "should be created and deleted" do
-      topic = pubsub.create_topic new_topic_name
-      topic.must_be_kind_of Google::Cloud::Pubsub::Topic
-      pubsub.topic(topic.name).wont_be :nil?
-      topic.delete
-      pubsub.topic(topic.name).must_be :nil?
-    end
-
-    it "should be created and fetched and deleted with labels" do
       topic = pubsub.create_topic new_topic_name, labels: labels
       topic.must_be_kind_of Google::Cloud::Pubsub::Topic
       topic = pubsub.topic(topic.name)
@@ -237,7 +229,7 @@ describe Google::Cloud::Pubsub, :pubsub do
       msg = topic.publish "hello-#{rand(1000)}"
       msg.wont_be :nil?
 
-      snapshot = subscription.create_snapshot
+      snapshot = subscription.create_snapshot labels: labels
 
       # Check it pulls the message
       events = pull_with_retry subscription
@@ -273,6 +265,9 @@ describe Google::Cloud::Pubsub, :pubsub do
       # No messages, should be empty
       events = subscription.pull
       events.must_be :empty?
+
+      snapshot.labels.must_equal labels
+      snapshot.labels.must_be :frozen?
 
       # Remove the subscription
       subscription.delete

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -163,6 +163,14 @@ module Google
         # Creates a new topic.
         #
         # @param [String] topic_name Name of a topic.
+        # @param [Hash] labels A hash of user-provided labels associated with
+        #   the topic. You can use these to organize and group your topics.
+        #   Label keys and values can be no longer than 63 characters, can only
+        #   contain lowercase letters, numeric characters, underscores and
+        #   dashes. International characters are allowed. Label values are
+        #   optional. Label keys must start with a letter and each label in the
+        #   list must have a different key. See [Creating and Managing
+        #   Labels](https://cloud.google.com/pubsub/docs/labels).
         # @param [Hash] async A hash of values to configure the topic's
         #   {AsyncPublisher} that is created when {Topic#publish_async}
         #   is called. Optional.
@@ -191,9 +199,9 @@ module Google
         #   pubsub = Google::Cloud::Pubsub.new
         #   topic = pubsub.create_topic "my-topic"
         #
-        def create_topic topic_name, async: nil
+        def create_topic topic_name, labels: nil, async: nil
           ensure_service!
-          grpc = service.create_topic topic_name
+          grpc = service.create_topic topic_name, labels: labels
           Topic.from_grpc grpc, service, async: async
         end
         alias new_topic create_topic

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -214,6 +214,7 @@ module Google
           deadline = options[:deadline]
           retain_acked = options[:retain_acked]
           mrd = Convert.number_to_duration options[:retention]
+          labels = options[:labels]
 
           execute do
             subscriber.create_subscription name,
@@ -222,6 +223,7 @@ module Google
                                            ack_deadline_seconds: deadline,
                                            retain_acked_messages: retain_acked,
                                            message_retention_duration: mrd,
+                                           labels: labels,
                                            options: default_options
           end
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -123,9 +123,10 @@ module Google
 
         ##
         # Creates the given topic with the given name.
-        def create_topic topic_name, options = {}
+        def create_topic topic_name, labels: nil, options: {}
           execute do
             publisher.create_topic topic_path(topic_name, options),
+                                   labels: labels,
                                    options: default_options
           end
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -323,11 +323,12 @@ module Google
 
         ##
         # Creates a snapshot on a given subscription.
-        def create_snapshot subscription, snapshot_name
+        def create_snapshot subscription, snapshot_name, labels: nil
           name = snapshot_path snapshot_name
           execute do
             subscriber.create_snapshot name,
                                        subscription_path(subscription),
+                                       labels: labels,
                                        options: default_options
           end
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
@@ -111,6 +111,20 @@ module Google
         end
 
         ##
+        # A hash of user-provided labels associated with this snapshot.
+        # Labels can be provided when the snapshot is created, and used to
+        # organize and group snapshots.See [Creating and Managing
+        # Labels](https://cloud.google.com/pubsub/docs/labels).
+        #
+        # The returned hash is frozen and changes are not allowed.
+        #
+        # @return [Hash] The frozen labels hash.
+        #
+        def labels
+          @grpc.labels.to_h.freeze
+        end
+
+        ##
         # Removes an existing snapshot. All messages retained in the snapshot
         # are immediately dropped. After a snapshot is deleted, a new one may be
         # created with the same name, but the new one has no association with

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -175,6 +175,20 @@ module Google
         end
 
         ##
+        # A hash of user-provided labels associated with this subscription.
+        # Labels can be provided when the subscription is created, and used to
+        # organize and group subscriptions.See [Creating and Managing
+        # Labels](https://cloud.google.com/pubsub/docs/labels).
+        #
+        # The returned hash is frozen and changes are not allowed.
+        #
+        # @return [Hash] The frozen labels hash.
+        #
+        def labels
+          @grpc.labels.to_h.freeze
+        end
+
+        ##
         # Determines whether the subscription exists in the Pub/Sub service.
         #
         # @example

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -498,6 +498,14 @@ module Google
         #   ([0-9], dashes (-), underscores (_), periods (.), tildes (~), plus
         #   (+) or percent signs (%). It must be between 3 and 255 characters in
         #   length, and it must not start with "goog". Optional.
+        # @param [Hash] labels A hash of user-provided labels associated with
+        #   the snapshot. You can use these to organize and group your
+        #   snapshots. Label keys and values can be no longer than 63
+        #   characters, can only contain lowercase letters, numeric characters,
+        #   underscores and dashes. International characters are allowed. Label
+        #   values are optional. Label keys must start with a letter and each
+        #   label in the list must have a different key. See [Creating and
+        #   Managing Labels](https://cloud.google.com/pubsub/docs/labels).
         #
         # @return [Google::Cloud::Pubsub::Snapshot]
         #
@@ -519,9 +527,9 @@ module Google
         #   snapshot = sub.create_snapshot
         #   snapshot.name #=> "projects/my-project/snapshots/gcr-analysis-..."
         #
-        def create_snapshot snapshot_name = nil
+        def create_snapshot snapshot_name = nil, labels: nil
           ensure_service!
-          grpc = service.create_snapshot name, snapshot_name
+          grpc = service.create_snapshot name, snapshot_name, labels: labels
           Snapshot.from_grpc grpc, service
         end
         alias new_snapshot create_snapshot

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -150,6 +150,14 @@ module Google
         #   Default is 604,800 seconds (7 days).
         # @param [String] endpoint A URL locating the endpoint to which messages
         #   should be pushed.
+        # @param [Hash] labels A hash of user-provided labels associated with
+        #   the subscription. You can use these to organize and group your
+        #   subscriptions. Label keys and values can be no longer than 63
+        #   characters, can only contain lowercase letters, numeric characters,
+        #   underscores and dashes. International characters are allowed. Label
+        #   values are optional. Label keys must start with a letter and each
+        #   label in the list must have a different key. See [Creating and
+        #   Managing Labels](https://cloud.google.com/pubsub/docs/labels).
         #
         # @return [Google::Cloud::Pubsub::Subscription]
         #
@@ -173,10 +181,10 @@ module Google
         #                         endpoint: "https://example.com/push"
         #
         def subscribe subscription_name, deadline: nil, retain_acked: false,
-                      retention: nil, endpoint: nil
+                      retention: nil, endpoint: nil, labels: nil
           ensure_service!
           options = { deadline: deadline, retain_acked: retain_acked,
-                      retention: retention, endpoint: endpoint }
+                      retention: retention, endpoint: endpoint, labels: labels }
           grpc = service.create_subscription name, subscription_name, options
           Subscription.from_grpc grpc, service
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -28,6 +28,8 @@ module Google
       #
       # A named resource to which messages are published.
       #
+      # See {Project#create_topic} and {Project#topic}.
+      #
       # @example
       #   require "google/cloud/pubsub"
       #
@@ -84,8 +86,25 @@ module Google
         ##
         # The name of the topic in the form of
         # "/projects/project-identifier/topics/topic-name".
+        #
+        # @return [String]
+        #
         def name
           @grpc.name
+        end
+
+        ##
+        # A hash of user-provided labels associated with this topic. Labels can
+        # be provided when the topic is created, and used to organize and group
+        # topics.See [Creating and Managing
+        # Labels](https://cloud.google.com/pubsub/docs/labels).
+        #
+        # The returned hash is frozen and changes are not allowed.
+        #
+        # @return [Hash] The frozen labels hash.
+        #
+        def labels
+          @grpc.labels.to_h.freeze
         end
 
         ##

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -51,6 +51,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     response = Google::Pubsub::V1::ListSnapshotsResponse.decode_json snapshots_json("fake-topic", 3, "second_page_token")
     paged_enum_struct response
   end
+  let(:labels) { { "foo" => "bar" } }
 
   it "knows the project identifier" do
     pubsub.project.must_equal project
@@ -61,7 +62,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     create_res = Google::Pubsub::V1::Topic.decode_json topic_json(new_topic_name)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), options: default_options]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.create_topic new_topic_name
@@ -76,7 +77,7 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
 
     create_res = Google::Pubsub::V1::Topic.decode_json topic_json(new_topic_name)
     mock = Minitest::Mock.new
-    mock.expect :create_topic, create_res, [topic_path(new_topic_name), options: default_options]
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: nil, options: default_options]
     pubsub.service.mocked_publisher = mock
 
     topic = pubsub.new_topic new_topic_name
@@ -84,6 +85,23 @@ describe Google::Cloud::Pubsub::Project, :mock_pubsub do
     mock.verify
 
     topic.name.must_equal topic_path(new_topic_name)
+  end
+
+  it "creates a topic with labels" do
+    new_topic_name = "new-topic-#{Time.now.to_i}"
+
+    create_res = Google::Pubsub::V1::Topic.decode_json topic_json(new_topic_name, labels: labels)
+    mock = Minitest::Mock.new
+    mock.expect :create_topic, create_res, [topic_path(new_topic_name), labels: labels, options: default_options]
+    pubsub.service.mocked_publisher = mock
+
+    topic = pubsub.create_topic new_topic_name, labels: labels
+
+    mock.verify
+
+    topic.name.must_equal topic_path(new_topic_name)
+    topic.labels.must_equal labels
+    topic.labels.must_be :frozen?
   end
 
   it "gets a topic" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -19,11 +19,12 @@ describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
   let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
                                                 pubsub.service }
   let(:new_sub_name) { "new-sub-#{Time.now.to_i}" }
+  let(:labels) { { "foo" => "bar" } }
 
   it "creates a subscription when calling subscribe" do
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name
@@ -34,6 +35,22 @@ describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
     sub.name.must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
   end
 
+  it "creates a subscription with labels" do
+    create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name, labels: labels)
+    mock = Minitest::Mock.new
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, options: default_options]
+    topic.service.mocked_subscriber = mock
+
+    sub = topic.subscribe new_sub_name, labels: labels
+
+    mock.verify
+
+    sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
+    sub.name.must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
+    sub.labels.must_equal labels
+    sub.labels.must_be :frozen?
+  end
+
   describe "lazy topic that exists" do
     let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name,
                                                  pubsub.service }
@@ -41,7 +58,7 @@ describe Google::Cloud::Pubsub::Topic, :subscribe, :mock_pubsub do
     it "creates a subscription when calling subscribe" do
       create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
       mock = Minitest::Mock.new
-      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, options: default_options]
+      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
       topic.service.mocked_subscriber = mock
 
       sub = topic.subscribe new_sub_name

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name
@@ -71,7 +71,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.create_subscription new_sub_name
@@ -86,7 +86,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.new_subscription new_sub_name
@@ -102,7 +102,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     deadline = 42
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: 42, retain_acked_messages: false, message_retention_duration: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: 42, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, deadline: deadline
@@ -119,7 +119,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
     duration = Google::Protobuf::Duration.new seconds: 600, nanos: 0
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: true, message_retention_duration: duration, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: true, message_retention_duration: duration, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, retain_acked: true, retention: 600
@@ -136,7 +136,7 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
     push_config = Google::Pubsub::V1::PushConfig.new(push_endpoint: endpoint)
     create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: push_config, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: push_config, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, endpoint: endpoint
@@ -145,6 +145,23 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
     sub.wont_be :nil?
     sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
+  end
+
+  it "creates a subscription with labels" do
+    new_sub_name = "new-sub-#{Time.now.to_i}"
+    create_res = Google::Pubsub::V1::Subscription.decode_json subscription_json(topic_name, new_sub_name, labels: labels)
+    mock = Minitest::Mock.new
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, options: default_options]
+    topic.service.mocked_subscriber = mock
+
+    sub = topic.subscribe new_sub_name, labels: labels
+
+    mock.verify
+
+    sub.wont_be :nil?
+    sub.must_be_kind_of Google::Cloud::Pubsub::Subscription
+    sub.labels.must_equal labels
+    sub.labels.must_be :frozen?
   end
 
   it "raises when creating a subscription that already exists" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -16,7 +16,8 @@ require "helper"
 
 describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
-  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name)),
+  let(:labels) { { "foo" => "bar" } }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc Google::Pubsub::V1::Topic.decode_json(topic_json(topic_name, labels: labels)),
                                                 pubsub.service }
   let(:subscriptions_with_token) do
     response = Google::Pubsub::V1::ListTopicSubscriptionsResponse.decode_json topic_subscriptions_json(3, "next_page_token")
@@ -33,6 +34,11 @@ describe Google::Cloud::Pubsub::Topic, :mock_pubsub do
 
   it "knows its name" do
     topic.name.must_equal topic_path(topic_name)
+  end
+
+  it "knows its labels" do
+    topic.labels.must_equal labels
+    topic.labels.must_be :frozen?
   end
 
   it "can delete itself" do

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -120,8 +120,8 @@ class MockPubsub < Minitest::Spec
     data.to_json
   end
 
-  def topic_json topic_name
-    { "name" => topic_path(topic_name) }.to_json
+  def topic_json topic_name, labels: nil
+    { "name" => topic_path(topic_name), labels: labels }.to_json
   end
 
   def topic_subscriptions_json num_subs, token = nil

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -144,13 +144,14 @@ class MockPubsub < Minitest::Spec
 
   def subscription_json topic_name, sub_name,
                         deadline = 60,
-                        endpoint = "http://example.com/callback"
+                        endpoint = "http://example.com/callback", labels: nil
     { "name" => subscription_path(sub_name),
       "topic" => topic_path(topic_name),
       "push_config" => { "push_endpoint" => endpoint },
       "ack_deadline_seconds" => deadline,
       "retain_acked_messages" => true,
-      "message_retention_duration" => {"seconds" => 600, "nanos" => 900000000} # 600.9 seconds
+      "message_retention_duration" => {"seconds" => 600, "nanos" => 900000000}, # 600.9 seconds
+      "labels" => labels
     }.to_json
   end
 

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -164,7 +164,7 @@ class MockPubsub < Minitest::Spec
     data.to_json
   end
 
-  def snapshot_json topic_name, snapshot_name
+  def snapshot_json topic_name, snapshot_name, labels: nil
     time = Time.now
     timestamp = {
       "seconds" => time.to_i,
@@ -172,7 +172,8 @@ class MockPubsub < Minitest::Spec
     }
     { "name" => snapshot_path(snapshot_name),
       "topic" => topic_path(topic_name),
-      "expire_time" => timestamp
+      "expire_time" => timestamp,
+      "labels" => labels
     }.to_json
   end
 


### PR DESCRIPTION
This PR provides support for creating Snapshot, Subscription and Topic instances with user-defined labels, and reading those labels. It does not provide support for updating labels on existing instances.

[closes #2344]