### PR TITLE
Fix circular require warnings

### DIFF
--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -19,7 +19,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-bigtable/lib/google-cloud-bigtable.rb
+++ b/google-cloud-bigtable/lib/google-cloud-bigtable.rb
@@ -21,7 +21,7 @@ gem "google-cloud-core"
 
 require "googleauth"
 require "grpc"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 
 module Google

--- a/google-cloud-datastore/lib/google-cloud-datastore.rb
+++ b/google-cloud-datastore/lib/google-cloud-datastore.rb
@@ -20,7 +20,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-debugger/lib/google-cloud-debugger.rb
+++ b/google-cloud-debugger/lib/google-cloud-debugger.rb
@@ -20,7 +20,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-dns/lib/google-cloud-dns.rb
+++ b/google-cloud-dns/lib/google-cloud-dns.rb
@@ -19,7 +19,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
@@ -18,7 +18,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-firestore/lib/google-cloud-firestore.rb
+++ b/google-cloud-firestore/lib/google-cloud-firestore.rb
@@ -20,7 +20,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-logging/lib/google-cloud-logging.rb
+++ b/google-cloud-logging/lib/google-cloud-logging.rb
@@ -20,7 +20,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-pubsub/lib/google-cloud-pubsub.rb
+++ b/google-cloud-pubsub/lib/google-cloud-pubsub.rb
@@ -20,7 +20,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
+++ b/google-cloud-resource_manager/lib/google-cloud-resource_manager.rb
@@ -20,7 +20,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-spanner/lib/google-cloud-spanner.rb
+++ b/google-cloud-spanner/lib/google-cloud-spanner.rb
@@ -20,7 +20,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-storage/lib/google-cloud-storage.rb
+++ b/google-cloud-storage/lib/google-cloud-storage.rb
@@ -19,7 +19,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-trace/lib/google-cloud-trace.rb
+++ b/google-cloud-trace/lib/google-cloud-trace.rb
@@ -20,7 +20,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-translate/lib/google-cloud-translate.rb
+++ b/google-cloud-translate/lib/google-cloud-translate.rb
@@ -19,7 +19,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud-vision/lib/google-cloud-vision.rb
+++ b/google-cloud-vision/lib/google-cloud-vision.rb
@@ -20,7 +20,7 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new
 require "google/cloud/config"
 require "googleauth"
 

--- a/google-cloud/lib/google-cloud.rb
+++ b/google-cloud/lib/google-cloud.rb
@@ -17,4 +17,4 @@
 
 
 gem "google-cloud-core"
-require "google/cloud"
+require "google/cloud" unless defined? Google::Cloud.new


### PR DESCRIPTION
Place a conditional on the google/cloud require.
This will stop the circular require warnings when gems are
loaded by the google-cloud-core auto-load mechanism.